### PR TITLE
DDS-236 Add Sample Rejected and Sample Lost reader listeners

### DIFF
--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -154,7 +154,6 @@ pub struct RtpsReader {
     instance_handle_builder: InstanceHandleBuilder,
     instances: HashMap<InstanceHandle, Instance>,
     instance_reception_time: HashMap<InstanceHandle, Time>,
-    data_available: bool,
 }
 
 impl RtpsReader {
@@ -180,7 +179,6 @@ impl RtpsReader {
             instance_handle_builder,
             instances: HashMap::new(),
             instance_reception_time: HashMap::new(),
-            data_available: false,
         }
     }
 
@@ -514,8 +512,6 @@ impl RtpsReader {
                 .mark_viewed()
         }
 
-        self.data_available = false;
-
         if indexed_samples.is_empty() {
             Err(DdsError::NoData)
         } else {
@@ -585,12 +581,6 @@ impl RtpsReader {
         }
 
         Ok(samples)
-    }
-
-    pub fn take_data_available(&mut self) -> bool {
-        let data_available = self.data_available;
-        self.data_available = false;
-        data_available
     }
 
     pub fn get_deadline_missed_instances(&mut self, now: Time) -> Vec<InstanceHandle> {

--- a/dds/src/implementation/rtps/stateful_reader.rs
+++ b/dds/src/implementation/rtps/stateful_reader.rs
@@ -2,6 +2,7 @@ use crate::{
     implementation::dds_impl::message_receiver::MessageReceiver,
     infrastructure::{
         qos_policy::ReliabilityQosPolicyKind,
+        status::SampleRejectedStatusKind,
         time::{Duration, DURATION_ZERO},
     },
 };
@@ -17,7 +18,7 @@ use super::{
         types::ProtocolId,
         RtpsMessage, RtpsSubmessageKind,
     },
-    reader::RtpsReader,
+    reader::{RtpsReader, RtpsReaderError},
     transport::TransportWrite,
     types::{Guid, GuidPrefix, PROTOCOLVERSION, VENDOR_ID_S2E},
     writer_proxy::RtpsWriterProxy,
@@ -37,6 +38,34 @@ pub enum ChangeFromWriterStatusKind {
     Missing,
     Received,
     Unknown,
+}
+
+pub enum StatefulReaderDataReceivedResult {
+    NoMatchedWriterProxy,
+    UnexpectedDataSequenceNumber,
+    NewSampleAdded,
+    NewSampleAddedAndSamplesLost,
+    SampleRejected(SampleRejectedStatusKind),
+    InvalidData(&'static str),
+}
+
+impl From<RtpsReaderError> for StatefulReaderDataReceivedResult {
+    fn from(e: RtpsReaderError) -> Self {
+        match e {
+            RtpsReaderError::InvalidData(s) => StatefulReaderDataReceivedResult::InvalidData(s),
+            RtpsReaderError::MaxSamples => StatefulReaderDataReceivedResult::SampleRejected(
+                SampleRejectedStatusKind::RejectedBySamplesLimit,
+            ),
+            RtpsReaderError::MaxInstances => StatefulReaderDataReceivedResult::SampleRejected(
+                SampleRejectedStatusKind::RejectedByInstancesLimit,
+            ),
+            RtpsReaderError::MaxSamplesPerInstance => {
+                StatefulReaderDataReceivedResult::SampleRejected(
+                    SampleRejectedStatusKind::RejectedBySamplesPerInstanceLimit,
+                )
+            }
+        }
+    }
 }
 
 pub struct RtpsStatefulReader {
@@ -81,12 +110,6 @@ impl RtpsStatefulReader {
     pub fn matched_writer_remove(&mut self, a_writer_guid: Guid) {
         self.matched_writers
             .retain(|x| x.remote_writer_guid() != a_writer_guid)
-    }
-
-    pub fn matched_writer_lookup(&mut self, a_writer_guid: Guid) -> Option<&mut RtpsWriterProxy> {
-        self.matched_writers
-            .iter_mut()
-            .find(|x| x.remote_writer_guid() == a_writer_guid)
     }
 }
 
@@ -176,56 +199,73 @@ impl RtpsStatefulReader {
         &mut self,
         data_submessage: &DataSubmessage<'_>,
         message_receiver: &MessageReceiver,
-    ) {
+    ) -> StatefulReaderDataReceivedResult {
         let sequence_number = data_submessage.writer_sn.value;
         let writer_guid = Guid::new(
             message_receiver.source_guid_prefix(),
             data_submessage.writer_id.value,
         );
 
-        if let Some(writer_proxy) = self.matched_writer_lookup(writer_guid) {
+        if let Some(writer_proxy) = self
+            .matched_writers
+            .iter_mut()
+            .find(|w| w.remote_writer_guid() == writer_guid)
+        {
             if data_submessage.writer_sn.value < writer_proxy.first_available_seq_num
                 || data_submessage.writer_sn.value > writer_proxy.last_available_seq_num
                 || writer_proxy
                     .missing_changes()
                     .contains(&data_submessage.writer_sn.value)
             {
-                let reliability_kind = self.reader().get_qos().reliability.kind.clone();
-                if let Some(writer_proxy) = self.matched_writer_lookup(writer_guid) {
-                    match reliability_kind {
-                        ReliabilityQosPolicyKind::BestEffort => {
-                            let expected_seq_num = writer_proxy.available_changes_max() + 1;
-                            if sequence_number >= expected_seq_num {
-                                writer_proxy.received_change_set(sequence_number);
-                                if sequence_number > expected_seq_num {
-                                    writer_proxy.lost_changes_update(sequence_number);
+                match &self.reader.get_qos().reliability.kind {
+                    ReliabilityQosPolicyKind::BestEffort => {
+                        let expected_seq_num = writer_proxy.available_changes_max() + 1;
+                        if sequence_number >= expected_seq_num {
+                            let add_change_result = self.reader.add_change(
+                                data_submessage,
+                                Some(message_receiver.timestamp()),
+                                message_receiver.source_guid_prefix(),
+                                message_receiver.reception_timestamp(),
+                            );
+
+                            match add_change_result {
+                                Ok(_) => {
+                                    writer_proxy.received_change_set(sequence_number);
+                                    if sequence_number > expected_seq_num {
+                                        writer_proxy.lost_changes_update(sequence_number);
+                                        StatefulReaderDataReceivedResult::NewSampleAddedAndSamplesLost
+                                    } else {
+                                        StatefulReaderDataReceivedResult::NewSampleAdded
+                                    }
                                 }
-
-                                self.reader_mut()
-                                    .add_change(
-                                        data_submessage,
-                                        Some(message_receiver.timestamp()),
-                                        message_receiver.source_guid_prefix(),
-                                        message_receiver.reception_timestamp(),
-                                    )
-                                    .ok();
+                                Err(err) => err.into(),
                             }
+                        } else {
+                            StatefulReaderDataReceivedResult::UnexpectedDataSequenceNumber
                         }
-                        ReliabilityQosPolicyKind::Reliable => {
-                            writer_proxy.received_change_set(data_submessage.writer_sn.value);
+                    }
+                    ReliabilityQosPolicyKind::Reliable => {
+                        let add_change_result = self.reader.add_change(
+                            data_submessage,
+                            Some(message_receiver.timestamp()),
+                            message_receiver.source_guid_prefix(),
+                            message_receiver.reception_timestamp(),
+                        );
 
-                            self.reader_mut()
-                                .add_change(
-                                    data_submessage,
-                                    Some(message_receiver.timestamp()),
-                                    message_receiver.source_guid_prefix(),
-                                    message_receiver.reception_timestamp(),
-                                )
-                                .ok();
+                        match add_change_result {
+                            Ok(_) => {
+                                writer_proxy.received_change_set(data_submessage.writer_sn.value);
+                                StatefulReaderDataReceivedResult::NewSampleAdded
+                            }
+                            Err(err) => err.into(),
                         }
                     }
                 }
+            } else {
+                StatefulReaderDataReceivedResult::UnexpectedDataSequenceNumber
             }
+        } else {
+            StatefulReaderDataReceivedResult::NoMatchedWriterProxy
         }
     }
 }

--- a/dds/src/subscription/data_reader.rs
+++ b/dds/src/subscription/data_reader.rs
@@ -311,17 +311,17 @@ where
 
     /// This operation allows access to the [`SampleLostStatus`].
     pub fn get_sample_lost_status(&self) -> DdsResult<SampleLostStatus> {
-        self.0.upgrade()?.get_sample_lost_status()
+        Ok(self.0.upgrade()?.get_sample_lost_status())
     }
 
     /// This operation allows access to the [`SampleRejectedStatus`].
     pub fn get_sample_rejected_status(&self) -> DdsResult<SampleRejectedStatus> {
-        self.0.upgrade()?.get_sample_rejected_status()
+        Ok(self.0.upgrade()?.get_sample_rejected_status())
     }
 
     /// This operation allows access to the [`SubscriptionMatchedStatus`].
     pub fn get_subscription_matched_status(&self) -> DdsResult<SubscriptionMatchedStatus> {
-        self.0.upgrade()?.get_subscription_matched_status()
+        Ok(self.0.upgrade()?.get_subscription_matched_status())
     }
 
     /// This operation returns the [`Topic`] associated with the [`DataReader`]. This is the same [`Topic`]
@@ -378,7 +378,7 @@ where
     /// the corresponding matched [`DataWriter`](crate::publication::data_writer::DataWriter) entities. These handles match the ones that appear in the
     /// [`SampleInfo::instance_handle`](crate::subscription::sample_info::SampleInfo) when reading the “DCPSPublications” builtin topic.
     pub fn get_matched_publications(&self) -> DdsResult<Vec<InstanceHandle>> {
-        self.0.upgrade()?.get_matched_publications()
+        Ok(self.0.upgrade()?.get_matched_publications())
     }
 }
 

--- a/dds/tests/data_reader_listener.rs
+++ b/dds/tests/data_reader_listener.rs
@@ -2,16 +2,15 @@ use dust_dds::{
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{
         qos::{DataReaderQos, DataWriterQos, QosKind},
-        qos_policy::{DeadlineQosPolicy, ReliabilityQosPolicy, ReliabilityQosPolicyKind},
-        status::{RequestedDeadlineMissedStatus, StatusKind, NO_STATUS},
+        qos_policy::{
+            DeadlineQosPolicy, HistoryQosPolicy, HistoryQosPolicyKind, Length,
+            ReliabilityQosPolicy, ReliabilityQosPolicyKind, ResourceLimitsQosPolicy,
+        },
+        status::{RequestedDeadlineMissedStatus, SampleRejectedStatus, StatusKind, NO_STATUS},
         time::Duration,
         wait_set::{Condition, WaitSet},
     },
-    subscription::{
-        data_reader::DataReader,
-        data_reader_listener::DataReaderListener,
-        sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    },
+    subscription::{data_reader::DataReader, data_reader_listener::DataReaderListener},
     topic_definition::type_support::{DdsSerde, DdsType},
 };
 
@@ -110,11 +109,123 @@ fn deadline_missed_listener() {
         .wait_for_acknowledgments(Duration::new(1, 0))
         .unwrap();
 
-    let samples = reader
-        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+    let reader_cond = reader.get_statuscondition().unwrap();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::RequestedDeadlineMissed])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond))
         .unwrap();
 
-    assert_eq!(samples.len(), 1);
+    wait_set.wait(Duration::new(2, 0)).unwrap();
+}
 
-    std::thread::sleep(std::time::Duration::from_secs(2));
+#[test]
+fn sample_rejected_listener() {
+    mock! {
+        SampleRejectedListener{}
+
+        impl DataReaderListener for SampleRejectedListener {
+            type Foo = MyData;
+
+            fn on_sample_rejected(
+                &mut self,
+                _the_reader: &DataReader<MyData>,
+                _status: SampleRejectedStatus,
+            );
+        }
+
+    }
+
+    let domain_id = 0;
+    let participant_factory = DomainParticipantFactory::get_instance();
+
+    let participant = participant_factory
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let topic = participant
+        .create_topic::<MyData>(
+            "SampleRejectedListenerTopic",
+            QosKind::Default,
+            None,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let data_writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: Duration::new(1, 0),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(&topic, QosKind::Specific(data_writer_qos), None, NO_STATUS)
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: Duration::new(1, 0),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+            ..Default::default()
+        },
+        resource_limits: ResourceLimitsQosPolicy {
+            max_samples: Length::Limited(2),
+            max_instances: Length::Unlimited,
+            max_samples_per_instance: Length::Limited(2),
+        },
+        ..Default::default()
+    };
+    let mut reader_listener = MockSampleRejectedListener::new();
+    reader_listener
+        .expect_on_sample_rejected()
+        .return_const(());
+
+    let reader = subscriber
+        .create_datareader(
+            &topic,
+            QosKind::Specific(reader_qos),
+            Some(Box::new(reader_listener)),
+            &[StatusKind::SampleRejected],
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition().unwrap();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    writer.write(&MyData { id: 1, value: 0 }, None).unwrap();
+    writer.write(&MyData { id: 1, value: 1 }, None).unwrap();
+    writer.write(&MyData { id: 1, value: 2 }, None).unwrap();
+
+    let reader_cond = reader.get_statuscondition().unwrap();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::SampleRejected])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond))
+        .unwrap();
+
+    wait_set.wait(Duration::new(2, 0)).unwrap();
 }

--- a/dds/tests/write_read_unkeyed_topic.rs
+++ b/dds/tests/write_read_unkeyed_topic.rs
@@ -157,9 +157,16 @@ fn data_reader_resource_limits() {
     writer.write(&UserData(2), None).unwrap();
     writer.write(&UserData(3), None).unwrap();
 
-    writer
-        .wait_for_acknowledgments(Duration::new(5, 0))
+    let reader_cond = reader.get_statuscondition().unwrap();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::SampleRejected])
         .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond))
+        .unwrap();
+
+    wait_set.wait(Duration::new(5, 0)).unwrap();
 
     let samples = reader
         .read(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)


### PR DESCRIPTION
Add listener trigger for Sample Rejected and Sample Lost. To do this triggering some additional information is return from the called to the RtpsReader data submessage processing. As part of this the triggering of the on_data_available has also been modified to not require the separate thread to look at the flag value.