### PR TITLE
DDS-212 Replace EntityKind's by an enum

### DIFF
--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -260,7 +260,7 @@ impl DdsDeserialize<'_> for DiscoveredReaderData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::implementation::rtps::types::GuidPrefix;
+    use crate::implementation::rtps::types::{EntityKind, GuidPrefix};
     use crate::infrastructure::qos_policy::{
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
         LatencyBudgetQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy, PartitionQosPolicy,
@@ -280,9 +280,12 @@ mod tests {
             reader_proxy: ReaderProxy {
                 remote_reader_guid: Guid::new(
                     GuidPrefix::from([5; 12]),
-                    EntityId::new([11, 12, 13], 15),
+                    EntityId::new([11, 12, 13], EntityKind::UserDefinedReaderWithKey),
                 ),
-                remote_group_entity_id: EntityId::new([21, 22, 23], 25),
+                remote_group_entity_id: EntityId::new(
+                    [21, 22, 23],
+                    EntityKind::BuiltInWriterWithKey,
+                ),
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
                 expects_inline_qos: *ExpectsInlineQosSerialize::default().0,
@@ -315,7 +318,8 @@ mod tests {
         let expected = vec![
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
             0x53, 0x00, 4, 0, //PID_GROUP_ENTITYID
-            21, 22, 23, 25, 0x5a, 0x00, 16, 0, //PID_ENDPOINT_GUID, length
+            21, 22, 23, 0xc2, //
+            0x5a, 0x00, 16, 0, //PID_ENDPOINT_GUID, length
             1, 0, 0, 0, // ,
             2, 0, 0, 0, // ,
             3, 0, 0, 0, // ,
@@ -343,9 +347,12 @@ mod tests {
                 // must correspond to subscription_builtin_topic_data.key
                 remote_reader_guid: Guid::new(
                     GuidPrefix::from([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]),
-                    EntityId::new([4, 0, 0], 0),
+                    EntityId::new([4, 0, 0], EntityKind::UserDefinedUnknown),
                 ),
-                remote_group_entity_id: EntityId::new([21, 22, 23], 25),
+                remote_group_entity_id: EntityId::new(
+                    [21, 22, 23],
+                    EntityKind::BuiltInWriterWithKey,
+                ),
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
                 expects_inline_qos: ExpectsInlineQosDeserialize::default().0,
@@ -378,7 +385,7 @@ mod tests {
         let mut data = &[
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
             0x53, 0x00, 4, 0, //PID_GROUP_ENTITYID
-            21, 22, 23, 25, // u8[3], u8
+            21, 22, 23, 0xc2, // u8[3], u8
             0x5a, 0x00, 16, 0, //PID_ENDPOINT_GUID, length
             1, 0, 0, 0, // ,
             2, 0, 0, 0, // ,

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -254,7 +254,7 @@ impl DdsDeserialize<'_> for DiscoveredWriterData {
 
 #[cfg(test)]
 mod tests {
-    use crate::implementation::rtps::types::GuidPrefix;
+    use crate::implementation::rtps::types::{GuidPrefix, EntityKind};
     use crate::infrastructure::qos_policy::{
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
         LatencyBudgetQosPolicy, LifespanQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy,
@@ -276,12 +276,12 @@ mod tests {
             writer_proxy: WriterProxy {
                 remote_writer_guid: Guid::new(
                     GuidPrefix::from([5; 12]),
-                    EntityId::new([11, 12, 13], 15),
+                    EntityId::new([11, 12, 13], EntityKind::BuiltInWriterWithKey),
                 ),
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
                 data_max_size_serialized: None,
-                remote_group_entity_id: EntityId::new([21, 22, 23], 25),
+                remote_group_entity_id: EntityId::new([21, 22, 23], EntityKind::BuiltInReaderGroup),
             },
             publication_builtin_topic_data: PublicationBuiltinTopicData {
                 key: BuiltInTopicKey {
@@ -311,7 +311,7 @@ mod tests {
         let expected = vec![
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
             0x53, 0x00, 4, 0, //PID_GROUP_ENTITYID
-            21, 22, 23, 25, // u8[3], u8
+            21, 22, 23, 0xc9, // u8[3], u8
             0x5a, 0x00, 16, 0, //PID_ENDPOINT_GUID, length
             1, 0, 0, 0, // ,
             2, 0, 0, 0, // ,
@@ -340,12 +340,12 @@ mod tests {
                 // must correspond to publication_builtin_topic_data.key
                 remote_writer_guid: Guid::new(
                     GuidPrefix::from([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]),
-                    EntityId::new([4, 0, 0], 0),
+                    EntityId::new([4, 0, 0], EntityKind::UserDefinedUnknown),
                 ),
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
                 data_max_size_serialized: None,
-                remote_group_entity_id: EntityId::new([21, 22, 23], 25),
+                remote_group_entity_id: EntityId::new([21, 22, 23], EntityKind::BuiltInParticipant),
             },
             publication_builtin_topic_data: PublicationBuiltinTopicData {
                 key: BuiltInTopicKey {
@@ -375,7 +375,7 @@ mod tests {
         let mut data = &[
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
             0x53, 0x00, 4, 0, //PID_GROUP_ENTITYID
-            21, 22, 23, 25, // u8[3], u8
+            21, 22, 23, 0xc1, // u8[3], u8
             0x5a, 0x00, 16, 0, //PID_ENDPOINT_GUID, length
             1, 0, 0, 0, // ,
             2, 0, 0, 0, // ,

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -249,7 +249,7 @@ impl<'de> DdsDeserialize<'de> for SpdpDiscoveredParticipantData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::implementation::rtps::types::EntityId;
+    use crate::implementation::rtps::types::{EntityId, EntityKind};
     use crate::infrastructure::qos_policy::UserDataQosPolicy;
     use crate::topic_definition::type_support::LittleEndian;
 
@@ -268,7 +268,7 @@ mod tests {
         let domain_tag = "ab".to_string();
         let protocol_version = ProtocolVersion { major: 2, minor: 4 };
         let guid_prefix = GuidPrefix::from([8; 12]);
-        let guid = Guid::new(guid_prefix, EntityId::new([0, 0, 1], 0xc1));
+        let guid = Guid::new(guid_prefix, EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant));
         let vendor_id = [73, 74];
         let expects_inline_qos = true;
         let metatraffic_unicast_locator_list = vec![locator1, locator2];
@@ -386,7 +386,7 @@ mod tests {
         let domain_tag = "ab".to_string();
         let protocol_version = ProtocolVersion { major: 2, minor: 4 };
         let guid_prefix = GuidPrefix::from([8; 12]);
-        let guid = Guid::new(guid_prefix, EntityId::new([0, 0, 1], 0xc1));
+        let guid = Guid::new(guid_prefix, EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant));
         let vendor_id = [73, 74];
         let expects_inline_qos = true;
         let metatraffic_unicast_locator_list = vec![locator1, locator2];

--- a/dds/src/implementation/dds_impl/builtin_publisher.rs
+++ b/dds/src/implementation/dds_impl/builtin_publisher.rs
@@ -1,7 +1,7 @@
 use crate::implementation::rtps::messages::submessages::AckNackSubmessage;
 use crate::implementation::rtps::transport::TransportWrite;
 use crate::implementation::rtps::types::{
-    EntityId, Guid, GuidPrefix, Locator, BUILT_IN_WRITER_GROUP,
+    EntityId, Guid, GuidPrefix, Locator, EntityKind,
 };
 
 use crate::implementation::rtps::group::RtpsGroupImpl;
@@ -40,7 +40,7 @@ impl BuiltinPublisher {
     ) -> DdsShared<Self> {
         let qos = PublisherQos::default();
 
-        let entity_id = EntityId::new([0, 0, 0], BUILT_IN_WRITER_GROUP);
+        let entity_id = EntityId::new([0, 0, 0], EntityKind::BuiltInWriterGroup);
         let guid = Guid::new(guid_prefix, entity_id);
         let rtps_group = RtpsGroupImpl::new(guid);
 

--- a/dds/src/implementation/dds_impl/builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/builtin_subscriber.rs
@@ -7,7 +7,7 @@ use crate::implementation::data_representation_builtin_endpoints::spdp_discovere
 use crate::implementation::rtps::group::RtpsGroupImpl;
 use crate::implementation::rtps::messages::submessages::{DataSubmessage, HeartbeatSubmessage};
 use crate::implementation::rtps::transport::TransportWrite;
-use crate::implementation::rtps::types::{EntityId, Guid, GuidPrefix, BUILT_IN_READER_GROUP};
+use crate::implementation::rtps::types::{EntityId, Guid, GuidPrefix, EntityKind};
 use crate::infrastructure::error::DdsResult;
 use crate::infrastructure::instance::InstanceHandle;
 use crate::infrastructure::status::StatusKind;
@@ -49,7 +49,7 @@ impl BuiltInSubscriber {
     ) -> DdsShared<Self> {
         let qos = SubscriberQos::default();
 
-        let entity_id = EntityId::new([0, 0, 0], BUILT_IN_READER_GROUP);
+        let entity_id = EntityId::new([0, 0, 0], EntityKind::BuiltInReaderGroup);
         let guid = Guid::new(guid_prefix, entity_id);
         let rtps_group = RtpsGroupImpl::new(guid);
 

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -22,11 +22,7 @@ use crate::{
             discovery_types::{BuiltinEndpointQos, BuiltinEndpointSet},
             messages::RtpsMessage,
             transport::TransportWrite,
-            types::{
-                Count, EntityId, Guid, Locator, BUILT_IN_READER_WITH_KEY, BUILT_IN_TOPIC,
-                BUILT_IN_WRITER_WITH_KEY, USER_DEFINED_READER_GROUP, USER_DEFINED_TOPIC,
-                USER_DEFINED_WRITER_GROUP,
-            },
+            types::{Count, EntityId, EntityKind, Guid, Locator},
         },
         utils::shared_object::DdsWeak,
     },
@@ -70,28 +66,28 @@ use super::{
 use crate::domain::domain_participant_listener::DomainParticipantListener;
 
 pub const ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER: EntityId =
-    EntityId::new([0x00, 0x01, 0x00], BUILT_IN_WRITER_WITH_KEY);
+    EntityId::new([0x00, 0x01, 0x00], EntityKind::BuiltInWriterWithKey);
 
 pub const ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER: EntityId =
-    EntityId::new([0x00, 0x01, 0x00], BUILT_IN_READER_WITH_KEY);
+    EntityId::new([0x00, 0x01, 0x00], EntityKind::BuiltInReaderWithKey);
 
 pub const ENTITYID_SEDP_BUILTIN_TOPICS_ANNOUNCER: EntityId =
-    EntityId::new([0, 0, 0x02], BUILT_IN_WRITER_WITH_KEY);
+    EntityId::new([0, 0, 0x02], EntityKind::BuiltInWriterWithKey);
 
 pub const ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR: EntityId =
-    EntityId::new([0, 0, 0x02], BUILT_IN_READER_WITH_KEY);
+    EntityId::new([0, 0, 0x02], EntityKind::BuiltInReaderWithKey);
 
 pub const ENTITYID_SEDP_BUILTIN_PUBLICATIONS_ANNOUNCER: EntityId =
-    EntityId::new([0, 0, 0x03], BUILT_IN_WRITER_WITH_KEY);
+    EntityId::new([0, 0, 0x03], EntityKind::BuiltInWriterWithKey);
 
 pub const ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR: EntityId =
-    EntityId::new([0, 0, 0x03], BUILT_IN_READER_WITH_KEY);
+    EntityId::new([0, 0, 0x03], EntityKind::BuiltInReaderWithKey);
 
 pub const ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_ANNOUNCER: EntityId =
-    EntityId::new([0, 0, 0x04], BUILT_IN_WRITER_WITH_KEY);
+    EntityId::new([0, 0, 0x04], EntityKind::BuiltInWriterWithKey);
 
 pub const ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR: EntityId =
-    EntityId::new([0, 0, 0x04], BUILT_IN_READER_WITH_KEY);
+    EntityId::new([0, 0, 0x04], EntityKind::BuiltInReaderWithKey);
 
 pub struct DomainParticipantImpl {
     rtps_participant: RtpsParticipant,
@@ -137,7 +133,7 @@ impl DomainParticipantImpl {
         let lease_duration = Duration::new(100, 0);
         let guid_prefix = rtps_participant.guid().prefix();
 
-        let spdp_topic_entity_id = EntityId::new([0, 0, 0], BUILT_IN_TOPIC);
+        let spdp_topic_entity_id = EntityId::new([0, 0, 0], EntityKind::BuiltInTopic);
         let spdp_topic_guid = Guid::new(guid_prefix, spdp_topic_entity_id);
         let spdp_topic_participant = TopicImpl::new(
             spdp_topic_guid,
@@ -147,7 +143,7 @@ impl DomainParticipantImpl {
             DdsWeak::new(),
         );
 
-        let sedp_topics_entity_id = EntityId::new([0, 0, 1], BUILT_IN_TOPIC);
+        let sedp_topics_entity_id = EntityId::new([0, 0, 1], EntityKind::BuiltInTopic);
         let sedp_topics_guid = Guid::new(guid_prefix, sedp_topics_entity_id);
         let sedp_topic_topics = TopicImpl::new(
             sedp_topics_guid,
@@ -157,7 +153,7 @@ impl DomainParticipantImpl {
             DdsWeak::new(),
         );
 
-        let sedp_publications_entity_id = EntityId::new([0, 0, 2], BUILT_IN_TOPIC);
+        let sedp_publications_entity_id = EntityId::new([0, 0, 2], EntityKind::BuiltInTopic);
         let sedp_publications_guid = Guid::new(guid_prefix, sedp_publications_entity_id);
         let sedp_topic_publications = TopicImpl::new(
             sedp_publications_guid,
@@ -167,7 +163,7 @@ impl DomainParticipantImpl {
             DdsWeak::new(),
         );
 
-        let sedp_subscriptions_entity_id = EntityId::new([0, 0, 2], BUILT_IN_TOPIC);
+        let sedp_subscriptions_entity_id = EntityId::new([0, 0, 2], EntityKind::BuiltInTopic);
         let sedp_subscriptions_guid = Guid::new(guid_prefix, sedp_subscriptions_entity_id);
         let sedp_topic_subscriptions = TopicImpl::new(
             sedp_subscriptions_guid,
@@ -255,7 +251,7 @@ impl DdsShared<DomainParticipantImpl> {
         let publisher_counter = self
             .user_defined_publisher_counter
             .fetch_add(1, Ordering::Relaxed);
-        let entity_id = EntityId::new([publisher_counter, 0, 0], USER_DEFINED_WRITER_GROUP);
+        let entity_id = EntityId::new([publisher_counter, 0, 0], EntityKind::UserDefinedWriterGroup);
         let guid = Guid::new(self.rtps_participant.guid().prefix(), entity_id);
         let rtps_group = RtpsGroupImpl::new(guid);
         let publisher_impl_shared = UserDefinedPublisher::new(
@@ -316,7 +312,7 @@ impl DdsShared<DomainParticipantImpl> {
         let subcriber_counter = self
             .user_defined_subscriber_counter
             .fetch_add(1, Ordering::Relaxed);
-        let entity_id = EntityId::new([subcriber_counter, 0, 0], USER_DEFINED_READER_GROUP);
+        let entity_id = EntityId::new([subcriber_counter, 0, 0], EntityKind::UserDefinedWriterGroup);
         let guid = Guid::new(self.rtps_participant.guid().prefix(), entity_id);
         let rtps_group = RtpsGroupImpl::new(guid);
         let subscriber_shared = UserDefinedSubscriber::new(
@@ -380,7 +376,7 @@ impl DdsShared<DomainParticipantImpl> {
             .fetch_add(1, Ordering::Relaxed);
         let topic_guid = Guid::new(
             self.rtps_participant.guid().prefix(),
-            EntityId::new([topic_counter, 0, 0], USER_DEFINED_TOPIC),
+            EntityId::new([topic_counter, 0, 0], EntityKind::UserDefinedTopic),
         );
         let qos = match qos {
             QosKind::Default => self.default_topic_qos.clone(),
@@ -997,8 +993,8 @@ impl DdsShared<DomainParticipantImpl> {
     pub fn on_notification_received(&self, notification: (Guid, StatusKind)) {
         let (guid, _) = notification;
         match guid.entity_id().entity_kind() {
-            crate::implementation::rtps::types::USER_DEFINED_READER_NO_KEY
-            | crate::implementation::rtps::types::USER_DEFINED_READER_WITH_KEY => {
+            crate::implementation::rtps::types::EntityKind::UserDefinedReaderNoKey
+            | crate::implementation::rtps::types::EntityKind::UserDefinedReaderWithKey => {
                 for subscriber in self.user_defined_subscriber_list.read_lock().iter() {
                     subscriber.on_notification_received(notification);
                 }

--- a/dds/src/implementation/dds_impl/topic_impl.rs
+++ b/dds/src/implementation/dds_impl/topic_impl.rs
@@ -178,13 +178,13 @@ impl From<&DdsShared<TopicImpl>> for DiscoveredTopicData {
 #[cfg(test)]
 mod tests {
 
-    use crate::implementation::rtps::types::{EntityId, GuidPrefix};
+    use crate::implementation::rtps::types::{EntityId, GuidPrefix, EntityKind};
 
     use super::*;
 
     #[test]
     fn get_instance_handle() {
-        let guid = Guid::new(GuidPrefix::from([2; 12]), EntityId::new([3; 3], 1));
+        let guid = Guid::new(GuidPrefix::from([2; 12]), EntityId::new([3; 3], EntityKind::BuiltInParticipant));
         let topic = TopicImpl::new(guid, TopicQos::default(), "", "", DdsWeak::new());
         *topic.enabled.write_lock() = true;
 

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -785,7 +785,7 @@ mod tests {
             reader_cache_change::RtpsReaderCacheChange,
             types::{
                 ChangeKind, EntityId, Guid, SequenceNumber, TopicKind, ENTITYID_UNKNOWN,
-                GUID_UNKNOWN,
+                GUID_UNKNOWN, EntityKind,
             },
         },
         infrastructure::{
@@ -991,7 +991,7 @@ mod tests {
     #[test]
     fn get_instance_handle() {
         let (notifications_sender, _notifications_receiver) = sync_channel(1);
-        let guid = Guid::new(GuidPrefix::from([4; 12]), EntityId::new([3; 3], 1));
+        let guid = Guid::new(GuidPrefix::from([4; 12]), EntityId::new([3; 3], EntityKind::BuiltInParticipant));
         let dummy_topic = TopicImpl::new(GUID_UNKNOWN, TopicQos::default(), "", "", DdsWeak::new());
         let qos = DataReaderQos::default();
         let stateful_reader = RtpsStatefulReader::new(RtpsReader::new::<UserData>(
@@ -1077,7 +1077,7 @@ mod tests {
         };
         let discovered_writer_data = DiscoveredWriterData {
             writer_proxy: WriterProxy {
-                remote_writer_guid: Guid::new(GuidPrefix::from([2; 12]), EntityId::new([2; 3], 2)),
+                remote_writer_guid: Guid::new(GuidPrefix::from([2; 12]), EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey)),
                 remote_group_entity_id: ENTITYID_UNKNOWN,
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
@@ -1165,7 +1165,7 @@ mod tests {
         };
         let discovered_writer_data = DiscoveredWriterData {
             writer_proxy: WriterProxy {
-                remote_writer_guid: Guid::new(GuidPrefix::from([2; 12]), EntityId::new([2; 3], 2)),
+                remote_writer_guid: Guid::new(GuidPrefix::from([2; 12]), EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey)),
                 remote_group_entity_id: ENTITYID_UNKNOWN,
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -20,7 +20,7 @@ use crate::{
             },
             reader_proxy::RtpsReaderProxy,
             transport::TransportWrite,
-            types::{ChangeKind, EntityId, PROTOCOLVERSION, VENDOR_ID_S2E},
+            types::{ChangeKind, EntityId, PROTOCOLVERSION, VENDOR_ID_S2E, EntityKind},
         },
         utils::condvar::DdsCondvar,
     },
@@ -760,7 +760,7 @@ impl TryFrom<&DdsShared<UserDefinedDataWriter>> for DiscoveredWriterData {
                 unicast_locator_list: rtps_writer_lock.writer().unicast_locator_list().to_vec(),
                 multicast_locator_list: rtps_writer_lock.writer().multicast_locator_list().to_vec(),
                 data_max_size_serialized: None,
-                remote_group_entity_id: EntityId::new([0; 3], 0),
+                remote_group_entity_id: EntityId::new([0; 3], EntityKind::UserDefinedUnknown),
             },
 
             publication_builtin_topic_data: PublicationBuiltinTopicData {
@@ -1087,7 +1087,7 @@ mod test {
         };
         let discovered_reader_data = DiscoveredReaderData {
             reader_proxy: ReaderProxy {
-                remote_reader_guid: Guid::new(GuidPrefix::from([2; 12]), EntityId::new([2; 3], 2)),
+                remote_reader_guid: Guid::new(GuidPrefix::from([2; 12]), EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey)),
                 remote_group_entity_id: ENTITYID_UNKNOWN,
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
@@ -1176,7 +1176,7 @@ mod test {
         };
         let discovered_reader_data = DiscoveredReaderData {
             reader_proxy: ReaderProxy {
-                remote_reader_guid: Guid::new(GuidPrefix::from([2; 12]), EntityId::new([2; 3], 2)),
+                remote_reader_guid: Guid::new(GuidPrefix::from([2; 12]), EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey)),
                 remote_group_entity_id: ENTITYID_UNKNOWN,
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],

--- a/dds/src/implementation/dds_impl/user_defined_publisher.rs
+++ b/dds/src/implementation/dds_impl/user_defined_publisher.rs
@@ -3,9 +3,7 @@ use std::sync::atomic::{self, AtomicU8};
 use crate::implementation::rtps::endpoint::RtpsEndpoint;
 use crate::implementation::rtps::messages::submessages::AckNackSubmessage;
 use crate::implementation::rtps::transport::TransportWrite;
-use crate::implementation::rtps::types::{
-    EntityId, Guid, TopicKind, USER_DEFINED_WRITER_NO_KEY, USER_DEFINED_WRITER_WITH_KEY,
-};
+use crate::implementation::rtps::types::{EntityId, EntityKind, Guid, TopicKind};
 use crate::implementation::rtps::writer::RtpsWriter;
 use crate::implementation::rtps::{group::RtpsGroupImpl, stateful_writer::RtpsStatefulWriter};
 use crate::implementation::utils::condvar::DdsCondvar;
@@ -92,8 +90,8 @@ impl DdsShared<UserDefinedPublisher> {
                 .fetch_add(1, atomic::Ordering::SeqCst);
 
             let entity_kind = match Foo::has_key() {
-                true => USER_DEFINED_WRITER_WITH_KEY,
-                false => USER_DEFINED_WRITER_NO_KEY,
+                true => EntityKind::UserDefinedWriterWithKey,
+                false => EntityKind::UserDefinedWriterNoKey,
             };
 
             Guid::new(

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -4,9 +4,7 @@ use crate::implementation::rtps::endpoint::RtpsEndpoint;
 use crate::implementation::rtps::messages::submessages::{DataSubmessage, HeartbeatSubmessage};
 use crate::implementation::rtps::reader::RtpsReader;
 use crate::implementation::rtps::transport::TransportWrite;
-use crate::implementation::rtps::types::{
-    EntityId, Guid, GuidPrefix, TopicKind, USER_DEFINED_READER_NO_KEY, USER_DEFINED_READER_WITH_KEY,
-};
+use crate::implementation::rtps::types::{EntityId, EntityKind, Guid, GuidPrefix, TopicKind};
 use crate::implementation::rtps::{group::RtpsGroupImpl, stateful_reader::RtpsStatefulReader};
 use crate::implementation::utils::condvar::DdsCondvar;
 use crate::infrastructure::error::{DdsError, DdsResult};
@@ -92,8 +90,8 @@ impl DdsShared<UserDefinedSubscriber> {
         // /////// Build the GUID
         let entity_id = {
             let entity_kind = match Foo::has_key() {
-                true => USER_DEFINED_READER_WITH_KEY,
-                false => USER_DEFINED_READER_NO_KEY,
+                true => EntityKind::UserDefinedReaderWithKey,
+                false => EntityKind::UserDefinedReaderNoKey,
             };
 
             EntityId::new(

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -55,7 +55,7 @@ impl From<Guid> for [u8; 16] {
             guid.entity_id.entity_key[0],
             guid.entity_id.entity_key[1],
             guid.entity_id.entity_key[2],
-            guid.entity_id.entity_kind,
+            guid.entity_id.entity_kind.into(),
         ]
     }
 }
@@ -69,7 +69,7 @@ impl From<[u8; 16]> for Guid {
             ]),
             entity_id: EntityId {
                 entity_key: [value[12], value[13], value[14]],
-                entity_kind: value[15],
+                entity_kind: value[15].into(),
             },
         }
     }
@@ -130,7 +130,7 @@ impl From<EntityId> for [u8; 4] {
             value.entity_key[0],
             value.entity_key[1],
             value.entity_key[2],
-            value.entity_kind,
+            value.entity_kind.into(),
         ]
     }
 }
@@ -139,47 +139,154 @@ impl From<[u8; 4]> for EntityId {
     fn from(value: [u8; 4]) -> Self {
         Self {
             entity_key: [value[0], value[1], value[2]],
-            entity_kind: value[3],
+            entity_kind: value[3].into(),
         }
     }
 }
 
 pub const ENTITYID_UNKNOWN: EntityId = EntityId {
     entity_key: [0; 3],
-    entity_kind: USER_DEFINED_UNKNOWN,
+    entity_kind: EntityKind::UserDefinedUnknown,
 };
 
 pub const ENTITYID_PARTICIPANT: EntityId = EntityId {
     entity_key: [0, 0, 0x01],
-    entity_kind: BUILT_IN_PARTICIPANT,
+    entity_kind: EntityKind::BuiltInParticipant,
 };
 
-pub type EntityKind = u8;
+// pub type EntityKind = u8;
 
-// Table 9.1 - entityKind octet of an EntityId_t
-pub const USER_DEFINED_UNKNOWN: EntityKind = 0x00;
-#[allow(dead_code)]
-pub const BUILT_IN_UNKNOWN: EntityKind = 0xc0;
-pub const BUILT_IN_PARTICIPANT: EntityKind = 0xc1;
-pub const USER_DEFINED_WRITER_WITH_KEY: EntityKind = 0x02;
-pub const BUILT_IN_WRITER_WITH_KEY: EntityKind = 0xc2;
-pub const USER_DEFINED_WRITER_NO_KEY: EntityKind = 0x03;
-#[allow(dead_code)]
-pub const BUILT_IN_WRITER_NO_KEY: EntityKind = 0xc3;
-#[allow(dead_code)]
-pub const USER_DEFINED_READER_WITH_KEY: EntityKind = 0x07;
-pub const BUILT_IN_READER_WITH_KEY: EntityKind = 0xc7;
-#[allow(dead_code)]
-pub const USER_DEFINED_READER_NO_KEY: EntityKind = 0x04;
-#[allow(dead_code)]
-pub const BUILT_IN_READER_NO_KEY: EntityKind = 0xc4;
-pub const USER_DEFINED_WRITER_GROUP: EntityKind = 0x08;
-pub const BUILT_IN_WRITER_GROUP: EntityKind = 0xc8;
-pub const USER_DEFINED_READER_GROUP: EntityKind = 0x09;
-pub const BUILT_IN_READER_GROUP: EntityKind = 0xc9;
-// Added in comparison to the RTPS standard
-pub const BUILT_IN_TOPIC: EntityKind = 0xca;
-pub const USER_DEFINED_TOPIC: EntityKind = 0x0a;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EntityKind {
+    UserDefinedUnknown,
+    BuiltInUnknown,
+    BuiltInParticipant,
+    UserDefinedWriterWithKey,
+    BuiltInWriterWithKey,
+    UserDefinedWriterNoKey,
+    BuiltInWriterNoKey,
+    UserDefinedReaderWithKey,
+    BuiltInReaderWithKey,
+    UserDefinedReaderNoKey,
+    BuiltInReaderNoKey,
+    UserDefinedWriterGroup,
+    BuiltInWriterGroup,
+    UserDefinedReaderGroup,
+    BuiltInReaderGroup,
+    BuiltInTopic,
+    UserDefinedTopic,
+}
+
+impl serde::Serialize for EntityKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serde::Serialize::serialize(
+            &Into::<u8>::into(*self),
+            serializer,
+        )
+    }
+}
+
+struct EntityKindVisitor;
+
+impl<'de> serde::de::Visitor<'de> for EntityKindVisitor {
+    type Value = EntityKind;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str(&format!("value must be valid EntityKind"))
+    }
+
+    fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(value.into())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for EntityKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: serde::Deserializer<'de>
+    {
+        deserializer.deserialize_u8(EntityKindVisitor)
+    }
+}
+
+impl From<EntityKind> for u8 {
+    fn from(value: EntityKind) -> Self {
+        match value {
+            EntityKind::UserDefinedUnknown => 0x00,
+            EntityKind::BuiltInUnknown => 0xc0,
+            EntityKind::BuiltInParticipant => 0xc1,
+            EntityKind::UserDefinedWriterWithKey => 0x02,
+            EntityKind::BuiltInWriterWithKey => 0xc2,
+            EntityKind::UserDefinedWriterNoKey => 0x03,
+            EntityKind::BuiltInWriterNoKey => 0xc3,
+            EntityKind::UserDefinedReaderWithKey => 0x07,
+            EntityKind::BuiltInReaderWithKey => 0xc7,
+            EntityKind::UserDefinedReaderNoKey => 0x04,
+            EntityKind::BuiltInReaderNoKey => 0xc4,
+            EntityKind::UserDefinedWriterGroup => 0x08,
+            EntityKind::BuiltInWriterGroup => 0xc8,
+            EntityKind::UserDefinedReaderGroup => 0x09,
+            EntityKind::BuiltInReaderGroup => 0xc9,
+            EntityKind::UserDefinedTopic => 0x0a,
+            EntityKind::BuiltInTopic => 0xca,
+        }
+    }
+}
+
+impl From<u8> for EntityKind {
+    fn from(value: u8) -> Self {
+        match value {
+            0x00 => EntityKind::UserDefinedUnknown,
+            0xc0 => EntityKind::BuiltInUnknown,
+            0xc1 => EntityKind::BuiltInParticipant,
+            0x02 => EntityKind::UserDefinedWriterWithKey,
+            0xc2 => EntityKind::BuiltInWriterWithKey,
+            0x03 => EntityKind::UserDefinedWriterNoKey,
+            0xc3 => EntityKind::BuiltInWriterNoKey,
+            0x07 => EntityKind::UserDefinedReaderWithKey,
+            0xc7 => EntityKind::BuiltInReaderWithKey,
+            0x04 => EntityKind::UserDefinedReaderNoKey,
+            0xc4 => EntityKind::BuiltInReaderNoKey,
+            0x08 => EntityKind::UserDefinedWriterGroup,
+            0xc8 => EntityKind::BuiltInWriterGroup,
+            0x09 => EntityKind::UserDefinedReaderGroup,
+            0xc9 => EntityKind::BuiltInReaderGroup,
+            0x0a => EntityKind::UserDefinedTopic,
+            0xca => EntityKind::BuiltInTopic,
+            _ => EntityKind::UserDefinedUnknown,
+        }
+    }
+}
+
+// // Table 9.1 - entityKind octet of an EntityId_t
+// pub const USER_DEFINED_UNKNOWN: EntityKind = 0x00;
+// #[allow(dead_code)]
+// pub const BUILT_IN_UNKNOWN: EntityKind = 0xc0;
+// pub const BUILT_IN_PARTICIPANT: EntityKind = 0xc1;
+// pub const USER_DEFINED_WRITER_WITH_KEY: EntityKind = 0x02;
+// pub const BUILT_IN_WRITER_WITH_KEY: EntityKind = 0xc2;
+// pub const USER_DEFINED_WRITER_NO_KEY: EntityKind = 0x03;
+// #[allow(dead_code)]
+// pub const BUILT_IN_WRITER_NO_KEY: EntityKind = 0xc3;
+// #[allow(dead_code)]
+// pub const USER_DEFINED_READER_WITH_KEY: EntityKind = 0x07;
+// pub const BUILT_IN_READER_WITH_KEY: EntityKind = 0xc7;
+// #[allow(dead_code)]
+// pub const USER_DEFINED_READER_NO_KEY: EntityKind = 0x04;
+// #[allow(dead_code)]
+// pub const BUILT_IN_READER_NO_KEY: EntityKind = 0xc4;
+// pub const USER_DEFINED_WRITER_GROUP: EntityKind = 0x08;
+// pub const BUILT_IN_WRITER_GROUP: EntityKind = 0xc8;
+// pub const USER_DEFINED_READER_GROUP: EntityKind = 0x09;
+// pub const BUILT_IN_READER_GROUP: EntityKind = 0xc9;
+// // Added in comparison to the RTPS standard
+// pub const BUILT_IN_TOPIC: EntityKind = 0xca;
+// pub const USER_DEFINED_TOPIC: EntityKind = 0x0a;
 
 pub type EntityKey = [u8; 3];
 

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -195,7 +195,7 @@ impl<'de> serde::de::Visitor<'de> for EntityKindVisitor {
     type Value = EntityKind;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str(&format!("value must be valid EntityKind"))
+        formatter.write_str("value must be valid EntityKind")
     }
 
     fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>

--- a/dds/src/infrastructure/instance.rs
+++ b/dds/src/infrastructure/instance.rs
@@ -39,7 +39,7 @@ impl From<InstanceHandle> for Guid {
         let prefix = GuidPrefix::from(<[u8; 12]>::try_from(&x.0[0..12]).expect("Invalid length"));
         let entity_id = EntityId::new(
             <[u8; 3]>::try_from(&x.0[12..15]).expect("Invalid length"),
-            x.0[15],
+            x.0[15].into(),
         );
         Guid::new(prefix, entity_id)
     }


### PR DESCRIPTION
The EntityKind's like BUILT_IN_WRITER_WITH_KEY used to be constants of type u8. This was matching the idl but does not provide the benefits of type safety and readability. This PR replaces all the constants by an enum. For that the enum needs a custom serde::Serialize and Deserialize. The deserialization does at this moment not fail and falls back to 0. 