### PR TITLE
DDS-247 Use SPDP default locators for matched readers and writers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,3 +78,9 @@ jobs:
             pid=$!
             ../build/InteroperabilityPublisher
             wait $pid
+workflows:
+  version: 2
+  all:
+    jobs:
+      - build
+      - interoperability_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,15 +68,14 @@ jobs:
           command: |
             export RUSTFLAGS="-Cinstrument-coverage"
             export LLVM_PROFILE_FILE="test-%p-%m.profraw"
-            cd ..
-            cargo build --example
+            cargo build --examples
       - run:
           name: Hello world inteoperability test
           no_output_timeout: 30s
           command: |
             cargo run --example hello_world_publisher &
             pid=$!
-            ../build/InteroperabilityPublisher
+            build/InteroperabilityPublisher
             wait $pid
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           command: |
             mkdir build
             cd build
-            cmake -DCMAKE_PREFIX_PATH="/usr/local/lib/cmake/CycloneDDS/idlc" ../dds/tests/interoperability
+            cmake ../dds/tests/interoperability
             cmake --build .
       - run:
           name: Build examples
@@ -73,7 +73,9 @@ jobs:
           name: Hello world inteoperability test
           no_output_timeout: 30s
           command: |
-            cargo run --example hello_world_publisher &
+            export RUSTFLAGS="-Cinstrument-coverage"
+            export LLVM_PROFILE_FILE="test-%p-%m.profraw"
+            cargo run --example hello_world_subscriber &
             pid=$!
             build/InteroperabilityPublisher
             wait $pid

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,15 +66,11 @@ jobs:
       - run:
           name: Build examples
           command: |
-            export RUSTFLAGS="-Cinstrument-coverage"
-            export LLVM_PROFILE_FILE="test-%p-%m.profraw"
             cargo build --examples
       - run:
-          name: Hello world inteoperability test
+          name: Hello world interoperability test
           no_output_timeout: 30s
           command: |
-            export RUSTFLAGS="-Cinstrument-coverage"
-            export LLVM_PROFILE_FILE="test-%p-%m.profraw"
             cargo run --example hello_world_subscriber &
             pid=$!
             build/InteroperabilityPublisher

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -91,6 +91,14 @@ impl SpdpDiscoveredParticipantData {
         self.participant_proxy.guid_prefix
     }
 
+    pub fn default_unicast_locator_list(&self) -> &[Locator] {
+        &self.participant_proxy.default_unicast_locator_list
+    }
+
+    pub fn default_multicast_locator_list(&self) -> &[Locator] {
+        &self.participant_proxy.default_multicast_locator_list
+    }
+
     pub fn metatraffic_unicast_locator_list(&self) -> &[Locator] {
         &self.participant_proxy.metatraffic_unicast_locator_list
     }

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -916,19 +916,49 @@ impl DdsShared<DomainParticipantImpl> {
         if let Ok(samples) = self
             .builtin_subscriber
             .sedp_builtin_subscriptions_reader()
-            .take(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
-        {
-            for discovered_reader_data_sample in samples.iter() {
-                for publisher in self.user_defined_publisher_list.read_lock().iter() {
-                    match discovered_reader_data_sample.sample_info.instance_state {
-                        InstanceStateKind::Alive => publisher.add_matched_reader(
-                            discovered_reader_data_sample.data.as_ref().unwrap(),
-                        ),
-                        InstanceStateKind::NotAliveDisposed => publisher.remove_matched_reader(
-                            discovered_reader_data_sample.sample_info.instance_handle,
-                        ),
-                        InstanceStateKind::NotAliveNoWriters => todo!(),
+            .take::<DiscoveredReaderData>(
+            1,
+            ANY_SAMPLE_STATE,
+            ANY_VIEW_STATE,
+            ANY_INSTANCE_STATE,
+        ) {
+            for discovered_reader_data_sample in samples.into_iter() {
+                match discovered_reader_data_sample.sample_info.instance_state {
+                    InstanceStateKind::Alive => {
+                        if let Some(discovered_reader_data) = discovered_reader_data_sample.data {
+                            let remote_reader_guid_prefix = discovered_reader_data
+                                .reader_proxy
+                                .remote_reader_guid
+                                .prefix();
+                            let reader_parent_participant_guid =
+                                Guid::new(remote_reader_guid_prefix, ENTITYID_PARTICIPANT);
+
+                            if let Some(discovered_participant_data) = self
+                                .discovered_participant_list
+                                .read_lock()
+                                .get(&reader_parent_participant_guid.into())
+                            {
+                                for publisher in self.user_defined_publisher_list.read_lock().iter()
+                                {
+                                    publisher.add_matched_reader(
+                                        &discovered_reader_data,
+                                        discovered_participant_data.default_unicast_locator_list(),
+                                        discovered_participant_data
+                                            .default_multicast_locator_list(),
+                                    );
+                                }
+                            }
+                        }
                     }
+                    InstanceStateKind::NotAliveDisposed => {
+                        for publisher in self.user_defined_publisher_list.read_lock().iter() {
+                            publisher.remove_matched_reader(
+                                discovered_reader_data_sample.sample_info.instance_handle,
+                            )
+                        }
+                    }
+
+                    InstanceStateKind::NotAliveNoWriters => todo!(),
                 }
             }
         }

--- a/dds/src/implementation/dds_impl/user_defined_publisher.rs
+++ b/dds/src/implementation/dds_impl/user_defined_publisher.rs
@@ -10,7 +10,8 @@ use crate::{
             stateful_writer::RtpsStatefulWriter,
             transport::TransportWrite,
             types::{
-                EntityId, Guid, TopicKind, USER_DEFINED_WRITER_NO_KEY, USER_DEFINED_WRITER_WITH_KEY,
+                EntityId, Guid, Locator, TopicKind, USER_DEFINED_WRITER_NO_KEY,
+                USER_DEFINED_WRITER_WITH_KEY,
             },
             writer::RtpsWriter,
         },
@@ -351,9 +352,18 @@ impl DdsShared<UserDefinedPublisher> {
         self.rtps_group.guid().into()
     }
 
-    pub fn add_matched_reader(&self, discovered_reader_data: &DiscoveredReaderData) {
+    pub fn add_matched_reader(
+        &self,
+        discovered_reader_data: &DiscoveredReaderData,
+        default_unicast_locator_list: &[Locator],
+        default_multicast_locator_list: &[Locator],
+    ) {
         for data_writer in self.data_writer_list.read_lock().iter() {
-            data_writer.add_matched_reader(discovered_reader_data)
+            data_writer.add_matched_reader(
+                discovered_reader_data,
+                default_unicast_locator_list,
+                default_multicast_locator_list,
+            )
         }
     }
 

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -9,7 +9,7 @@ use crate::{
             stateful_reader::RtpsStatefulReader,
             transport::TransportWrite,
             types::{
-                EntityId, Guid, GuidPrefix, TopicKind, USER_DEFINED_READER_NO_KEY,
+                EntityId, Guid, GuidPrefix, Locator, TopicKind, USER_DEFINED_READER_NO_KEY,
                 USER_DEFINED_READER_WITH_KEY,
             },
         },
@@ -326,9 +326,18 @@ impl DdsShared<UserDefinedSubscriber> {
 }
 
 impl DdsShared<UserDefinedSubscriber> {
-    pub fn add_matched_writer(&self, discovered_writer_data: &DiscoveredWriterData) {
+    pub fn add_matched_writer(
+        &self,
+        discovered_writer_data: &DiscoveredWriterData,
+        default_unicast_locator_list: &[Locator],
+        default_multicast_locator_list: &[Locator],
+    ) {
         for data_reader in self.data_reader_list.read_lock().iter() {
-            data_reader.add_matched_writer(discovered_writer_data)
+            data_reader.add_matched_writer(
+                discovered_writer_data,
+                default_unicast_locator_list,
+                default_multicast_locator_list,
+            )
         }
     }
 


### PR DESCRIPTION
This PR adds the capability of using the SPDP default locator when the discovered readers and writers do not report their own locator lists.