### PR TITLE
DDS-250 Fix deadlock on sample rejected test

### DIFF
--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -817,25 +817,26 @@ impl DdsShared<UserDefinedDataReader> {
     }
 
     fn on_data_available(&self) {
-        self.status_condition
-            .write_lock()
-            .add_communication_state(StatusKind::DataAvailable);
-
         if let Some(listener) = self.listener.write_lock().as_mut() {
             listener.trigger_on_data_available(self);
         }
+
+        self.status_condition
+            .write_lock()
+            .add_communication_state(StatusKind::DataAvailable);
     }
 
     fn on_sample_lost(&self) {
         self.sample_lost_status.write_lock().increment();
-        self.status_condition
-            .write_lock()
-            .add_communication_state(StatusKind::SampleLost);
 
         if let Some(listener) = self.listener.write_lock().as_mut() {
             let status = self.get_sample_lost_status();
             listener.trigger_on_sample_lost(self, status);
         }
+
+        self.status_condition
+            .write_lock()
+            .add_communication_state(StatusKind::SampleLost);
     }
 
     fn on_sample_rejected(
@@ -846,25 +847,26 @@ impl DdsShared<UserDefinedDataReader> {
         self.sample_rejected_status
             .write_lock()
             .increment(instance_handle, rejected_reason);
-        self.status_condition
-            .write_lock()
-            .add_communication_state(StatusKind::SampleRejected);
 
         if let Some(listener) = self.listener.write_lock().as_mut() {
             let status = self.get_sample_rejected_status();
             listener.trigger_on_sample_rejected(self, status);
         }
+
+        self.status_condition
+            .write_lock()
+            .add_communication_state(StatusKind::SampleRejected);
     }
 
     fn on_requested_deadline_missed(&self) {
-        self.status_condition
-            .write_lock()
-            .add_communication_state(StatusKind::RequestedDeadlineMissed);
-
         if let Some(listener) = self.listener.write_lock().as_mut() {
             let status = self.get_requested_deadline_missed_status().unwrap();
             listener.trigger_on_requested_deadline_missed(self, status);
         }
+
+        self.status_condition
+            .write_lock()
+            .add_communication_state(StatusKind::RequestedDeadlineMissed);
     }
 }
 


### PR DESCRIPTION
This PR fixes the deadlock on the sample rejected test.

The reason why the deadlock is happening is because the drop being called on the DataReader available as part of the listener was actually attempting to delete the reader. This is not expected since the main thread should still have a weak reference to the data reader. However, because the main thread is waiting on the status condition and this status condition was triggered before running the listener this sometimes cause the object of the main thread to be already dropped by the time the listener finished executing. 

The fix to this problem is to trigger the status condition only after running the listener. This is also how it is described by the DDS standard in 2.2.4.6 Combination