### PR TITLE
DDS-199 Move common writer methods to RTPS Writer

### DIFF
--- a/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::implementation::rtps::{stateful_writer::RtpsStatefulWriter, utils::clock::StdTimer};
 use crate::{
     implementation::rtps::{
@@ -19,7 +17,7 @@ use crate::{
             DEFAULT_NACK_SUPPRESSION_DURATION,
         },
         transport::TransportWrite,
-        types::{ChangeKind, Guid, TopicKind, PROTOCOLVERSION, VENDOR_ID_S2E},
+        types::{Guid, TopicKind, PROTOCOLVERSION, VENDOR_ID_S2E},
         writer::RtpsWriter,
     },
     infrastructure::{
@@ -27,11 +25,8 @@ use crate::{
         qos::DataWriterQos,
         time::Time,
     },
-    infrastructure::{
-        instance::{InstanceHandle, HANDLE_NIL},
-        qos_policy::{ReliabilityQosPolicyKind, LENGTH_UNLIMITED},
-    },
-    topic_definition::type_support::{DdsSerialize, DdsType, LittleEndian},
+    infrastructure::{instance::InstanceHandle, qos_policy::ReliabilityQosPolicyKind},
+    topic_definition::type_support::{DdsSerialize, DdsType},
 };
 
 use crate::implementation::{
@@ -49,7 +44,6 @@ use super::{
 
 pub struct BuiltinStatefulWriter {
     rtps_writer: DdsRwLock<RtpsStatefulWriter<StdTimer>>,
-    registered_instance_list: DdsRwLock<HashMap<InstanceHandle, Vec<u8>>>,
     topic: DdsShared<TopicImpl>,
     enabled: DdsRwLock<bool>,
 }
@@ -81,7 +75,6 @@ impl BuiltinStatefulWriter {
 
         DdsShared::new(BuiltinStatefulWriter {
             rtps_writer: DdsRwLock::new(rtps_writer),
-            registered_instance_list: DdsRwLock::new(HashMap::new()),
             topic,
             enabled: DdsRwLock::new(false),
         })
@@ -130,49 +123,10 @@ impl DdsShared<BuiltinStatefulWriter> {
 }
 
 impl DdsShared<BuiltinStatefulWriter> {
-    pub fn register_instance_w_timestamp<Foo>(
-        &self,
-        instance: &Foo,
-        _timestamp: Time,
-    ) -> DdsResult<Option<InstanceHandle>>
-    where
-        Foo: DdsType + DdsSerialize,
-    {
-        if !*self.enabled.read_lock() {
-            return Err(DdsError::NotEnabled);
-        }
-
-        let serialized_key = instance.get_serialized_key::<LittleEndian>();
-        let instance_handle = serialized_key.as_slice().into();
-
-        let mut registered_instances_lock = self.registered_instance_list.write_lock();
-        let rtps_writer_lock = self.rtps_writer.read_lock();
-        if !registered_instances_lock.contains_key(&instance_handle) {
-            if rtps_writer_lock
-                .writer()
-                .get_qos()
-                .resource_limits
-                .max_instances
-                == LENGTH_UNLIMITED
-                || (registered_instances_lock.len() as i32)
-                    < rtps_writer_lock
-                        .writer()
-                        .get_qos()
-                        .resource_limits
-                        .max_instances
-            {
-                registered_instances_lock.insert(instance_handle, serialized_key);
-            } else {
-                return Err(DdsError::OutOfResources);
-            }
-        }
-        Ok(Some(instance_handle))
-    }
-
     pub fn write_w_timestamp<Foo>(
         &self,
         data: &Foo,
-        _handle: Option<InstanceHandle>,
+        handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()>
     where
@@ -182,22 +136,9 @@ impl DdsShared<BuiltinStatefulWriter> {
             return Err(DdsError::NotEnabled);
         }
 
-        let mut serialized_data = Vec::new();
-        data.serialize::<_, LittleEndian>(&mut serialized_data)?;
-        let handle = self
-            .register_instance_w_timestamp(data, timestamp)?
-            .unwrap_or(HANDLE_NIL);
-        let mut rtps_writer_lock = self.rtps_writer.write_lock();
-        let change = rtps_writer_lock.writer_mut().new_change(
-            ChangeKind::Alive,
-            serialized_data,
-            vec![],
-            handle,
-            timestamp,
-        );
-        rtps_writer_lock.add_change(change);
-
-        Ok(())
+        self.rtps_writer
+            .write_lock()
+            .write_w_timestamp(data, handle, timestamp)
     }
 }
 

--- a/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
@@ -84,22 +84,15 @@ impl BuiltinStatefulWriter {
     /// type for those.
     pub fn add_matched_participant(&self, participant_discovery: &ParticipantDiscovery) {
         let mut rtps_writer_lock = self.rtps_writer.write_lock();
-        if !rtps_writer_lock
-            .matched_readers()
-            .iter_mut()
-            .any(|r| r.remote_reader_guid().prefix() == participant_discovery.guid_prefix())
-        {
-            let type_name = self.topic.get_type_name().unwrap();
-            if type_name == DiscoveredWriterData::type_name() {
-                participant_discovery
-                    .discovered_participant_add_publications_writer(&mut rtps_writer_lock);
-            } else if type_name == DiscoveredReaderData::type_name() {
-                participant_discovery
-                    .discovered_participant_add_subscriptions_writer(&mut rtps_writer_lock);
-            } else if type_name == DiscoveredTopicData::type_name() {
-                participant_discovery
-                    .discovered_participant_add_topics_writer(&mut rtps_writer_lock);
-            }
+        let type_name = self.topic.get_type_name().unwrap();
+        if type_name == DiscoveredWriterData::type_name() {
+            participant_discovery
+                .discovered_participant_add_publications_writer(&mut rtps_writer_lock);
+        } else if type_name == DiscoveredReaderData::type_name() {
+            participant_discovery
+                .discovered_participant_add_subscriptions_writer(&mut rtps_writer_lock);
+        } else if type_name == DiscoveredTopicData::type_name() {
+            participant_discovery.discovered_participant_add_topics_writer(&mut rtps_writer_lock);
         }
     }
 }

--- a/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
@@ -111,9 +111,7 @@ impl DdsShared<BuiltinStatefulWriter> {
         message_receiver: &MessageReceiver,
     ) {
         let mut rtps_writer_lock = self.rtps_writer.write_lock();
-        if rtps_writer_lock.writer().get_qos().reliability.kind
-            == ReliabilityQosPolicyKind::Reliable
-        {
+        if rtps_writer_lock.get_qos().reliability.kind == ReliabilityQosPolicyKind::Reliable {
             rtps_writer_lock.on_acknack_submessage_received(
                 acknack_submessage,
                 message_receiver.source_guid_prefix(),
@@ -153,7 +151,7 @@ impl DdsShared<BuiltinStatefulWriter> {
 impl DdsShared<BuiltinStatefulWriter> {
     pub fn send_message(&self, transport: &mut impl TransportWrite) {
         let mut rtps_writer_lock = self.rtps_writer.write_lock();
-        let guid_prefix = rtps_writer_lock.writer().guid().prefix();
+        let guid_prefix = rtps_writer_lock.guid().prefix();
 
         let destined_submessages = rtps_writer_lock.produce_submessages();
 

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -132,7 +132,6 @@ where
 
 pub struct UserDefinedDataWriter {
     rtps_writer: DdsRwLock<RtpsStatefulWriter<StdTimer>>,
-    registered_instance_list: DdsRwLock<HashMap<InstanceHandle, Vec<u8>>>,
     topic: DdsShared<TopicImpl>,
     publisher: DdsWeak<UserDefinedPublisher>,
     publication_matched_status: DdsRwLock<PublicationMatchedStatus>,
@@ -182,7 +181,6 @@ impl UserDefinedDataWriter {
 
         DdsShared::new(UserDefinedDataWriter {
             rtps_writer: DdsRwLock::new(rtps_writer),
-            registered_instance_list: DdsRwLock::new(HashMap::new()),
             topic,
             publisher,
             publication_matched_status: DdsRwLock::new(publication_matched_status),

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -546,7 +546,7 @@ impl DdsShared<UserDefinedDataWriter> {
                 .check_immutability(&qos)?;
         }
 
-        rtps_writer_lock.writer_mut().set_qos(qos)
+        rtps_writer_lock.set_qos(qos)
     }
 
     pub fn get_qos(&self) -> DataWriterQos {

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -11,6 +11,7 @@ use crate::{
     infrastructure::{
         error::{DdsError, DdsResult},
         instance::{InstanceHandle, HANDLE_NIL},
+        qos::DataWriterQos,
         qos_policy::ReliabilityQosPolicyKind,
         time::{Duration, Time, DURATION_ZERO},
     },
@@ -33,9 +34,7 @@ use super::{
 };
 
 pub const DEFAULT_HEARTBEAT_PERIOD: Duration = Duration::new(2, 0);
-
 pub const DEFAULT_NACK_RESPONSE_DELAY: Duration = Duration::new(0, 200);
-
 pub const DEFAULT_NACK_SUPPRESSION_DURATION: Duration = DURATION_ZERO;
 
 pub struct RtpsStatefulWriter<T> {
@@ -48,10 +47,6 @@ pub struct RtpsStatefulWriter<T> {
 impl<T> RtpsStatefulWriter<T> {
     pub fn writer(&self) -> &RtpsWriter {
         &self.writer
-    }
-
-    pub fn writer_mut(&mut self) -> &mut RtpsWriter {
-        &mut self.writer
     }
 }
 
@@ -512,9 +507,7 @@ impl<T: Timer> RtpsStatefulWriter<T> {
         }
         destined_submessages
     }
-}
 
-impl<T> RtpsStatefulWriter<T> {
     pub fn on_acknack_submessage_received(
         &mut self,
         acknack_submessage: &AckNackSubmessage,
@@ -534,5 +527,9 @@ impl<T> RtpsStatefulWriter<T> {
                 reader_proxy.reliable_receive_acknack(acknack_submessage);
             }
         }
+    }
+
+    pub fn set_qos(&mut self, qos: DataWriterQos) -> DdsResult<()> {
+        self.writer.set_qos(qos)
     }
 }

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use super::{
-    history_cache::{RtpsParameter, RtpsWriterCacheChange},
+    history_cache::{RtpsParameter, RtpsWriterCacheChange, WriterHistoryCache},
     messages::{
         submessage_elements::{
             CountSubmessageElement, EntityIdSubmessageElement, SequenceNumberSubmessageElement,
@@ -29,7 +29,7 @@ use super::{
         RtpsSubmessageType,
     },
     reader_proxy::{ChangeForReaderStatusKind, RtpsChangeForReader, RtpsReaderProxy},
-    types::{ChangeKind, Count, Guid, GuidPrefix, ENTITYID_UNKNOWN},
+    types::{ChangeKind, Count, Guid, GuidPrefix, Locator, ENTITYID_UNKNOWN},
     writer::RtpsWriter,
 };
 
@@ -42,12 +42,6 @@ pub struct RtpsStatefulWriter<T> {
     matched_readers: Vec<RtpsReaderProxy>,
     heartbeat_timer: T,
     heartbeat_count: Count,
-}
-
-impl<T> RtpsStatefulWriter<T> {
-    pub fn writer(&self) -> &RtpsWriter {
-        &self.writer
-    }
 }
 
 impl<T> RtpsStatefulWriter<T> {
@@ -317,6 +311,30 @@ impl<T> RtpsStatefulWriter<T> {
     {
         self.writer.lookup_instance(instance)
     }
+
+    pub fn guid(&self) -> Guid {
+        self.writer.guid()
+    }
+
+    pub fn unicast_locator_list(&self) -> &[Locator] {
+        self.writer.unicast_locator_list()
+    }
+
+    pub fn multicast_locator_list(&self) -> &[Locator] {
+        self.writer.multicast_locator_list()
+    }
+
+    pub fn set_qos(&mut self, qos: DataWriterQos) -> DdsResult<()> {
+        self.writer.set_qos(qos)
+    }
+
+    pub fn get_qos(&self) -> &DataWriterQos {
+        self.writer.get_qos()
+    }
+
+    pub fn writer_cache(&self) -> &WriterHistoryCache {
+        self.writer.writer_cache()
+    }
 }
 
 impl<T: Timer> RtpsStatefulWriter<T> {
@@ -527,9 +545,5 @@ impl<T: Timer> RtpsStatefulWriter<T> {
                 reader_proxy.reliable_receive_acknack(acknack_submessage);
             }
         }
-    }
-
-    pub fn set_qos(&mut self, qos: DataWriterQos) -> DdsResult<()> {
-        self.writer.set_qos(qos)
     }
 }

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -44,12 +44,6 @@ pub struct RtpsStatefulWriter<T> {
     heartbeat_count: Count,
 }
 
-impl<T> RtpsStatefulWriter<T> {
-    pub fn matched_readers(&mut self) -> &mut Vec<RtpsReaderProxy> {
-        &mut self.matched_readers
-    }
-}
-
 impl<T: TimerConstructor> RtpsStatefulWriter<T> {
     pub fn new(writer: RtpsWriter) -> Self {
         Self {
@@ -142,13 +136,10 @@ impl<T> RtpsStatefulWriter<T> {
         );
         self.add_change(change);
 
-        // TODO: Trigger condvar
-        // self.user_defined_data_send_condvar.notify_all();
-
         Ok(())
     }
 
-    pub fn add_change(&mut self, change: RtpsWriterCacheChange) {
+    fn add_change(&mut self, change: RtpsWriterCacheChange) {
         let sequence_number = change.sequence_number();
         self.writer.writer_cache_mut().add_change(change);
 


### PR DESCRIPTION
To be able to announce the deletion of a user-defined datawriter it is required that the built-in writer provides the dispose functionality. Right now it the functionality was copied in multiple places so this PR implements the functionality that is common to all writers in the underlying RTPS writer. This is a similar strategy to what was done in the RTPS reader.