### PR TITLE
DDS-206 Create a dedicated type for DdsSerializedKey

### DIFF
--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -9,7 +9,7 @@ use crate::infrastructure::qos_policy::{
     PresentationQosPolicy, ReliabilityQosPolicy, TimeBasedFilterQosPolicy, TopicDataQosPolicy,
     UserDataQosPolicy, DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS,
 };
-use crate::topic_definition::type_support::LittleEndian;
+use crate::topic_definition::type_support::DdsSerializedKey;
 use crate::{
     implementation::parameter_list_serde::{
         parameter_list_deserializer::ParameterListDeserializer,
@@ -73,11 +73,15 @@ impl DdsType for DiscoveredReaderData {
         true
     }
 
-    fn get_serialized_key<E: Endianness>(&self) -> Vec<u8> {
-        self.subscription_builtin_topic_data.key.value.to_vec()
+    fn get_serialized_key(&self) -> DdsSerializedKey {
+        self.subscription_builtin_topic_data
+            .key
+            .value
+            .as_ref()
+            .into()
     }
 
-    fn set_key_fields_from_serialized_key<E: Endianness>(&mut self, _key: &[u8]) -> DdsResult<()> {
+    fn set_key_fields_from_serialized_key(&mut self, _key: &DdsSerializedKey) -> DdsResult<()> {
         if Self::has_key() {
             unimplemented!("DdsType with key must provide an implementation for set_key_fields_from_serialized_key")
         }
@@ -250,10 +254,6 @@ impl DdsDeserialize<'_> for DiscoveredReaderData {
                 group_data,
             },
         })
-    }
-
-    fn deserialize_key(mut buf: &[u8]) -> DdsResult<Vec<u8>> {
-        Ok(Self::deserialize(&mut buf)?.get_serialized_key::<LittleEndian>())
     }
 }
 

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_topic_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_topic_data.rs
@@ -6,7 +6,7 @@ use crate::infrastructure::qos_policy::{
     ReliabilityQosPolicy, ResourceLimitsQosPolicy, TopicDataQosPolicy, TransportPriorityQosPolicy,
     DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS,
 };
-use crate::topic_definition::type_support::LittleEndian;
+use crate::topic_definition::type_support::DdsSerializedKey;
 use crate::{
     implementation::parameter_list_serde::{
         parameter_list_deserializer::ParameterListDeserializer,
@@ -57,11 +57,11 @@ impl DdsType for DiscoveredTopicData {
         true
     }
 
-    fn get_serialized_key<E: Endianness>(&self) -> Vec<u8> {
-        self.topic_builtin_topic_data.key.value.to_vec()
+    fn get_serialized_key(&self) -> DdsSerializedKey {
+        self.topic_builtin_topic_data.key.value.as_ref().into()
     }
 
-    fn set_key_fields_from_serialized_key<E: Endianness>(&mut self, _key: &[u8]) -> DdsResult<()> {
+    fn set_key_fields_from_serialized_key(&mut self, _key: &DdsSerializedKey) -> DdsResult<()> {
         if Self::has_key() {
             unimplemented!("DdsType with key must provide an implementation for set_key_fields_from_serialized_key")
         }
@@ -190,10 +190,6 @@ impl DdsDeserialize<'_> for DiscoveredTopicData {
                 topic_data,
             },
         })
-    }
-
-    fn deserialize_key(mut buf: &[u8]) -> DdsResult<Vec<u8>> {
-        Ok(Self::deserialize(&mut buf)?.get_serialized_key::<LittleEndian>())
     }
 }
 

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -9,7 +9,7 @@ use crate::infrastructure::qos_policy::{
     PartitionQosPolicy, PresentationQosPolicy, ReliabilityQosPolicy, TopicDataQosPolicy,
     UserDataQosPolicy, DEFAULT_RELIABILITY_QOS_POLICY_DATA_WRITER,
 };
-use crate::topic_definition::type_support::LittleEndian;
+use crate::topic_definition::type_support::DdsSerializedKey;
 use crate::{
     implementation::parameter_list_serde::{
         parameter_list_deserializer::ParameterListDeserializer,
@@ -70,11 +70,15 @@ impl DdsType for DiscoveredWriterData {
         true
     }
 
-    fn get_serialized_key<E: Endianness>(&self) -> Vec<u8> {
-        self.publication_builtin_topic_data.key.value.to_vec()
+    fn get_serialized_key(&self) -> DdsSerializedKey {
+        self.publication_builtin_topic_data
+            .key
+            .value
+            .as_ref()
+            .into()
     }
 
-    fn set_key_fields_from_serialized_key<E: Endianness>(&mut self, _key: &[u8]) -> DdsResult<()> {
+    fn set_key_fields_from_serialized_key(&mut self, _key: &DdsSerializedKey) -> DdsResult<()> {
         if Self::has_key() {
             unimplemented!("DdsType with key must provide an implementation for set_key_fields_from_serialized_key")
         }
@@ -246,15 +250,11 @@ impl DdsDeserialize<'_> for DiscoveredWriterData {
             },
         })
     }
-
-    fn deserialize_key(mut buf: &[u8]) -> DdsResult<Vec<u8>> {
-        Ok(Self::deserialize(&mut buf)?.get_serialized_key::<LittleEndian>())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::implementation::rtps::types::{GuidPrefix, EntityKind};
+    use crate::implementation::rtps::types::{EntityKind, GuidPrefix};
     use crate::infrastructure::qos_policy::{
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
         LatencyBudgetQosPolicy, LifespanQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy,

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -7,7 +7,7 @@ use crate::implementation::rtps::types::{
 };
 use crate::infrastructure::error::DdsResult;
 use crate::infrastructure::qos_policy::UserDataQosPolicy;
-use crate::topic_definition::type_support::LittleEndian;
+use crate::topic_definition::type_support::DdsSerializedKey;
 use crate::{
     implementation::parameter_list_serde::{
         parameter_list_deserializer::ParameterListDeserializer,
@@ -111,11 +111,11 @@ impl DdsType for SpdpDiscoveredParticipantData {
         true
     }
 
-    fn get_serialized_key<E: Endianness>(&self) -> Vec<u8> {
-        self.dds_participant_data.key.value.to_vec()
+    fn get_serialized_key(&self) -> DdsSerializedKey {
+        self.dds_participant_data.key.value.as_ref().into()
     }
 
-    fn set_key_fields_from_serialized_key<E: Endianness>(&mut self, _key: &[u8]) -> DdsResult<()> {
+    fn set_key_fields_from_serialized_key(&mut self, _key: &DdsSerializedKey) -> DdsResult<()> {
         if Self::has_key() {
             unimplemented!("DdsType with key must provide an implementation for set_key_fields_from_serialized_key")
         }
@@ -240,10 +240,6 @@ impl<'de> DdsDeserialize<'de> for SpdpDiscoveredParticipantData {
             lease_duration,
         })
     }
-
-    fn deserialize_key(mut buf: &[u8]) -> DdsResult<Vec<u8>> {
-        Ok(Self::deserialize(&mut buf)?.get_serialized_key::<LittleEndian>())
-    }
 }
 
 #[cfg(test)]
@@ -268,7 +264,10 @@ mod tests {
         let domain_tag = "ab".to_string();
         let protocol_version = ProtocolVersion { major: 2, minor: 4 };
         let guid_prefix = GuidPrefix::from([8; 12]);
-        let guid = Guid::new(guid_prefix, EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant));
+        let guid = Guid::new(
+            guid_prefix,
+            EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant),
+        );
         let vendor_id = [73, 74];
         let expects_inline_qos = true;
         let metatraffic_unicast_locator_list = vec![locator1, locator2];
@@ -386,7 +385,10 @@ mod tests {
         let domain_tag = "ab".to_string();
         let protocol_version = ProtocolVersion { major: 2, minor: 4 };
         let guid_prefix = GuidPrefix::from([8; 12]);
-        let guid = Guid::new(guid_prefix, EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant));
+        let guid = Guid::new(
+            guid_prefix,
+            EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant),
+        );
         let vendor_id = [73, 74];
         let expects_inline_qos = true;
         let metatraffic_unicast_locator_list = vec![locator1, locator2];

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -785,12 +785,7 @@ impl DdsShared<DomainParticipantImpl> {
             sedp_builtin_topic_reader_shared.add_matched_participant(&participant_discovery);
 
             self.discovered_participant_list.write_lock().insert(
-                discovered_participant_data
-                    .dds_participant_data
-                    .key
-                    .value
-                    .as_ref()
-                    .into(),
+                discovered_participant_data.get_serialized_key().into(),
                 discovered_participant_data.dds_participant_data.clone(),
             );
         }
@@ -947,12 +942,7 @@ impl DdsShared<DomainParticipantImpl> {
             for sample in samples {
                 if let Some(topic_data) = sample.data.as_ref() {
                     self.discovered_topic_list.write_lock().insert(
-                        topic_data
-                            .topic_builtin_topic_data
-                            .key
-                            .value
-                            .as_ref()
-                            .into(),
+                        topic_data.get_serialized_key().into(),
                         topic_data.topic_builtin_topic_data.clone(),
                     );
                 }

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -307,9 +307,10 @@ impl DdsShared<UserDefinedDataReader> {
 
                 rtps_reader_lock.matched_writer_add(writer_proxy);
 
-                self.matched_publication_list
-                    .write_lock()
-                    .insert(writer_info.key.value.as_ref().into(), writer_info.clone());
+                self.matched_publication_list.write_lock().insert(
+                    discovered_writer_data.get_serialized_key().into(),
+                    writer_info.clone(),
+                );
 
                 // Drop the subscription_matched_status_lock such that the listener can be triggered
                 // if needed
@@ -838,10 +839,6 @@ mod tests {
         fn deserialize(buf: &mut &'de [u8]) -> DdsResult<Self> {
             Ok(UserData(buf[0]))
         }
-
-        fn deserialize_key(_buf: &[u8]) -> DdsResult<Vec<u8>> {
-            Ok(vec![])
-        }
     }
 
     impl DdsSerialize for UserData {
@@ -975,12 +972,13 @@ mod tests {
             group_data: GroupDataQosPolicy::default(),
             lifespan: LifespanQosPolicy::default(),
         };
+        let remote_writer_guid = Guid::new(
+            GuidPrefix::from([2; 12]),
+            EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey),
+        );
         let discovered_writer_data = DiscoveredWriterData {
             writer_proxy: WriterProxy {
-                remote_writer_guid: Guid::new(
-                    GuidPrefix::from([2; 12]),
-                    EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey),
-                ),
+                remote_writer_guid,
                 remote_group_entity_id: ENTITYID_UNKNOWN,
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
@@ -998,7 +996,7 @@ mod tests {
 
         let matched_publications = data_reader.get_matched_publications().unwrap();
         assert_eq!(matched_publications.len(), 1);
-        assert_eq!(matched_publications[0], [2; 16].as_ref().into());
+        assert_eq!(matched_publications[0], remote_writer_guid.into());
         let matched_publication_data = data_reader
             .get_matched_publication_data(matched_publications[0])
             .unwrap();

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -846,14 +846,18 @@ mod test {
     #[test]
     fn get_key_value_unknown_instance() {
         let data_writer = create_data_writer_test_fixture();
-        let foo = MockKeyedFoo { key: vec![1, 2] };
+        let not_registered_foo = MockKeyedFoo { key: vec![1, 16] };
+        let registered_foo = MockKeyedFoo { key: vec![1, 2] };
         data_writer
-            .register_instance_w_timestamp(&foo, Time { sec: 0, nanosec: 0 })
+            .register_instance_w_timestamp(&registered_foo, Time { sec: 0, nanosec: 0 })
             .unwrap();
 
         let mut keyed_foo = MockKeyedFoo { key: vec![] };
         assert_eq!(
-            data_writer.get_key_value(&mut keyed_foo, foo.get_serialized_key().into()),
+            data_writer.get_key_value(
+                &mut keyed_foo,
+                not_registered_foo.get_serialized_key().into()
+            ),
             Err(DdsError::BadParameter)
         );
     }

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -270,9 +270,10 @@ impl DdsShared<UserDefinedDataWriter> {
 
                 rtps_writer_lock.matched_reader_add(reader_proxy);
 
-                self.matched_subscription_list
-                    .write_lock()
-                    .insert(reader_info.key.value.as_ref().into(), reader_info.clone());
+                self.matched_subscription_list.write_lock().insert(
+                    discovered_reader_data.get_serialized_key().into(),
+                    reader_info.clone(),
+                );
 
                 // Drop the publication_matched_status_lock such that the listener can be triggered
                 // if needed
@@ -680,7 +681,7 @@ mod test {
                 TopicDataQosPolicy, UserDataQosPolicy,
             },
         },
-        topic_definition::type_support::Endianness,
+        topic_definition::type_support::{DdsSerializedKey, Endianness},
     };
 
     use mockall::mock;
@@ -727,15 +728,12 @@ mod test {
             true
         }
 
-        fn get_serialized_key<E: Endianness>(&self) -> Vec<u8> {
-            self.key.clone()
+        fn get_serialized_key(&self) -> DdsSerializedKey {
+            self.key.as_slice().into()
         }
 
-        fn set_key_fields_from_serialized_key<E: Endianness>(
-            &mut self,
-            key: &[u8],
-        ) -> DdsResult<()> {
-            self.key = key.to_vec();
+        fn set_key_fields_from_serialized_key(&mut self, key: &DdsSerializedKey) -> DdsResult<()> {
+            self.key = key.as_ref().to_vec();
             Ok(())
         }
     }
@@ -848,17 +846,14 @@ mod test {
     #[test]
     fn get_key_value_unknown_instance() {
         let data_writer = create_data_writer_test_fixture();
-
+        let foo = MockKeyedFoo { key: vec![1, 2] };
         data_writer
-            .register_instance_w_timestamp(
-                &MockKeyedFoo { key: vec![1, 2] },
-                Time { sec: 0, nanosec: 0 },
-            )
+            .register_instance_w_timestamp(&foo, Time { sec: 0, nanosec: 0 })
             .unwrap();
 
         let mut keyed_foo = MockKeyedFoo { key: vec![] };
         assert_eq!(
-            data_writer.get_key_value(&mut keyed_foo, [1; 16].as_ref().into()),
+            data_writer.get_key_value(&mut keyed_foo, foo.get_serialized_key().into()),
             Err(DdsError::BadParameter)
         );
     }
@@ -926,12 +921,13 @@ mod test {
             topic_data: TopicDataQosPolicy::default(),
             group_data: GroupDataQosPolicy::default(),
         };
+        let remote_reader_guid = Guid::new(
+            GuidPrefix::from([2; 12]),
+            EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey),
+        );
         let discovered_reader_data = DiscoveredReaderData {
             reader_proxy: ReaderProxy {
-                remote_reader_guid: Guid::new(
-                    GuidPrefix::from([2; 12]),
-                    EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey),
-                ),
+                remote_reader_guid,
                 remote_group_entity_id: ENTITYID_UNKNOWN,
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
@@ -949,7 +945,7 @@ mod test {
 
         let matched_subscriptions = data_writer.get_matched_subscriptions().unwrap();
         assert_eq!(matched_subscriptions.len(), 1);
-        assert_eq!(matched_subscriptions[0], [2; 16].as_ref().into());
+        assert_eq!(matched_subscriptions[0], remote_reader_guid.into());
         let matched_subscription_data = data_writer
             .get_matched_subscription_data(matched_subscriptions[0])
             .unwrap();

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -1215,12 +1215,13 @@ mod tests {
         reader
             .add_change(
                 &create_data_submessage_for_disposed_change(
-                    &KeyedType {
-                        key: 1,
-                        data: [0; 5],
-                    }
-                    .get_serialized_key()
-                    .as_ref(),
+                    &to_bytes_le(
+                        &KeyedType {
+                            key: 1,
+                            data: [0; 5],
+                        }
+                        .get_serialized_key(),
+                    ),
                     3,
                 ),
                 None,
@@ -1245,12 +1246,13 @@ mod tests {
         reader
             .add_change(
                 &create_data_submessage_for_disposed_change(
-                    &KeyedType {
-                        key: 1,
-                        data: [0; 5],
-                    }
-                    .get_serialized_key()
-                    .as_ref(),
+                    &to_bytes_le(
+                        &KeyedType {
+                            key: 1,
+                            data: [0; 5],
+                        }
+                        .get_serialized_key(),
+                    ),
                     5,
                 ),
                 None,
@@ -1330,12 +1332,13 @@ mod tests {
         reader
             .add_change(
                 &create_data_submessage_for_disposed_change(
-                    &KeyedType {
-                        key: 1,
-                        data: [0; 5],
-                    }
-                    .get_serialized_key()
-                    .as_ref(),
+                    &to_bytes_le(
+                        &KeyedType {
+                            key: 1,
+                            data: [0; 5],
+                        }
+                        .get_serialized_key(),
+                    ),
                     2,
                 ),
                 None,
@@ -1360,12 +1363,13 @@ mod tests {
         reader
             .add_change(
                 &create_data_submessage_for_disposed_change(
-                    &KeyedType {
-                        key: 1,
-                        data: [0; 5],
-                    }
-                    .get_serialized_key()
-                    .as_ref(),
+                    &to_bytes_le(
+                        &KeyedType {
+                            key: 1,
+                            data: [0; 5],
+                        }
+                        .get_serialized_key(),
+                    ),
                     2,
                 ),
                 None,

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -232,13 +232,9 @@ impl RtpsWriter {
                 serialized_status_info,
             )];
 
-            // Hardcoded CDR header to satisfy wireshark
-            let mut data = vec![0, 1, 0, 0];
-            data.extend(serialized_key);
-
             Ok(self.new_change(
                 ChangeKind::NotAliveUnregistered,
-                data,
+                serialized_key,
                 inline_qos,
                 instance_handle,
                 timestamp,

--- a/dds/src/infrastructure/instance.rs
+++ b/dds/src/infrastructure/instance.rs
@@ -1,6 +1,9 @@
 use std::convert::TryFrom;
 
-use crate::implementation::rtps::types::{EntityId, Guid, GuidPrefix};
+use crate::{
+    implementation::rtps::types::{EntityId, Guid, GuidPrefix},
+    topic_definition::type_support::DdsSerializedKey,
+};
 
 /// Type for the instance handle representing an Entity
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
@@ -9,14 +12,15 @@ pub struct InstanceHandle([u8; 16]);
 /// Special constant value representing a 'nil' [`InstanceHandle`]
 pub const HANDLE_NIL: InstanceHandle = InstanceHandle([0; 16]);
 
-impl From<&[u8]> for InstanceHandle {
-    fn from(x: &[u8]) -> Self {
-        let handle = if x.len() <= 16 {
+impl From<DdsSerializedKey> for InstanceHandle {
+    fn from(x: DdsSerializedKey) -> Self {
+        let data = x.as_ref();
+        let handle = if data.len() <= 16 {
             let mut h = [0; 16];
-            h[..x.len()].clone_from_slice(x);
+            h[..data.len()].clone_from_slice(data);
             h
         } else {
-            <[u8; 16]>::from(md5::compute(x))
+            <[u8; 16]>::from(md5::compute(data))
         };
         Self(handle)
     }

--- a/dds/src/topic_definition/type_support.rs
+++ b/dds/src/topic_definition/type_support.rs
@@ -30,7 +30,7 @@ impl Endianness for BigEndian {
     const REPRESENTATION_OPTIONS: RepresentationType = [0, 0];
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DdsSerializedKey(Vec<u8>);
 
 impl From<&[u8]> for DdsSerializedKey {

--- a/dds/src/topic_definition/type_support.rs
+++ b/dds/src/topic_definition/type_support.rs
@@ -30,6 +30,29 @@ impl Endianness for BigEndian {
     const REPRESENTATION_OPTIONS: RepresentationType = [0, 0];
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct DdsSerializedKey(Vec<u8>);
+
+impl From<&[u8]> for DdsSerializedKey {
+    fn from(x: &[u8]) -> Self {
+        Self(x.to_vec())
+    }
+}
+
+impl From<Vec<u8>> for DdsSerializedKey {
+    fn from(x: Vec<u8>) -> Self {
+        Self(x)
+    }
+}
+
+impl AsRef<[u8]> for DdsSerializedKey {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl DdsSerde for DdsSerializedKey {}
+
 pub trait DdsType {
     fn type_name() -> &'static str;
 
@@ -37,15 +60,15 @@ pub trait DdsType {
         false
     }
 
-    fn get_serialized_key<E: Endianness>(&self) -> Vec<u8> {
+    fn get_serialized_key(&self) -> DdsSerializedKey {
         if Self::has_key() {
             unimplemented!("DdsType with key must provide an implementation for get_serialized_key")
         } else {
-            vec![]
+            DdsSerializedKey(vec![])
         }
     }
 
-    fn set_key_fields_from_serialized_key<E: Endianness>(&mut self, _key: &[u8]) -> DdsResult<()> {
+    fn set_key_fields_from_serialized_key(&mut self, _key: &DdsSerializedKey) -> DdsResult<()> {
         if Self::has_key() {
             unimplemented!("DdsType with key must provide an implementation for set_key_fields_from_serialized_key")
         }
@@ -59,8 +82,6 @@ pub trait DdsSerialize {
 
 pub trait DdsDeserialize<'de>: Sized {
     fn deserialize(buf: &mut &'de [u8]) -> DdsResult<Self>;
-
-    fn deserialize_key(buf: &[u8]) -> DdsResult<Vec<u8>>;
 }
 
 pub trait DdsSerde {}
@@ -93,15 +114,9 @@ where
 
 impl<'de, Foo> DdsDeserialize<'de> for Foo
 where
-    Foo: serde::Deserialize<'de> + DdsSerde + DdsType,
+    Foo: serde::Deserialize<'de> + DdsSerde,
 {
     fn deserialize(buf: &mut &'de [u8]) -> DdsResult<Self> {
         cdr::deserialize(buf).map_err(|e| DdsError::PreconditionNotMet(e.to_string()))
-    }
-
-    fn deserialize_key(buf: &[u8]) -> DdsResult<Vec<u8>> {
-        let deserialized: Self =
-            cdr::deserialize(buf).map_err(|e| DdsError::PreconditionNotMet(e.to_string()))?;
-        Ok(deserialized.get_serialized_key::<LittleEndian>())
     }
 }

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -30,10 +30,6 @@ impl<'de> DdsDeserialize<'de> for TestType {
     fn deserialize(_buf: &mut &'de [u8]) -> DdsResult<Self> {
         todo!()
     }
-
-    fn deserialize_key(_buf: &[u8]) -> DdsResult<Vec<u8>> {
-        todo!()
-    }
 }
 
 #[test]

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -166,7 +166,7 @@ fn write_read_disposed_samples() {
     wait_set
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
-    wait_set.wait(Duration::new(50, 0)).unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
 
     let data1 = KeyedData { id: 1, value: 1 };
 
@@ -174,14 +174,13 @@ fn write_read_disposed_samples() {
     writer.dispose(&data1, None).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(100, 0))
+        .wait_for_acknowledgments(Duration::new(1, 0))
         .unwrap();
 
     let samples = reader
         .read(2, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
 
-    
     assert_eq!(samples.len(), 2);
     assert_eq!(
         samples[0].sample_info.instance_state,

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -90,25 +90,19 @@ fn each_key_sample_is_read() {
     assert_eq!(samples[0].data.as_ref().unwrap(), &data1);
     assert_eq!(
         samples[0].sample_info.instance_handle,
-        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-            .as_ref()
-            .into()
+        data1.get_serialized_key().into()
     );
 
     assert_eq!(samples[1].data.as_ref().unwrap(), &data2);
     assert_eq!(
         samples[1].sample_info.instance_handle,
-        [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-            .as_ref()
-            .into()
+        data2.get_serialized_key().into()
     );
 
     assert_eq!(samples[2].data.as_ref().unwrap(), &data3);
     assert_eq!(
         samples[2].sample_info.instance_handle,
-        [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-            .as_ref()
-            .into()
+        data3.get_serialized_key().into()
     );
 }
 

--- a/dds_derive/tests/test_dds_type_derive.rs
+++ b/dds_derive/tests/test_dds_type_derive.rs
@@ -1,4 +1,4 @@
-use dust_dds::topic_definition::type_support::{BigEndian, DdsSerde, DdsType, LittleEndian};
+use dust_dds::topic_definition::type_support::{DdsSerde, DdsType};
 use serde::{Deserialize, Serialize};
 
 #[derive(DdsType, DdsSerde)]
@@ -16,13 +16,14 @@ fn test_struct_no_key_info() {
 #[test]
 fn test_struct_no_key_get() {
     let snk = StructNoKey { a: 1, b: 2 };
-    assert!(snk.get_serialized_key::<BigEndian>().is_empty());
+    assert!(snk.get_serialized_key().as_ref().is_empty());
 }
 
 #[test]
 fn test_struct_no_key_set() {
     let mut snk2 = StructNoKey { a: 3, b: 4 };
-    snk2.set_key_fields_from_serialized_key::<LittleEndian>(&[]).unwrap();
+    snk2.set_key_fields_from_serialized_key(&[][..].into())
+        .unwrap();
     assert_eq!(snk2.a, 3);
     assert_eq!(snk2.b, 4);
 }
@@ -43,17 +44,14 @@ fn test_struct_with_key_info() {
 #[test]
 fn test_struct_with_key_get() {
     let swk = StructWithKey { a: 1, b: 2 };
-    assert_eq!(
-        swk.get_serialized_key::<BigEndian>(),
-        &[0, 0, 0, 2]
-    );
+    assert_eq!(swk.get_serialized_key(), [0, 0, 0, 2][..].into());
 }
 
 #[test]
 fn test_struct_with_key_set() {
     let mut swk = StructWithKey { a: 0, b: 0 };
-    let key = [42, 0, 0, 0];
-    swk.set_key_fields_from_serialized_key::<LittleEndian>(&key).unwrap();
+    let key = [42, 0, 0, 0][..].into();
+    swk.set_key_fields_from_serialized_key(&key).unwrap();
     assert_eq!(swk.a, 0);
     assert_eq!(swk.b, 42)
 }
@@ -88,10 +86,7 @@ fn test_struct_many_keys_get() {
         c: 'X',
         d: false,
     };
-    assert_eq!(
-        smk.get_serialized_key::<LittleEndian>(),
-        [1, 0, 0, 0, b'X', 0]
-    );
+    assert_eq!(smk.get_serialized_key(), [1, 0, 0, 0, b'X', 0][..].into());
 }
 
 #[test]
@@ -102,8 +97,8 @@ fn test_struct_many_keys_set() {
         c: '\0',
         d: false,
     };
-    let key = [69, 0, 0, 0, b'X', 1];
-    smk.set_key_fields_from_serialized_key::<LittleEndian>(&key).unwrap();
+    let key = [69, 0, 0, 0, b'X', 1][..].into();
+    smk.set_key_fields_from_serialized_key(&key).unwrap();
     assert_eq!(smk.a, 69);
     assert_eq!(smk.b, 0);
     assert_eq!(smk.c, 'X');
@@ -134,10 +129,7 @@ fn test_dds_type_derive_with_generic_get() {
         a: vec![0, 1, 0],
         b: 42,
     };
-    assert_eq!(
-        twg.get_serialized_key::<LittleEndian>(),
-        [42, 0, 0, 0]
-    )
+    assert_eq!(twg.get_serialized_key(), [42, 0, 0, 0][..].into())
 }
 
 #[test]
@@ -146,8 +138,8 @@ fn test_dds_type_derive_with_generic_set() {
         a: vec![false],
         b: 0,
     };
-    let key = [42, 0, 0, 0];
-    twg.set_key_fields_from_serialized_key::<LittleEndian>(&key).unwrap();
+    let key = [42, 0, 0, 0][..].into();
+    twg.set_key_fields_from_serialized_key(&key).unwrap();
     assert_eq!(twg.a, vec![false]);
     assert_eq!(twg.b, 42);
 }
@@ -164,13 +156,14 @@ fn test_tuple_no_key_info() {
 #[test]
 fn test_tuple_no_key_get() {
     let twk = TupleNoKey(10, 25);
-    assert!(twk.get_serialized_key::<LittleEndian>().is_empty());
+    assert!(twk.get_serialized_key().as_ref().is_empty());
 }
 
 #[test]
 fn test_tuple_no_key_set() {
     let mut twk = TupleNoKey(1, 2);
-    twk.set_key_fields_from_serialized_key::<LittleEndian>(&[]).unwrap();
+    twk.set_key_fields_from_serialized_key(&[][..].into())
+        .unwrap();
     assert_eq!(twk.0, 1);
     assert_eq!(twk.1, 2);
 }
@@ -187,17 +180,14 @@ fn test_tuple_with_keys_info() {
 #[test]
 fn test_tuple_with_keys_get() {
     let twk = TupleWithKeys(1, 2, true, '🦀');
-    assert_eq!(
-        twk.get_serialized_key::<LittleEndian>(),
-        [2, 0, 0, 0, 1]
-    )
+    assert_eq!(twk.get_serialized_key(), [2, 0, 0, 0, 1][..].into())
 }
 
 #[test]
 fn test_tuple_with_keys_set() {
     let mut twk = TupleWithKeys(0, 0, false, '\0');
-    let key = [2, 0, 0, 0, 1];
-    twk.set_key_fields_from_serialized_key::<LittleEndian>(&key).unwrap();
+    let key = [2, 0, 0, 0, 1][..].into();
+    twk.set_key_fields_from_serialized_key(&key).unwrap();
     assert_eq!(twk.0, 0);
     assert_eq!(twk.1, 2);
     assert_eq!(twk.2, true);
@@ -220,13 +210,14 @@ fn test_enum_no_key_info() {
 #[test]
 fn test_enum_no_key_get() {
     let enk = EnumNoKey::_Two;
-    assert!(enk.get_serialized_key::<LittleEndian>().is_empty());
+    assert!(enk.get_serialized_key().as_ref().is_empty());
 }
 
 #[test]
 fn test_enum_no_key_set() {
     let mut enk = EnumNoKey::_Two;
-    enk.set_key_fields_from_serialized_key::<LittleEndian>(&[]).unwrap();
+    enk.set_key_fields_from_serialized_key(&[][..].into())
+        .unwrap();
     assert_eq!(enk, EnumNoKey::_Two);
 }
 
@@ -247,16 +238,13 @@ fn test_enum_key_info() {
 #[test]
 fn test_enum_key_get() {
     let ek = EnumKey::_Two;
-    assert_eq!(
-        ek.get_serialized_key::<LittleEndian>(),
-        [1, 0, 0, 0]
-    );
+    assert_eq!(ek.get_serialized_key(), [1, 0, 0, 0][..].into());
 }
 
 #[test]
 fn test_enum_key_set() {
     let mut ek = EnumKey::_One;
-    let key = [1, 0, 0, 0];
-    ek.set_key_fields_from_serialized_key::<LittleEndian>(&key).unwrap();
+    let key = [1, 0, 0, 0][..].into();
+    ek.set_key_fields_from_serialized_key(&key).unwrap();
     assert_eq!(ek, EnumKey::_Two);
 }

--- a/dds_derive/tests/test_dds_type_derive.rs
+++ b/dds_derive/tests/test_dds_type_derive.rs
@@ -44,7 +44,7 @@ fn test_struct_with_key_info() {
 #[test]
 fn test_struct_with_key_get() {
     let swk = StructWithKey { a: 1, b: 2 };
-    assert_eq!(swk.get_serialized_key(), [0, 0, 0, 2][..].into());
+    assert_eq!(swk.get_serialized_key(), [2, 0, 0, 0][..].into());
 }
 
 #[test]


### PR DESCRIPTION
This PR creates a dedicated type for DdsSerializedKey and removes the endianness generic input from those methods. The new DdsSerializedKey is then placed on the wire using the regular CDR serialize and deserialize methods.