### PR TITLE
DDS-239 Fix QoS consistency bug

### DIFF
--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -12,7 +12,7 @@ use crate::{
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::DataReaderQos,
-        qos_policy::{DestinationOrderQosPolicyKind, HistoryQosPolicyKind, LENGTH_UNLIMITED},
+        qos_policy::{DestinationOrderQosPolicyKind, HistoryQosPolicyKind},
         status::StatusKind,
         time::{Duration, Time},
     },
@@ -267,29 +267,25 @@ impl RtpsReader {
             })
             .collect();
 
-        let max_samples_limit_not_reached = self.qos.resource_limits.max_samples
-            == LENGTH_UNLIMITED
-            || (self.changes.len() as i32) < self.qos.resource_limits.max_samples;
+        let max_samples_limit_not_reached =
+            self.changes.len() < self.qos.resource_limits.max_samples;
 
         let max_instances_limit_not_reached = instance_handle_list
             .contains(&change_instance_handle)
-            || self.qos.resource_limits.max_instances == LENGTH_UNLIMITED
-            || (instance_handle_list.len() as i32) < self.qos.resource_limits.max_instances;
+            || instance_handle_list.len() < self.qos.resource_limits.max_instances;
 
-        let max_samples_per_instance_limit_not_reached =
-            self.qos.resource_limits.max_samples_per_instance == LENGTH_UNLIMITED
-                || (self
-                    .changes
-                    .as_slice()
-                    .iter()
-                    .filter(|cc| {
-                        self.instance_handle_builder
-                            .build_instance_handle(change_kind, cc.data.as_slice())
-                            .unwrap()
-                            == change_instance_handle
-                    })
-                    .count() as i32)
-                    < self.qos.resource_limits.max_samples_per_instance;
+        let max_samples_per_instance_limit_not_reached = self
+            .changes
+            .as_slice()
+            .iter()
+            .filter(|cc| {
+                self.instance_handle_builder
+                    .build_instance_handle(change_kind, cc.data.as_slice())
+                    .unwrap()
+                    == change_instance_handle
+            })
+            .count()
+            < self.qos.resource_limits.max_samples_per_instance;
 
         if max_samples_limit_not_reached
             && max_instances_limit_not_reached
@@ -574,7 +570,7 @@ mod tests {
         },
         infrastructure::{
             error::DdsError,
-            qos_policy::{HistoryQosPolicy, ResourceLimitsQosPolicy},
+            qos_policy::{HistoryQosPolicy, Length, ResourceLimitsQosPolicy},
             time::{DURATION_ZERO, TIME_INVALID},
         },
         subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
@@ -1018,12 +1014,12 @@ mod tests {
         let qos = DataReaderQos {
             history: HistoryQosPolicy {
                 kind: HistoryQosPolicyKind::KeepAll,
-                depth: LENGTH_UNLIMITED,
+                ..Default::default()
             },
             resource_limits: ResourceLimitsQosPolicy {
-                max_samples: 1,
-                max_instances: LENGTH_UNLIMITED,
-                max_samples_per_instance: LENGTH_UNLIMITED,
+                max_samples: Length::Limited(1),
+                max_instances: Length::Unlimited,
+                max_samples_per_instance: Length::Unlimited,
             },
             ..Default::default()
         };
@@ -1062,12 +1058,12 @@ mod tests {
         let qos = DataReaderQos {
             history: HistoryQosPolicy {
                 kind: HistoryQosPolicyKind::KeepAll,
-                depth: LENGTH_UNLIMITED,
+                ..Default::default()
             },
             resource_limits: ResourceLimitsQosPolicy {
-                max_samples: LENGTH_UNLIMITED,
-                max_instances: 1,
-                max_samples_per_instance: LENGTH_UNLIMITED,
+                max_samples: Length::Unlimited,
+                max_instances: Length::Limited(1),
+                max_samples_per_instance: Length::Unlimited,
             },
             ..Default::default()
         };
@@ -1112,12 +1108,12 @@ mod tests {
         let qos = DataReaderQos {
             history: HistoryQosPolicy {
                 kind: HistoryQosPolicyKind::KeepAll,
-                depth: LENGTH_UNLIMITED,
+                ..Default::default()
             },
             resource_limits: ResourceLimitsQosPolicy {
-                max_samples: LENGTH_UNLIMITED,
-                max_instances: LENGTH_UNLIMITED,
-                max_samples_per_instance: 1,
+                max_samples: Length::Unlimited,
+                max_instances: Length::Unlimited,
+                max_samples_per_instance: Length::Limited(1),
             },
             ..Default::default()
         };
@@ -1176,7 +1172,7 @@ mod tests {
         let qos = DataReaderQos {
             history: HistoryQosPolicy {
                 kind: HistoryQosPolicyKind::KeepAll,
-                depth: LENGTH_UNLIMITED,
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -1293,7 +1289,7 @@ mod tests {
         let qos = DataReaderQos {
             history: HistoryQosPolicy {
                 kind: HistoryQosPolicyKind::KeepAll,
-                depth: LENGTH_UNLIMITED,
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -1423,7 +1419,7 @@ mod tests {
         let qos = DataReaderQos {
             history: HistoryQosPolicy {
                 kind: HistoryQosPolicyKind::KeepAll,
-                depth: LENGTH_UNLIMITED,
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -280,7 +280,7 @@ impl RtpsReader {
             .iter()
             .filter(|cc| {
                 self.instance_handle_builder
-                    .build_instance_handle(change_kind, cc.data.as_slice())
+                    .build_instance_handle(cc.kind, cc.data.as_slice())
                     .unwrap()
                     == change_instance_handle
             })

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -11,7 +11,6 @@ use crate::{
         error::{DdsError, DdsResult},
         instance::{InstanceHandle, HANDLE_NIL},
         qos::DataWriterQos,
-        qos_policy::LENGTH_UNLIMITED,
         time::{Duration, Time},
     },
     topic_definition::type_support::{DdsSerialize, DdsSerializedKey, DdsType, LittleEndian},
@@ -286,10 +285,7 @@ impl RtpsWriter {
         let instance_handle = instance.get_serialized_key().into();
 
         if !self.registered_instance_list.contains_key(&instance_handle) {
-            if self.qos.resource_limits.max_instances == LENGTH_UNLIMITED
-                || (self.registered_instance_list.len() as i32)
-                    < self.qos.resource_limits.max_instances
-            {
+            if self.registered_instance_list.len() < self.qos.resource_limits.max_instances {
                 self.registered_instance_list
                     .insert(instance_handle, serialized_key);
             } else {

--- a/dds/src/infrastructure/qos.rs
+++ b/dds/src/infrastructure/qos.rs
@@ -96,14 +96,14 @@ impl DataWriterQos {
     pub fn is_consistent(&self) -> DdsResult<()> {
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
         // values to be consistent they must verify that “max_samples >= max_samples_per_instanc
-        if !(self.resource_limits.max_samples >= self.resource_limits.max_samples_per_instance) {
+        if self.resource_limits.max_samples < self.resource_limits.max_samples_per_instance {
             return Err(DdsError::InconsistentPolicy);
         }
 
         // The setting of RESOURCE_LIMITS max_samples_per_instance must be consistent with the HISTORY depth. For these two
         // QoS to be consistent, they must verify that “depth <= max_samples_per_instance.”
         if self.history.kind == HistoryQosPolicyKind::KeepLast
-            && !(self.history.depth as usize <= self.resource_limits.max_samples_per_instance)
+            && self.history.depth as usize > self.resource_limits.max_samples_per_instance
         {
             return Err(DdsError::InconsistentPolicy);
         }
@@ -189,21 +189,21 @@ impl DataReaderQos {
     pub fn is_consistent(&self) -> DdsResult<()> {
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
         // values to be consistent they must verify that “max_samples >= max_samples_per_instance.”
-        if !(self.resource_limits.max_samples >= self.resource_limits.max_samples_per_instance) {
+        if self.resource_limits.max_samples < self.resource_limits.max_samples_per_instance {
             return Err(DdsError::InconsistentPolicy);
         }
 
         // The setting of RESOURCE_LIMITS max_samples_per_instance must be consistent with the HISTORY depth. For these two
         // QoS to be consistent, they must verify that “depth <= max_samples_per_instance.”
         if self.history.kind == HistoryQosPolicyKind::KeepLast
-            && !(self.history.depth as usize <= self.resource_limits.max_samples_per_instance)
+            && self.history.depth as usize > self.resource_limits.max_samples_per_instance
         {
             return Err(DdsError::InconsistentPolicy);
         }
 
         // The setting of the DEADLINE policy must be set consistently with that of the TIME_BASED_FILTER. For these two policies
         // to be consistent the settings must be such that “deadline period>= minimum_separation.”
-        if !(self.deadline.period >= self.time_based_filter.minimum_separation) {
+        if self.deadline.period < self.time_based_filter.minimum_separation {
             return Err(DdsError::InconsistentPolicy);
         }
 
@@ -269,14 +269,14 @@ impl TopicQos {
     pub fn is_consistent(&self) -> DdsResult<()> {
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
         // values to be consistent they must verify that “max_samples >= max_samples_per_instance.”
-        if !(self.resource_limits.max_samples >= self.resource_limits.max_samples_per_instance) {
+        if self.resource_limits.max_samples < self.resource_limits.max_samples_per_instance {
             return Err(DdsError::InconsistentPolicy);
         }
 
         // The setting of RESOURCE_LIMITS max_samples_per_instance must be consistent with the HISTORY depth. For these two
         // QoS to be consistent, they must verify that “depth <= max_samples_per_instance.”
         if self.history.kind == HistoryQosPolicyKind::KeepLast
-            && !(self.history.depth as usize <= self.resource_limits.max_samples_per_instance)
+            && self.history.depth as usize > self.resource_limits.max_samples_per_instance
         {
             return Err(DdsError::InconsistentPolicy);
         }

--- a/dds/src/infrastructure/qos.rs
+++ b/dds/src/infrastructure/qos.rs
@@ -299,3 +299,106 @@ impl TopicQos {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::infrastructure::qos_policy::Length;
+
+    use super::*;
+
+    #[test]
+    fn data_writer_qos_consistency() {
+        assert_eq!(DataWriterQos::default().is_consistent(), Ok(()));
+        assert_eq!(
+            DataWriterQos {
+                resource_limits: ResourceLimitsQosPolicy {
+                    max_samples_per_instance: Length::Limited(2),
+                    max_samples: Length::Limited(1),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+            .is_consistent(),
+            Err(DdsError::InconsistentPolicy)
+        );
+        assert_eq!(
+            DataWriterQos {
+                history: HistoryQosPolicy {
+                    kind: HistoryQosPolicyKind::KeepLast,
+                    depth: 3
+                },
+                resource_limits: ResourceLimitsQosPolicy {
+                    max_samples_per_instance: Length::Limited(2),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+            .is_consistent(),
+            Err(DdsError::InconsistentPolicy)
+        );
+    }
+
+    #[test]
+    fn data_reader_qos_consistency() {
+        assert_eq!(DataReaderQos::default().is_consistent(), Ok(()));
+        assert_eq!(
+            DataReaderQos {
+                resource_limits: ResourceLimitsQosPolicy {
+                    max_samples_per_instance: Length::Limited(2),
+                    max_samples: Length::Limited(1),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+            .is_consistent(),
+            Err(DdsError::InconsistentPolicy)
+        );
+        assert_eq!(
+            DataReaderQos {
+                history: HistoryQosPolicy {
+                    kind: HistoryQosPolicyKind::KeepLast,
+                    depth: 3
+                },
+                resource_limits: ResourceLimitsQosPolicy {
+                    max_samples_per_instance: Length::Limited(2),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+            .is_consistent(),
+            Err(DdsError::InconsistentPolicy)
+        );
+    }
+
+    #[test]
+    fn topic_qos_consistency() {
+        assert_eq!(TopicQos::default().is_consistent(), Ok(()));
+        assert_eq!(
+            TopicQos {
+                resource_limits: ResourceLimitsQosPolicy {
+                    max_samples_per_instance: Length::Limited(2),
+                    max_samples: Length::Limited(1),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+            .is_consistent(),
+            Err(DdsError::InconsistentPolicy)
+        );
+        assert_eq!(
+            TopicQos {
+                history: HistoryQosPolicy {
+                    kind: HistoryQosPolicyKind::KeepLast,
+                    depth: 3
+                },
+                resource_limits: ResourceLimitsQosPolicy {
+                    max_samples_per_instance: Length::Limited(2),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+            .is_consistent(),
+            Err(DdsError::InconsistentPolicy)
+        );
+    }
+}

--- a/dds/src/infrastructure/qos.rs
+++ b/dds/src/infrastructure/qos.rs
@@ -10,7 +10,7 @@ use super::qos_policy::{
     PresentationQosPolicy, ReaderDataLifecycleQosPolicy, ReliabilityQosPolicy,
     ReliabilityQosPolicyKind, ResourceLimitsQosPolicy, TimeBasedFilterQosPolicy,
     TopicDataQosPolicy, TransportPriorityQosPolicy, UserDataQosPolicy,
-    WriterDataLifecycleQosPolicy, LENGTH_UNLIMITED,
+    WriterDataLifecycleQosPolicy,
 };
 
 /// QoS policies applicable to the [`DomainParticipantFactory`](crate::domain::domain_participant_factory::DomainParticipantFactory)
@@ -95,25 +95,15 @@ impl Default for DataWriterQos {
 impl DataWriterQos {
     pub fn is_consistent(&self) -> DdsResult<()> {
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
-        // values to be consistent they must verify that “max_samples >= max_samples_per_instance.”
-        let limited_samples = self.resource_limits.max_samples != LENGTH_UNLIMITED;
-        let samples_per_instance_over_limit = self.resource_limits.max_samples == LENGTH_UNLIMITED
-            || self.resource_limits.max_samples_per_instance > self.resource_limits.max_samples;
-
-        if limited_samples && samples_per_instance_over_limit {
+        // values to be consistent they must verify that “max_samples >= max_samples_per_instanc
+        if !(self.resource_limits.max_samples >= self.resource_limits.max_samples_per_instance) {
             return Err(DdsError::InconsistentPolicy);
         }
 
         // The setting of RESOURCE_LIMITS max_samples_per_instance must be consistent with the HISTORY depth. For these two
         // QoS to be consistent, they must verify that “depth <= max_samples_per_instance.”
-        let limited_samples_per_instance =
-            self.resource_limits.max_samples_per_instance != LENGTH_UNLIMITED;
-        let history_depth_over_limit = self.history.depth == LENGTH_UNLIMITED
-            || self.history.depth > self.resource_limits.max_samples_per_instance;
-
         if self.history.kind == HistoryQosPolicyKind::KeepLast
-            && limited_samples_per_instance
-            && history_depth_over_limit
+            && !(self.history.depth as usize <= self.resource_limits.max_samples_per_instance)
         {
             return Err(DdsError::InconsistentPolicy);
         }
@@ -199,31 +189,21 @@ impl DataReaderQos {
     pub fn is_consistent(&self) -> DdsResult<()> {
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
         // values to be consistent they must verify that “max_samples >= max_samples_per_instance.”
-        let limited_samples = self.resource_limits.max_samples != LENGTH_UNLIMITED;
-        let samples_per_instance_over_limit = self.resource_limits.max_samples == LENGTH_UNLIMITED
-            || self.resource_limits.max_samples_per_instance > self.resource_limits.max_samples;
-
-        if limited_samples && samples_per_instance_over_limit {
+        if !(self.resource_limits.max_samples >= self.resource_limits.max_samples_per_instance) {
             return Err(DdsError::InconsistentPolicy);
         }
 
         // The setting of RESOURCE_LIMITS max_samples_per_instance must be consistent with the HISTORY depth. For these two
         // QoS to be consistent, they must verify that “depth <= max_samples_per_instance.”
-        let limited_samples_per_instance =
-            self.resource_limits.max_samples_per_instance != LENGTH_UNLIMITED;
-        let history_depth_over_limit = self.history.depth == LENGTH_UNLIMITED
-            || self.history.depth > self.resource_limits.max_samples_per_instance;
-
         if self.history.kind == HistoryQosPolicyKind::KeepLast
-            && limited_samples_per_instance
-            && history_depth_over_limit
+            && !(self.history.depth as usize <= self.resource_limits.max_samples_per_instance)
         {
             return Err(DdsError::InconsistentPolicy);
         }
 
         // The setting of the DEADLINE policy must be set consistently with that of the TIME_BASED_FILTER. For these two policies
         // to be consistent the settings must be such that “deadline period>= minimum_separation.”
-        if self.deadline.period < self.time_based_filter.minimum_separation {
+        if !(self.deadline.period >= self.time_based_filter.minimum_separation) {
             return Err(DdsError::InconsistentPolicy);
         }
 
@@ -289,24 +269,14 @@ impl TopicQos {
     pub fn is_consistent(&self) -> DdsResult<()> {
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
         // values to be consistent they must verify that “max_samples >= max_samples_per_instance.”
-        let limited_samples = self.resource_limits.max_samples != LENGTH_UNLIMITED;
-        let samples_per_instance_over_limit = self.resource_limits.max_samples == LENGTH_UNLIMITED
-            || self.resource_limits.max_samples_per_instance > self.resource_limits.max_samples;
-
-        if limited_samples && samples_per_instance_over_limit {
+        if !(self.resource_limits.max_samples >= self.resource_limits.max_samples_per_instance) {
             return Err(DdsError::InconsistentPolicy);
         }
 
         // The setting of RESOURCE_LIMITS max_samples_per_instance must be consistent with the HISTORY depth. For these two
         // QoS to be consistent, they must verify that “depth <= max_samples_per_instance.”
-        let limited_samples_per_instance =
-            self.resource_limits.max_samples_per_instance != LENGTH_UNLIMITED;
-        let history_depth_over_limit = self.history.depth == LENGTH_UNLIMITED
-            || self.history.depth > self.resource_limits.max_samples_per_instance;
-
         if self.history.kind == HistoryQosPolicyKind::KeepLast
-            && limited_samples_per_instance
-            && history_depth_over_limit
+            && !(self.history.depth as usize <= self.resource_limits.max_samples_per_instance)
         {
             return Err(DdsError::InconsistentPolicy);
         }

--- a/dds/src/infrastructure/qos_policy.rs
+++ b/dds/src/infrastructure/qos_policy.rs
@@ -1075,4 +1075,23 @@ mod tests {
                 == DestinationOrderQosPolicyKind::BySourceTimestamp
         );
     }
+
+    #[test]
+    fn length_ordering() {
+        assert!(Length::Unlimited > Length::Limited(10));
+        assert!(Length::Unlimited == Length::Unlimited);
+        assert!(Length::Limited(10) < Length::Unlimited);
+        assert!(Length::Limited(10) < Length::Limited(20));
+        assert!(Length::Limited(20) > Length::Limited(10));
+    }
+
+    #[test]
+    fn length_usize_ordering() {
+        assert!(Length::Unlimited > 10usize);
+        assert!(10usize < Length::Unlimited);
+        assert!(Length::Limited(20) > 10usize);
+        assert!(10usize < Length::Limited(20));
+        assert!(Length::Limited(10) == 10usize);
+        assert!(10usize == Length::Limited(10));
+    }
 }

--- a/dds/tests/write_read_unkeyed_topic.rs
+++ b/dds/tests/write_read_unkeyed_topic.rs
@@ -1,17 +1,20 @@
-use dust_dds::infrastructure::qos::{DataReaderQos, DataWriterQos, QosKind};
-use dust_dds::infrastructure::qos_policy::{
-    DestinationOrderQosPolicy, DestinationOrderQosPolicyKind, HistoryQosPolicy,
-    HistoryQosPolicyKind, ReliabilityQosPolicy, ReliabilityQosPolicyKind, ResourceLimitsQosPolicy,
-    LENGTH_UNLIMITED,
+use dust_dds::{
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        qos::{DataReaderQos, DataWriterQos, QosKind},
+        qos_policy::{
+            DestinationOrderQosPolicy, DestinationOrderQosPolicyKind, HistoryQosPolicy,
+            HistoryQosPolicyKind, Length, ReliabilityQosPolicy, ReliabilityQosPolicyKind,
+            ResourceLimitsQosPolicy,
+        },
+        status::{StatusKind, NO_STATUS},
+        time::{Duration, Time},
+        wait_set::{Condition, WaitSet},
+    },
+    subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+    topic_definition::type_support::{DdsSerde, DdsType},
 };
-use dust_dds::topic_definition::type_support::{DdsSerde, DdsType};
 
-use dust_dds::infrastructure::status::{StatusKind, NO_STATUS};
-use dust_dds::infrastructure::time::{Duration, Time};
-use dust_dds::infrastructure::wait_set::{Condition, WaitSet};
-
-use dust_dds::domain::domain_participant_factory::DomainParticipantFactory;
-use dust_dds::subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE};
 #[derive(Debug, PartialEq, DdsType, DdsSerde, serde::Serialize, serde::Deserialize)]
 struct UserData(u8);
 
@@ -109,7 +112,7 @@ fn data_reader_resource_limits() {
         },
         history: HistoryQosPolicy {
             kind: HistoryQosPolicyKind::KeepAll,
-            depth: LENGTH_UNLIMITED,
+            ..Default::default()
         },
         ..Default::default()
     };
@@ -127,12 +130,12 @@ fn data_reader_resource_limits() {
         },
         history: HistoryQosPolicy {
             kind: HistoryQosPolicyKind::KeepAll,
-            depth: LENGTH_UNLIMITED,
+            ..Default::default()
         },
         resource_limits: ResourceLimitsQosPolicy {
-            max_samples: 2,
-            max_instances: LENGTH_UNLIMITED,
-            max_samples_per_instance: LENGTH_UNLIMITED,
+            max_samples: Length::Limited(2),
+            max_instances: Length::Unlimited,
+            max_samples_per_instance: Length::Unlimited,
         },
         ..Default::default()
     };
@@ -190,7 +193,7 @@ fn data_reader_order_by_source_timestamp() {
         },
         history: HistoryQosPolicy {
             kind: HistoryQosPolicyKind::KeepAll,
-            depth: LENGTH_UNLIMITED,
+            ..Default::default()
         },
         ..Default::default()
     };

--- a/dds/tests/write_read_unkeyed_topic.rs
+++ b/dds/tests/write_read_unkeyed_topic.rs
@@ -135,7 +135,7 @@ fn data_reader_resource_limits() {
         resource_limits: ResourceLimitsQosPolicy {
             max_samples: Length::Limited(2),
             max_instances: Length::Unlimited,
-            max_samples_per_instance: Length::Unlimited,
+            max_samples_per_instance: Length::Limited(2),
         },
         ..Default::default()
     };


### PR DESCRIPTION
The QoS was considered consistent in some combinations of unlimited length for max samples and max samples per instance. This was mostly due to the complicated comparisons in the if clauses. To solve this problem I have introduced a new Length type that makes the comparison more explicit.