### PR TITLE
Make EntityKey new type

### DIFF
--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -270,7 +270,8 @@ impl DdsDeserialize<'_> for DiscoveredReaderData {
 mod tests {
     use super::*;
     use crate::implementation::rtps::types::{
-        GuidPrefix, BUILT_IN_WRITER_WITH_KEY, USER_DEFINED_READER_WITH_KEY, USER_DEFINED_UNKNOWN,
+        EntityKey, GuidPrefix, BUILT_IN_WRITER_WITH_KEY, USER_DEFINED_READER_WITH_KEY,
+        USER_DEFINED_UNKNOWN,
     };
     use crate::infrastructure::qos_policy::{
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
@@ -291,9 +292,12 @@ mod tests {
             reader_proxy: ReaderProxy {
                 remote_reader_guid: Guid::new(
                     GuidPrefix::new([5; 12]),
-                    EntityId::new([11, 12, 13], USER_DEFINED_READER_WITH_KEY),
+                    EntityId::new(EntityKey::new([11, 12, 13]), USER_DEFINED_READER_WITH_KEY),
                 ),
-                remote_group_entity_id: EntityId::new([21, 22, 23], BUILT_IN_WRITER_WITH_KEY),
+                remote_group_entity_id: EntityId::new(
+                    EntityKey::new([21, 22, 23]),
+                    BUILT_IN_WRITER_WITH_KEY,
+                ),
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
                 expects_inline_qos: *ExpectsInlineQosSerialize::default().0,
@@ -355,9 +359,12 @@ mod tests {
                 // must correspond to subscription_builtin_topic_data.key
                 remote_reader_guid: Guid::new(
                     GuidPrefix::new([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]),
-                    EntityId::new([4, 0, 0], USER_DEFINED_UNKNOWN),
+                    EntityId::new(EntityKey::new([4, 0, 0]), USER_DEFINED_UNKNOWN),
                 ),
-                remote_group_entity_id: EntityId::new([21, 22, 23], BUILT_IN_WRITER_WITH_KEY),
+                remote_group_entity_id: EntityId::new(
+                    EntityKey::new([21, 22, 23]),
+                    BUILT_IN_WRITER_WITH_KEY,
+                ),
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
                 expects_inline_qos: ExpectsInlineQosDeserialize::default().0,

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -264,8 +264,8 @@ impl DdsDeserialize<'_> for DiscoveredWriterData {
 #[cfg(test)]
 mod tests {
     use crate::implementation::rtps::types::{
-        GuidPrefix, BUILT_IN_PARTICIPANT, BUILT_IN_READER_GROUP, BUILT_IN_WRITER_WITH_KEY,
-        USER_DEFINED_UNKNOWN,
+        EntityKey, GuidPrefix, BUILT_IN_PARTICIPANT, BUILT_IN_READER_GROUP,
+        BUILT_IN_WRITER_WITH_KEY, USER_DEFINED_UNKNOWN,
     };
     use crate::infrastructure::qos_policy::{
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
@@ -288,12 +288,15 @@ mod tests {
             writer_proxy: WriterProxy {
                 remote_writer_guid: Guid::new(
                     GuidPrefix::new([5; 12]),
-                    EntityId::new([11, 12, 13], BUILT_IN_WRITER_WITH_KEY),
+                    EntityId::new(EntityKey::new([11, 12, 13]), BUILT_IN_WRITER_WITH_KEY),
                 ),
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
                 data_max_size_serialized: None,
-                remote_group_entity_id: EntityId::new([21, 22, 23], BUILT_IN_READER_GROUP),
+                remote_group_entity_id: EntityId::new(
+                    EntityKey::new([21, 22, 23]),
+                    BUILT_IN_READER_GROUP,
+                ),
             },
             publication_builtin_topic_data: PublicationBuiltinTopicData {
                 key: BuiltInTopicKey {
@@ -352,12 +355,15 @@ mod tests {
                 // must correspond to publication_builtin_topic_data.key
                 remote_writer_guid: Guid::new(
                     GuidPrefix::new([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0]),
-                    EntityId::new([4, 0, 0], USER_DEFINED_UNKNOWN),
+                    EntityId::new(EntityKey::new([4, 0, 0]), USER_DEFINED_UNKNOWN),
                 ),
                 unicast_locator_list: vec![],
                 multicast_locator_list: vec![],
                 data_max_size_serialized: None,
-                remote_group_entity_id: EntityId::new([21, 22, 23], BUILT_IN_PARTICIPANT),
+                remote_group_entity_id: EntityId::new(
+                    EntityKey::new([21, 22, 23]),
+                    BUILT_IN_PARTICIPANT,
+                ),
             },
             publication_builtin_topic_data: PublicationBuiltinTopicData {
                 key: BuiltInTopicKey {

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -266,7 +266,7 @@ impl<'de> DdsDeserialize<'de> for SpdpDiscoveredParticipantData {
 mod tests {
     use super::*;
     use crate::implementation::rtps::types::{
-        EntityId, LocatorAddress, LocatorKind, LocatorPort, BUILT_IN_PARTICIPANT,
+        EntityId, EntityKey, LocatorAddress, LocatorKind, LocatorPort, BUILT_IN_PARTICIPANT,
     };
     use crate::infrastructure::qos_policy::UserDataQosPolicy;
     use crate::topic_definition::type_support::LittleEndian;
@@ -294,7 +294,10 @@ mod tests {
         let domain_tag = "ab".to_string();
         let protocol_version = ProtocolVersion::new(2, 4);
         let guid_prefix = GuidPrefix::new([8; 12]);
-        let guid = Guid::new(guid_prefix, EntityId::new([0, 0, 1], BUILT_IN_PARTICIPANT));
+        let guid = Guid::new(
+            guid_prefix,
+            EntityId::new(EntityKey::new([0, 0, 1]), BUILT_IN_PARTICIPANT),
+        );
         let vendor_id = VendorId::new([73, 74]);
         let expects_inline_qos = true;
         let metatraffic_unicast_locator_list = vec![locator1, locator2];
@@ -420,7 +423,10 @@ mod tests {
         let domain_tag = "ab".to_string();
         let protocol_version = ProtocolVersion::new(2, 4);
         let guid_prefix = GuidPrefix::new([8; 12]);
-        let guid = Guid::new(guid_prefix, EntityId::new([0, 0, 1], BUILT_IN_PARTICIPANT));
+        let guid = Guid::new(
+            guid_prefix,
+            EntityId::new(EntityKey::new([0, 0, 1]), BUILT_IN_PARTICIPANT),
+        );
         let vendor_id = VendorId::new([73, 74]);
         let expects_inline_qos = true;
         let metatraffic_unicast_locator_list = vec![locator1, locator2];

--- a/dds/src/implementation/dds_impl/builtin_publisher.rs
+++ b/dds/src/implementation/dds_impl/builtin_publisher.rs
@@ -1,7 +1,7 @@
 use crate::implementation::rtps::messages::submessages::AckNackSubmessage;
 use crate::implementation::rtps::transport::TransportWrite;
 use crate::implementation::rtps::types::{
-    EntityId, Guid, GuidPrefix, Locator, BUILT_IN_WRITER_GROUP,
+    EntityId, EntityKey, Guid, GuidPrefix, Locator, BUILT_IN_WRITER_GROUP,
 };
 
 use crate::implementation::rtps::group::RtpsGroupImpl;
@@ -40,7 +40,7 @@ impl BuiltinPublisher {
     ) -> DdsShared<Self> {
         let qos = PublisherQos::default();
 
-        let entity_id = EntityId::new([0, 0, 0], BUILT_IN_WRITER_GROUP);
+        let entity_id = EntityId::new(EntityKey::new([0, 0, 0]), BUILT_IN_WRITER_GROUP);
         let guid = Guid::new(guid_prefix, entity_id);
         let rtps_group = RtpsGroupImpl::new(guid);
 

--- a/dds/src/implementation/dds_impl/builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/builtin_subscriber.rs
@@ -10,7 +10,7 @@ use crate::{
             group::RtpsGroupImpl,
             messages::submessages::{DataSubmessage, HeartbeatSubmessage},
             transport::TransportWrite,
-            types::{EntityId, Guid, GuidPrefix, BUILT_IN_READER_GROUP},
+            types::{EntityId, EntityKey, Guid, GuidPrefix, BUILT_IN_READER_GROUP},
         },
         utils::shared_object::{DdsRwLock, DdsShared},
     },
@@ -54,7 +54,7 @@ impl BuiltInSubscriber {
     ) -> DdsShared<Self> {
         let qos = SubscriberQos::default();
 
-        let entity_id = EntityId::new([0, 0, 0], BUILT_IN_READER_GROUP);
+        let entity_id = EntityId::new(EntityKey::new([0, 0, 0]), BUILT_IN_READER_GROUP);
         let guid = Guid::new(guid_prefix, entity_id);
         let rtps_group = RtpsGroupImpl::new(guid);
 

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -28,9 +28,9 @@ use crate::{
             participant::RtpsParticipant,
             transport::TransportWrite,
             types::{
-                Count, EntityId, Guid, Locator, BUILT_IN_READER_WITH_KEY, BUILT_IN_TOPIC,
-                BUILT_IN_WRITER_WITH_KEY, ENTITYID_PARTICIPANT, USER_DEFINED_READER_GROUP,
-                USER_DEFINED_TOPIC, USER_DEFINED_WRITER_GROUP,
+                Count, EntityId, EntityKey, Guid, Locator, BUILT_IN_READER_WITH_KEY,
+                BUILT_IN_TOPIC, BUILT_IN_WRITER_WITH_KEY, ENTITYID_PARTICIPANT,
+                USER_DEFINED_READER_GROUP, USER_DEFINED_TOPIC, USER_DEFINED_WRITER_GROUP,
             },
         },
         utils::{
@@ -64,28 +64,28 @@ use super::{
 };
 
 pub const ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER: EntityId =
-    EntityId::new([0x00, 0x01, 0x00], BUILT_IN_WRITER_WITH_KEY);
+    EntityId::new(EntityKey::new([0x00, 0x01, 0x00]), BUILT_IN_WRITER_WITH_KEY);
 
 pub const ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER: EntityId =
-    EntityId::new([0x00, 0x01, 0x00], BUILT_IN_READER_WITH_KEY);
+    EntityId::new(EntityKey::new([0x00, 0x01, 0x00]), BUILT_IN_READER_WITH_KEY);
 
 pub const ENTITYID_SEDP_BUILTIN_TOPICS_ANNOUNCER: EntityId =
-    EntityId::new([0, 0, 0x02], BUILT_IN_WRITER_WITH_KEY);
+    EntityId::new(EntityKey::new([0, 0, 0x02]), BUILT_IN_WRITER_WITH_KEY);
 
 pub const ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR: EntityId =
-    EntityId::new([0, 0, 0x02], BUILT_IN_READER_WITH_KEY);
+    EntityId::new(EntityKey::new([0, 0, 0x02]), BUILT_IN_READER_WITH_KEY);
 
 pub const ENTITYID_SEDP_BUILTIN_PUBLICATIONS_ANNOUNCER: EntityId =
-    EntityId::new([0, 0, 0x03], BUILT_IN_WRITER_WITH_KEY);
+    EntityId::new(EntityKey::new([0, 0, 0x03]), BUILT_IN_WRITER_WITH_KEY);
 
 pub const ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR: EntityId =
-    EntityId::new([0, 0, 0x03], BUILT_IN_READER_WITH_KEY);
+    EntityId::new(EntityKey::new([0, 0, 0x03]), BUILT_IN_READER_WITH_KEY);
 
 pub const ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_ANNOUNCER: EntityId =
-    EntityId::new([0, 0, 0x04], BUILT_IN_WRITER_WITH_KEY);
+    EntityId::new(EntityKey::new([0, 0, 0x04]), BUILT_IN_WRITER_WITH_KEY);
 
 pub const ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR: EntityId =
-    EntityId::new([0, 0, 0x04], BUILT_IN_READER_WITH_KEY);
+    EntityId::new(EntityKey::new([0, 0, 0x04]), BUILT_IN_READER_WITH_KEY);
 
 pub struct DomainParticipantImpl {
     rtps_participant: RtpsParticipant,
@@ -130,7 +130,7 @@ impl DomainParticipantImpl {
         let lease_duration = Duration::new(100, 0);
         let guid_prefix = rtps_participant.guid().prefix();
 
-        let spdp_topic_entity_id = EntityId::new([0, 0, 0], BUILT_IN_TOPIC);
+        let spdp_topic_entity_id = EntityId::new(EntityKey::new([0, 0, 0]), BUILT_IN_TOPIC);
         let spdp_topic_guid = Guid::new(guid_prefix, spdp_topic_entity_id);
         let spdp_topic_participant = TopicImpl::new(
             spdp_topic_guid,
@@ -140,7 +140,7 @@ impl DomainParticipantImpl {
             DdsWeak::new(),
         );
 
-        let sedp_topics_entity_id = EntityId::new([0, 0, 1], BUILT_IN_TOPIC);
+        let sedp_topics_entity_id = EntityId::new(EntityKey::new([0, 0, 1]), BUILT_IN_TOPIC);
         let sedp_topics_guid = Guid::new(guid_prefix, sedp_topics_entity_id);
         let sedp_topic_topics = TopicImpl::new(
             sedp_topics_guid,
@@ -150,7 +150,7 @@ impl DomainParticipantImpl {
             DdsWeak::new(),
         );
 
-        let sedp_publications_entity_id = EntityId::new([0, 0, 2], BUILT_IN_TOPIC);
+        let sedp_publications_entity_id = EntityId::new(EntityKey::new([0, 0, 2]), BUILT_IN_TOPIC);
         let sedp_publications_guid = Guid::new(guid_prefix, sedp_publications_entity_id);
         let sedp_topic_publications = TopicImpl::new(
             sedp_publications_guid,
@@ -160,7 +160,7 @@ impl DomainParticipantImpl {
             DdsWeak::new(),
         );
 
-        let sedp_subscriptions_entity_id = EntityId::new([0, 0, 2], BUILT_IN_TOPIC);
+        let sedp_subscriptions_entity_id = EntityId::new(EntityKey::new([0, 0, 2]), BUILT_IN_TOPIC);
         let sedp_subscriptions_guid = Guid::new(guid_prefix, sedp_subscriptions_entity_id);
         let sedp_topic_subscriptions = TopicImpl::new(
             sedp_subscriptions_guid,
@@ -244,7 +244,10 @@ impl DdsShared<DomainParticipantImpl> {
         let publisher_counter = self
             .user_defined_publisher_counter
             .fetch_add(1, Ordering::Relaxed);
-        let entity_id = EntityId::new([publisher_counter, 0, 0], USER_DEFINED_WRITER_GROUP);
+        let entity_id = EntityId::new(
+            EntityKey::new([publisher_counter, 0, 0]),
+            USER_DEFINED_WRITER_GROUP,
+        );
         let guid = Guid::new(self.rtps_participant.guid().prefix(), entity_id);
         let rtps_group = RtpsGroupImpl::new(guid);
         let publisher_impl_shared = UserDefinedPublisher::new(
@@ -308,7 +311,10 @@ impl DdsShared<DomainParticipantImpl> {
         let subcriber_counter = self
             .user_defined_subscriber_counter
             .fetch_add(1, Ordering::Relaxed);
-        let entity_id = EntityId::new([subcriber_counter, 0, 0], USER_DEFINED_READER_GROUP);
+        let entity_id = EntityId::new(
+            EntityKey::new([subcriber_counter, 0, 0]),
+            USER_DEFINED_READER_GROUP,
+        );
         let guid = Guid::new(self.rtps_participant.guid().prefix(), entity_id);
         let rtps_group = RtpsGroupImpl::new(guid);
         let subscriber_shared = UserDefinedSubscriber::new(
@@ -374,7 +380,7 @@ impl DdsShared<DomainParticipantImpl> {
             .fetch_add(1, Ordering::Relaxed);
         let topic_guid = Guid::new(
             self.rtps_participant.guid().prefix(),
-            EntityId::new([topic_counter, 0, 0], USER_DEFINED_TOPIC),
+            EntityId::new(EntityKey::new([topic_counter, 0, 0]), USER_DEFINED_TOPIC),
         );
         let qos = match qos {
             QosKind::Default => self.default_topic_qos.clone(),

--- a/dds/src/implementation/dds_impl/message_receiver.rs
+++ b/dds/src/implementation/dds_impl/message_receiver.rs
@@ -80,12 +80,12 @@ impl MessageReceiver {
         self.source_vendor_id = message.header.vendor_id.value;
         self.source_guid_prefix = message.header.guid_prefix.value;
         self.unicast_reply_locator_list.push(Locator::new(
-            *source_locator.kind(),
+            source_locator.kind(),
             LOCATOR_PORT_INVALID,
-            *source_locator.address(),
+            source_locator.address(),
         ));
         self.multicast_reply_locator_list.push(Locator::new(
-            *source_locator.kind(),
+            source_locator.kind(),
             LOCATOR_PORT_INVALID,
             LOCATOR_ADDRESS_INVALID,
         ));

--- a/dds/src/implementation/dds_impl/topic_impl.rs
+++ b/dds/src/implementation/dds_impl/topic_impl.rs
@@ -172,7 +172,9 @@ impl DdsShared<TopicImpl> {
 #[cfg(test)]
 mod tests {
 
-    use crate::implementation::rtps::types::{EntityId, GuidPrefix, BUILT_IN_PARTICIPANT};
+    use crate::implementation::rtps::types::{
+        EntityId, EntityKey, GuidPrefix, BUILT_IN_PARTICIPANT,
+    };
 
     use super::*;
 
@@ -180,7 +182,7 @@ mod tests {
     fn get_instance_handle() {
         let guid = Guid::new(
             GuidPrefix::new([2; 12]),
-            EntityId::new([3; 3], BUILT_IN_PARTICIPANT),
+            EntityId::new(EntityKey::new([3; 3]), BUILT_IN_PARTICIPANT),
         );
         let topic = TopicImpl::new(guid, TopicQos::default(), "", "", DdsWeak::new());
         *topic.enabled.write_lock() = true;

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -876,8 +876,8 @@ mod tests {
             endpoint::RtpsEndpoint,
             reader::RtpsReader,
             types::{
-                EntityId, Guid, TopicKind, BUILT_IN_PARTICIPANT, ENTITYID_UNKNOWN, GUID_UNKNOWN,
-                USER_DEFINED_WRITER_WITH_KEY,
+                EntityId, EntityKey, Guid, TopicKind, BUILT_IN_PARTICIPANT, ENTITYID_UNKNOWN,
+                GUID_UNKNOWN, USER_DEFINED_WRITER_WITH_KEY,
             },
         },
         infrastructure::time::DURATION_ZERO,
@@ -973,7 +973,7 @@ mod tests {
     fn get_instance_handle() {
         let guid = Guid::new(
             GuidPrefix::new([4; 12]),
-            EntityId::new([3; 3], BUILT_IN_PARTICIPANT),
+            EntityId::new(EntityKey::new([3; 3]), BUILT_IN_PARTICIPANT),
         );
         let dummy_topic = TopicImpl::new(GUID_UNKNOWN, TopicQos::default(), "", "", DdsWeak::new());
         let qos = DataReaderQos::default();
@@ -1057,7 +1057,7 @@ mod tests {
         };
         let remote_writer_guid = Guid::new(
             GuidPrefix::new([2; 12]),
-            EntityId::new([2; 3], USER_DEFINED_WRITER_WITH_KEY),
+            EntityId::new(EntityKey::new([2; 3]), USER_DEFINED_WRITER_WITH_KEY),
         );
         let discovered_writer_data = DiscoveredWriterData {
             writer_proxy: WriterProxy {
@@ -1149,7 +1149,7 @@ mod tests {
             writer_proxy: WriterProxy {
                 remote_writer_guid: Guid::new(
                     GuidPrefix::new([2; 12]),
-                    EntityId::new([2; 3], USER_DEFINED_WRITER_WITH_KEY),
+                    EntityId::new(EntityKey::new([2; 3]), USER_DEFINED_WRITER_WITH_KEY),
                 ),
                 remote_group_entity_id: ENTITYID_UNKNOWN,
                 unicast_locator_list: vec![],

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -7,7 +7,7 @@ use crate::{
             messages::submessages::AckNackSubmessage,
             reader_proxy::RtpsReaderProxy,
             transport::TransportWrite,
-            types::{EntityId, Locator, GUID_UNKNOWN, USER_DEFINED_UNKNOWN},
+            types::{EntityId, EntityKey, Locator, GUID_UNKNOWN, USER_DEFINED_UNKNOWN},
         },
         utils::condvar::DdsCondvar,
     },
@@ -650,7 +650,7 @@ impl DdsShared<UserDefinedDataWriter> {
                     .multicast_locator_list()
                     .to_vec(),
                 data_max_size_serialized: None,
-                remote_group_entity_id: EntityId::new([0; 3], USER_DEFINED_UNKNOWN),
+                remote_group_entity_id: EntityId::new(EntityKey::new([0; 3]), USER_DEFINED_UNKNOWN),
             },
 
             publication_builtin_topic_data: PublicationBuiltinTopicData {
@@ -902,7 +902,7 @@ mod test {
         };
         let remote_reader_guid = Guid::new(
             GuidPrefix::new([2; 12]),
-            EntityId::new([2; 3], USER_DEFINED_WRITER_WITH_KEY),
+            EntityId::new(EntityKey::new([2; 3]), USER_DEFINED_WRITER_WITH_KEY),
         );
         let discovered_reader_data = DiscoveredReaderData {
             reader_proxy: ReaderProxy {
@@ -998,7 +998,7 @@ mod test {
             reader_proxy: ReaderProxy {
                 remote_reader_guid: Guid::new(
                     GuidPrefix::new([2; 12]),
-                    EntityId::new([2; 3], USER_DEFINED_WRITER_WITH_KEY),
+                    EntityId::new(EntityKey::new([2; 3]), USER_DEFINED_WRITER_WITH_KEY),
                 ),
                 remote_group_entity_id: ENTITYID_UNKNOWN,
                 unicast_locator_list: vec![],

--- a/dds/src/implementation/dds_impl/user_defined_publisher.rs
+++ b/dds/src/implementation/dds_impl/user_defined_publisher.rs
@@ -10,7 +10,7 @@ use crate::{
             stateful_writer::RtpsStatefulWriter,
             transport::TransportWrite,
             types::{
-                EntityId, Guid, Locator, TopicKind, USER_DEFINED_WRITER_NO_KEY,
+                EntityId, EntityKey, Guid, Locator, TopicKind, USER_DEFINED_WRITER_NO_KEY,
                 USER_DEFINED_WRITER_WITH_KEY,
             },
             writer::RtpsWriter,
@@ -105,11 +105,11 @@ impl DdsShared<UserDefinedPublisher> {
             Guid::new(
                 self.rtps_group.guid().prefix(),
                 EntityId::new(
-                    [
-                        self.rtps_group.guid().entity_id().entity_key()[0],
+                    EntityKey::new([
+                        <[u8; 3]>::from(self.rtps_group.guid().entity_id().entity_key())[0],
                         user_defined_data_writer_counter,
                         0,
-                    ],
+                    ]),
                     entity_kind,
                 ),
             )

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -9,8 +9,8 @@ use crate::{
             stateful_reader::RtpsStatefulReader,
             transport::TransportWrite,
             types::{
-                EntityId, Guid, GuidPrefix, Locator, TopicKind, USER_DEFINED_READER_NO_KEY,
-                USER_DEFINED_READER_WITH_KEY,
+                EntityId, EntityKey, Guid, GuidPrefix, Locator, TopicKind,
+                USER_DEFINED_READER_NO_KEY, USER_DEFINED_READER_WITH_KEY,
             },
         },
         utils::{
@@ -103,11 +103,11 @@ impl DdsShared<UserDefinedSubscriber> {
             };
 
             EntityId::new(
-                [
-                    self.rtps_group.guid().entity_id().entity_key()[0],
+                EntityKey::new([
+                    <[u8; 3]>::from(self.rtps_group.guid().entity_id().entity_key())[0],
                     self.user_defined_data_reader_counter,
                     0,
-                ],
+                ]),
                 entity_kind,
             )
         };

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -347,14 +347,14 @@ where
                             .writer
                             .writer_cache()
                             .get_seq_num_min()
-                            .unwrap_or_else(|| SequenceNumber::new(1)),
+                            .unwrap_or(SequenceNumber::new(1)),
                     },
                     last_sn: SequenceNumberSubmessageElement {
                         value: self
                             .writer
                             .writer_cache()
                             .get_seq_num_max()
-                            .unwrap_or_else(|| SequenceNumber::new(0)),
+                            .unwrap_or(SequenceNumber::new(0)),
                     },
                     count: CountSubmessageElement {
                         value: self.heartbeat_count,
@@ -380,14 +380,14 @@ where
                             .writer
                             .writer_cache()
                             .get_seq_num_min()
-                            .unwrap_or_else(|| SequenceNumber::new(1)),
+                            .unwrap_or(SequenceNumber::new(1)),
                     },
                     last_sn: SequenceNumberSubmessageElement {
                         value: self
                             .writer
                             .writer_cache()
                             .get_seq_num_max()
-                            .unwrap_or_else(|| SequenceNumber::new(0)),
+                            .unwrap_or(SequenceNumber::new(0)),
                     },
                     count: CountSubmessageElement {
                         value: self.heartbeat_count,
@@ -437,14 +437,14 @@ where
                             .writer
                             .writer_cache()
                             .get_seq_num_min()
-                            .unwrap_or_else(|| SequenceNumber::new(1)),
+                            .unwrap_or(SequenceNumber::new(1)),
                     },
                     last_sn: SequenceNumberSubmessageElement {
                         value: self
                             .writer
                             .writer_cache()
                             .get_seq_num_max()
-                            .unwrap_or_else(|| SequenceNumber::new(0)),
+                            .unwrap_or(SequenceNumber::new(0)),
                     },
                     count: CountSubmessageElement {
                         value: self.heartbeat_count,

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -429,13 +429,13 @@ impl Locator {
             address,
         }
     }
-    pub const fn kind(&self) -> &LocatorKind {
-        &self.kind
+    pub const fn kind(&self) -> LocatorKind {
+        self.kind
     }
-    pub const fn port(&self) -> &LocatorPort {
-        &self.port
+    pub const fn port(&self) -> LocatorPort {
+        self.port
     }
-    pub const fn address(&self) -> &LocatorAddress {
-        &self.address
+    pub const fn address(&self) -> LocatorAddress {
+        self.address
     }
 }

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -9,8 +9,6 @@ use std::ops::{Add, AddAssign, Sub, SubAssign};
 /// Type used to hold globally-unique RTPS-entity identifiers. These are identifiers used to uniquely refer to each RTPS Entity in the system.
 /// Must be possible to represent using 16 octets.
 /// The following values are reserved by the protocol: GUID_UNKNOWN
-///
-/// Note: Define the GUID as described in 8.2.4.1 Identifying RTPS entities: The GUID
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub struct Guid {
     prefix: GuidPrefix,
@@ -360,11 +358,6 @@ impl Count {
 impl PartialOrd<Count> for Count {
     fn partial_cmp(&self, other: &Count) -> Option<std::cmp::Ordering> {
         self.0.partial_cmp(&other.0)
-    }
-}
-impl AsRef<i32> for Count {
-    fn as_ref(&self) -> &i32 {
-        &self.0
     }
 }
 

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Sub};
+use std::ops::{Add, AddAssign, Sub, SubAssign};
 
 ///
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.3
@@ -17,24 +17,24 @@ pub struct Guid {
     entity_id: EntityId,
 }
 
+impl Guid {
+    pub const fn new(prefix: GuidPrefix, entity_id: EntityId) -> Self {
+        Self { prefix, entity_id }
+    }
+
+    pub const fn prefix(&self) -> GuidPrefix {
+        self.prefix
+    }
+
+    pub const fn entity_id(&self) -> EntityId {
+        self.entity_id
+    }
+}
+
 pub const GUID_UNKNOWN: Guid = Guid {
     prefix: GUIDPREFIX_UNKNOWN,
     entity_id: ENTITYID_UNKNOWN,
 };
-
-impl Guid {
-    pub fn new(prefix: GuidPrefix, entity_id: EntityId) -> Self {
-        Self { prefix, entity_id }
-    }
-
-    pub fn prefix(&self) -> GuidPrefix {
-        self.prefix
-    }
-
-    pub fn entity_id(&self) -> EntityId {
-        self.entity_id
-    }
-}
 
 impl From<[u8; 16]> for Guid {
     fn from(value: [u8; 16]) -> Self {
@@ -42,7 +42,10 @@ impl From<[u8; 16]> for Guid {
             value[0], value[1], value[2], value[3], value[4], value[5], value[6], value[7],
             value[8], value[9], value[10], value[11],
         ]);
-        let entity_id = EntityId::new([value[12], value[13], value[14]], EntityKind(value[15]));
+        let entity_id = EntityId::new(
+            EntityKey::new([value[12], value[13], value[14]]),
+            EntityKind(value[15]),
+        );
         Self { prefix, entity_id }
     }
 }
@@ -62,9 +65,9 @@ impl From<Guid> for [u8; 16] {
             guid.prefix.0[9],
             guid.prefix.0[10],
             guid.prefix.0[11],
-            guid.entity_id.entity_key[0],
-            guid.entity_id.entity_key[1],
-            guid.entity_id.entity_key[2],
+            guid.entity_id.entity_key.0[0],
+            guid.entity_id.entity_key.0[1],
+            guid.entity_id.entity_key.0[2],
             guid.entity_id.entity_kind.0,
         ]
     }
@@ -79,7 +82,7 @@ pub struct GuidPrefix([u8; 12]);
 pub const GUIDPREFIX_UNKNOWN: GuidPrefix = GuidPrefix([0; 12]);
 
 impl GuidPrefix {
-    pub fn new(value: [u8; 12]) -> Self {
+    pub const fn new(value: [u8; 12]) -> Self {
         Self(value)
     }
 }
@@ -102,13 +105,11 @@ impl EntityId {
         }
     }
 
-    /// Get a reference to the entity id's entity key.
-    pub fn entity_key(&self) -> EntityKey {
+    pub const fn entity_key(&self) -> EntityKey {
         self.entity_key
     }
 
-    /// Get a reference to the entity id's entity kind.
-    pub fn entity_kind(&self) -> EntityKind {
+    pub const fn entity_kind(&self) -> EntityKind {
         self.entity_kind
     }
 }
@@ -116,9 +117,9 @@ impl EntityId {
 impl From<EntityId> for [u8; 4] {
     fn from(value: EntityId) -> Self {
         [
-            value.entity_key[0],
-            value.entity_key[1],
-            value.entity_key[2],
+            value.entity_key.0[0],
+            value.entity_key.0[1],
+            value.entity_key.0[2],
             value.entity_kind.0,
         ]
     }
@@ -131,12 +132,12 @@ impl Default for EntityId {
 }
 
 pub const ENTITYID_UNKNOWN: EntityId = EntityId {
-    entity_key: [0; 3],
+    entity_key: EntityKey::new([0; 3]),
     entity_kind: USER_DEFINED_UNKNOWN,
 };
 
 pub const ENTITYID_PARTICIPANT: EntityId = EntityId {
-    entity_key: [0, 0, 0x01],
+    entity_key: EntityKey::new([0, 0, 0x01]),
     entity_kind: BUILT_IN_PARTICIPANT,
 };
 
@@ -144,7 +145,7 @@ pub const ENTITYID_PARTICIPANT: EntityId = EntityId {
 pub struct EntityKind(u8);
 
 impl EntityKind {
-    pub fn new(value: u8) -> Self {
+    pub const fn new(value: u8) -> Self {
         Self(value)
     }
 }
@@ -178,35 +179,58 @@ pub const BUILT_IN_READER_GROUP: EntityKind = EntityKind(0xc9);
 pub const BUILT_IN_TOPIC: EntityKind = EntityKind(0xca);
 pub const USER_DEFINED_TOPIC: EntityKind = EntityKind(0x0a);
 
-pub type EntityKey = [u8; 3];
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Debug,
+    derive_more::Into,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct EntityKey([u8; 3]);
+
+impl EntityKey {
+    pub const fn new(value: [u8; 3]) -> Self {
+        Self(value)
+    }
+}
 
 /// SequenceNumber_t
 /// Type used to hold sequence numbers.
 /// Must be possible to represent using 64 bits.
 /// The following values are reserved by the protocol: SEQUENCENUMBER_UNKNOWN
 #[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, derive_more::Into, derive_more::Constructor,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Debug,
+    derive_more::Into,
+    derive_more::Add,
+    derive_more::AddAssign,
+    derive_more::Sub,
+    derive_more::SubAssign,
 )]
 pub struct SequenceNumber(i64);
+
+impl SequenceNumber {
+    pub const fn new(value: i64) -> Self {
+        Self(value)
+    }
+}
 #[allow(dead_code)]
 pub const SEQUENCENUMBER_UNKNOWN: SequenceNumber = SequenceNumber(i64::MIN);
 
-impl AddAssign for SequenceNumber {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
-    }
-}
 impl AddAssign<i64> for SequenceNumber {
     fn add_assign(&mut self, rhs: i64) {
         self.0 += rhs;
-    }
-}
-
-impl Add for SequenceNumber {
-    type Output = SequenceNumber;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        SequenceNumber(self.0 + rhs.0)
     }
 }
 impl Add<i64> for SequenceNumber {
@@ -216,6 +240,11 @@ impl Add<i64> for SequenceNumber {
         SequenceNumber(self.0 + rhs)
     }
 }
+impl SubAssign<i64> for SequenceNumber {
+    fn sub_assign(&mut self, rhs: i64) {
+        self.0 -= rhs
+    }
+}
 impl Sub<i64> for SequenceNumber {
     type Output = SequenceNumber;
 
@@ -223,13 +252,7 @@ impl Sub<i64> for SequenceNumber {
         SequenceNumber(self.0 - rhs)
     }
 }
-impl Sub for SequenceNumber {
-    type Output = SequenceNumber;
 
-    fn sub(self, rhs: Self) -> Self::Output {
-        SequenceNumber(self.0 - rhs.0)
-    }
-}
 /// TopicKind_t
 /// Enumeration used to distinguish whether a Topic has defined some fields within to be used as the ‘key’ that identifies data-instances within the Topic. See the DDS specification for more details on keys.
 /// The following values are reserved by the protocol: NO_KEY
@@ -279,13 +302,13 @@ pub const PROTOCOLVERSION_2_3: ProtocolVersion = ProtocolVersion { major: 2, min
 pub const PROTOCOLVERSION_2_4: ProtocolVersion = ProtocolVersion { major: 2, minor: 4 };
 
 impl ProtocolVersion {
-    pub fn new(major: u8, minor: u8) -> Self {
+    pub const fn new(major: u8, minor: u8) -> Self {
         Self { major, minor }
     }
-    pub fn major(&self) -> u8 {
+    pub const fn major(&self) -> u8 {
         self.major
     }
-    pub fn minor(&self) -> u8 {
+    pub const fn minor(&self) -> u8 {
         self.minor
     }
 }
@@ -294,23 +317,36 @@ impl ProtocolVersion {
 /// Type used to represent the vendor of the service implementing the RTPS protocol. The possible values for the vendorId are assigned by the OMG.
 /// The following values are reserved by the protocol: VENDORID_UNKNOWN
 #[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    derive_more::Into,
-    derive_more::Constructor,
+    Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, derive_more::Into,
 )]
 pub struct VendorId([u8; 2]);
+
+impl VendorId {
+    pub const fn new(value: [u8; 2]) -> Self {
+        Self(value)
+    }
+}
+
 pub const VENDOR_ID_UNKNOWN: VendorId = VendorId([0, 0]);
 pub const VENDOR_ID_S2E: VendorId = VendorId([99, 99]);
 
 /// Count_t
 /// Type used to hold a count that is incremented monotonically, used to identify message duplicates.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize, Default)]
+#[derive(
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    Default,
+    derive_more::Into,
+    derive_more::Add,
+    derive_more::AddAssign,
+    derive_more::Sub,
+    derive_more::SubAssign,
+)]
 pub struct Count(i32);
 
 impl Count {
@@ -324,11 +360,6 @@ impl Count {
 impl PartialOrd<Count> for Count {
     fn partial_cmp(&self, other: &Count) -> Option<std::cmp::Ordering> {
         self.0.partial_cmp(&other.0)
-    }
-}
-impl AddAssign for Count {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
     }
 }
 impl AsRef<i32> for Count {
@@ -349,41 +380,37 @@ pub struct Locator {
 }
 
 #[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Debug,
-    serde::Serialize,
-    serde::Deserialize,
-    derive_more::Into,
-    derive_more::Constructor,
+    Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize, derive_more::Into,
 )]
 pub struct LocatorKind(i32);
+
+impl LocatorKind {
+    pub const fn new(value: i32) -> Self {
+        Self(value)
+    }
+}
+
 #[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Debug,
-    serde::Serialize,
-    serde::Deserialize,
-    derive_more::Into,
-    derive_more::Constructor,
+    Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize, derive_more::Into,
 )]
 pub struct LocatorPort(u32);
+
+impl LocatorPort {
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+}
+
 #[derive(
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    Debug,
-    serde::Serialize,
-    serde::Deserialize,
-    derive_more::Into,
-    derive_more::Constructor,
+    Clone, Copy, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize, derive_more::Into,
 )]
 pub struct LocatorAddress([u8; 16]);
+
+impl LocatorAddress {
+    pub const fn new(value: [u8; 16]) -> Self {
+        Self(value)
+    }
+}
 
 #[allow(dead_code)]
 pub const LOCATOR_KIND_INVALID: LocatorKind = LocatorKind(-1);
@@ -402,20 +429,20 @@ pub const LOCATOR_INVALID: Locator = Locator {
 };
 
 impl Locator {
-    pub fn new(kind: LocatorKind, port: LocatorPort, address: LocatorAddress) -> Self {
+    pub const fn new(kind: LocatorKind, port: LocatorPort, address: LocatorAddress) -> Self {
         Self {
             kind,
             port,
             address,
         }
     }
-    pub fn kind(&self) -> &LocatorKind {
+    pub const fn kind(&self) -> &LocatorKind {
         &self.kind
     }
-    pub fn port(&self) -> &LocatorPort {
+    pub const fn port(&self) -> &LocatorPort {
         &self.port
     }
-    pub fn address(&self) -> &LocatorAddress {
+    pub const fn address(&self) -> &LocatorAddress {
         &self.address
     }
 }

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -101,13 +101,13 @@ impl RtpsWriterProxy {
             .iter()
             .max()
             .cloned()
-            .unwrap_or_else(|| SequenceNumber::new(0));
+            .unwrap_or(SequenceNumber::new(0));
         let highest_irrelevant_seq_num = self
             .irrelevant_changes
             .iter()
             .max()
             .cloned()
-            .unwrap_or_else(|| SequenceNumber::new(0));
+            .unwrap_or(SequenceNumber::new(0));
         // The highest sequence number of all present
         let highest_number = max(
             self.last_available_seq_num, max(

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -149,7 +149,7 @@ mod tests {
                 types::ProtocolId,
             },
             types::{
-                EntityId, GuidPrefix, ProtocolVersion, SequenceNumber, VendorId,
+                EntityId, EntityKey, GuidPrefix, ProtocolVersion, SequenceNumber, VendorId,
                 USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY,
             },
         },
@@ -206,10 +206,10 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
         let writer_sn = SequenceNumberSubmessageElement {
             value: SequenceNumber::new(5),
@@ -316,10 +316,10 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
         let writer_sn = SequenceNumberSubmessageElement {
             value: SequenceNumber::new(5),
@@ -397,10 +397,10 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
         let writer_sn = SequenceNumberSubmessageElement {
             value: SequenceNumber::new(5),

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/count.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/count.rs
@@ -14,8 +14,7 @@ impl MappingWriteByteOrdered for Count {
         &self,
         mut writer: W,
     ) -> Result<(), Error> {
-        self.as_ref()
-            .mapping_write_byte_ordered::<_, B>(&mut writer)
+        <i32>::from(*self).mapping_write_byte_ordered::<_, B>(&mut writer)
     }
 }
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/entityid.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/entityid.rs
@@ -5,7 +5,7 @@ use byteorder::ByteOrder;
 use crate::implementation::{
     rtps::{
         messages::submessage_elements::EntityIdSubmessageElement,
-        types::{EntityId, EntityKind},
+        types::{EntityId, EntityKey, EntityKind},
     },
     rtps_udp_psm::mapping_traits::{
         MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
@@ -27,7 +27,7 @@ impl<'de> MappingReadByteOrdered<'de> for EntityIdSubmessageElement {
         let entity_key: [u8; 3] = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
         let entity_kind: u8 = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
         Ok(Self {
-            value: EntityId::new(entity_key, EntityKind::new(entity_kind)),
+            value: EntityId::new(EntityKey::new(entity_key), EntityKind::new(entity_kind)),
         })
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/ack_nack.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/ack_nack.rs
@@ -81,7 +81,10 @@ mod tests {
                 CountSubmessageElement, EntityIdSubmessageElement,
                 SequenceNumberSetSubmessageElement,
             },
-            types::{Count, EntityId, USER_DEFINED_READER_NO_KEY, USER_DEFINED_READER_GROUP, SequenceNumber},
+            types::{
+                Count, EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
+                USER_DEFINED_READER_NO_KEY,
+            },
         },
         rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
     };
@@ -93,10 +96,10 @@ mod tests {
         let endianness_flag = true;
         let final_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
         let submessage = AckNackSubmessage {
             endianness_flag,
@@ -142,10 +145,10 @@ mod tests {
                 endianness_flag: true,
                 final_flag: false,
                 reader_id: EntityIdSubmessageElement {
-                    value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+                    value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
                 },
                 writer_id: EntityIdSubmessageElement {
-                    value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+                    value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
                 },
                 reader_sn_state: SequenceNumberSetSubmessageElement {
                     base: SequenceNumber::new(10),

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data.rs
@@ -134,9 +134,15 @@ impl<'de: 'a, 'a> MappingReadSubmessage<'de> for DataSubmessage<'a> {
 mod tests {
 
     use crate::implementation::{
-        rtps::{messages::submessage_elements::{
-            EntityIdSubmessageElement, Parameter, SequenceNumberSubmessageElement,
-        }, types::{EntityId, USER_DEFINED_READER_NO_KEY, USER_DEFINED_READER_GROUP, SequenceNumber}},
+        rtps::{
+            messages::submessage_elements::{
+                EntityIdSubmessageElement, Parameter, SequenceNumberSubmessageElement,
+            },
+            types::{
+                EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
+                USER_DEFINED_READER_NO_KEY,
+            },
+        },
         rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
     };
 
@@ -150,12 +156,14 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
-        let writer_sn = SequenceNumberSubmessageElement { value: SequenceNumber::new(5) };
+        let writer_sn = SequenceNumberSubmessageElement {
+            value: SequenceNumber::new(5),
+        };
         let inline_qos = ParameterListSubmessageElement { parameter: vec![] };
         let serialized_payload = SerializedDataSubmessageElement { value: &[][..] };
         let submessage = DataSubmessage {
@@ -190,12 +198,14 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
-        let writer_sn = SequenceNumberSubmessageElement { value: SequenceNumber::new(5) };
+        let writer_sn = SequenceNumberSubmessageElement {
+            value: SequenceNumber::new(5),
+        };
         let parameter_1 = Parameter {
             parameter_id: 6,
             length: 4,
@@ -248,12 +258,14 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
-        let writer_sn = SequenceNumberSubmessageElement { value: SequenceNumber::new(5) };
+        let writer_sn = SequenceNumberSubmessageElement {
+            value: SequenceNumber::new(5),
+        };
         let inline_qos = ParameterListSubmessageElement { parameter: vec![] };
         let serialized_payload = SerializedDataSubmessageElement {
             value: &[1_u8, 2, 3, 4][..],
@@ -291,12 +303,14 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
-        let writer_sn = SequenceNumberSubmessageElement { value: SequenceNumber::new(5) };
+        let writer_sn = SequenceNumberSubmessageElement {
+            value: SequenceNumber::new(5),
+        };
         let inline_qos = ParameterListSubmessageElement { parameter: vec![] };
         let serialized_payload = SerializedDataSubmessageElement {
             value: &[1_u8, 2, 3][..],
@@ -334,12 +348,14 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
-        let writer_sn = SequenceNumberSubmessageElement { value: SequenceNumber::new(5) };
+        let writer_sn = SequenceNumberSubmessageElement {
+            value: SequenceNumber::new(5),
+        };
         let inline_qos = ParameterListSubmessageElement { parameter: vec![] };
         let serialized_payload = SerializedDataSubmessageElement { value: &[][..] };
         let expected = DataSubmessage {
@@ -374,12 +390,14 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
-        let writer_sn = SequenceNumberSubmessageElement { value: SequenceNumber::new(5) };
+        let writer_sn = SequenceNumberSubmessageElement {
+            value: SequenceNumber::new(5),
+        };
         let inline_qos = ParameterListSubmessageElement { parameter: vec![] };
         let serialized_payload = SerializedDataSubmessageElement {
             value: &[1, 2, 3, 4][..],
@@ -417,12 +435,14 @@ mod tests {
         let key_flag = false;
         let non_standard_payload_flag = false;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
-        let writer_sn = SequenceNumberSubmessageElement { value: SequenceNumber::new(5) };
+        let writer_sn = SequenceNumberSubmessageElement {
+            value: SequenceNumber::new(5),
+        };
         let parameter_1 = Parameter {
             parameter_id: 6,
             length: 4,

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/gap.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/gap.rs
@@ -77,7 +77,8 @@ mod tests {
                 SequenceNumberSubmessageElement,
             },
             types::{
-                EntityId, SequenceNumber, USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY,
+                EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
+                USER_DEFINED_READER_NO_KEY,
             },
         },
         rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
@@ -89,10 +90,10 @@ mod tests {
     fn serialize_gap() {
         let endianness_flag = true;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
         let gap_start = SequenceNumberSubmessageElement {
             value: SequenceNumber::new(5),
@@ -126,10 +127,10 @@ mod tests {
     fn deserialize_gap() {
         let endianness_flag = true;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
         let gap_start = SequenceNumberSubmessageElement {
             value: SequenceNumber::new(5),

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat.rs
@@ -79,7 +79,7 @@ mod tests {
                 CountSubmessageElement, EntityIdSubmessageElement, SequenceNumberSubmessageElement,
             },
             types::{
-                Count, EntityId, SequenceNumber, USER_DEFINED_READER_GROUP,
+                Count, EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
                 USER_DEFINED_READER_NO_KEY,
             },
         },
@@ -94,10 +94,10 @@ mod tests {
         let final_flag = false;
         let liveliness_flag = true;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
         let first_sn = SequenceNumberSubmessageElement {
             value: SequenceNumber::new(5),
@@ -138,10 +138,10 @@ mod tests {
         let final_flag = false;
         let liveliness_flag = true;
         let reader_id = EntityIdSubmessageElement {
-            value: EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
+            value: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
         };
         let writer_id = EntityIdSubmessageElement {
-            value: EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
+            value: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
         };
         let first_sn = SequenceNumberSubmessageElement {
             value: SequenceNumber::new(5),

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_types/submessage_or_builtin.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_types/submessage_or_builtin.rs
@@ -14,9 +14,9 @@ impl MappingWriteByteOrdered for Locator {
         &self,
         mut writer: W,
     ) -> Result<(), Error> {
-        <i32>::from(*self.kind()).mapping_write_byte_ordered::<_, B>(&mut writer)?;
-        <u32>::from(*self.port()).mapping_write_byte_ordered::<_, B>(&mut writer)?;
-        <[u8; 16]>::from(*self.address()).mapping_write_byte_ordered::<_, B>(&mut writer)
+        <i32>::from(self.kind()).mapping_write_byte_ordered::<_, B>(&mut writer)?;
+        <u32>::from(self.port()).mapping_write_byte_ordered::<_, B>(&mut writer)?;
+        <[u8; 16]>::from(self.address()).mapping_write_byte_ordered::<_, B>(&mut writer)
     }
 }
 

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -303,8 +303,8 @@ impl ToSocketAddrs for UdpLocator {
     type Iter = std::option::IntoIter<SocketAddr>;
 
     fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
-        let locator_address = <[u8; 16]>::from(*self.0.address());
-        match *self.0.kind() {
+        let locator_address = <[u8; 16]>::from(self.0.address());
+        match self.0.kind() {
             LOCATOR_KIND_UDP_V4 => {
                 let address = SocketAddrV4::new(
                     Ipv4Addr::new(
@@ -313,7 +313,7 @@ impl ToSocketAddrs for UdpLocator {
                         locator_address[14],
                         locator_address[15],
                     ),
-                    <u32>::from(*self.0.port()) as u16,
+                    <u32>::from(self.0.port()) as u16,
                 );
                 Ok(Some(SocketAddr::V4(address)).into_iter())
             }
@@ -346,8 +346,8 @@ impl From<SocketAddr> for UdpLocator {
 
 impl UdpLocator {
     fn is_multicast(&self) -> bool {
-        let locator_address = <[u8; 16]>::from(*self.0.address());
-        match *self.0.kind() {
+        let locator_address = <[u8; 16]>::from(self.0.address());
+        match self.0.kind() {
             LOCATOR_KIND_UDP_V4 => Ipv4Addr::new(
                 locator_address[12],
                 locator_address[13],
@@ -404,11 +404,11 @@ mod tests {
     fn socket_addr_to_locator_conversion() {
         let socket_addr = SocketAddr::from_str("127.0.0.1:7400").unwrap();
         let locator = UdpLocator::from(socket_addr).0;
-        assert_eq!(locator.kind(), &LOCATOR_KIND_UDP_V4);
-        assert_eq!(locator.port(), &LocatorPort::new(7400));
+        assert_eq!(locator.kind(), LOCATOR_KIND_UDP_V4);
+        assert_eq!(locator.port(), LocatorPort::new(7400));
         assert_eq!(
             locator.address(),
-            &LocatorAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 127, 0, 0, 1])
+            LocatorAddress::new([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 127, 0, 0, 1])
         );
     }
 


### PR DESCRIPTION
The derive::Constructor was removed as well since it derived to non const fn. The later is however required by some constants. 