### PR TITLE
DDS-223 Rework trigerring of data reader listener

### DIFF
--- a/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::mpsc::SyncSender};
+use std::collections::HashMap;
 
 use crate::{
     implementation::rtps::{
@@ -46,8 +46,8 @@ use crate::{
 };
 
 use super::{
-    dcps_service::ReceivedDataChannel, message_receiver::MessageReceiver,
-    participant_discovery::ParticipantDiscovery, topic_impl::TopicImpl,
+    message_receiver::MessageReceiver, participant_discovery::ParticipantDiscovery,
+    topic_impl::TopicImpl,
 };
 
 pub struct BuiltinStatefulReader {
@@ -63,11 +63,7 @@ pub struct BuiltinStatefulReader {
 }
 
 impl BuiltinStatefulReader {
-    pub fn new<Foo>(
-        guid: Guid,
-        topic: DdsShared<TopicImpl>,
-        notifications_sender: SyncSender<ReceivedDataChannel>,
-    ) -> DdsShared<Self>
+    pub fn new<Foo>(guid: Guid, topic: DdsShared<TopicImpl>) -> DdsShared<Self>
     where
         Foo: DdsType + for<'de> DdsDeserialize<'de>,
     {
@@ -100,7 +96,6 @@ impl BuiltinStatefulReader {
                 heartbeat_suppression_duration,
                 expects_inline_qos,
                 qos,
-                notifications_sender,
             ));
 
         DdsShared::new(BuiltinStatefulReader {

--- a/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
@@ -1,5 +1,3 @@
-use std::sync::mpsc::SyncSender;
-
 use crate::{
     implementation::rtps::{endpoint::RtpsEndpoint, reader::RtpsReader, types::TopicKind},
     infrastructure::qos::DataReaderQos,
@@ -24,9 +22,7 @@ use crate::{
     topic_definition::type_support::DdsDeserialize,
 };
 
-use super::{
-    dcps_service::ReceivedDataChannel, message_receiver::MessageReceiver, topic_impl::TopicImpl,
-};
+use super::{message_receiver::MessageReceiver, topic_impl::TopicImpl};
 
 pub struct BuiltinStatelessReader {
     rtps_reader: DdsRwLock<RtpsStatelessReader>,
@@ -35,11 +31,7 @@ pub struct BuiltinStatelessReader {
 }
 
 impl BuiltinStatelessReader {
-    pub fn new<Foo>(
-        guid: Guid,
-        topic: DdsShared<TopicImpl>,
-        notifications_sender: SyncSender<ReceivedDataChannel>,
-    ) -> DdsShared<Self>
+    pub fn new<Foo>(guid: Guid, topic: DdsShared<TopicImpl>) -> DdsShared<Self>
     where
         Foo: DdsType + for<'de> DdsDeserialize<'de>,
     {
@@ -63,7 +55,6 @@ impl BuiltinStatelessReader {
                 },
                 ..Default::default()
             },
-            notifications_sender,
         );
         let rtps_reader = RtpsStatelessReader::new(reader);
 

--- a/dds/src/implementation/dds_impl/builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/builtin_subscriber.rs
@@ -1,5 +1,3 @@
-use std::sync::mpsc::SyncSender;
-
 use crate::implementation::data_representation_builtin_endpoints::discovered_reader_data::DiscoveredReaderData;
 use crate::implementation::data_representation_builtin_endpoints::discovered_topic_data::DiscoveredTopicData;
 use crate::implementation::data_representation_builtin_endpoints::discovered_writer_data::DiscoveredWriterData;
@@ -21,7 +19,6 @@ use crate::implementation::utils::shared_object::{DdsRwLock, DdsShared};
 
 use super::builtin_stateful_reader::BuiltinStatefulReader;
 use super::builtin_stateless_reader::BuiltinStatelessReader;
-use super::dcps_service::ReceivedDataChannel;
 use super::domain_participant_impl::{
     ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR,
     ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR, ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER,
@@ -46,7 +43,6 @@ impl BuiltInSubscriber {
         sedp_topic_topics: DdsShared<TopicImpl>,
         sedp_topic_publications: DdsShared<TopicImpl>,
         sedp_topic_subscriptions: DdsShared<TopicImpl>,
-        notifications_sender: SyncSender<ReceivedDataChannel>,
     ) -> DdsShared<Self> {
         let qos = SubscriberQos::default();
 
@@ -60,7 +56,6 @@ impl BuiltInSubscriber {
             BuiltinStatelessReader::new::<SpdpDiscoveredParticipantData>(
                 spdp_builtin_participant_reader_guid,
                 spdp_topic_participant,
-                notifications_sender.clone(),
             );
 
         let sedp_builtin_topics_guid =
@@ -68,7 +63,6 @@ impl BuiltInSubscriber {
         let sedp_builtin_topics_reader = BuiltinStatefulReader::new::<DiscoveredTopicData>(
             sedp_builtin_topics_guid,
             sedp_topic_topics,
-            notifications_sender.clone(),
         );
 
         let sedp_builtin_publications_guid =
@@ -76,7 +70,6 @@ impl BuiltInSubscriber {
         let sedp_builtin_publications_reader = BuiltinStatefulReader::new::<DiscoveredWriterData>(
             sedp_builtin_publications_guid,
             sedp_topic_publications,
-            notifications_sender.clone(),
         );
 
         let sedp_builtin_subscriptions_reader =
@@ -84,7 +77,6 @@ impl BuiltInSubscriber {
         let sedp_builtin_subscriptions_reader = BuiltinStatefulReader::new::<DiscoveredReaderData>(
             sedp_builtin_subscriptions_reader,
             sedp_topic_subscriptions,
-            notifications_sender,
         );
 
         DdsShared::new(BuiltInSubscriber {

--- a/dds/src/implementation/dds_impl/dcps_service.rs
+++ b/dds/src/implementation/dds_impl/dcps_service.rs
@@ -83,8 +83,6 @@ impl DcpsService {
                         (notification.guid, notification.instance_handle),
                         (notification.time, notification.deadline),
                     );
-                    domain_participant
-                        .on_notification_received(notification.guid, StatusKind::DataAvailable)
                 }
 
                 // Remove all instances for which the deadline has expired to prevent calling two times
@@ -102,6 +100,8 @@ impl DcpsService {
                 }
 
                 instances = valid_instances;
+
+                domain_participant.update_communication_status();
                 std::thread::sleep(std::time::Duration::from_millis(50));
             }));
         }

--- a/dds/src/implementation/dds_impl/dcps_service.rs
+++ b/dds/src/implementation/dds_impl/dcps_service.rs
@@ -2,7 +2,6 @@ use std::{
     net::UdpSocket,
     sync::{
         atomic::{self, AtomicBool},
-        mpsc::sync_channel,
         Arc,
     },
     thread::JoinHandle,
@@ -11,26 +10,14 @@ use std::{
 use crate::{
     domain::domain_participant_factory::DomainId,
     implementation::{
-        rtps::{participant::RtpsParticipant, types::Guid},
+        rtps::participant::RtpsParticipant,
         rtps_udp_psm::udp_transport::{RtpsUdpPsm, UdpTransport},
         utils::{condvar::DdsCondvar, shared_object::DdsShared},
     },
-    infrastructure::{
-        error::DdsResult,
-        instance::InstanceHandle,
-        qos::DomainParticipantQos,
-        time::{Duration, Time},
-    },
+    infrastructure::{error::DdsResult, qos::DomainParticipantQos, time::Duration},
 };
 
 use super::{configuration::DustDdsConfiguration, domain_participant_impl::DomainParticipantImpl};
-
-pub struct ReceivedDataChannel {
-    pub guid: Guid,
-    pub instance_handle: InstanceHandle,
-    pub time: Time,
-    pub deadline: Duration,
-}
 
 pub struct DcpsService {
     participant: DdsShared<DomainParticipantImpl>,
@@ -48,7 +35,6 @@ impl DcpsService {
     ) -> DdsResult<Self> {
         let announcer_condvar = DdsCondvar::new();
         let user_defined_data_send_condvar = DdsCondvar::new();
-        let (notifications_sender, notifications_receiver) = sync_channel(10);
         let participant = DomainParticipantImpl::new(
             rtps_participant,
             domain_id,
@@ -58,7 +44,6 @@ impl DcpsService {
             transport.metatraffic_multicast_locator_list(),
             announcer_condvar.clone(),
             user_defined_data_send_condvar.clone(),
-            notifications_sender,
         );
 
         participant.enable()?;

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -1004,21 +1004,12 @@ impl DdsShared<DomainParticipantImpl> {
             .unwrap();
     }
 
-    pub fn update_communication_status(&self) {
+    pub fn update_communication_status(&self) -> DdsResult<()> {
+        let now = self.get_current_time()?;
         for subscriber in self.user_defined_subscriber_list.read_lock().iter() {
-            subscriber.update_communication_status();
+            subscriber.update_communication_status(now);
         }
-    }
 
-    pub fn on_notification_received(&self, guid: Guid, status_kind: StatusKind) {
-        match guid.entity_id().entity_kind() {
-            crate::implementation::rtps::types::EntityKind::UserDefinedReaderNoKey
-            | crate::implementation::rtps::types::EntityKind::UserDefinedReaderWithKey => {
-                for subscriber in self.user_defined_subscriber_list.read_lock().iter() {
-                    subscriber.on_notification_received(guid, status_kind);
-                }
-            }
-            _ => (),
-        };
+        Ok(())
     }
 }

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -1,9 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{
-        atomic::{AtomicU8, Ordering},
-        mpsc::SyncSender,
-    },
+    sync::atomic::{AtomicU8, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -58,9 +55,9 @@ use crate::implementation::{
 
 use super::{
     builtin_publisher::BuiltinPublisher, builtin_subscriber::BuiltInSubscriber,
-    dcps_service::ReceivedDataChannel, message_receiver::MessageReceiver,
-    participant_discovery::ParticipantDiscovery, topic_impl::TopicImpl,
-    user_defined_publisher::UserDefinedPublisher, user_defined_subscriber::UserDefinedSubscriber,
+    message_receiver::MessageReceiver, participant_discovery::ParticipantDiscovery,
+    topic_impl::TopicImpl, user_defined_publisher::UserDefinedPublisher,
+    user_defined_subscriber::UserDefinedSubscriber,
 };
 
 use crate::domain::domain_participant_listener::DomainParticipantListener;
@@ -114,7 +111,6 @@ pub struct DomainParticipantImpl {
     enabled: DdsRwLock<bool>,
     announce_condvar: DdsCondvar,
     user_defined_data_send_condvar: DdsCondvar,
-    notifications_sender: SyncSender<ReceivedDataChannel>,
 }
 
 impl DomainParticipantImpl {
@@ -128,7 +124,6 @@ impl DomainParticipantImpl {
         metatraffic_multicast_locator_list: Vec<Locator>,
         announce_condvar: DdsCondvar,
         user_defined_data_send_condvar: DdsCondvar,
-        notifications_sender: SyncSender<ReceivedDataChannel>,
     ) -> DdsShared<Self> {
         let lease_duration = Duration::new(100, 0);
         let guid_prefix = rtps_participant.guid().prefix();
@@ -179,7 +174,6 @@ impl DomainParticipantImpl {
             sedp_topic_topics.clone(),
             sedp_topic_publications.clone(),
             sedp_topic_subscriptions.clone(),
-            notifications_sender.clone(),
         );
 
         let builtin_publisher = BuiltinPublisher::new(
@@ -215,7 +209,6 @@ impl DomainParticipantImpl {
             enabled: DdsRwLock::new(false),
             announce_condvar,
             user_defined_data_send_condvar,
-            notifications_sender,
         })
     }
 
@@ -325,7 +318,6 @@ impl DdsShared<DomainParticipantImpl> {
             subscriber_qos,
             rtps_group,
             self.user_defined_data_send_condvar.clone(),
-            self.notifications_sender.clone(),
         );
         if *self.enabled.read_lock()
             && self

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -1004,6 +1004,12 @@ impl DdsShared<DomainParticipantImpl> {
             .unwrap();
     }
 
+    pub fn update_communication_status(&self) {
+        for subscriber in self.user_defined_subscriber_list.read_lock().iter() {
+            subscriber.update_communication_status();
+        }
+    }
+
     pub fn on_notification_received(&self, guid: Guid, status_kind: StatusKind) {
         match guid.entity_id().entity_kind() {
             crate::implementation::rtps::types::EntityKind::UserDefinedReaderNoKey

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -775,6 +775,24 @@ impl DdsShared<UserDefinedDataReader> {
             }
         }
     }
+
+    pub fn update_communication_status(&self) {
+        let mut rtps_reader = self.rtps_reader.write_lock();
+
+        if rtps_reader.reader_mut().is_data_available() {
+            self.on_data_available()
+        };
+    }
+
+    fn on_data_available(&self) {
+        self.status_condition
+            .write_lock()
+            .add_communication_state(StatusKind::DataAvailable);
+
+        if let Some(listener) = self.listener.write_lock().as_mut() {
+            listener.trigger_on_data_available(self);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -748,7 +748,7 @@ impl DdsShared<UserDefinedDataReader> {
     pub fn update_communication_status(&self, now: Time) {
         let mut rtps_reader = self.rtps_reader.write_lock();
 
-        if rtps_reader.reader_mut().is_data_available() {
+        if rtps_reader.reader_mut().take_data_available() {
             self.on_data_available()
         };
 

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -746,13 +746,18 @@ impl DdsShared<UserDefinedDataReader> {
     }
 
     pub fn update_communication_status(&self, now: Time) {
-        let mut rtps_reader = self.rtps_reader.write_lock();
-
-        if rtps_reader.reader_mut().take_data_available() {
+        if self
+            .rtps_reader
+            .write_lock()
+            .reader_mut()
+            .take_data_available()
+        {
             self.on_data_available()
         };
 
-        if !rtps_reader
+        if !self
+            .rtps_reader
+            .write_lock()
             .reader_mut()
             .get_deadline_missed_instances(now)
             .is_empty()

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -815,7 +815,7 @@ mod tests {
     };
 
     use mockall::mock;
-    use std::{io::Write, sync::mpsc::sync_channel};
+    use std::io::Write;
 
     struct UserData(u8);
 
@@ -887,7 +887,6 @@ mod tests {
 
     #[test]
     fn get_instance_handle() {
-        let (notifications_sender, _notifications_receiver) = sync_channel(1);
         let guid = Guid::new(
             GuidPrefix::from([4; 12]),
             EntityId::new([3; 3], EntityKind::BuiltInParticipant),
@@ -900,7 +899,6 @@ mod tests {
             DURATION_ZERO,
             false,
             qos,
-            notifications_sender,
         ));
 
         let data_reader: DdsShared<UserDefinedDataReader> = UserDefinedDataReader::new(
@@ -919,14 +917,12 @@ mod tests {
 
     #[test]
     fn add_compatible_matched_writer() {
-        let (notifications_sender, _notifications_receiver) = sync_channel(1);
         let type_name = "test_type";
         let topic_name = "test_topic".to_string();
         let parent_subscriber = UserDefinedSubscriber::new(
             SubscriberQos::default(),
             RtpsGroupImpl::new(GUID_UNKNOWN),
             DdsCondvar::new(),
-            notifications_sender.clone(),
         );
         let test_topic = TopicImpl::new(
             GUID_UNKNOWN,
@@ -942,7 +938,6 @@ mod tests {
             DURATION_ZERO,
             false,
             DataReaderQos::default(),
-            notifications_sender,
         ));
 
         let data_reader = UserDefinedDataReader::new(
@@ -1007,14 +1002,12 @@ mod tests {
 
     #[test]
     fn add_incompatible_matched_writer() {
-        let (notifications_sender, _notifications_receiver) = sync_channel(1);
         let type_name = "test_type";
         let topic_name = "test_topic".to_string();
         let parent_subscriber = UserDefinedSubscriber::new(
             SubscriberQos::default(),
             RtpsGroupImpl::new(GUID_UNKNOWN),
             DdsCondvar::new(),
-            notifications_sender.clone(),
         );
         let test_topic = TopicImpl::new(
             GUID_UNKNOWN,
@@ -1033,7 +1026,6 @@ mod tests {
             DURATION_ZERO,
             false,
             data_reader_qos,
-            notifications_sender,
         ));
 
         let data_reader = UserDefinedDataReader::new(

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -11,7 +11,7 @@ use crate::infrastructure::error::{DdsError, DdsResult};
 use crate::infrastructure::instance::InstanceHandle;
 use crate::infrastructure::qos::QosKind;
 use crate::infrastructure::status::{SampleLostStatus, StatusKind};
-use crate::infrastructure::time::DURATION_ZERO;
+use crate::infrastructure::time::{DURATION_ZERO, Time};
 use crate::subscription::subscriber_listener::SubscriberListener;
 use crate::topic_definition::type_support::DdsDeserialize;
 use crate::{
@@ -230,15 +230,9 @@ impl DdsShared<UserDefinedSubscriber> {
         todo!()
     }
 
-    pub fn update_communication_status(&self) {
+    pub fn update_communication_status(&self, now: Time) {
         for data_reader in self.data_reader_list.read_lock().iter() {
-            data_reader.update_communication_status();
-        }
-    }
-
-    pub fn on_notification_received(&self, guid: Guid, status_kind: StatusKind) {
-        for data_reader in self.data_reader_list.read_lock().iter() {
-            data_reader.on_notification_received(guid, status_kind)
+            data_reader.update_communication_status(now);
         }
     }
 }

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -230,6 +230,12 @@ impl DdsShared<UserDefinedSubscriber> {
         todo!()
     }
 
+    pub fn update_communication_status(&self) {
+        for data_reader in self.data_reader_list.read_lock().iter() {
+            data_reader.update_communication_status();
+        }
+    }
+
     pub fn on_notification_received(&self, guid: Guid, status_kind: StatusKind) {
         for data_reader in self.data_reader_list.read_lock().iter() {
             data_reader.on_notification_received(guid, status_kind)

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -133,6 +133,7 @@ pub struct RtpsReader {
     instance_handle_builder: InstanceHandleBuilder,
     instances: HashMap<InstanceHandle, Instance>,
     notifications_sender: SyncSender<ReceivedDataChannel>,
+    data_available: bool,
 }
 
 impl RtpsReader {
@@ -159,6 +160,7 @@ impl RtpsReader {
             instance_handle_builder,
             instances: HashMap::new(),
             notifications_sender,
+            data_available: false,
         }
     }
 
@@ -319,6 +321,8 @@ impl RtpsReader {
                 });
             }
 
+            self.data_available = true;
+
             self.notifications_sender
                 .send(ReceivedDataChannel {
                     guid: self.endpoint.guid(),
@@ -459,6 +463,8 @@ impl RtpsReader {
                 .mark_viewed()
         }
 
+        self.data_available = false;
+
         if indexed_samples.is_empty() {
             Err(DdsError::NoData)
         } else {
@@ -528,6 +534,12 @@ impl RtpsReader {
         }
 
         Ok(samples)
+    }
+
+    pub fn is_data_available(&mut self) -> bool {
+        let data_available = self.data_available;
+        self.data_available = false;
+        data_available
     }
 }
 

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -533,7 +533,7 @@ impl RtpsReader {
         Ok(samples)
     }
 
-    pub fn is_data_available(&mut self) -> bool {
+    pub fn take_data_available(&mut self) -> bool {
         let data_available = self.data_available;
         self.data_available = false;
         data_available


### PR DESCRIPTION
This PR removes the channel from the data reader and instead requires that the thread "asks" for state changes in order to trigger the listener.