### PR TITLE
DDS-254 Delete topic on drop

### DIFF
--- a/dds/src/domain/domain_participant.rs
+++ b/dds/src/domain/domain_participant.rs
@@ -19,11 +19,7 @@ use crate::{
         subscriber::{Subscriber, SubscriberKind},
         subscriber_listener::SubscriberListener,
     },
-    topic_definition::{
-        topic::Topic,
-        topic_listener::TopicListener,
-        type_support::{DdsDeserialize, DdsType},
-    },
+    topic_definition::{topic::Topic, topic_listener::TopicListener, type_support::DdsType},
 };
 
 use super::{
@@ -174,13 +170,9 @@ impl DomainParticipant {
     /// it, it will return [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError).
     /// The [`DomainParticipant::delete_topic()`] operation must be called on the same [`DomainParticipant`] object used to create the [`Topic`]. If [`DomainParticipant::delete_topic()`] is
     /// called on a different [`DomainParticipant`], the operation will have no effect and it will return [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError).
-    pub fn delete_topic<Foo>(&self, a_topic: &Topic<Foo>) -> DdsResult<()>
-    where
-        Foo: DdsType + for<'de> DdsDeserialize<'de> + 'static,
-    {
-        self.0
-            .upgrade()?
-            .delete_topic::<Foo>(a_topic.get_instance_handle()?)
+    pub fn delete_topic<'a, Foo: 'a>(&'a self, a_topic: &'a Topic<Foo>) -> DdsResult<()> {
+        let topic_handle = a_topic.0.upgrade()?.get_instance_handle();
+        self.0.upgrade()?.delete_topic(topic_handle)
     }
 
     /// This operation gives access to an existing (or ready to exist) enabled [`Topic`], based on its name. The operation takes

--- a/dds/src/domain/domain_participant.rs
+++ b/dds/src/domain/domain_participant.rs
@@ -276,7 +276,7 @@ impl DomainParticipant {
     /// This operation retrieves the [`DomainId`] used to create the DomainParticipant. The [`DomainId`] identifies the DDS domain to
     /// which the [`DomainParticipant`] belongs. Each DDS domain represents a separate data “communication plane” isolated from other domains.
     pub fn get_domain_id(&self) -> DdsResult<DomainId> {
-        self.0.upgrade()?.get_domain_id()
+        Ok(self.0.upgrade()?.get_domain_id())
     }
 
     /// This operation deletes all the entities that were created by means of the “create” operations on the DomainParticipant. That is,

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -440,7 +440,7 @@ impl DdsShared<DomainParticipantImpl> {
         Ok(topic_shared)
     }
 
-    pub fn delete_topic<Foo>(&self, a_topic_handle: InstanceHandle) -> DdsResult<()> {
+    pub fn delete_topic(&self, a_topic_handle: InstanceHandle) -> DdsResult<()> {
         if self
             .topic_list
             .read_lock()

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -574,12 +574,8 @@ impl DdsShared<DomainParticipantImpl> {
         todo!()
     }
 
-    pub fn get_domain_id(&self) -> DdsResult<DomainId> {
-        if !*self.enabled.read_lock() {
-            return Err(DdsError::NotEnabled);
-        }
-
-        todo!()
+    pub fn get_domain_id(&self) -> DomainId {
+        self.domain_id
     }
 
     pub fn delete_contained_entities(&self) -> DdsResult<()> {

--- a/dds/src/topic_definition/topic.rs
+++ b/dds/src/topic_definition/topic.rs
@@ -28,6 +28,16 @@ impl<Foo> Topic<Foo> {
     }
 }
 
+impl<Foo> Drop for Topic<Foo> {
+    fn drop(&mut self) {
+        if self.0.weak_count() == 1 {
+            if let Ok(p) = self.get_participant() {
+                p.delete_topic(self).ok();
+            }
+        }
+    }
+}
+
 impl<Foo> Topic<Foo> {
     /// This method allows the application to retrieve the [`InconsistentTopicStatus`] of the [`Topic`].
     pub fn get_inconsistent_topic_status(&self) -> DdsResult<InconsistentTopicStatus> {

--- a/dds/tests/domain_participant_factory.rs
+++ b/dds/tests/domain_participant_factory.rs
@@ -1,0 +1,93 @@
+use dust_dds::{
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        qos::{DataReaderQos, DataWriterQos, QosKind},
+        qos_policy::{ReliabilityQosPolicy, ReliabilityQosPolicyKind},
+        status::{StatusKind, NO_STATUS},
+        time::Duration,
+        wait_set::{Condition, WaitSet},
+    },
+    subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+    topic_definition::type_support::{DdsSerde, DdsType},
+};
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+struct KeyedData {
+    #[key]
+    id: u8,
+    value: u8,
+}
+
+#[test]
+fn all_objects_are_dropped() {
+    let domain_id = 0;
+    let domain_participant_factory = DomainParticipantFactory::get_instance();
+
+    {
+        let participant = domain_participant_factory
+            .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+            .unwrap();
+
+        let topic = participant
+            .create_topic::<KeyedData>("MyTopic", QosKind::Default, None, NO_STATUS)
+            .unwrap();
+
+        let publisher = participant
+            .create_publisher(QosKind::Default, None, NO_STATUS)
+            .unwrap();
+        let writer_qos = DataWriterQos {
+            reliability: ReliabilityQosPolicy {
+                kind: ReliabilityQosPolicyKind::Reliable,
+                max_blocking_time: Duration::new(1, 0),
+            },
+            ..Default::default()
+        };
+        let writer = publisher
+            .create_datawriter(&topic, QosKind::Specific(writer_qos), None, NO_STATUS)
+            .unwrap();
+
+        let subscriber = participant
+            .create_subscriber(QosKind::Default, None, NO_STATUS)
+            .unwrap();
+        let reader_qos = DataReaderQos {
+            reliability: ReliabilityQosPolicy {
+                kind: ReliabilityQosPolicyKind::Reliable,
+                max_blocking_time: Duration::new(1, 0),
+            },
+            ..Default::default()
+        };
+        let reader = subscriber
+            .create_datareader(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
+            .unwrap();
+
+        let cond = writer.get_statuscondition().unwrap();
+        cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+            .unwrap();
+
+        let mut wait_set = WaitSet::new();
+        wait_set
+            .attach_condition(Condition::StatusCondition(cond))
+            .unwrap();
+        wait_set.wait(Duration::new(5, 0)).unwrap();
+
+        let data1 = KeyedData { id: 1, value: 1 };
+        let data2 = KeyedData { id: 2, value: 10 };
+        let data3 = KeyedData { id: 3, value: 20 };
+
+        writer.write(&data1, None).unwrap();
+        writer.write(&data2, None).unwrap();
+        writer.write(&data3, None).unwrap();
+
+        writer
+            .wait_for_acknowledgments(Duration::new(1, 0))
+            .unwrap();
+
+        let _samples = reader
+            .read(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+            .unwrap();
+    }
+
+    assert!(domain_participant_factory
+        .lookup_participant(domain_id)
+        .is_none());
+}


### PR DESCRIPTION
The topic object was not deleted when the object was going out of scope. This was preventing other objects from being deleted as well which also caused the disposal messages not to be sent. A test is added to explicitly verify that once going out of scope a participant can't be found in the factory anymore.