### PR TITLE
DDS-234 refactor submessage elements

### DIFF
--- a/dds/src/domain/domain_participant_factory.rs
+++ b/dds/src/domain/domain_participant_factory.rs
@@ -82,7 +82,7 @@ impl DomainParticipantFactory {
 
         let rtps_udp_psm = RtpsUdpPsm::new(domain_id).map_err(DdsError::PreconditionNotMet)?;
         let rtps_participant = RtpsParticipant::new(
-            GuidPrefix::from(rtps_udp_psm.guid_prefix()),
+            GuidPrefix::new(rtps_udp_psm.guid_prefix()),
             rtps_udp_psm.default_unicast_locator_list().as_ref(),
             rtps_udp_psm.default_multicast_locator_list(),
             PROTOCOLVERSION,

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -280,7 +280,7 @@ mod tests {
         let data = DiscoveredReaderData {
             reader_proxy: ReaderProxy {
                 remote_reader_guid: Guid::new(
-                    GuidPrefix::from([5; 12]),
+                    GuidPrefix::new([5; 12]),
                     EntityId::new([11, 12, 13], EntityKind::UserDefinedReaderWithKey),
                 ),
                 remote_group_entity_id: EntityId::new(
@@ -347,7 +347,7 @@ mod tests {
             reader_proxy: ReaderProxy {
                 // must correspond to subscription_builtin_topic_data.key
                 remote_reader_guid: Guid::new(
-                    GuidPrefix::from([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]),
+                    GuidPrefix::new([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]),
                     EntityId::new([4, 0, 0], EntityKind::UserDefinedUnknown),
                 ),
                 remote_group_entity_id: EntityId::new(

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -276,7 +276,7 @@ mod tests {
         let data = DiscoveredWriterData {
             writer_proxy: WriterProxy {
                 remote_writer_guid: Guid::new(
-                    GuidPrefix::from([5; 12]),
+                    GuidPrefix::new([5; 12]),
                     EntityId::new([11, 12, 13], EntityKind::BuiltInWriterWithKey),
                 ),
                 unicast_locator_list: vec![],
@@ -340,7 +340,7 @@ mod tests {
             writer_proxy: WriterProxy {
                 // must correspond to publication_builtin_topic_data.key
                 remote_writer_guid: Guid::new(
-                    GuidPrefix::from([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]),
+                    GuidPrefix::new([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]),
                     EntityId::new([4, 0, 0], EntityKind::UserDefinedUnknown),
                 ),
                 unicast_locator_list: vec![],

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -263,7 +263,7 @@ mod tests {
         let domain_id = 1;
         let domain_tag = "ab".to_string();
         let protocol_version = ProtocolVersion { major: 2, minor: 4 };
-        let guid_prefix = GuidPrefix::from([8; 12]);
+        let guid_prefix = GuidPrefix::new([8; 12]);
         let guid = Guid::new(
             guid_prefix,
             EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant),
@@ -384,7 +384,7 @@ mod tests {
         let domain_id = 1;
         let domain_tag = "ab".to_string();
         let protocol_version = ProtocolVersion { major: 2, minor: 4 };
-        let guid_prefix = GuidPrefix::from([8; 12]);
+        let guid_prefix = GuidPrefix::new([8; 12]);
         let guid = Guid::new(
             guid_prefix,
             EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant),

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -142,7 +142,7 @@ impl DdsSerialize for SpdpDiscoveredParticipantData {
         )?;
         parameter_list_serializer.serialize_parameter::<&Guid, _>(PID_PARTICIPANT_GUID, &guid)?;
         parameter_list_serializer
-            .serialize_parameter::<&[u8; 2], _>(PID_VENDORID, &self.participant_proxy.vendor_id)?;
+            .serialize_parameter::<&VendorId, _>(PID_VENDORID, &self.participant_proxy.vendor_id)?;
         parameter_list_serializer
             .serialize_parameter_if_not_default::<ExpectsInlineQosSerialize, _>(
                 PID_EXPECTS_INLINE_QOS,
@@ -197,7 +197,7 @@ impl<'de> DdsDeserialize<'de> for SpdpDiscoveredParticipantData {
         let domain_id = param_list.get::<i32, _>(PID_DOMAIN_ID)?;
         let domain_tag = param_list.get_or_default::<DomainTagDeserialize, _>(PID_DOMAIN_TAG)?;
         let protocol_version = param_list.get::<ProtocolVersion, _>(PID_PROTOCOL_VERSION)?;
-        let vendor_id = param_list.get::<[u8; 2], _>(PID_VENDORID)?;
+        let vendor_id = param_list.get::<VendorId, _>(PID_VENDORID)?;
         let expects_inline_qos =
             param_list.get_or_default::<ExpectsInlineQosDeserialize, _>(PID_EXPECTS_INLINE_QOS)?;
         let metatraffic_unicast_locator_list =
@@ -268,7 +268,7 @@ mod tests {
             guid_prefix,
             EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant),
         );
-        let vendor_id = [73, 74];
+        let vendor_id = VendorId::new([73, 74]);
         let expects_inline_qos = true;
         let metatraffic_unicast_locator_list = vec![locator1, locator2];
         let metatraffic_multicast_locator_list = vec![locator1];
@@ -389,7 +389,7 @@ mod tests {
             guid_prefix,
             EntityId::new([0, 0, 1], EntityKind::BuiltInParticipant),
         );
-        let vendor_id = [73, 74];
+        let vendor_id = VendorId::new([73, 74]);
         let expects_inline_qos = true;
         let metatraffic_unicast_locator_list = vec![locator1, locator2];
         let metatraffic_multicast_locator_list = vec![locator1];

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -276,7 +276,7 @@ mod tests {
         let default_multicast_locator_list = vec![locator1];
         let available_builtin_endpoints =
             BuiltinEndpointSet::new(BuiltinEndpointSet::BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR);
-        let manual_liveliness_count = Count(2);
+        let manual_liveliness_count = Count::new(2);
         let builtin_endpoint_qos = BuiltinEndpointQos::new(
             BuiltinEndpointQos::BEST_EFFORT_PARTICIPANT_MESSAGE_DATA_READER,
         );
@@ -397,7 +397,7 @@ mod tests {
         let default_multicast_locator_list = vec![locator1];
         let available_builtin_endpoints =
             BuiltinEndpointSet::new(BuiltinEndpointSet::BUILTIN_ENDPOINT_PARTICIPANT_DETECTOR);
-        let manual_liveliness_count = Count(2);
+        let manual_liveliness_count = Count::new(2);
         let builtin_endpoint_qos = BuiltinEndpointQos::new(
             BuiltinEndpointQos::BEST_EFFORT_PARTICIPANT_MESSAGE_DATA_READER,
         );

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -262,7 +262,7 @@ mod tests {
 
         let domain_id = 1;
         let domain_tag = "ab".to_string();
-        let protocol_version = ProtocolVersion { major: 2, minor: 4 };
+        let protocol_version = ProtocolVersion ::new(2, 4);
         let guid_prefix = GuidPrefix::new([8; 12]);
         let guid = Guid::new(
             guid_prefix,
@@ -383,7 +383,7 @@ mod tests {
 
         let domain_id = 1;
         let domain_tag = "ab".to_string();
-        let protocol_version = ProtocolVersion { major: 2, minor: 4 };
+        let protocol_version = ProtocolVersion ::new(2, 4);
         let guid_prefix = GuidPrefix::new([8; 12]);
         let guid = Guid::new(
             guid_prefix,

--- a/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
@@ -166,13 +166,13 @@ impl DdsShared<BuiltinStatefulWriter> {
             let header = RtpsMessageHeader {
                 protocol: ProtocolId::PROTOCOL_RTPS,
                 version: ProtocolVersionSubmessageElement {
-                    value: PROTOCOLVERSION.into(),
+                    value: PROTOCOLVERSION,
                 },
                 vendor_id: VendorIdSubmessageElement {
                     value: VENDOR_ID_S2E,
                 },
                 guid_prefix: GuidPrefixSubmessageElement {
-                    value: guid_prefix.into(),
+                    value: guid_prefix,
                 },
             };
 

--- a/dds/src/implementation/dds_impl/builtin_stateless_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateless_writer.rs
@@ -116,13 +116,13 @@ impl DdsShared<BuiltinStatelessWriter> {
             let header = RtpsMessageHeader {
                 protocol: ProtocolId::PROTOCOL_RTPS,
                 version: ProtocolVersionSubmessageElement {
-                    value: PROTOCOLVERSION.into(),
+                    value: PROTOCOLVERSION,
                 },
                 vendor_id: VendorIdSubmessageElement {
                     value: VENDOR_ID_S2E,
                 },
                 guid_prefix: GuidPrefixSubmessageElement {
-                    value: guid_prefix.into(),
+                    value: guid_prefix,
                 },
             };
 

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -197,7 +197,7 @@ impl DomainParticipantImpl {
             topic_list: DdsRwLock::new(Vec::new()),
             user_defined_topic_counter: AtomicU8::new(0),
             default_topic_qos: TopicQos::default(),
-            manual_liveliness_count: Count(0),
+            manual_liveliness_count: Count::new(0),
             lease_duration,
             metatraffic_unicast_locator_list,
             metatraffic_multicast_locator_list,

--- a/dds/src/implementation/dds_impl/message_receiver.rs
+++ b/dds/src/implementation/dds_impl/message_receiver.rs
@@ -142,7 +142,7 @@ impl MessageReceiver {
     }
 
     #[allow(dead_code)]
-    pub fn source_vendor_id(&self) -> [u8; 2] {
+    pub fn source_vendor_id(&self) -> VendorId {
         self.source_vendor_id
     }
 

--- a/dds/src/implementation/dds_impl/message_receiver.rs
+++ b/dds/src/implementation/dds_impl/message_receiver.rs
@@ -75,9 +75,9 @@ impl MessageReceiver {
         message: &RtpsMessage<'_>,
     ) -> DdsResult<()> {
         self.dest_guid_prefix = participant_guid_prefix;
-        self.source_version = message.header.version.value.into();
+        self.source_version = message.header.version.value;
         self.source_vendor_id = message.header.vendor_id.value;
-        self.source_guid_prefix = message.header.guid_prefix.value.into();
+        self.source_guid_prefix = message.header.guid_prefix.value;
         self.unicast_reply_locator_list.push(Locator::new(
             *source_locator.kind(),
             LOCATOR_PORT_INVALID,

--- a/dds/src/implementation/dds_impl/topic_impl.rs
+++ b/dds/src/implementation/dds_impl/topic_impl.rs
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn get_instance_handle() {
         let guid = Guid::new(
-            GuidPrefix::from([2; 12]),
+            GuidPrefix::new([2; 12]),
             EntityId::new([3; 3], EntityKind::BuiltInParticipant),
         );
         let topic = TopicImpl::new(guid, TopicQos::default(), "", "", DdsWeak::new());

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -898,7 +898,7 @@ mod tests {
     #[test]
     fn get_instance_handle() {
         let guid = Guid::new(
-            GuidPrefix::from([4; 12]),
+            GuidPrefix::new([4; 12]),
             EntityId::new([3; 3], EntityKind::BuiltInParticipant),
         );
         let dummy_topic = TopicImpl::new(GUID_UNKNOWN, TopicQos::default(), "", "", DdsWeak::new());
@@ -982,7 +982,7 @@ mod tests {
             lifespan: LifespanQosPolicy::default(),
         };
         let remote_writer_guid = Guid::new(
-            GuidPrefix::from([2; 12]),
+            GuidPrefix::new([2; 12]),
             EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey),
         );
         let discovered_writer_data = DiscoveredWriterData {
@@ -1074,7 +1074,7 @@ mod tests {
         let discovered_writer_data = DiscoveredWriterData {
             writer_proxy: WriterProxy {
                 remote_writer_guid: Guid::new(
-                    GuidPrefix::from([2; 12]),
+                    GuidPrefix::new([2; 12]),
                     EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey),
                 ),
                 remote_group_entity_id: ENTITYID_UNKNOWN,

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -664,13 +664,13 @@ impl DdsShared<UserDefinedDataWriter> {
             let header = RtpsMessageHeader {
                 protocol: ProtocolId::PROTOCOL_RTPS,
                 version: ProtocolVersionSubmessageElement {
-                    value: PROTOCOLVERSION.into(),
+                    value: PROTOCOLVERSION,
                 },
                 vendor_id: VendorIdSubmessageElement {
                     value: VENDOR_ID_S2E,
                 },
                 guid_prefix: GuidPrefixSubmessageElement {
-                    value: guid_prefix.into(),
+                    value: guid_prefix,
                 },
             };
 

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -952,7 +952,7 @@ mod test {
             group_data: GroupDataQosPolicy::default(),
         };
         let remote_reader_guid = Guid::new(
-            GuidPrefix::from([2; 12]),
+            GuidPrefix::new([2; 12]),
             EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey),
         );
         let discovered_reader_data = DiscoveredReaderData {
@@ -1048,7 +1048,7 @@ mod test {
         let discovered_reader_data = DiscoveredReaderData {
             reader_proxy: ReaderProxy {
                 remote_reader_guid: Guid::new(
-                    GuidPrefix::from([2; 12]),
+                    GuidPrefix::new([2; 12]),
                     EntityId::new([2; 3], EntityKind::UserDefinedWriterWithKey),
                 ),
                 remote_group_entity_id: ENTITYID_UNKNOWN,

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::types::{Locator, EntityId, GuidPrefix, VendorId};
+use crate::implementation::rtps::types::{Locator, EntityId, GuidPrefix, VendorId, ProtocolVersion};
 
 ///
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.3
@@ -11,18 +11,8 @@ pub struct UShortSubmessageElement {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ShortSubmessageElement {
-    pub value: i16,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ULongSubmessageElement {
     pub value: u32,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct LongSubmessageElementConstructor {
-    pub value: i32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -42,7 +32,7 @@ pub struct VendorIdSubmessageElement {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProtocolVersionSubmessageElement {
-    pub value: [u8; 2],
+    pub value: ProtocolVersion,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::types::{Locator, EntityId, GuidPrefix, VendorId, ProtocolVersion};
+use crate::implementation::rtps::types::{Locator, EntityId, GuidPrefix, VendorId, ProtocolVersion, Count};
 
 ///
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.3
@@ -76,7 +76,7 @@ pub struct ParameterListSubmessageElement<'a> {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CountSubmessageElement {
-    pub value: i32,
+    pub value: Count,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::types::{Locator, EntityId, GuidPrefix};
+use crate::implementation::rtps::types::{Locator, EntityId, GuidPrefix, VendorId};
 
 ///
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.3
@@ -37,7 +37,7 @@ pub struct EntityIdSubmessageElement {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VendorIdSubmessageElement {
-    pub value: [u8; 2],
+    pub value: VendorId,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::types::{Locator, EntityId};
+use crate::implementation::rtps::types::{Locator, EntityId, GuidPrefix};
 
 ///
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.3
@@ -27,7 +27,7 @@ pub struct LongSubmessageElementConstructor {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GuidPrefixSubmessageElement {
-    pub value: [u8; 12],
+    pub value: GuidPrefix,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -55,7 +55,7 @@ impl RtpsReaderProxy {
             changes_for_reader: vec![],
             expects_inline_qos,
             is_active,
-            last_received_acknack_count: Count(0),
+            last_received_acknack_count: Count::new(0),
         }
     }
 }
@@ -74,11 +74,11 @@ impl RtpsReaderProxy {
     }
 
     pub fn reliable_receive_acknack(&mut self, acknack_submessage: &AckNackSubmessage) {
-        if acknack_submessage.count.value > self.last_received_acknack_count.0 {
+        if acknack_submessage.count.value > self.last_received_acknack_count {
             self.acked_changes_set(acknack_submessage.reader_sn_state.base - 1);
             self.requested_changes_set(acknack_submessage.reader_sn_state.set.as_ref());
 
-            self.last_received_acknack_count.0 = acknack_submessage.count.value;
+            self.last_received_acknack_count = acknack_submessage.count.value;
         }
     }
 }

--- a/dds/src/implementation/rtps/stateful_reader.rs
+++ b/dds/src/implementation/rtps/stateful_reader.rs
@@ -151,13 +151,13 @@ impl RtpsStatefulReader {
             let header = RtpsMessageHeader {
                 protocol: ProtocolId::PROTOCOL_RTPS,
                 version: ProtocolVersionSubmessageElement {
-                    value: PROTOCOLVERSION.into(),
+                    value: PROTOCOLVERSION,
                 },
                 vendor_id: VendorIdSubmessageElement {
                     value: VENDOR_ID_S2E,
                 },
                 guid_prefix: GuidPrefixSubmessageElement {
-                    value: self.reader().guid().prefix().into(),
+                    value: self.reader().guid().prefix(),
                 },
             };
 

--- a/dds/src/implementation/rtps/stateful_reader.rs
+++ b/dds/src/implementation/rtps/stateful_reader.rs
@@ -19,7 +19,7 @@ use super::{
     },
     reader::RtpsReader,
     transport::TransportWrite,
-    types::{Count, Guid, GuidPrefix, PROTOCOLVERSION, VENDOR_ID_S2E},
+    types::{Guid, GuidPrefix, PROTOCOLVERSION, VENDOR_ID_S2E},
     writer_proxy::RtpsWriterProxy,
 };
 
@@ -97,19 +97,15 @@ impl RtpsStatefulReader {
         source_guid_prefix: GuidPrefix,
     ) {
         if self.reader.get_qos().reliability.kind == ReliabilityQosPolicyKind::Reliable {
-            let writer_guid = Guid::new(
-                source_guid_prefix,
-                heartbeat_submessage.writer_id.value,
-            );
+            let writer_guid = Guid::new(source_guid_prefix, heartbeat_submessage.writer_id.value);
 
             if let Some(writer_proxy) = self
                 .matched_writers
                 .iter_mut()
                 .find(|x| x.remote_writer_guid() == writer_guid)
             {
-                if writer_proxy.last_received_heartbeat_count.0 != heartbeat_submessage.count.value
-                {
-                    writer_proxy.last_received_heartbeat_count.0 = heartbeat_submessage.count.value;
+                if writer_proxy.last_received_heartbeat_count != heartbeat_submessage.count.value {
+                    writer_proxy.last_received_heartbeat_count = heartbeat_submessage.count.value;
 
                     writer_proxy.must_send_acknacks = !heartbeat_submessage.final_flag
                         || (!heartbeat_submessage.liveliness_flag
@@ -130,7 +126,7 @@ impl RtpsStatefulReader {
         let entity_id = self.reader.guid().entity_id();
         for writer_proxy in self.matched_writers.iter_mut() {
             if writer_proxy.must_send_acknacks || !writer_proxy.missing_changes().is_empty() {
-                writer_proxy.acknack_count = Count(writer_proxy.acknack_count.0.wrapping_add(1));
+                writer_proxy.acknack_count = writer_proxy.acknack_count.wrapping_add(1);
 
                 writer_proxy.reliable_send_ack_nack(
                     entity_id,

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -41,7 +41,7 @@ impl<T: TimerConstructor> RtpsStatefulWriter<T> {
             writer,
             matched_readers: Vec::new(),
             heartbeat_timer: T::new(),
-            heartbeat_count: Count(0),
+            heartbeat_count: Count::new(0),
         }
     }
 }
@@ -263,7 +263,7 @@ impl<T: Timer> RtpsStatefulWriter<T> {
                 + std::time::Duration::from_nanos(self.writer.heartbeat_period().nanosec() as u64);
         if time_for_heartbeat {
             self.heartbeat_timer.reset();
-            self.heartbeat_count = Count(self.heartbeat_count.0.wrapping_add(1));
+            self.heartbeat_count = self.heartbeat_count.wrapping_add(1);
         }
         for reader_proxy in self.matched_readers.iter_mut() {
             let mut submessages = Vec::new();
@@ -294,7 +294,7 @@ impl<T: Timer> RtpsStatefulWriter<T> {
                 }
 
                 self.heartbeat_timer.reset();
-                self.heartbeat_count = Count(self.heartbeat_count.0.wrapping_add(1));
+                self.heartbeat_count = self.heartbeat_count.wrapping_add(1);
                 let heartbeat = HeartbeatSubmessage {
                     endianness_flag: true,
                     final_flag: false,
@@ -368,7 +368,7 @@ impl<T: Timer> RtpsStatefulWriter<T> {
                     }
                 }
                 self.heartbeat_timer.reset();
-                self.heartbeat_count = Count(self.heartbeat_count.0.wrapping_add(1));
+                self.heartbeat_count = self.heartbeat_count.wrapping_add(1);
                 let heartbeat = HeartbeatSubmessage {
                     endianness_flag: true,
                     final_flag: false,

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -312,7 +312,7 @@ impl<T: Timer> RtpsStatefulWriter<T> {
                         value: self.writer.writer_cache().get_seq_num_max().unwrap_or(0),
                     },
                     count: CountSubmessageElement {
-                        value: self.heartbeat_count.into(),
+                        value: self.heartbeat_count,
                     },
                 };
 
@@ -337,7 +337,7 @@ impl<T: Timer> RtpsStatefulWriter<T> {
                         value: self.writer.writer_cache().get_seq_num_max().unwrap_or(0),
                     },
                     count: CountSubmessageElement {
-                        value: self.heartbeat_count.into(),
+                        value: self.heartbeat_count,
                     },
                 };
 
@@ -386,7 +386,7 @@ impl<T: Timer> RtpsStatefulWriter<T> {
                         value: self.writer.writer_cache().get_seq_num_max().unwrap_or(0),
                     },
                     count: CountSubmessageElement {
-                        value: self.heartbeat_count.into(),
+                        value: self.heartbeat_count,
                     },
                 };
 

--- a/dds/src/implementation/rtps/stateless_writer.rs
+++ b/dds/src/implementation/rtps/stateless_writer.rs
@@ -25,7 +25,7 @@ impl RtpsStatelessWriter {
         Self {
             writer,
             reader_locators: Vec::new(),
-            _heartbeat_count: Count(0),
+            _heartbeat_count: Count::new(0),
         }
     }
 

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -91,6 +91,18 @@ impl TryFrom<BuiltInTopicKey> for Guid {
 pub struct GuidPrefix([u8; 12]);
 pub const GUIDPREFIX_UNKNOWN: GuidPrefix = GuidPrefix([0; 12]);
 
+impl GuidPrefix {
+    pub fn new(value: [u8; 12]) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<[u8; 12]> for GuidPrefix {
+    fn as_ref(&self) -> &[u8; 12] {
+        &self.0
+    }
+}
+
 impl From<GuidPrefix> for [u8; 12] {
     fn from(value: GuidPrefix) -> Self {
         value.0

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -301,8 +301,8 @@ pub enum ChangeKind {
 /// PROTOCOLVERSION is an alias for the most recent version, in this case PROTOCOLVERSION_2_4
 #[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ProtocolVersion {
-    pub major: u8,
-    pub minor: u8,
+    major: u8,
+    minor: u8,
 }
 
 pub const PROTOCOLVERSION: ProtocolVersion = PROTOCOLVERSION_2_4;
@@ -320,17 +320,15 @@ pub const PROTOCOLVERSION_2_2: ProtocolVersion = ProtocolVersion { major: 2, min
 pub const PROTOCOLVERSION_2_3: ProtocolVersion = ProtocolVersion { major: 2, minor: 3 };
 pub const PROTOCOLVERSION_2_4: ProtocolVersion = ProtocolVersion { major: 2, minor: 4 };
 
-impl From<ProtocolVersion> for [u8; 2] {
-    fn from(value: ProtocolVersion) -> Self {
-        [value.major, value.minor]
+impl ProtocolVersion {
+    pub fn new(major: u8, minor: u8) -> Self {
+        Self { major, minor }
     }
-}
-impl From<[u8; 2]> for ProtocolVersion {
-    fn from(value: [u8; 2]) -> Self {
-        Self {
-            major: value[0],
-            minor: value[1],
-        }
+    pub fn major(&self) -> u8 {
+        self.major
+    }
+    pub fn minor(&self) -> u8 {
+        self.minor
     }
 }
 

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -262,31 +262,6 @@ impl From<EntityKind> for u8 {
     }
 }
 
-// // Table 9.1 - entityKind octet of an EntityId_t
-// pub const USER_DEFINED_UNKNOWN: EntityKind = 0x00;
-// #[allow(dead_code)]
-// pub const BUILT_IN_UNKNOWN: EntityKind = 0xc0;
-// pub const BUILT_IN_PARTICIPANT: EntityKind = 0xc1;
-// pub const USER_DEFINED_WRITER_WITH_KEY: EntityKind = 0x02;
-// pub const BUILT_IN_WRITER_WITH_KEY: EntityKind = 0xc2;
-// pub const USER_DEFINED_WRITER_NO_KEY: EntityKind = 0x03;
-// #[allow(dead_code)]
-// pub const BUILT_IN_WRITER_NO_KEY: EntityKind = 0xc3;
-// #[allow(dead_code)]
-// pub const USER_DEFINED_READER_WITH_KEY: EntityKind = 0x07;
-// pub const BUILT_IN_READER_WITH_KEY: EntityKind = 0xc7;
-// #[allow(dead_code)]
-// pub const USER_DEFINED_READER_NO_KEY: EntityKind = 0x04;
-// #[allow(dead_code)]
-// pub const BUILT_IN_READER_NO_KEY: EntityKind = 0xc4;
-// pub const USER_DEFINED_WRITER_GROUP: EntityKind = 0x08;
-// pub const BUILT_IN_WRITER_GROUP: EntityKind = 0xc8;
-// pub const USER_DEFINED_READER_GROUP: EntityKind = 0x09;
-// pub const BUILT_IN_READER_GROUP: EntityKind = 0xc9;
-// // Added in comparison to the RTPS standard
-// pub const BUILT_IN_TOPIC: EntityKind = 0xca;
-// pub const USER_DEFINED_TOPIC: EntityKind = 0x0a;
-
 pub type EntityKey = [u8; 3];
 
 /// SequenceNumber_t
@@ -362,10 +337,22 @@ impl From<[u8; 2]> for ProtocolVersion {
 /// VendorId_t
 /// Type used to represent the vendor of the service implementing the RTPS protocol. The possible values for the vendorId are assigned by the OMG.
 /// The following values are reserved by the protocol: VENDORID_UNKNOWN
-pub type VendorId = [u8; 2];
-pub const VENDOR_ID_UNKNOWN: VendorId = [0, 0];
-pub const VENDOR_ID_S2E: VendorId = [99, 99];
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VendorId([u8; 2]);
+pub const VENDOR_ID_UNKNOWN: VendorId = VendorId([0, 0]);
+pub const VENDOR_ID_S2E: VendorId = VendorId([99, 99]);
 
+impl VendorId {
+    pub fn new(value: [u8; 2]) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<[u8; 2]> for VendorId {
+    fn as_ref(&self) -> &[u8; 2] {
+        &self.0
+    }
+}
 /// Count_t
 /// Type used to hold a count that is incremented monotonically, used to identify message duplicates.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -354,23 +354,29 @@ impl AsRef<[u8; 2]> for VendorId {
 /// Count_t
 /// Type used to hold a count that is incremented monotonically, used to identify message duplicates.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
-pub struct Count(pub i32);
+pub struct Count(i32);
 
+impl Count {
+    pub const fn new(value: i32) -> Self {
+        Self(value)
+    }
+    pub const fn wrapping_add(self, rhs: i32) -> Self {
+        Self(self.0.wrapping_add(rhs))
+    }
+}
+impl PartialOrd<Count> for Count {
+    fn partial_cmp(&self, other: &Count) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
 impl AddAssign for Count {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0;
     }
 }
-
-impl From<i32> for Count {
-    fn from(value: i32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Count> for i32 {
-    fn from(value: Count) -> Self {
-        value.0
+impl AsRef<i32> for Count {
+    fn as_ref(&self) -> &i32 {
+        &self.0
     }
 }
 
@@ -380,9 +386,9 @@ impl From<Count> for i32 {
 /// The following values are reserved by the protocol: LOCATOR_INVALID LOCATOR_KIND_INVALID LOCATOR_KIND_RESERVED LOCATOR_KIND_UDPv4 LOCATOR_KIND_UDPv6 LOCATOR_ADDRESS_INVALID LOCATOR_PORT_INVALID
 #[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Locator {
-    pub kind: LocatorKind,
-    pub port: LocatorPort,
-    pub address: LocatorAddress,
+    kind: LocatorKind,
+    port: LocatorPort,
+    address: LocatorAddress,
 }
 type LocatorKind = i32;
 type LocatorPort = u32;

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -103,18 +103,6 @@ impl AsRef<[u8; 12]> for GuidPrefix {
     }
 }
 
-impl From<GuidPrefix> for [u8; 12] {
-    fn from(value: GuidPrefix) -> Self {
-        value.0
-    }
-}
-
-impl From<[u8; 12]> for GuidPrefix {
-    fn from(value: [u8; 12]) -> Self {
-        Self(value)
-    }
-}
-
 /// EntityId_t
 /// Type used to hold the suffix part of the globally-unique RTPS-entity identifiers. The
 /// EntityId_t uniquely identifies an Entity within a Participant. Must be possible to represent using 4 octets.

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -88,8 +88,8 @@ impl RtpsWriterProxy {
             irrelevant_changes: Vec::new(),
             received_changes: Vec::new(),
             must_send_acknacks: false,
-            last_received_heartbeat_count: Count(0),
-            acknack_count: Count(0),
+            last_received_heartbeat_count: Count::new(0),
+            acknack_count: Count::new(0),
         }
     }
 }

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -45,7 +45,7 @@ impl RtpsWriterProxy {
             set: self.missing_changes(),
         };
         let count = CountSubmessageElement {
-            value: acknack_count.into(),
+            value: acknack_count,
         };
 
         let acknack_submessage = AckNackSubmessage {

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -148,7 +148,7 @@ mod tests {
                 submessages::DataSubmessage,
                 types::ProtocolId,
             },
-            types::{EntityId, EntityKind, GuidPrefix, VendorId},
+            types::{EntityId, EntityKind, GuidPrefix, ProtocolVersion, VendorId},
         },
         rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
     };
@@ -159,9 +159,15 @@ mod tests {
     fn serialize_rtps_message_no_submessage() {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
-            version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
-            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
+            version: ProtocolVersionSubmessageElement {
+                value: ProtocolVersion::new(2, 3),
+            },
+            vendor_id: VendorIdSubmessageElement {
+                value: VendorId::new([9, 8]),
+            },
+            guid_prefix: GuidPrefixSubmessageElement {
+                value: GuidPrefix::new([3; 12]),
+            },
         };
         let value = RtpsMessage {
             header,
@@ -181,9 +187,15 @@ mod tests {
     fn serialize_rtps_message() {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
-            version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
-            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
+            version: ProtocolVersionSubmessageElement {
+                value: ProtocolVersion::new(2, 3),
+            },
+            vendor_id: VendorIdSubmessageElement {
+                value: VendorId::new([9, 8]),
+            },
+            guid_prefix: GuidPrefixSubmessageElement {
+                value: GuidPrefix::new([3; 12]),
+            },
         };
         let endianness_flag = true;
         let inline_qos_flag = true;
@@ -253,9 +265,15 @@ mod tests {
     fn deserialize_rtps_message_no_submessage() {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
-            version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
-            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
+            version: ProtocolVersionSubmessageElement {
+                value: ProtocolVersion::new(2, 3),
+            },
+            vendor_id: VendorIdSubmessageElement {
+                value: VendorId::new([9, 8]),
+            },
+            guid_prefix: GuidPrefixSubmessageElement {
+                value: GuidPrefix::new([3; 12]),
+            },
         };
 
         let expected = RtpsMessage {
@@ -277,9 +295,15 @@ mod tests {
     fn deserialize_rtps_message() {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
-            version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
-            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
+            version: ProtocolVersionSubmessageElement {
+                value: ProtocolVersion::new(2, 3),
+            },
+            vendor_id: VendorIdSubmessageElement {
+                value: VendorId::new([9, 8]),
+            },
+            guid_prefix: GuidPrefixSubmessageElement {
+                value: GuidPrefix::new([3; 12]),
+            },
         };
         let endianness_flag = true;
         let inline_qos_flag = true;
@@ -350,9 +374,15 @@ mod tests {
     fn deserialize_rtps_message_unknown_submessage() {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
-            version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
-            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
+            version: ProtocolVersionSubmessageElement {
+                value: ProtocolVersion::new(2, 3),
+            },
+            vendor_id: VendorIdSubmessageElement {
+                value: VendorId::new([9, 8]),
+            },
+            guid_prefix: GuidPrefixSubmessageElement {
+                value: GuidPrefix::new([3; 12]),
+            },
         };
         let endianness_flag = true;
         let inline_qos_flag = true;

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -148,7 +148,7 @@ mod tests {
                 submessages::DataSubmessage,
                 types::ProtocolId,
             },
-            types::{EntityId, EntityKind, GuidPrefix},
+            types::{EntityId, EntityKind, GuidPrefix, VendorId},
         },
         rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
     };
@@ -160,7 +160,7 @@ mod tests {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: [9, 8] },
+            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
             guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         let value = RtpsMessage {
@@ -182,7 +182,7 @@ mod tests {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: [9, 8] },
+            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
             guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         let endianness_flag = true;
@@ -254,7 +254,7 @@ mod tests {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: [9, 8] },
+            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
             guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
 
@@ -278,7 +278,7 @@ mod tests {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: [9, 8] },
+            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
             guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         let endianness_flag = true;
@@ -351,7 +351,7 @@ mod tests {
         let header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: [9, 8] },
+            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
             guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         let endianness_flag = true;

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -148,7 +148,7 @@ mod tests {
                 submessages::DataSubmessage,
                 types::ProtocolId,
             },
-            types::{EntityId, EntityKind},
+            types::{EntityId, EntityKind, GuidPrefix},
         },
         rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
     };
@@ -161,7 +161,7 @@ mod tests {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
             vendor_id: VendorIdSubmessageElement { value: [9, 8] },
-            guid_prefix: GuidPrefixSubmessageElement { value: [3; 12] },
+            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         let value = RtpsMessage {
             header,
@@ -183,7 +183,7 @@ mod tests {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
             vendor_id: VendorIdSubmessageElement { value: [9, 8] },
-            guid_prefix: GuidPrefixSubmessageElement { value: [3; 12] },
+            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         let endianness_flag = true;
         let inline_qos_flag = true;
@@ -255,7 +255,7 @@ mod tests {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
             vendor_id: VendorIdSubmessageElement { value: [9, 8] },
-            guid_prefix: GuidPrefixSubmessageElement { value: [3; 12] },
+            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
 
         let expected = RtpsMessage {
@@ -279,7 +279,7 @@ mod tests {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
             vendor_id: VendorIdSubmessageElement { value: [9, 8] },
-            guid_prefix: GuidPrefixSubmessageElement { value: [3; 12] },
+            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         let endianness_flag = true;
         let inline_qos_flag = true;
@@ -352,7 +352,7 @@ mod tests {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
             vendor_id: VendorIdSubmessageElement { value: [9, 8] },
-            guid_prefix: GuidPrefixSubmessageElement { value: [3; 12] },
+            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         let endianness_flag = true;
         let inline_qos_flag = true;

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
@@ -50,7 +50,7 @@ mod tests {
         rtps::{messages::submessage_elements::{
             GuidPrefixSubmessageElement, ProtocolVersionSubmessageElement,
             VendorIdSubmessageElement,
-        }, types::GuidPrefix},
+        }, types::{GuidPrefix, VendorId}},
         rtps_udp_psm::mapping_traits::{from_bytes_le, to_bytes_le},
     };
 
@@ -61,7 +61,7 @@ mod tests {
         let value = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: [9, 8] },
+            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
             guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         #[rustfmt::skip]
@@ -79,7 +79,7 @@ mod tests {
         let expected = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: [9, 8] },
+            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
             guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         #[rustfmt::skip]

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
@@ -47,10 +47,10 @@ impl<'de> MappingReadByteOrdered<'de> for RtpsMessageHeader {
 #[cfg(test)]
 mod tests {
     use crate::implementation::{
-        rtps::messages::submessage_elements::{
+        rtps::{messages::submessage_elements::{
             GuidPrefixSubmessageElement, ProtocolVersionSubmessageElement,
             VendorIdSubmessageElement,
-        },
+        }, types::GuidPrefix},
         rtps_udp_psm::mapping_traits::{from_bytes_le, to_bytes_le},
     };
 
@@ -62,7 +62,7 @@ mod tests {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
             vendor_id: VendorIdSubmessageElement { value: [9, 8] },
-            guid_prefix: GuidPrefixSubmessageElement { value: [3; 12] },
+            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         #[rustfmt::skip]
         assert_eq!(to_bytes_le(&value).unwrap(), vec![
@@ -80,7 +80,7 @@ mod tests {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersionSubmessageElement { value: [2, 3] },
             vendor_id: VendorIdSubmessageElement { value: [9, 8] },
-            guid_prefix: GuidPrefixSubmessageElement { value: [3; 12] },
+            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
         };
         #[rustfmt::skip]
         let result = from_bytes_le(&[

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/rtps_header.rs
@@ -47,10 +47,13 @@ impl<'de> MappingReadByteOrdered<'de> for RtpsMessageHeader {
 #[cfg(test)]
 mod tests {
     use crate::implementation::{
-        rtps::{messages::submessage_elements::{
-            GuidPrefixSubmessageElement, ProtocolVersionSubmessageElement,
-            VendorIdSubmessageElement,
-        }, types::{GuidPrefix, VendorId}},
+        rtps::{
+            messages::submessage_elements::{
+                GuidPrefixSubmessageElement, ProtocolVersionSubmessageElement,
+                VendorIdSubmessageElement,
+            },
+            types::{GuidPrefix, ProtocolVersion, VendorId},
+        },
         rtps_udp_psm::mapping_traits::{from_bytes_le, to_bytes_le},
     };
 
@@ -60,9 +63,15 @@ mod tests {
     fn serialize_rtps_header() {
         let value = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
-            version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
-            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
+            version: ProtocolVersionSubmessageElement {
+                value: ProtocolVersion::new(2, 3),
+            },
+            vendor_id: VendorIdSubmessageElement {
+                value: VendorId::new([9, 8]),
+            },
+            guid_prefix: GuidPrefixSubmessageElement {
+                value: GuidPrefix::new([3; 12]),
+            },
         };
         #[rustfmt::skip]
         assert_eq!(to_bytes_le(&value).unwrap(), vec![
@@ -78,9 +87,15 @@ mod tests {
     fn deserialize_rtps_header() {
         let expected = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
-            version: ProtocolVersionSubmessageElement { value: [2, 3] },
-            vendor_id: VendorIdSubmessageElement { value: VendorId::new([9, 8]) },
-            guid_prefix: GuidPrefixSubmessageElement { value: GuidPrefix::new([3; 12]) },
+            version: ProtocolVersionSubmessageElement {
+                value: ProtocolVersion::new(2, 3),
+            },
+            vendor_id: VendorIdSubmessageElement {
+                value: VendorId::new([9, 8]),
+            },
+            guid_prefix: GuidPrefixSubmessageElement {
+                value: GuidPrefix::new([3; 12]),
+            },
         };
         #[rustfmt::skip]
         let result = from_bytes_le(&[

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/count.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/count.rs
@@ -3,11 +3,29 @@ use std::io::{Error, Write};
 use byteorder::ByteOrder;
 
 use crate::implementation::{
-    rtps::messages::submessage_elements::CountSubmessageElement,
+    rtps::{messages::submessage_elements::CountSubmessageElement, types::Count},
     rtps_udp_psm::mapping_traits::{
         MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
     },
 };
+
+impl MappingWriteByteOrdered for Count {
+    fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(
+        &self,
+        mut writer: W,
+    ) -> Result<(), Error> {
+        self.as_ref()
+            .mapping_write_byte_ordered::<_, B>(&mut writer)
+    }
+}
+
+impl<'de> MappingReadByteOrdered<'de> for Count {
+    fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        Ok(Self::new(
+            MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
+        ))
+    }
+}
 
 impl MappingWriteByteOrdered for CountSubmessageElement {
     fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(
@@ -40,7 +58,9 @@ mod tests {
 
     #[test]
     fn serialize_guid_prefix() {
-        let data = CountSubmessageElement { value: 7 };
+        let data = CountSubmessageElement {
+            value: Count::new(7),
+        };
         assert_eq!(
             to_bytes_le(&data).unwrap(),
             vec![
@@ -51,7 +71,9 @@ mod tests {
 
     #[test]
     fn deserialize_guid_prefix() {
-        let expected = CountSubmessageElement { value: 7 };
+        let expected = CountSubmessageElement {
+            value: Count::new(7),
+        };
         assert_eq!(
             expected,
             from_bytes_le(&[

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/guid_prefix.rs
@@ -3,9 +3,21 @@ use std::io::{Error, Write};
 use byteorder::ByteOrder;
 
 use crate::implementation::{
-    rtps::messages::submessage_elements::GuidPrefixSubmessageElement,
+    rtps::{messages::submessage_elements::GuidPrefixSubmessageElement, types::GuidPrefix},
     rtps_udp_psm::mapping_traits::{MappingReadByteOrdered, MappingWriteByteOrdered},
 };
+
+impl MappingWriteByteOrdered for GuidPrefix {
+    fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(&self, mut writer: W) -> Result<(), Error> {
+        self.as_ref().mapping_write_byte_ordered::<_, B>(&mut writer)
+    }
+}
+
+impl<'de> MappingReadByteOrdered<'de> for GuidPrefix {
+    fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        Ok(Self::new(MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?))
+    }
+}
 
 impl MappingWriteByteOrdered for GuidPrefixSubmessageElement {
     fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(
@@ -33,7 +45,7 @@ mod tests {
 
     #[test]
     fn serialize_guid_prefix() {
-        let data = GuidPrefixSubmessageElement { value: [1; 12] };
+        let data = GuidPrefixSubmessageElement { value: GuidPrefix::new([1; 12]) };
         #[rustfmt::skip]
         assert_eq!(to_bytes_le(&data).unwrap(), vec![
             1, 1, 1, 1,
@@ -44,7 +56,7 @@ mod tests {
 
     #[test]
     fn deserialize_guid_prefix() {
-        let expected = GuidPrefixSubmessageElement { value: [1; 12] };
+        let expected = GuidPrefixSubmessageElement { value: GuidPrefix::new([1; 12]) };
         #[rustfmt::skip]
         assert_eq!(expected, from_bytes_le(&[
             1, 1, 1, 1,

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/vendor_id.rs
@@ -3,9 +3,21 @@ use std::io::{Error, Write};
 use byteorder::{ByteOrder};
 
 use crate::implementation::{
-    rtps::messages::submessage_elements::VendorIdSubmessageElement,
+    rtps::{messages::submessage_elements::VendorIdSubmessageElement, types::VendorId},
     rtps_udp_psm::mapping_traits::{MappingReadByteOrdered, MappingWriteByteOrdered},
 };
+
+impl MappingWriteByteOrdered for VendorId {
+    fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(&self, mut writer: W) -> Result<(), Error> {
+        self.as_ref().mapping_write_byte_ordered::<_, B>(&mut writer)
+    }
+}
+
+impl<'de> MappingReadByteOrdered<'de> for VendorId {
+    fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        Ok(Self::new(MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?))
+    }
+}
 
 impl MappingWriteByteOrdered for VendorIdSubmessageElement {
     fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(
@@ -26,19 +38,19 @@ impl<'de> MappingReadByteOrdered<'de> for VendorIdSubmessageElement {
 
 #[cfg(test)]
 mod tests {
-    use crate::implementation::rtps_udp_psm::mapping_traits::{from_bytes_le, to_bytes_le};
+    use crate::implementation::{rtps_udp_psm::mapping_traits::{from_bytes_le, to_bytes_le}, rtps::types::VendorId};
 
     use super::*;
 
     #[test]
     fn serialize_vendor_id() {
-        let data = VendorIdSubmessageElement { value: [1, 2] };
+        let data = VendorIdSubmessageElement { value: VendorId::new([1, 2]) };
         assert_eq!(to_bytes_le(&data).unwrap(), vec![1, 2,]);
     }
 
     #[test]
     fn deserialize_vendor_id() {
-        let expected = VendorIdSubmessageElement { value: [1, 2] };
+        let expected = VendorIdSubmessageElement { value: VendorId::new([1, 2]) };
         assert_eq!(expected, from_bytes_le(&[1, 2,]).unwrap());
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/ack_nack.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/ack_nack.rs
@@ -76,9 +76,13 @@ impl<'de> MappingReadSubmessage<'de> for AckNackSubmessage {
 #[cfg(test)]
 mod tests {
     use crate::implementation::{
-        rtps::{messages::submessage_elements::{
-            CountSubmessageElement, EntityIdSubmessageElement, SequenceNumberSetSubmessageElement,
-        }, types::{EntityId, EntityKind}},
+        rtps::{
+            messages::submessage_elements::{
+                CountSubmessageElement, EntityIdSubmessageElement,
+                SequenceNumberSetSubmessageElement,
+            },
+            types::{Count, EntityId, EntityKind},
+        },
         rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
     };
 
@@ -103,7 +107,9 @@ mod tests {
                 base: 10,
                 set: vec![],
             },
-            count: CountSubmessageElement { value: 0 },
+            count: CountSubmessageElement {
+                value: Count::new(0),
+            },
         };
         #[rustfmt::skip]
         assert_eq!(to_bytes(&submessage).unwrap(), vec![
@@ -145,7 +151,9 @@ mod tests {
                     base: 10,
                     set: vec![],
                 },
-                count: CountSubmessageElement { value: 0 },
+                count: CountSubmessageElement {
+                    value: Count::new(0)
+                },
             },
             from_bytes(&buf).unwrap()
         );

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat.rs
@@ -74,9 +74,12 @@ impl<'de> MappingReadSubmessage<'de> for HeartbeatSubmessage {
 mod tests {
 
     use crate::implementation::{
-        rtps::{messages::submessage_elements::{
-            CountSubmessageElement, EntityIdSubmessageElement, SequenceNumberSubmessageElement,
-        }, types::{EntityId, EntityKind}},
+        rtps::{
+            messages::submessage_elements::{
+                CountSubmessageElement, EntityIdSubmessageElement, SequenceNumberSubmessageElement,
+            },
+            types::{Count, EntityId, EntityKind},
+        },
         rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
     };
 
@@ -95,7 +98,9 @@ mod tests {
         };
         let first_sn = SequenceNumberSubmessageElement { value: 5 };
         let last_sn = SequenceNumberSubmessageElement { value: 7 };
-        let count = CountSubmessageElement { value: 2 };
+        let count = CountSubmessageElement {
+            value: Count::new(2),
+        };
         let submessage = HeartbeatSubmessage {
             endianness_flag,
             final_flag,
@@ -133,7 +138,9 @@ mod tests {
         };
         let first_sn = SequenceNumberSubmessageElement { value: 5 };
         let last_sn = SequenceNumberSubmessageElement { value: 7 };
-        let count = CountSubmessageElement { value: 2 };
+        let count = CountSubmessageElement {
+            value: Count::new(2),
+        };
         let expected = HeartbeatSubmessage {
             endianness_flag,
             final_flag,

--- a/dds/src/infrastructure/instance.rs
+++ b/dds/src/infrastructure/instance.rs
@@ -40,7 +40,7 @@ impl From<Guid> for InstanceHandle {
 
 impl From<InstanceHandle> for Guid {
     fn from(x: InstanceHandle) -> Self {
-        let prefix = GuidPrefix::from(<[u8; 12]>::try_from(&x.0[0..12]).expect("Invalid length"));
+        let prefix = GuidPrefix::new(<[u8; 12]>::try_from(&x.0[0..12]).expect("Invalid length"));
         let entity_id = EntityId::new(
             <[u8; 3]>::try_from(&x.0[12..15]).expect("Invalid length"),
             TryFrom::try_from(x.0[15]).unwrap(),


### PR DESCRIPTION
Replace types of submessage elements by non representation types. So far the types as they were intended of the UDP mapping were used. This is unnecessary since the impl of the Mapping traits makes sure the submessage elements are mapped as specified. 