### PR TITLE
DDS-261 Add default datareader QoS to subscriber

### DIFF
--- a/dds/src/domain/domain_participant_factory.rs
+++ b/dds/src/domain/domain_participant_factory.rs
@@ -1,20 +1,16 @@
 use crate::{
     domain::domain_participant_listener::DomainParticipantListener,
     implementation::{
-        dds_impl::{
-            configuration::DustDdsConfiguration, dcps_service::DcpsService,
-            domain_participant_impl::DomainParticipantImpl,
-        },
+        dds_impl::{configuration::DustDdsConfiguration, dcps_service::DcpsService},
         rtps::{
             participant::RtpsParticipant,
             types::{GuidPrefix, PROTOCOLVERSION, VENDOR_ID_S2E},
         },
         rtps_udp_psm::udp_transport::RtpsUdpPsm,
-        utils::shared_object::{DdsRwLock, DdsShared},
+        utils::shared_object::DdsRwLock,
     },
     infrastructure::{
         error::{DdsError, DdsResult},
-        instance::InstanceHandle,
         qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
         status::StatusKind,
     },
@@ -187,29 +183,5 @@ impl DomainParticipantFactory {
     /// This operation returns the value of the [`DomainParticipantFactoryQos`] policies.
     pub fn get_qos(&self) -> DomainParticipantFactoryQos {
         self.qos.read_lock().clone()
-    }
-}
-
-impl DomainParticipantFactory {
-    /// This functions returns the participant which is the parent
-    /// of the object passed as instance handle.
-    pub(crate) fn lookup_participant_by_entity_handle(
-        &self,
-        instance_handle: InstanceHandle,
-    ) -> DdsShared<DomainParticipantImpl> {
-        let participant_list_lock = self.participant_list.read_lock();
-        participant_list_lock
-            .iter()
-            .find(|x| {
-                if let Ok(handle) = x.participant().get_instance_handle() {
-                    <[u8; 16]>::from(handle)[0..12] == <[u8; 16]>::from(instance_handle)[0..12]
-                } else {
-                    false
-                }
-            })
-            .map(|x| x.participant().clone())
-            // This function is only used internally and only for valid handles
-            // so it should never fail to find an existing participant
-            .expect("Failed to find participant in factory")
     }
 }

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -357,7 +357,7 @@ impl DdsShared<DomainParticipantImpl> {
                 .entity_factory
                 .autoenable_created_entities
         {
-            subscriber_shared.enable(self)?;
+            subscriber_shared.enable()?;
         }
 
         self.user_defined_subscriber_list
@@ -746,7 +746,7 @@ impl DdsShared<DomainParticipantImpl> {
                 }
 
                 for subscriber in self.user_defined_subscriber_list.read_lock().iter() {
-                    subscriber.enable(self)?;
+                    subscriber.enable()?;
                 }
 
                 for topic in self.topic_list.read_lock().iter() {

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -303,8 +303,8 @@ impl DdsShared<UserDefinedSubscriber> {
         todo!()
     }
 
-    pub fn enable(&self, parent_participant: &DdsShared<DomainParticipantImpl>) -> DdsResult<()> {
-        if !parent_participant.is_enabled() {
+    pub fn enable(&self) -> DdsResult<()> {
+        if !self.get_participant().is_enabled() {
             return Err(DdsError::PreconditionNotMet(
                 "Parent participant is disabled".to_string(),
             ));

--- a/dds/src/subscription/subscriber.rs
+++ b/dds/src/subscription/subscriber.rs
@@ -204,7 +204,7 @@ impl Subscriber {
     pub fn get_default_datareader_qos(&self) -> DdsResult<DataReaderQos> {
         match &self.0 {
             SubscriberKind::BuiltIn(_) => Err(DdsError::IllegalOperation),
-            SubscriberKind::UserDefined(s) => s.upgrade()?.get_default_datareader_qos(),
+            SubscriberKind::UserDefined(s) => Ok(s.upgrade()?.get_default_datareader_qos()),
         }
     }
 

--- a/dds/tests/subscriber_api.rs
+++ b/dds/tests/subscriber_api.rs
@@ -1,7 +1,15 @@
 use dust_dds::{
     domain::domain_participant_factory::DomainParticipantFactory,
-    infrastructure::{qos::QosKind, status::NO_STATUS},
+    infrastructure::{
+        qos::{DataReaderQos, QosKind},
+        qos_policy::UserDataQosPolicy,
+        status::NO_STATUS,
+    },
+    topic_definition::type_support::{DdsSerde, DdsType},
 };
+
+#[derive(serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+struct UserType(i32);
 
 #[test]
 fn get_subscriber_parent_participant() {
@@ -17,4 +25,46 @@ fn get_subscriber_parent_participant() {
     let subscriber_parent_participant = subscriber.get_participant().unwrap();
 
     assert_eq!(participant, subscriber_parent_participant);
+}
+
+#[test]
+fn default_data_reader_qos() {
+    let domain_participant_factory = DomainParticipantFactory::get_instance();
+    let participant = domain_participant_factory
+        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<UserType>("default_data_reader_qos", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let user_data = vec![1, 2, 3];
+    let qos = DataReaderQos {
+        user_data: UserDataQosPolicy {
+            value: user_data.clone(),
+        },
+        ..Default::default()
+    };
+
+    subscriber
+        .set_default_datareader_qos(QosKind::Specific(qos))
+        .unwrap();
+
+    let reader = subscriber
+        .create_datareader(&topic, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    assert_eq!(
+        &subscriber
+            .get_default_datareader_qos()
+            .unwrap()
+            .user_data
+            .value,
+        &user_data
+    );
+    assert_eq!(&reader.get_qos().unwrap().user_data.value, &user_data);
 }


### PR DESCRIPTION
Add default datareader QoS to subscriber and clean-up an old way of getting the parent participant.