### PR TITLE
DDS-234 remove redundant mapping impls

### DIFF
--- a/dds/src/implementation/dds_impl/message_receiver.rs
+++ b/dds/src/implementation/dds_impl/message_receiver.rs
@@ -4,7 +4,7 @@ use crate::{
             submessages::{
                 AckNackSubmessage, DataSubmessage, HeartbeatSubmessage, InfoTimestampSubmessage,
             },
-            RtpsMessage, RtpsSubmessageType,
+            RtpsMessage, RtpsSubmessageKind,
         },
         types::{
             GuidPrefix, Locator, ProtocolVersion, VendorId, GUIDPREFIX_UNKNOWN,
@@ -91,19 +91,19 @@ impl MessageReceiver {
 
         for submessage in &message.submessages {
             match submessage {
-                RtpsSubmessageType::AckNack(acknack_submessage) => {
+                RtpsSubmessageKind::AckNack(acknack_submessage) => {
                     for publisher in publisher_list {
                         publisher.on_acknack_submessage_received(acknack_submessage, self)
                     }
                 }
-                RtpsSubmessageType::Data(data_submessage) => {
+                RtpsSubmessageKind::Data(data_submessage) => {
                     for subscriber in subscriber_list {
                         subscriber.on_data_submessage_received(data_submessage, self)
                     }
                 }
-                RtpsSubmessageType::DataFrag(_) => todo!(),
-                RtpsSubmessageType::Gap(_) => todo!(),
-                RtpsSubmessageType::Heartbeat(heartbeat_submessage) => {
+                RtpsSubmessageKind::DataFrag(_) => todo!(),
+                RtpsSubmessageKind::Gap(_) => todo!(),
+                RtpsSubmessageKind::Heartbeat(heartbeat_submessage) => {
                     for subscriber in subscriber_list {
                         subscriber.on_heartbeat_submessage_received(
                             heartbeat_submessage,
@@ -111,15 +111,15 @@ impl MessageReceiver {
                         )
                     }
                 }
-                RtpsSubmessageType::HeartbeatFrag(_) => todo!(),
-                RtpsSubmessageType::InfoDestination(_) => todo!(),
-                RtpsSubmessageType::InfoReply(_) => todo!(),
-                RtpsSubmessageType::InfoSource(_) => todo!(),
-                RtpsSubmessageType::InfoTimestamp(info_timestamp) => {
+                RtpsSubmessageKind::HeartbeatFrag(_) => todo!(),
+                RtpsSubmessageKind::InfoDestination(_) => todo!(),
+                RtpsSubmessageKind::InfoReply(_) => todo!(),
+                RtpsSubmessageKind::InfoSource(_) => todo!(),
+                RtpsSubmessageKind::InfoTimestamp(info_timestamp) => {
                     self.process_info_timestamp_submessage(info_timestamp)
                 }
-                RtpsSubmessageType::NackFrag(_) => todo!(),
-                RtpsSubmessageType::Pad(_) => todo!(),
+                RtpsSubmessageKind::NackFrag(_) => todo!(),
+                RtpsSubmessageKind::Pad(_) => todo!(),
             }
         }
 

--- a/dds/src/implementation/rtps/messages/mod.rs
+++ b/dds/src/implementation/rtps/messages/mod.rs
@@ -16,11 +16,11 @@ pub mod types;
 #[derive(Debug, PartialEq, Eq)]
 pub struct RtpsMessage<'a> {
     pub header: RtpsMessageHeader,
-    pub submessages: Vec<RtpsSubmessageType<'a>>,
+    pub submessages: Vec<RtpsSubmessageKind<'a>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum RtpsSubmessageType<'a> {
+pub enum RtpsSubmessageKind<'a> {
     AckNack(AckNackSubmessage),
     Data(DataSubmessage<'a>),
     DataFrag(DataFragSubmessage<'a>),

--- a/dds/src/implementation/rtps/stateful_reader.rs
+++ b/dds/src/implementation/rtps/stateful_reader.rs
@@ -15,7 +15,7 @@ use super::{
         },
         submessages::{AckNackSubmessage, DataSubmessage, HeartbeatSubmessage},
         types::ProtocolId,
-        RtpsMessage, RtpsSubmessageType,
+        RtpsMessage, RtpsSubmessageKind,
     },
     reader::RtpsReader,
     transport::TransportWrite,
@@ -147,7 +147,7 @@ impl RtpsStatefulReader {
         self.send_submessages(|wp, acknack| {
             acknacks.push((
                 wp.unicast_locator_list().to_vec(),
-                vec![RtpsSubmessageType::AckNack(acknack)],
+                vec![RtpsSubmessageKind::AckNack(acknack)],
             ))
         });
 

--- a/dds/src/implementation/rtps/stateless_writer.rs
+++ b/dds/src/implementation/rtps/stateless_writer.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::{
     history_cache::RtpsWriterCacheChange,
-    messages::RtpsSubmessageType,
+    messages::RtpsSubmessageKind,
     reader_locator::RtpsReaderLocator,
     types::{Count, Guid},
     writer::RtpsWriter,
@@ -68,7 +68,7 @@ impl RtpsStatelessWriter {
         Ok(())
     }
 
-    pub fn produce_submessages(&mut self) -> Vec<(&RtpsReaderLocator, Vec<RtpsSubmessageType>)> {
+    pub fn produce_submessages(&mut self) -> Vec<(&RtpsReaderLocator, Vec<RtpsSubmessageKind>)> {
         let mut destined_submessages = Vec::new();
         let reliability_kind = &self.writer.get_qos().reliability.kind;
         let writer_cache = self.writer.writer_cache();
@@ -83,11 +83,11 @@ impl RtpsStatelessWriter {
                         // should be full-filled by next_unsent_change()
                         if change.is_in_cache() {
                             let (info_ts_submessage, data_submessage) = change.into();
-                            submessages.push(RtpsSubmessageType::InfoTimestamp(info_ts_submessage));
-                            submessages.push(RtpsSubmessageType::Data(data_submessage));
+                            submessages.push(RtpsSubmessageKind::InfoTimestamp(info_ts_submessage));
+                            submessages.push(RtpsSubmessageKind::Data(data_submessage));
                         } else {
                             let gap_submessage = change.into();
-                            submessages.push(RtpsSubmessageType::Gap(gap_submessage));
+                            submessages.push(RtpsSubmessageKind::Gap(gap_submessage));
                         }
                     }
                     if !submessages.is_empty() {

--- a/dds/src/implementation/rtps_udp_psm/mapping_basic_types.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_basic_types.rs
@@ -6,14 +6,8 @@ use std::{
 use byteorder::{ByteOrder, ReadBytesExt, WriteBytesExt};
 
 use super::mapping_traits::{
-    MappingRead, MappingReadByteOrdered, MappingWrite, MappingWriteByteOrdered, NumberOfBytes,
+    MappingRead, MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
 };
-
-impl MappingWrite for u8 {
-    fn mapping_write<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        writer.write_u8(*self)
-    }
-}
 
 impl MappingWriteByteOrdered for u8 {
     fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(

--- a/dds/src/implementation/rtps_udp_psm/mapping_basic_types.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_basic_types.rs
@@ -6,7 +6,7 @@ use std::{
 use byteorder::{ByteOrder, ReadBytesExt, WriteBytesExt};
 
 use super::mapping_traits::{
-    MappingRead, MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
+    MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
 };
 
 impl MappingWriteByteOrdered for u8 {
@@ -94,8 +94,8 @@ impl MappingWriteByteOrdered for bool {
     }
 }
 
-impl<'de> MappingRead<'de> for u8 {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for u8 {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
         buf.read_u8()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_basic_types.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_basic_types.rs
@@ -92,12 +92,6 @@ impl MappingWriteByteOrdered for bool {
     }
 }
 
-// impl<'de> MappingReadByteOrderInfoInData<'de> for u8 {
-//     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
-//         buf.read_u8()
-//     }
-// }
-
 impl<'de> MappingReadByteOrdered<'de> for u8 {
     fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
         buf.read_u8()

--- a/dds/src/implementation/rtps_udp_psm/mapping_basic_types.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_basic_types.rs
@@ -5,9 +5,7 @@ use std::{
 
 use byteorder::{ByteOrder, ReadBytesExt, WriteBytesExt};
 
-use super::mapping_traits::{
-    MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
-};
+use super::mapping_traits::{MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes};
 
 impl MappingWriteByteOrdered for u8 {
     fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(
@@ -94,17 +92,14 @@ impl MappingWriteByteOrdered for bool {
     }
 }
 
-impl<'de> MappingReadByteOrderInfoInData<'de> for u8 {
-    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        buf.read_u8()
-    }
-}
+// impl<'de> MappingReadByteOrderInfoInData<'de> for u8 {
+//     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
+//         buf.read_u8()
+//     }
+// }
 
 impl<'de> MappingReadByteOrdered<'de> for u8 {
-    fn mapping_read_byte_ordered<B>(buf: &mut &'de [u8]) -> Result<Self, Error>
-    where
-        B: ByteOrder,
-    {
+    fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
         buf.read_u8()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -4,7 +4,7 @@ use byteorder::LittleEndian;
 
 use crate::implementation::{
     rtps::messages::{overall_structure::RtpsSubmessageHeader, RtpsMessage, RtpsSubmessageKind},
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered},
+    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered},
 };
 
 use super::submessages::submessage_header::{
@@ -42,9 +42,9 @@ impl MappingWriteByteOrderInfoInData for RtpsMessage<'_> {
     }
 }
 
-impl<'a, 'de: 'a> MappingRead<'de> for RtpsMessage<'a> {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        let header = MappingRead::mapping_read(buf)?;
+impl<'a, 'de: 'a> MappingReadByteOrderInfoInData<'de> for RtpsMessage<'a> {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        let header = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
         const MAX_SUBMESSAGES: usize = 2_usize.pow(16);
         let mut submessages = vec![];
         for _ in 0..MAX_SUBMESSAGES {
@@ -54,22 +54,22 @@ impl<'a, 'de: 'a> MappingRead<'de> for RtpsMessage<'a> {
             // Preview byte only (to allow full deserialization of submessage header)
             let submessage_id = buf[0];
             let submessage = match submessage_id {
-                ACKNACK => RtpsSubmessageKind::AckNack(MappingRead::mapping_read(buf)?),
-                DATA => RtpsSubmessageKind::Data(MappingRead::mapping_read(buf)?),
-                DATA_FRAG => RtpsSubmessageKind::DataFrag(MappingRead::mapping_read(buf)?),
-                GAP => RtpsSubmessageKind::Gap(MappingRead::mapping_read(buf)?),
-                HEARTBEAT => RtpsSubmessageKind::Heartbeat(MappingRead::mapping_read(buf)?),
+                ACKNACK => RtpsSubmessageKind::AckNack(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                DATA => RtpsSubmessageKind::Data(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                DATA_FRAG => RtpsSubmessageKind::DataFrag(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                GAP => RtpsSubmessageKind::Gap(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                HEARTBEAT => RtpsSubmessageKind::Heartbeat(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
                 HEARTBEAT_FRAG => {
-                    RtpsSubmessageKind::HeartbeatFrag(MappingRead::mapping_read(buf)?)
+                    RtpsSubmessageKind::HeartbeatFrag(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?)
                 }
-                INFO_DST => RtpsSubmessageKind::InfoDestination(MappingRead::mapping_read(buf)?),
-                INFO_REPLY => RtpsSubmessageKind::InfoReply(MappingRead::mapping_read(buf)?),
-                INFO_SRC => RtpsSubmessageKind::InfoSource(MappingRead::mapping_read(buf)?),
-                INFO_TS => RtpsSubmessageKind::InfoTimestamp(MappingRead::mapping_read(buf)?),
-                NACK_FRAG => RtpsSubmessageKind::NackFrag(MappingRead::mapping_read(buf)?),
-                PAD => RtpsSubmessageKind::Pad(MappingRead::mapping_read(buf)?),
+                INFO_DST => RtpsSubmessageKind::InfoDestination(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                INFO_REPLY => RtpsSubmessageKind::InfoReply(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                INFO_SRC => RtpsSubmessageKind::InfoSource(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                INFO_TS => RtpsSubmessageKind::InfoTimestamp(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                NACK_FRAG => RtpsSubmessageKind::NackFrag(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                PAD => RtpsSubmessageKind::Pad(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
                 _ => {
-                    let submessage_header: RtpsSubmessageHeader = MappingRead::mapping_read(buf)?;
+                    let submessage_header: RtpsSubmessageHeader = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
                     buf.consume(submessage_header.submessage_length as usize);
                     continue;
                 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -2,7 +2,7 @@ use std::io::{BufRead, Error, Write};
 
 use crate::implementation::{
     rtps::messages::{overall_structure::RtpsSubmessageHeader, RtpsMessage, RtpsSubmessageType},
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
 use super::submessages::submessage_header::{
@@ -10,31 +10,31 @@ use super::submessages::submessage_header::{
     INFO_TS, NACK_FRAG, PAD,
 };
 
-impl MappingWrite for RtpsSubmessageType<'_> {
-    fn mapping_write<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+impl MappingWriteByteOrderInfoInData for RtpsSubmessageType<'_> {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
         match self {
-            RtpsSubmessageType::AckNack(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::Data(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::DataFrag(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::Gap(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::Heartbeat(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::HeartbeatFrag(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::InfoDestination(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::InfoReply(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::InfoSource(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::InfoTimestamp(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::NackFrag(s) => s.mapping_write(&mut writer)?,
-            RtpsSubmessageType::Pad(s) => s.mapping_write(&mut writer)?,
+            RtpsSubmessageType::AckNack(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::Data(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::DataFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::Gap(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::Heartbeat(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::HeartbeatFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::InfoDestination(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::InfoReply(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::InfoSource(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::InfoTimestamp(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::NackFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageType::Pad(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
         };
         Ok(())
     }
 }
 
-impl MappingWrite for RtpsMessage<'_> {
-    fn mapping_write<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.header.mapping_write(&mut writer)?;
+impl MappingWriteByteOrderInfoInData for RtpsMessage<'_> {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+        self.header.mapping_write_byte_order_info_in_data(&mut writer)?;
         for submessage in &self.submessages {
-            submessage.mapping_write(&mut writer)?;
+            submessage.mapping_write_byte_order_info_in_data(&mut writer)?;
         }
         Ok(())
     }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -4,7 +4,10 @@ use byteorder::LittleEndian;
 
 use crate::implementation::{
     rtps::messages::{overall_structure::RtpsSubmessageHeader, RtpsMessage, RtpsSubmessageKind},
-    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered},
+    rtps_udp_psm::mapping_traits::{
+        MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrderInfoInData,
+        MappingWriteByteOrdered,
+    },
 };
 
 use super::submessages::submessage_header::{
@@ -15,17 +18,35 @@ use super::submessages::submessage_header::{
 impl MappingWriteByteOrderInfoInData for RtpsSubmessageKind<'_> {
     fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
         match self {
-            RtpsSubmessageKind::AckNack(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::AckNack(s) => {
+                s.mapping_write_byte_order_info_in_data(&mut writer)?
+            }
             RtpsSubmessageKind::Data(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageKind::DataFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::DataFrag(s) => {
+                s.mapping_write_byte_order_info_in_data(&mut writer)?
+            }
             RtpsSubmessageKind::Gap(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageKind::Heartbeat(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageKind::HeartbeatFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageKind::InfoDestination(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageKind::InfoReply(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageKind::InfoSource(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageKind::InfoTimestamp(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageKind::NackFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::Heartbeat(s) => {
+                s.mapping_write_byte_order_info_in_data(&mut writer)?
+            }
+            RtpsSubmessageKind::HeartbeatFrag(s) => {
+                s.mapping_write_byte_order_info_in_data(&mut writer)?
+            }
+            RtpsSubmessageKind::InfoDestination(s) => {
+                s.mapping_write_byte_order_info_in_data(&mut writer)?
+            }
+            RtpsSubmessageKind::InfoReply(s) => {
+                s.mapping_write_byte_order_info_in_data(&mut writer)?
+            }
+            RtpsSubmessageKind::InfoSource(s) => {
+                s.mapping_write_byte_order_info_in_data(&mut writer)?
+            }
+            RtpsSubmessageKind::InfoTimestamp(s) => {
+                s.mapping_write_byte_order_info_in_data(&mut writer)?
+            }
+            RtpsSubmessageKind::NackFrag(s) => {
+                s.mapping_write_byte_order_info_in_data(&mut writer)?
+            }
             RtpsSubmessageKind::Pad(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
         };
         Ok(())
@@ -34,7 +55,8 @@ impl MappingWriteByteOrderInfoInData for RtpsSubmessageKind<'_> {
 
 impl MappingWriteByteOrderInfoInData for RtpsMessage<'_> {
     fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.header.mapping_write_byte_ordered::<_, LittleEndian>(&mut writer)?;
+        self.header
+            .mapping_write_byte_ordered::<_, LittleEndian>(&mut writer)?;
         for submessage in &self.submessages {
             submessage.mapping_write_byte_order_info_in_data(&mut writer)?;
         }
@@ -44,7 +66,7 @@ impl MappingWriteByteOrderInfoInData for RtpsMessage<'_> {
 
 impl<'a, 'de: 'a> MappingReadByteOrderInfoInData<'de> for RtpsMessage<'a> {
     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        let header = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
+        let header = MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
         const MAX_SUBMESSAGES: usize = 2_usize.pow(16);
         let mut submessages = vec![];
         for _ in 0..MAX_SUBMESSAGES {
@@ -54,22 +76,45 @@ impl<'a, 'de: 'a> MappingReadByteOrderInfoInData<'de> for RtpsMessage<'a> {
             // Preview byte only (to allow full deserialization of submessage header)
             let submessage_id = buf[0];
             let submessage = match submessage_id {
-                ACKNACK => RtpsSubmessageKind::AckNack(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                DATA => RtpsSubmessageKind::Data(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                DATA_FRAG => RtpsSubmessageKind::DataFrag(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                GAP => RtpsSubmessageKind::Gap(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                HEARTBEAT => RtpsSubmessageKind::Heartbeat(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                HEARTBEAT_FRAG => {
-                    RtpsSubmessageKind::HeartbeatFrag(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?)
-                }
-                INFO_DST => RtpsSubmessageKind::InfoDestination(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                INFO_REPLY => RtpsSubmessageKind::InfoReply(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                INFO_SRC => RtpsSubmessageKind::InfoSource(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                INFO_TS => RtpsSubmessageKind::InfoTimestamp(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                NACK_FRAG => RtpsSubmessageKind::NackFrag(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
-                PAD => RtpsSubmessageKind::Pad(MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?),
+                ACKNACK => RtpsSubmessageKind::AckNack(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                DATA => RtpsSubmessageKind::Data(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                DATA_FRAG => RtpsSubmessageKind::DataFrag(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                GAP => RtpsSubmessageKind::Gap(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                HEARTBEAT => RtpsSubmessageKind::Heartbeat(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                HEARTBEAT_FRAG => RtpsSubmessageKind::HeartbeatFrag(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                INFO_DST => RtpsSubmessageKind::InfoDestination(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                INFO_REPLY => RtpsSubmessageKind::InfoReply(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                INFO_SRC => RtpsSubmessageKind::InfoSource(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                INFO_TS => RtpsSubmessageKind::InfoTimestamp(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                NACK_FRAG => RtpsSubmessageKind::NackFrag(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
+                PAD => RtpsSubmessageKind::Pad(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+                ),
                 _ => {
-                    let submessage_header: RtpsSubmessageHeader = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
+                    let submessage_header: RtpsSubmessageHeader =
+                        MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
                     buf.consume(submessage_header.submessage_length as usize);
                     continue;
                 }
@@ -87,17 +132,20 @@ impl<'a, 'de: 'a> MappingReadByteOrderInfoInData<'de> for RtpsMessage<'a> {
 mod tests {
 
     use crate::implementation::{
-        rtps::{messages::{
-            overall_structure::RtpsMessageHeader,
-            submessage_elements::{
-                EntityIdSubmessageElement, GuidPrefixSubmessageElement, Parameter,
-                ParameterListSubmessageElement, ProtocolVersionSubmessageElement,
-                SequenceNumberSubmessageElement, SerializedDataSubmessageElement,
-                VendorIdSubmessageElement,
+        rtps::{
+            messages::{
+                overall_structure::RtpsMessageHeader,
+                submessage_elements::{
+                    EntityIdSubmessageElement, GuidPrefixSubmessageElement, Parameter,
+                    ParameterListSubmessageElement, ProtocolVersionSubmessageElement,
+                    SequenceNumberSubmessageElement, SerializedDataSubmessageElement,
+                    VendorIdSubmessageElement,
+                },
+                submessages::DataSubmessage,
+                types::ProtocolId,
             },
-            submessages::DataSubmessage,
-            types::ProtocolId,
-        }, types::{EntityId, EntityKind}},
+            types::{EntityId, EntityKind},
+        },
         rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
     };
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -1,8 +1,10 @@
 use std::io::{BufRead, Error, Write};
 
+use byteorder::LittleEndian;
+
 use crate::implementation::{
     rtps::messages::{overall_structure::RtpsSubmessageHeader, RtpsMessage, RtpsSubmessageKind},
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered},
 };
 
 use super::submessages::submessage_header::{
@@ -32,7 +34,7 @@ impl MappingWriteByteOrderInfoInData for RtpsSubmessageKind<'_> {
 
 impl MappingWriteByteOrderInfoInData for RtpsMessage<'_> {
     fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.header.mapping_write_byte_order_info_in_data(&mut writer)?;
+        self.header.mapping_write_byte_ordered::<_, LittleEndian>(&mut writer)?;
         for submessage in &self.submessages {
             submessage.mapping_write_byte_order_info_in_data(&mut writer)?;
         }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -55,6 +55,8 @@ impl MappingWriteByteOrderInfoInData for RtpsSubmessageKind<'_> {
 
 impl MappingWriteByteOrderInfoInData for RtpsMessage<'_> {
     fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+        // The byteorder is determined by each submessage individually. Hence
+        // decide here for a byteorder for the header
         self.header
             .mapping_write_byte_ordered::<_, LittleEndian>(&mut writer)?;
         for submessage in &self.submessages {
@@ -66,6 +68,8 @@ impl MappingWriteByteOrderInfoInData for RtpsMessage<'_> {
 
 impl<'a, 'de: 'a> MappingReadByteOrderInfoInData<'de> for RtpsMessage<'a> {
     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        // The byteorder is determined by each submessage individually. Hence
+        // decide here for a byteorder for the header
         let header = MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
         const MAX_SUBMESSAGES: usize = 2_usize.pow(16);
         let mut submessages = vec![];

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -1,7 +1,7 @@
 use std::io::{BufRead, Error, Write};
 
 use crate::implementation::{
-    rtps::messages::{overall_structure::RtpsSubmessageHeader, RtpsMessage, RtpsSubmessageType},
+    rtps::messages::{overall_structure::RtpsSubmessageHeader, RtpsMessage, RtpsSubmessageKind},
     rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
@@ -10,21 +10,21 @@ use super::submessages::submessage_header::{
     INFO_TS, NACK_FRAG, PAD,
 };
 
-impl MappingWriteByteOrderInfoInData for RtpsSubmessageType<'_> {
+impl MappingWriteByteOrderInfoInData for RtpsSubmessageKind<'_> {
     fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
         match self {
-            RtpsSubmessageType::AckNack(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::Data(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::DataFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::Gap(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::Heartbeat(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::HeartbeatFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::InfoDestination(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::InfoReply(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::InfoSource(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::InfoTimestamp(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::NackFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
-            RtpsSubmessageType::Pad(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::AckNack(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::Data(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::DataFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::Gap(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::Heartbeat(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::HeartbeatFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::InfoDestination(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::InfoReply(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::InfoSource(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::InfoTimestamp(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::NackFrag(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
+            RtpsSubmessageKind::Pad(s) => s.mapping_write_byte_order_info_in_data(&mut writer)?,
         };
         Ok(())
     }
@@ -52,20 +52,20 @@ impl<'a, 'de: 'a> MappingRead<'de> for RtpsMessage<'a> {
             // Preview byte only (to allow full deserialization of submessage header)
             let submessage_id = buf[0];
             let submessage = match submessage_id {
-                ACKNACK => RtpsSubmessageType::AckNack(MappingRead::mapping_read(buf)?),
-                DATA => RtpsSubmessageType::Data(MappingRead::mapping_read(buf)?),
-                DATA_FRAG => RtpsSubmessageType::DataFrag(MappingRead::mapping_read(buf)?),
-                GAP => RtpsSubmessageType::Gap(MappingRead::mapping_read(buf)?),
-                HEARTBEAT => RtpsSubmessageType::Heartbeat(MappingRead::mapping_read(buf)?),
+                ACKNACK => RtpsSubmessageKind::AckNack(MappingRead::mapping_read(buf)?),
+                DATA => RtpsSubmessageKind::Data(MappingRead::mapping_read(buf)?),
+                DATA_FRAG => RtpsSubmessageKind::DataFrag(MappingRead::mapping_read(buf)?),
+                GAP => RtpsSubmessageKind::Gap(MappingRead::mapping_read(buf)?),
+                HEARTBEAT => RtpsSubmessageKind::Heartbeat(MappingRead::mapping_read(buf)?),
                 HEARTBEAT_FRAG => {
-                    RtpsSubmessageType::HeartbeatFrag(MappingRead::mapping_read(buf)?)
+                    RtpsSubmessageKind::HeartbeatFrag(MappingRead::mapping_read(buf)?)
                 }
-                INFO_DST => RtpsSubmessageType::InfoDestination(MappingRead::mapping_read(buf)?),
-                INFO_REPLY => RtpsSubmessageType::InfoReply(MappingRead::mapping_read(buf)?),
-                INFO_SRC => RtpsSubmessageType::InfoSource(MappingRead::mapping_read(buf)?),
-                INFO_TS => RtpsSubmessageType::InfoTimestamp(MappingRead::mapping_read(buf)?),
-                NACK_FRAG => RtpsSubmessageType::NackFrag(MappingRead::mapping_read(buf)?),
-                PAD => RtpsSubmessageType::Pad(MappingRead::mapping_read(buf)?),
+                INFO_DST => RtpsSubmessageKind::InfoDestination(MappingRead::mapping_read(buf)?),
+                INFO_REPLY => RtpsSubmessageKind::InfoReply(MappingRead::mapping_read(buf)?),
+                INFO_SRC => RtpsSubmessageKind::InfoSource(MappingRead::mapping_read(buf)?),
+                INFO_TS => RtpsSubmessageKind::InfoTimestamp(MappingRead::mapping_read(buf)?),
+                NACK_FRAG => RtpsSubmessageKind::NackFrag(MappingRead::mapping_read(buf)?),
+                PAD => RtpsSubmessageKind::Pad(MappingRead::mapping_read(buf)?),
                 _ => {
                     let submessage_header: RtpsSubmessageHeader = MappingRead::mapping_read(buf)?;
                     buf.consume(submessage_header.submessage_length as usize);
@@ -158,7 +158,7 @@ mod tests {
         };
         let serialized_payload = SerializedDataSubmessageElement { value: &[][..] };
 
-        let submessage = RtpsSubmessageType::Data(DataSubmessage {
+        let submessage = RtpsSubmessageKind::Data(DataSubmessage {
             endianness_flag,
             inline_qos_flag,
             data_flag,
@@ -254,7 +254,7 @@ mod tests {
         };
         let serialized_payload = SerializedDataSubmessageElement { value: &[][..] };
 
-        let submessage = RtpsSubmessageType::Data(DataSubmessage {
+        let submessage = RtpsSubmessageKind::Data(DataSubmessage {
             endianness_flag,
             inline_qos_flag,
             data_flag,
@@ -327,7 +327,7 @@ mod tests {
         };
         let serialized_payload = SerializedDataSubmessageElement { value: &[][..] };
 
-        let submessage = RtpsSubmessageType::Data(DataSubmessage {
+        let submessage = RtpsSubmessageKind::Data(DataSubmessage {
             endianness_flag,
             inline_qos_flag,
             data_flag,

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
@@ -4,11 +4,11 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::{overall_structure::RtpsMessageHeader, types::ProtocolId},
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingReadByteOrdered, MappingWriteByteOrdered},
+    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrdered},
 };
 
-impl<'de, const N: usize> MappingRead<'de> for [u8; N] {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de, const N: usize> MappingReadByteOrderInfoInData<'de> for [u8; N] {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
         let mut value = [0; N];
         buf.read_exact(value.as_mut())?;
         Ok(value)
@@ -45,16 +45,16 @@ impl<'de> MappingReadByteOrdered<'de> for RtpsMessageHeader {
         };
         Ok(Self {
             protocol,
-            version: MappingRead::mapping_read(buf)?,
+            version: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
             vendor_id: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
             guid_prefix: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
         })
     }
 }
 
-impl<'de> MappingRead<'de> for RtpsMessageHeader {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        let protocol: [u8; 4] = MappingRead::mapping_read(buf)?;
+impl<'de> MappingReadByteOrderInfoInData<'de> for RtpsMessageHeader {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        let protocol: [u8; 4] = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
         let protocol = if &protocol == b"RTPS" {
             ProtocolId::PROTOCOL_RTPS
         } else {
@@ -65,9 +65,9 @@ impl<'de> MappingRead<'de> for RtpsMessageHeader {
         };
         Ok(Self {
             protocol,
-            version: MappingRead::mapping_read(buf)?,
-            vendor_id: MappingRead::mapping_read(buf)?,
-            guid_prefix: MappingRead::mapping_read(buf)?,
+            version: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+            vendor_id: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+            guid_prefix: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
         })
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
@@ -4,11 +4,11 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::{overall_structure::RtpsMessageHeader, types::ProtocolId},
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingReadByteOrdered, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingReadByteOrdered, MappingWriteByteOrderInfoInData},
 };
 
-impl<const N: usize> MappingWrite for [u8; N] {
-    fn mapping_write<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+impl<const N: usize> MappingWriteByteOrderInfoInData for [u8; N] {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
         writer.write_all(self)
     }
 }
@@ -20,14 +20,14 @@ impl<'de, const N: usize> MappingRead<'de> for [u8; N] {
     }
 }
 
-impl MappingWrite for RtpsMessageHeader {
-    fn mapping_write<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+impl MappingWriteByteOrderInfoInData for RtpsMessageHeader {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
         match self.protocol {
-            ProtocolId::PROTOCOL_RTPS => b"RTPS".mapping_write(&mut writer)?,
+            ProtocolId::PROTOCOL_RTPS => b"RTPS".mapping_write_byte_order_info_in_data(&mut writer)?,
         }
-        self.version.mapping_write(&mut writer)?;
-        self.vendor_id.mapping_write(&mut writer)?;
-        self.guid_prefix.mapping_write(&mut writer)
+        self.version.mapping_write_byte_order_info_in_data(&mut writer)?;
+        self.vendor_id.mapping_write_byte_order_info_in_data(&mut writer)?;
+        self.guid_prefix.mapping_write_byte_order_info_in_data(&mut writer)
     }
 }
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
@@ -4,7 +4,7 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::submessage_elements::GuidPrefixSubmessageElement,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingReadByteOrdered, MappingWriteByteOrdered},
+    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrdered},
 };
 
 impl MappingWriteByteOrdered for GuidPrefixSubmessageElement {
@@ -19,15 +19,15 @@ impl MappingWriteByteOrdered for GuidPrefixSubmessageElement {
 impl<'de> MappingReadByteOrdered<'de> for GuidPrefixSubmessageElement {
     fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
         Ok(Self {
-            value: MappingRead::mapping_read(buf)?,
+            value: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
         })
     }
 }
 
-impl<'de> MappingRead<'de> for GuidPrefixSubmessageElement {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for GuidPrefixSubmessageElement {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
         Ok(Self {
-            value: MappingRead::mapping_read(buf)?,
+            value: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
         })
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
@@ -4,7 +4,7 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::submessage_elements::GuidPrefixSubmessageElement,
-    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrdered},
+    rtps_udp_psm::mapping_traits::{MappingReadByteOrdered, MappingWriteByteOrdered},
 };
 
 impl MappingWriteByteOrdered for GuidPrefixSubmessageElement {
@@ -19,18 +19,11 @@ impl MappingWriteByteOrdered for GuidPrefixSubmessageElement {
 impl<'de> MappingReadByteOrdered<'de> for GuidPrefixSubmessageElement {
     fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
         Ok(Self {
-            value: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+            value: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
         })
     }
 }
 
-impl<'de> MappingReadByteOrderInfoInData<'de> for GuidPrefixSubmessageElement {
-    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        Ok(Self {
-            value: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-        })
-    }
-}
 #[cfg(test)]
 mod tests {
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
@@ -5,7 +5,7 @@ use byteorder::ByteOrder;
 use crate::implementation::{
     rtps::messages::submessage_elements::GuidPrefixSubmessageElement,
     rtps_udp_psm::mapping_traits::{
-        MappingRead, MappingReadByteOrdered, MappingWrite, MappingWriteByteOrdered,
+        MappingRead, MappingReadByteOrdered, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered,
     },
 };
 
@@ -14,7 +14,7 @@ impl MappingWriteByteOrdered for GuidPrefixSubmessageElement {
         &self,
         mut writer: W,
     ) -> Result<(), Error> {
-        self.value.mapping_write(&mut writer)
+        self.value.mapping_write_byte_order_info_in_data(&mut writer)
     }
 }
 
@@ -26,9 +26,9 @@ impl<'de> MappingReadByteOrdered<'de> for GuidPrefixSubmessageElement {
     }
 }
 
-impl MappingWrite for GuidPrefixSubmessageElement {
-    fn mapping_write<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.value.mapping_write(&mut writer)
+impl MappingWriteByteOrderInfoInData for GuidPrefixSubmessageElement {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+        self.value.mapping_write_byte_order_info_in_data(&mut writer)
     }
 }
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
@@ -4,9 +4,7 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::submessage_elements::GuidPrefixSubmessageElement,
-    rtps_udp_psm::mapping_traits::{
-        MappingRead, MappingReadByteOrdered, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered,
-    },
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingReadByteOrdered, MappingWriteByteOrdered},
 };
 
 impl MappingWriteByteOrdered for GuidPrefixSubmessageElement {
@@ -14,7 +12,7 @@ impl MappingWriteByteOrdered for GuidPrefixSubmessageElement {
         &self,
         mut writer: W,
     ) -> Result<(), Error> {
-        self.value.mapping_write_byte_order_info_in_data(&mut writer)
+        self.value.mapping_write_byte_ordered::<_, B>(&mut writer)
     }
 }
 
@@ -23,12 +21,6 @@ impl<'de> MappingReadByteOrdered<'de> for GuidPrefixSubmessageElement {
         Ok(Self {
             value: MappingRead::mapping_read(buf)?,
         })
-    }
-}
-
-impl MappingWriteByteOrderInfoInData for GuidPrefixSubmessageElement {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.value.mapping_write_byte_order_info_in_data(&mut writer)
     }
 }
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/protocol_version.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/protocol_version.rs
@@ -4,7 +4,7 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::submessage_elements::ProtocolVersionSubmessageElement,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrdered, NumberOfBytes},
+    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingWriteByteOrdered, NumberOfBytes},
 };
 
 impl NumberOfBytes for ProtocolVersionSubmessageElement {
@@ -22,10 +22,10 @@ impl MappingWriteByteOrdered for ProtocolVersionSubmessageElement {
     }
 }
 
-impl<'de> MappingRead<'de> for ProtocolVersionSubmessageElement {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for ProtocolVersionSubmessageElement {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
         Ok(Self {
-            value: MappingRead::mapping_read(buf)?,
+            value: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
         })
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/protocol_version.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/protocol_version.rs
@@ -1,8 +1,10 @@
 use std::io::{Error, Write};
 
+use byteorder::ByteOrder;
+
 use crate::implementation::{
     rtps::messages::submessage_elements::ProtocolVersionSubmessageElement,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData, NumberOfBytes},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrdered, NumberOfBytes},
 };
 
 impl NumberOfBytes for ProtocolVersionSubmessageElement {
@@ -11,9 +13,12 @@ impl NumberOfBytes for ProtocolVersionSubmessageElement {
     }
 }
 
-impl MappingWriteByteOrderInfoInData for ProtocolVersionSubmessageElement {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.value.mapping_write_byte_order_info_in_data(&mut writer)
+impl MappingWriteByteOrdered for ProtocolVersionSubmessageElement {
+    fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(
+        &self,
+        mut writer: W,
+    ) -> Result<(), Error> {
+        self.value.mapping_write_byte_ordered::<_, B>(&mut writer)
     }
 }
 
@@ -27,14 +32,14 @@ impl<'de> MappingRead<'de> for ProtocolVersionSubmessageElement {
 
 #[cfg(test)]
 mod tests {
-    use crate::implementation::rtps_udp_psm::mapping_traits::{from_bytes, to_bytes};
+    use crate::implementation::rtps_udp_psm::mapping_traits::{from_bytes, to_bytes_le};
 
     use super::*;
 
     #[test]
     fn serialize_protocol_version() {
         let data = ProtocolVersionSubmessageElement { value: [2, 3] };
-        assert_eq!(to_bytes(&data).unwrap(), vec![2, 3]);
+        assert_eq!(to_bytes_le(&data).unwrap(), vec![2, 3]);
     }
 
     #[test]

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/protocol_version.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/protocol_version.rs
@@ -2,7 +2,7 @@ use std::io::{Error, Write};
 
 use crate::implementation::{
     rtps::messages::submessage_elements::ProtocolVersionSubmessageElement,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite, NumberOfBytes},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData, NumberOfBytes},
 };
 
 impl NumberOfBytes for ProtocolVersionSubmessageElement {
@@ -11,9 +11,9 @@ impl NumberOfBytes for ProtocolVersionSubmessageElement {
     }
 }
 
-impl MappingWrite for ProtocolVersionSubmessageElement {
-    fn mapping_write<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.value.mapping_write(&mut writer)
+impl MappingWriteByteOrderInfoInData for ProtocolVersionSubmessageElement {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+        self.value.mapping_write_byte_order_info_in_data(&mut writer)
     }
 }
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/protocol_version.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/protocol_version.rs
@@ -1,10 +1,13 @@
 use std::io::{Error, Write};
 
-use byteorder::ByteOrder;
+use byteorder::{ByteOrder};
 
 use crate::implementation::{
     rtps::messages::submessage_elements::ProtocolVersionSubmessageElement,
-    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingWriteByteOrdered, NumberOfBytes},
+    rtps_udp_psm::mapping_traits::{
+        MappingReadByteOrdered, MappingWriteByteOrdered,
+        NumberOfBytes,
+    },
 };
 
 impl NumberOfBytes for ProtocolVersionSubmessageElement {
@@ -22,17 +25,17 @@ impl MappingWriteByteOrdered for ProtocolVersionSubmessageElement {
     }
 }
 
-impl<'de> MappingReadByteOrderInfoInData<'de> for ProtocolVersionSubmessageElement {
-    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrdered<'de> for ProtocolVersionSubmessageElement {
+    fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
         Ok(Self {
-            value: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+            value: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::implementation::rtps_udp_psm::mapping_traits::{from_bytes, to_bytes_le};
+    use crate::implementation::rtps_udp_psm::mapping_traits::{to_bytes_le, from_bytes_le};
 
     use super::*;
 
@@ -45,6 +48,6 @@ mod tests {
     #[test]
     fn deserialize_protocol_version() {
         let expected = ProtocolVersionSubmessageElement { value: [2, 3] };
-        assert_eq!(expected, from_bytes(&[2, 3]).unwrap());
+        assert_eq!(expected, from_bytes_le(&[2, 3]).unwrap());
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
@@ -4,13 +4,13 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::submessage_elements::VendorIdSubmessageElement,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingReadByteOrdered, MappingWriteByteOrdered},
+    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrdered},
 };
 
-impl<'de> MappingRead<'de> for VendorIdSubmessageElement {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for VendorIdSubmessageElement {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
         Ok(Self {
-            value: MappingRead::mapping_read(buf)?,
+            value: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
         })
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
@@ -4,16 +4,8 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::submessage_elements::VendorIdSubmessageElement,
-    rtps_udp_psm::mapping_traits::{
-        MappingRead, MappingReadByteOrdered, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered,
-    },
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingReadByteOrdered, MappingWriteByteOrdered},
 };
-
-impl MappingWriteByteOrderInfoInData for VendorIdSubmessageElement {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.value.mapping_write_byte_order_info_in_data(&mut writer)
-    }
-}
 
 impl<'de> MappingRead<'de> for VendorIdSubmessageElement {
     fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
@@ -5,13 +5,13 @@ use byteorder::ByteOrder;
 use crate::implementation::{
     rtps::messages::submessage_elements::VendorIdSubmessageElement,
     rtps_udp_psm::mapping_traits::{
-        MappingRead, MappingReadByteOrdered, MappingWrite, MappingWriteByteOrdered,
+        MappingRead, MappingReadByteOrdered, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered,
     },
 };
 
-impl MappingWrite for VendorIdSubmessageElement {
-    fn mapping_write<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.value.mapping_write(&mut writer)
+impl MappingWriteByteOrderInfoInData for VendorIdSubmessageElement {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+        self.value.mapping_write_byte_order_info_in_data(&mut writer)
     }
 }
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
@@ -1,6 +1,6 @@
 use std::io::{Error, Write};
 
-use byteorder::ByteOrder;
+use byteorder::{ByteOrder, LittleEndian};
 
 use crate::implementation::{
     rtps::messages::submessage_elements::VendorIdSubmessageElement,
@@ -10,7 +10,7 @@ use crate::implementation::{
 impl<'de> MappingReadByteOrderInfoInData<'de> for VendorIdSubmessageElement {
     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
         Ok(Self {
-            value: MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+            value: MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?,
         })
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
@@ -1,19 +1,11 @@
 use std::io::{Error, Write};
 
-use byteorder::{ByteOrder, LittleEndian};
+use byteorder::{ByteOrder};
 
 use crate::implementation::{
     rtps::messages::submessage_elements::VendorIdSubmessageElement,
-    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrdered},
+    rtps_udp_psm::mapping_traits::{MappingReadByteOrdered, MappingWriteByteOrdered},
 };
-
-impl<'de> MappingReadByteOrderInfoInData<'de> for VendorIdSubmessageElement {
-    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        Ok(Self {
-            value: MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?,
-        })
-    }
-}
 
 impl MappingWriteByteOrdered for VendorIdSubmessageElement {
     fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
@@ -4,7 +4,7 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::{overall_structure::RtpsSubmessageHeader, submessages::DataFragSubmessage},
-    rtps_udp_psm::mapping_traits::MappingRead,
+    rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
 };
 
 use super::submessage::MappingWriteSubmessage;
@@ -21,8 +21,8 @@ impl MappingWriteSubmessage for DataFragSubmessage<'_> {
         todo!()
     }
 }
-impl<'a, 'de: 'a> MappingRead<'de> for DataFragSubmessage<'a> {
-    fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'a, 'de: 'a> MappingReadByteOrderInfoInData<'de> for DataFragSubmessage<'a> {
+    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
@@ -1,12 +1,23 @@
 use std::io::{Error, Write};
 
+use byteorder::ByteOrder;
+
 use crate::implementation::{
-    rtps::messages::submessages::DataFragSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
+    rtps::messages::{overall_structure::RtpsSubmessageHeader, submessages::DataFragSubmessage},
+    rtps_udp_psm::mapping_traits::MappingRead,
 };
 
-impl MappingWriteByteOrderInfoInData for DataFragSubmessage<'_> {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+use super::submessage::MappingWriteSubmessage;
+
+impl MappingWriteSubmessage for DataFragSubmessage<'_> {
+    fn submessage_header(&self) -> RtpsSubmessageHeader {
+        todo!()
+    }
+
+    fn mapping_write_submessage_elements<W: Write, B: ByteOrder>(
+        &self,
+        _writer: W,
+    ) -> Result<(), Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
@@ -2,11 +2,11 @@ use std::io::{Error, Write};
 
 use crate::implementation::{
     rtps::messages::submessages::DataFragSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
-impl MappingWrite for DataFragSubmessage<'_> {
-    fn mapping_write<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+impl MappingWriteByteOrderInfoInData for DataFragSubmessage<'_> {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
@@ -2,12 +2,11 @@ use std::io::{Error, Write};
 
 use byteorder::ByteOrder;
 
-use crate::implementation::{
-    rtps::messages::{overall_structure::RtpsSubmessageHeader, submessages::DataFragSubmessage},
-    rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
+use crate::implementation::rtps::messages::{
+    overall_structure::RtpsSubmessageHeader, submessages::DataFragSubmessage,
 };
 
-use super::submessage::MappingWriteSubmessage;
+use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
 
 impl MappingWriteSubmessage for DataFragSubmessage<'_> {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
@@ -21,8 +20,12 @@ impl MappingWriteSubmessage for DataFragSubmessage<'_> {
         todo!()
     }
 }
-impl<'a, 'de: 'a> MappingReadByteOrderInfoInData<'de> for DataFragSubmessage<'a> {
-    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+
+impl<'de: 'a, 'a> MappingReadSubmessage<'de> for DataFragSubmessage<'a> {
+    fn mapping_read_submessage<B: ByteOrder>(
+        _buf: &mut &'de [u8],
+        _header: RtpsSubmessageHeader,
+    ) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
@@ -2,11 +2,11 @@ use std::io::{Error, Write};
 
 use crate::implementation::{
     rtps::messages::submessages::HeartbeatFragSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
-impl MappingWrite for HeartbeatFragSubmessage {
-    fn mapping_write<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+impl MappingWriteByteOrderInfoInData for HeartbeatFragSubmessage {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
@@ -2,11 +2,9 @@ use std::io::{Error, Write};
 
 use byteorder::ByteOrder;
 
-use crate::implementation::{
-    rtps::messages::submessages::HeartbeatFragSubmessage, rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
-};
+use crate::implementation::rtps::messages::{submessages::HeartbeatFragSubmessage, overall_structure::RtpsSubmessageHeader};
 
-use super::submessage::MappingWriteSubmessage;
+use super::submessage::{MappingWriteSubmessage, MappingReadSubmessage};
 
 impl MappingWriteSubmessage for HeartbeatFragSubmessage {
     fn submessage_header(
@@ -23,8 +21,11 @@ impl MappingWriteSubmessage for HeartbeatFragSubmessage {
     }
 }
 
-impl<'de> MappingReadByteOrderInfoInData<'de> for HeartbeatFragSubmessage {
-    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadSubmessage<'de> for HeartbeatFragSubmessage {
+    fn mapping_read_submessage<B: ByteOrder>(
+        _buf: &mut &'de [u8],
+        _header: RtpsSubmessageHeader,
+    ) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
@@ -1,15 +1,28 @@
 use std::io::{Error, Write};
 
+use byteorder::ByteOrder;
+
 use crate::implementation::{
-    rtps::messages::submessages::HeartbeatFragSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
+    rtps::messages::submessages::HeartbeatFragSubmessage, rtps_udp_psm::mapping_traits::MappingRead,
 };
 
-impl MappingWriteByteOrderInfoInData for HeartbeatFragSubmessage {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+use super::submessage::MappingWriteSubmessage;
+
+impl MappingWriteSubmessage for HeartbeatFragSubmessage {
+    fn submessage_header(
+        &self,
+    ) -> crate::implementation::rtps::messages::overall_structure::RtpsSubmessageHeader {
+        todo!()
+    }
+
+    fn mapping_write_submessage_elements<W: Write, B: ByteOrder>(
+        &self,
+        _writer: W,
+    ) -> Result<(), Error> {
         todo!()
     }
 }
+
 impl<'de> MappingRead<'de> for HeartbeatFragSubmessage {
     fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
@@ -3,7 +3,7 @@ use std::io::{Error, Write};
 use byteorder::ByteOrder;
 
 use crate::implementation::{
-    rtps::messages::submessages::HeartbeatFragSubmessage, rtps_udp_psm::mapping_traits::MappingRead,
+    rtps::messages::submessages::HeartbeatFragSubmessage, rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
 };
 
 use super::submessage::MappingWriteSubmessage;
@@ -23,8 +23,8 @@ impl MappingWriteSubmessage for HeartbeatFragSubmessage {
     }
 }
 
-impl<'de> MappingRead<'de> for HeartbeatFragSubmessage {
-    fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for HeartbeatFragSubmessage {
+    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
@@ -2,14 +2,11 @@ use std::io::{Error, Write};
 
 use byteorder::ByteOrder;
 
-use crate::implementation::{
-    rtps::messages::{
-        overall_structure::RtpsSubmessageHeader, submessages::InfoDestinationSubmessage,
-    },
-    rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
+use crate::implementation::rtps::messages::{
+    overall_structure::RtpsSubmessageHeader, submessages::InfoDestinationSubmessage,
 };
 
-use super::submessage::MappingWriteSubmessage;
+use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
 
 impl MappingWriteSubmessage for InfoDestinationSubmessage {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
@@ -24,8 +21,11 @@ impl MappingWriteSubmessage for InfoDestinationSubmessage {
     }
 }
 
-impl<'de> MappingReadByteOrderInfoInData<'de> for InfoDestinationSubmessage {
-    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadSubmessage<'de> for InfoDestinationSubmessage {
+    fn mapping_read_submessage<B: ByteOrder>(
+        _buf: &mut &'de [u8],
+        _header: RtpsSubmessageHeader,
+    ) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
@@ -1,15 +1,29 @@
 use std::io::{Error, Write};
 
+use byteorder::ByteOrder;
+
 use crate::implementation::{
-    rtps::messages::submessages::InfoDestinationSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
+    rtps::messages::{
+        overall_structure::RtpsSubmessageHeader, submessages::InfoDestinationSubmessage,
+    },
+    rtps_udp_psm::mapping_traits::MappingRead,
 };
 
-impl MappingWriteByteOrderInfoInData for InfoDestinationSubmessage {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+use super::submessage::MappingWriteSubmessage;
+
+impl MappingWriteSubmessage for InfoDestinationSubmessage {
+    fn submessage_header(&self) -> RtpsSubmessageHeader {
+        todo!()
+    }
+
+    fn mapping_write_submessage_elements<W: Write, B: ByteOrder>(
+        &self,
+        _writer: W,
+    ) -> Result<(), Error> {
         todo!()
     }
 }
+
 impl<'de> MappingRead<'de> for InfoDestinationSubmessage {
     fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
@@ -6,7 +6,7 @@ use crate::implementation::{
     rtps::messages::{
         overall_structure::RtpsSubmessageHeader, submessages::InfoDestinationSubmessage,
     },
-    rtps_udp_psm::mapping_traits::MappingRead,
+    rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
 };
 
 use super::submessage::MappingWriteSubmessage;
@@ -24,8 +24,8 @@ impl MappingWriteSubmessage for InfoDestinationSubmessage {
     }
 }
 
-impl<'de> MappingRead<'de> for InfoDestinationSubmessage {
-    fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for InfoDestinationSubmessage {
+    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
@@ -2,11 +2,11 @@ use std::io::{Error, Write};
 
 use crate::implementation::{
     rtps::messages::submessages::InfoDestinationSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
-impl MappingWrite for InfoDestinationSubmessage {
-    fn mapping_write<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+impl MappingWriteByteOrderInfoInData for InfoDestinationSubmessage {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
@@ -1,12 +1,23 @@
 use std::io::{Error, Write};
 
+use byteorder::ByteOrder;
+
 use crate::implementation::{
-    rtps::messages::submessages::InfoReplySubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
+    rtps::messages::{overall_structure::RtpsSubmessageHeader, submessages::InfoReplySubmessage},
+    rtps_udp_psm::mapping_traits::MappingRead,
 };
 
-impl MappingWriteByteOrderInfoInData for InfoReplySubmessage {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+use super::submessage::MappingWriteSubmessage;
+
+impl MappingWriteSubmessage for InfoReplySubmessage {
+    fn submessage_header(&self) -> RtpsSubmessageHeader {
+        todo!()
+    }
+
+    fn mapping_write_submessage_elements<W: Write, B: ByteOrder>(
+        &self,
+        _writer: W,
+    ) -> Result<(), Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
@@ -2,11 +2,11 @@ use std::io::{Error, Write};
 
 use crate::implementation::{
     rtps::messages::submessages::InfoReplySubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
-impl MappingWrite for InfoReplySubmessage {
-    fn mapping_write<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+impl MappingWriteByteOrderInfoInData for InfoReplySubmessage {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
@@ -4,7 +4,7 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::{overall_structure::RtpsSubmessageHeader, submessages::InfoReplySubmessage},
-    rtps_udp_psm::mapping_traits::MappingRead,
+    rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
 };
 
 use super::submessage::MappingWriteSubmessage;
@@ -21,8 +21,8 @@ impl MappingWriteSubmessage for InfoReplySubmessage {
         todo!()
     }
 }
-impl<'de> MappingRead<'de> for InfoReplySubmessage {
-    fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for InfoReplySubmessage {
+    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
@@ -2,12 +2,11 @@ use std::io::{Error, Write};
 
 use byteorder::ByteOrder;
 
-use crate::implementation::{
-    rtps::messages::{overall_structure::RtpsSubmessageHeader, submessages::InfoReplySubmessage},
-    rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
+use crate::implementation::rtps::messages::{
+    overall_structure::RtpsSubmessageHeader, submessages::InfoReplySubmessage,
 };
 
-use super::submessage::MappingWriteSubmessage;
+use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
 
 impl MappingWriteSubmessage for InfoReplySubmessage {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
@@ -21,8 +20,12 @@ impl MappingWriteSubmessage for InfoReplySubmessage {
         todo!()
     }
 }
-impl<'de> MappingReadByteOrderInfoInData<'de> for InfoReplySubmessage {
-    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+
+impl<'de> MappingReadSubmessage<'de> for InfoReplySubmessage {
+    fn mapping_read_submessage<B: ByteOrder>(
+        _buf: &mut &'de [u8],
+        _header: RtpsSubmessageHeader,
+    ) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_source.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_source.rs
@@ -1,15 +1,28 @@
 use std::io::{Error, Write};
 
+use byteorder::ByteOrder;
+
+use crate::implementation::rtps::messages::overall_structure::RtpsSubmessageHeader;
+
 use crate::implementation::{
-    rtps::messages::submessages::InfoSourceSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
+    rtps::messages::submessages::InfoSourceSubmessage, rtps_udp_psm::mapping_traits::MappingRead,
 };
 
-impl MappingWriteByteOrderInfoInData for InfoSourceSubmessage {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+use super::submessage::MappingWriteSubmessage;
+
+impl MappingWriteSubmessage for InfoSourceSubmessage {
+    fn submessage_header(&self) -> RtpsSubmessageHeader {
+        todo!()
+    }
+
+    fn mapping_write_submessage_elements<W: Write, B: ByteOrder>(
+        &self,
+        _writer: W,
+    ) -> Result<(), Error> {
         todo!()
     }
 }
+
 impl<'de> MappingRead<'de> for InfoSourceSubmessage {
     fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_source.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_source.rs
@@ -4,11 +4,9 @@ use byteorder::ByteOrder;
 
 use crate::implementation::rtps::messages::overall_structure::RtpsSubmessageHeader;
 
-use crate::implementation::{
-    rtps::messages::submessages::InfoSourceSubmessage, rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
-};
+use crate::implementation::rtps::messages::submessages::InfoSourceSubmessage;
 
-use super::submessage::MappingWriteSubmessage;
+use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
 
 impl MappingWriteSubmessage for InfoSourceSubmessage {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
@@ -23,8 +21,11 @@ impl MappingWriteSubmessage for InfoSourceSubmessage {
     }
 }
 
-impl<'de> MappingReadByteOrderInfoInData<'de> for InfoSourceSubmessage {
-    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadSubmessage<'de> for InfoSourceSubmessage {
+    fn mapping_read_submessage<B: ByteOrder>(
+        _buf: &mut &'de [u8],
+        _header: RtpsSubmessageHeader,
+    ) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_source.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_source.rs
@@ -2,11 +2,11 @@ use std::io::{Error, Write};
 
 use crate::implementation::{
     rtps::messages::submessages::InfoSourceSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
-impl MappingWrite for InfoSourceSubmessage {
-    fn mapping_write<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+impl MappingWriteByteOrderInfoInData for InfoSourceSubmessage {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_source.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_source.rs
@@ -5,7 +5,7 @@ use byteorder::ByteOrder;
 use crate::implementation::rtps::messages::overall_structure::RtpsSubmessageHeader;
 
 use crate::implementation::{
-    rtps::messages::submessages::InfoSourceSubmessage, rtps_udp_psm::mapping_traits::MappingRead,
+    rtps::messages::submessages::InfoSourceSubmessage, rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
 };
 
 use super::submessage::MappingWriteSubmessage;
@@ -23,8 +23,8 @@ impl MappingWriteSubmessage for InfoSourceSubmessage {
     }
 }
 
-impl<'de> MappingRead<'de> for InfoSourceSubmessage {
-    fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for InfoSourceSubmessage {
+    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
@@ -1,15 +1,28 @@
 use std::io::{Error, Write};
 
+use byteorder::ByteOrder;
+
+use crate::implementation::rtps::messages::overall_structure::RtpsSubmessageHeader;
+
 use crate::implementation::{
-    rtps::messages::submessages::NackFragSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
+    rtps::messages::submessages::NackFragSubmessage, rtps_udp_psm::mapping_traits::MappingRead,
 };
 
-impl MappingWriteByteOrderInfoInData for NackFragSubmessage {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+use super::submessage::MappingWriteSubmessage;
+
+impl MappingWriteSubmessage for NackFragSubmessage {
+    fn submessage_header(&self) -> RtpsSubmessageHeader {
+        todo!()
+    }
+
+    fn mapping_write_submessage_elements<W: Write, B: ByteOrder>(
+        &self,
+        _writer: W,
+    ) -> Result<(), Error> {
         todo!()
     }
 }
+
 impl<'de> MappingRead<'de> for NackFragSubmessage {
     fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
@@ -2,11 +2,11 @@ use std::io::{Error, Write};
 
 use crate::implementation::{
     rtps::messages::submessages::NackFragSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
-impl MappingWrite for NackFragSubmessage {
-    fn mapping_write<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+impl MappingWriteByteOrderInfoInData for NackFragSubmessage {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
@@ -5,7 +5,7 @@ use byteorder::ByteOrder;
 use crate::implementation::rtps::messages::overall_structure::RtpsSubmessageHeader;
 
 use crate::implementation::{
-    rtps::messages::submessages::NackFragSubmessage, rtps_udp_psm::mapping_traits::MappingRead,
+    rtps::messages::submessages::NackFragSubmessage, rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
 };
 
 use super::submessage::MappingWriteSubmessage;
@@ -23,8 +23,8 @@ impl MappingWriteSubmessage for NackFragSubmessage {
     }
 }
 
-impl<'de> MappingRead<'de> for NackFragSubmessage {
-    fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for NackFragSubmessage {
+    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
@@ -4,11 +4,9 @@ use byteorder::ByteOrder;
 
 use crate::implementation::rtps::messages::overall_structure::RtpsSubmessageHeader;
 
-use crate::implementation::{
-    rtps::messages::submessages::NackFragSubmessage, rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
-};
+use crate::implementation::rtps::messages::submessages::NackFragSubmessage;
 
-use super::submessage::MappingWriteSubmessage;
+use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
 
 impl MappingWriteSubmessage for NackFragSubmessage {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
@@ -23,8 +21,11 @@ impl MappingWriteSubmessage for NackFragSubmessage {
     }
 }
 
-impl<'de> MappingReadByteOrderInfoInData<'de> for NackFragSubmessage {
-    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadSubmessage<'de> for NackFragSubmessage {
+    fn mapping_read_submessage<B: ByteOrder>(
+        _buf: &mut &'de [u8],
+        _header: RtpsSubmessageHeader,
+    ) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
@@ -1,15 +1,27 @@
 use std::io::{Error, Write};
 
+use byteorder::ByteOrder;
+
 use crate::implementation::{
-    rtps::messages::submessages::PadSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
+    rtps::messages::{overall_structure::RtpsSubmessageHeader, submessages::PadSubmessage},
+    rtps_udp_psm::mapping_traits::MappingRead,
 };
 
-impl MappingWriteByteOrderInfoInData for PadSubmessage {
-    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+use super::submessage::MappingWriteSubmessage;
+
+impl MappingWriteSubmessage for PadSubmessage {
+    fn submessage_header(&self) -> RtpsSubmessageHeader {
+        todo!()
+    }
+
+    fn mapping_write_submessage_elements<W: Write, B: ByteOrder>(
+        &self,
+        _writer: W,
+    ) -> Result<(), Error> {
         todo!()
     }
 }
+
 impl<'de> MappingRead<'de> for PadSubmessage {
     fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
@@ -2,12 +2,11 @@ use std::io::{Error, Write};
 
 use byteorder::ByteOrder;
 
-use crate::implementation::{
-    rtps::messages::{overall_structure::RtpsSubmessageHeader, submessages::PadSubmessage},
-    rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
+use crate::implementation::rtps::messages::{
+    overall_structure::RtpsSubmessageHeader, submessages::PadSubmessage,
 };
 
-use super::submessage::MappingWriteSubmessage;
+use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
 
 impl MappingWriteSubmessage for PadSubmessage {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
@@ -22,8 +21,11 @@ impl MappingWriteSubmessage for PadSubmessage {
     }
 }
 
-impl<'de> MappingReadByteOrderInfoInData<'de> for PadSubmessage {
-    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadSubmessage<'de> for PadSubmessage {
+    fn mapping_read_submessage<B: ByteOrder>(
+        _buf: &mut &'de [u8],
+        _header: RtpsSubmessageHeader,
+    ) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
@@ -4,7 +4,7 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::{overall_structure::RtpsSubmessageHeader, submessages::PadSubmessage},
-    rtps_udp_psm::mapping_traits::MappingRead,
+    rtps_udp_psm::mapping_traits::MappingReadByteOrderInfoInData,
 };
 
 use super::submessage::MappingWriteSubmessage;
@@ -22,8 +22,8 @@ impl MappingWriteSubmessage for PadSubmessage {
     }
 }
 
-impl<'de> MappingRead<'de> for PadSubmessage {
-    fn mapping_read(_buf: &mut &'de [u8]) -> Result<Self, Error> {
+impl<'de> MappingReadByteOrderInfoInData<'de> for PadSubmessage {
+    fn mapping_read_byte_order_info_in_data(_buf: &mut &'de [u8]) -> Result<Self, Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
@@ -2,11 +2,11 @@ use std::io::{Error, Write};
 
 use crate::implementation::{
     rtps::messages::submessages::PadSubmessage,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
-impl MappingWrite for PadSubmessage {
-    fn mapping_write<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
+impl MappingWriteByteOrderInfoInData for PadSubmessage {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut _writer: W) -> Result<(), Error> {
         todo!()
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage.rs
@@ -4,7 +4,7 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian};
 
 use crate::implementation::{
     rtps::messages::overall_structure::RtpsSubmessageHeader,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
+    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingWriteByteOrderInfoInData},
 };
 
 pub trait MappingWriteSubmessage {
@@ -36,12 +36,12 @@ pub trait MappingReadSubmessage<'de>: Sized {
     ) -> Result<Self, Error>;
 }
 
-impl<'a, 'de: 'a, T> MappingRead<'de> for T
+impl<'a, 'de: 'a, T> MappingReadByteOrderInfoInData<'de> for T
 where
     T: MappingReadSubmessage<'de>,
 {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        let header: RtpsSubmessageHeader = MappingRead::mapping_read(buf)?;
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        let header: RtpsSubmessageHeader = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
         if header.flags[0] {
             Self::mapping_read_submessage::<LittleEndian>(buf, header)
         } else {

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage.rs
@@ -1,10 +1,13 @@
 use std::io::{Error, Write};
 
-use byteorder::{BigEndian, ByteOrder, LittleEndian};
+use byteorder::LittleEndian;
+use byteorder::{BigEndian, ByteOrder};
 
 use crate::implementation::{
     rtps::messages::overall_structure::RtpsSubmessageHeader,
-    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingWriteByteOrderInfoInData, MappingReadByteOrdered},
+    rtps_udp_psm::mapping_traits::{
+        MappingReadByteOrderInfoInData, MappingWriteByteOrderInfoInData,
+    },
 };
 
 pub trait MappingWriteSubmessage {
@@ -20,7 +23,8 @@ where
     T: MappingWriteSubmessage,
 {
     fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.submessage_header().mapping_write_byte_order_info_in_data(&mut writer)?;
+        self.submessage_header()
+            .mapping_write_byte_order_info_in_data(&mut writer)?;
         if self.submessage_header().flags[0] {
             self.mapping_write_submessage_elements::<_, LittleEndian>(&mut writer)
         } else {
@@ -41,7 +45,8 @@ where
     T: MappingReadSubmessage<'de>,
 {
     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        let header: RtpsSubmessageHeader = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
+        let header: RtpsSubmessageHeader =
+            MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
         if header.flags[0] {
             Self::mapping_read_submessage::<LittleEndian>(buf, header)
         } else {

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage.rs
@@ -4,7 +4,7 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian};
 
 use crate::implementation::{
     rtps::messages::overall_structure::RtpsSubmessageHeader,
-    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingWriteByteOrderInfoInData},
+    rtps_udp_psm::mapping_traits::{MappingReadByteOrderInfoInData, MappingWriteByteOrderInfoInData, MappingReadByteOrdered},
 };
 
 pub trait MappingWriteSubmessage {

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage.rs
@@ -4,7 +4,7 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian};
 
 use crate::implementation::{
     rtps::messages::overall_structure::RtpsSubmessageHeader,
-    rtps_udp_psm::mapping_traits::{MappingRead, MappingWrite},
+    rtps_udp_psm::mapping_traits::{MappingRead, MappingWriteByteOrderInfoInData},
 };
 
 pub trait MappingWriteSubmessage {
@@ -15,12 +15,12 @@ pub trait MappingWriteSubmessage {
     ) -> Result<(), Error>;
 }
 
-impl<T> MappingWrite for T
+impl<T> MappingWriteByteOrderInfoInData for T
 where
     T: MappingWriteSubmessage,
 {
-    fn mapping_write<W: Write>(&self, mut writer: W) -> Result<(), Error> {
-        self.submessage_header().mapping_write(&mut writer)?;
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+        self.submessage_header().mapping_write_byte_order_info_in_data(&mut writer)?;
         if self.submessage_header().flags[0] {
             self.mapping_write_submessage_elements::<_, LittleEndian>(&mut writer)
         } else {

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage_header.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage_header.rs
@@ -69,7 +69,7 @@ impl<'de> MappingReadByteOrdered<'de> for [SubmessageFlag; 8] {
 
 impl<'de> MappingReadByteOrderInfoInData<'de> for [SubmessageFlag; 8] {
     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        let value: u8 = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
+        let value: u8 = MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
         let mut flags = [false; 8];
         for (index, flag) in flags.iter_mut().enumerate() {
             *flag = value & (0b_0000_0001 << index) != 0;
@@ -147,7 +147,7 @@ impl MappingWriteByteOrdered for RtpsSubmessageHeader {
 
 impl<'de> MappingReadByteOrderInfoInData<'de> for RtpsSubmessageHeader {
     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        let submessage_id: u8 = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
+        let submessage_id: u8 = MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
         let submessage_id = match submessage_id {
             DATA => SubmessageKind::DATA,
             GAP => SubmessageKind::GAP,

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage_header.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage_header.rs
@@ -8,7 +8,7 @@ use crate::implementation::{
         types::{SubmessageFlag, SubmessageKind},
     },
     rtps_udp_psm::mapping_traits::{
-        MappingRead, MappingReadByteOrdered, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered,
+        MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered,
     },
 };
 
@@ -67,9 +67,9 @@ impl<'de> MappingReadByteOrdered<'de> for [SubmessageFlag; 8] {
     }
 }
 
-impl<'de> MappingRead<'de> for [SubmessageFlag; 8] {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        let value: u8 = MappingRead::mapping_read(buf)?;
+impl<'de> MappingReadByteOrderInfoInData<'de> for [SubmessageFlag; 8] {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        let value: u8 = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
         let mut flags = [false; 8];
         for (index, flag) in flags.iter_mut().enumerate() {
             *flag = value & (0b_0000_0001 << index) != 0;
@@ -145,9 +145,9 @@ impl MappingWriteByteOrdered for RtpsSubmessageHeader {
     }
 }
 
-impl<'de> MappingRead<'de> for RtpsSubmessageHeader {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        let submessage_id: u8 = MappingRead::mapping_read(buf)?;
+impl<'de> MappingReadByteOrderInfoInData<'de> for RtpsSubmessageHeader {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        let submessage_id: u8 = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
         let submessage_id = match submessage_id {
             DATA => SubmessageKind::DATA,
             GAP => SubmessageKind::GAP,
@@ -163,7 +163,7 @@ impl<'de> MappingRead<'de> for RtpsSubmessageHeader {
             HEARTBEAT_FRAG => SubmessageKind::HEARTBEAT_FRAG,
             _ => SubmessageKind::UNKNOWN,
         };
-        let flags: [SubmessageFlag; 8] = MappingRead::mapping_read(buf)?;
+        let flags: [SubmessageFlag; 8] = MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
         let submessage_length = if flags[0] {
             MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?
         } else {

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage_header.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage_header.rs
@@ -139,6 +139,8 @@ impl MappingWriteByteOrdered for RtpsSubmessageHeader {
 
 impl<'de> MappingReadByteOrderInfoInData<'de> for RtpsSubmessageHeader {
     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        // The byteorder is determined by the one after next element. Since the submessage_id
+        // is not byteorder dependent, just use a specific one (to avoid look ahead)
         let submessage_id: u8 =
             MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
         let submessage_id = match submessage_id {
@@ -156,6 +158,7 @@ impl<'de> MappingReadByteOrderInfoInData<'de> for RtpsSubmessageHeader {
             HEARTBEAT_FRAG => SubmessageKind::HEARTBEAT_FRAG,
             _ => SubmessageKind::UNKNOWN,
         };
+        // Also decide byteorder here
         let flags: [SubmessageFlag; 8] =
             MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
         let submessage_length = if flags[0] {

--- a/dds/src/implementation/rtps_udp_psm/mapping_traits.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_traits.rs
@@ -14,8 +14,8 @@ pub trait NumberOfBytes {
     fn number_of_bytes(&self) -> usize;
 }
 
-pub trait MappingRead<'de>: Sized {
-    fn mapping_read(buf: &mut &'de [u8]) -> Result<Self, Error>;
+pub trait MappingReadByteOrderInfoInData<'de>: Sized {
+    fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error>;
 }
 
 pub trait MappingReadByteOrdered<'de>: Sized {
@@ -42,6 +42,6 @@ pub fn from_bytes_le<'de, D: MappingReadByteOrdered<'de>>(mut buf: &'de [u8]) ->
     D::mapping_read_byte_ordered::<LittleEndian>(&mut buf)
 }
 
-pub fn from_bytes<'de, D: MappingRead<'de>>(mut buf: &'de [u8]) -> Result<D, Error> {
-    D::mapping_read(&mut buf)
+pub fn from_bytes<'de, D: MappingReadByteOrderInfoInData<'de>>(mut buf: &'de [u8]) -> Result<D, Error> {
+    D::mapping_read_byte_order_info_in_data(&mut buf)
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_traits.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_traits.rs
@@ -2,8 +2,8 @@ use std::io::{Error, Write};
 
 use byteorder::{ByteOrder, LittleEndian};
 
-pub trait MappingWrite {
-    fn mapping_write<W: Write>(&self, writer: W) -> Result<(), Error>;
+pub trait MappingWriteByteOrderInfoInData {
+    fn mapping_write_byte_order_info_in_data<W: Write>(&self, writer: W) -> Result<(), Error>;
 }
 
 pub trait MappingWriteByteOrdered {
@@ -31,9 +31,9 @@ pub fn to_bytes_le<S: MappingWriteByteOrdered>(value: &S) -> Result<Vec<u8>, Err
     Ok(writer)
 }
 
-pub fn to_bytes<S: MappingWrite>(value: &S) -> Result<Vec<u8>, Error> {
+pub fn to_bytes<S: MappingWriteByteOrderInfoInData>(value: &S) -> Result<Vec<u8>, Error> {
     let mut writer = Vec::<u8>::new();
-    value.mapping_write(&mut writer)?;
+    value.mapping_write_byte_order_info_in_data(&mut writer)?;
     Ok(writer)
 }
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_traits.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_traits.rs
@@ -19,9 +19,7 @@ pub trait MappingReadByteOrderInfoInData<'de>: Sized {
 }
 
 pub trait MappingReadByteOrdered<'de>: Sized {
-    fn mapping_read_byte_ordered<B>(buf: &mut &'de [u8]) -> Result<Self, Error>
-    where
-        B: ByteOrder;
+    fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error>;
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Some of the PSM types implemented MappingWrite and MappingWriteByteOrdered. This unnecessary double implementation is removed here. Likewise the Read implementations. The name of the traits are made more explicit. 