### PR TITLE
DDS-232 add info to manifest

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -8,6 +8,12 @@ authors = [
 ]
 license = "Apache-2.0"
 edition = "2018"
+readme = "../README.md"
+description = "Data Distribution Service (DDS) implementation"
+homepage = "https://s2e-systems.com/products/dust-dds"
+repository = "https://github.com/s2e-systems/dust-dds"
+keywords = ["dds", "rtps", "middleware", "network", "udp"]
+categories = ["api-bindings", "network-programming"]
 
 [dependencies]
 dust_dds_derive = { path = "../dds_derive" }

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -106,12 +106,12 @@ impl RtpsUdpPsm {
             .into_iter()
             .flat_map(|i| {
                 i.addresses.into_iter().filter_map(|a| match a.address? {
-                    SocketAddr::V4(v4) if !v4.ip().is_loopback() && !v4.ip().is_link_local() => Some(*v4.ip()),
+                    SocketAddr::V4(v4) if !v4.ip().is_loopback() => Some(*v4.ip()),
                     _ => None,
                 })
             })
             .collect();
-        // let unicast_address_list = vec![[192, 168, 178, 38].into()];
+
         assert!(
             !unicast_address_list.is_empty(),
             "Could not find any IPv4 address"

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -106,12 +106,12 @@ impl RtpsUdpPsm {
             .into_iter()
             .flat_map(|i| {
                 i.addresses.into_iter().filter_map(|a| match a.address? {
-                    SocketAddr::V4(v4) if !v4.ip().is_loopback() => Some(*v4.ip()),
+                    SocketAddr::V4(v4) if !v4.ip().is_loopback() && !v4.ip().is_link_local() => Some(*v4.ip()),
                     _ => None,
                 })
             })
             .collect();
-
+        // let unicast_address_list = vec![[192, 168, 178, 38].into()];
         assert!(
             !unicast_address_list.is_empty(),
             "Could not find any IPv4 address"

--- a/dds_derive/Cargo.toml
+++ b/dds_derive/Cargo.toml
@@ -1,8 +1,19 @@
 [package]
 name = "dust_dds_derive"
 version = "0.1.0"
-edition = "2021"
+authors = [
+	"Joao Rebelo <jrebelo@s2e-systems.com>",
+	"Stefan Kimmer <skimmer@s2e-systems.com>",
+	"Pierre Martinet <pmartinet@s2e-systems.com>"
+]
+edition = "2018"
 license = "Apache-2.0"
+description = "Derive macro for `DdsType` from `dust-dds`"
+readme = "README.md"
+homepage = "https://s2e-systems.com/products/dust-dds"
+repository = "https://github.com/s2e-systems/dust-dds"
+keywords = ["dds", "rtps", "middleware", "network", "udp"]
+categories = ["api-bindings", "network-programming"]
 
 [lib]
 proc-macro = true

--- a/dds_derive/README.md
+++ b/dds_derive/README.md
@@ -1,6 +1,6 @@
 # Derive macro for `DdsType`
 
-This package provides the derive macro for `DdsType` and `DdsSerde` from [dust-dds](https://bitbucket.org/s2e-systems/rust-rtps).
+This package provides derive macros for `DdsType` and `DdsSerde` to support [dust-dds](https://github.com/s2e-systems/dust-dds).
 
 `DdsType` can only be derived for `struct`s, tuples and `enum`s. For `struct`s and tuples, the attribute `#[key]` can be specified either on the whole type or on a subset of fields. For `enum`s, the `#[key]` attribute can only be specified on the whole type.
 
@@ -9,21 +9,14 @@ This package provides the derive macro for `DdsType` and `DdsSerde` from [dust-d
 A typical user DDS type will look like this:
 
 ```rust
-
 use dust_dds::topic_definition::type_support::{DdsSerde, DdsType}
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, DdsType, DdsSerde)]
-
 struct HelloWorldType {
-
     #[key]
-
     id: u8,
-
     msg: String,
-
 }
 
 ```

--- a/dds_derive/README.md
+++ b/dds_derive/README.md
@@ -1,0 +1,29 @@
+# Derive macro for `DdsType`
+
+This package provides the derive macro for `DdsType` and `DdsSerde` from [dust-dds](https://bitbucket.org/s2e-systems/rust-rtps).
+
+`DdsType` can only be derived for `struct`s, tuples and `enum`s. For `struct`s and tuples, the attribute `#[key]` can be specified either on the whole type or on a subset of fields. For `enum`s, the `#[key]` attribute can only be specified on the whole type.
+
+## Example
+
+A typical user DDS type will look like this:
+
+```rust
+
+use dust_dds::topic_definition::type_support::{DdsSerde, DdsType}
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, DdsType, DdsSerde)]
+
+struct HelloWorldType {
+
+    #[key]
+
+    id: u8,
+
+    msg: String,
+
+}
+
+```


### PR DESCRIPTION
To support crates.io publication add package definitions to the manifest files.