### PR TITLE
DDS-264 Add delete_contained_entities functionality

### DIFF
--- a/dds/src/domain/domain_participant_factory.rs
+++ b/dds/src/domain/domain_participant_factory.rs
@@ -117,10 +117,16 @@ impl DomainParticipantFactory {
             .position(|pm| DomainParticipant::new(pm.participant().downgrade()).eq(participant))
             .ok_or(DdsError::AlreadyDeleted)?;
 
-        participant_list[index].shutdown_tasks();
-        participant_list.remove(index);
+        if participant_list[index].participant().is_empty() {
+            participant_list[index].shutdown_tasks();
+            participant_list.remove(index);
 
-        Ok(())
+            Ok(())
+        } else {
+            Err(DdsError::PreconditionNotMet(
+                "Domain participant still contains other entities".to_string(),
+            ))
+        }
     }
 
     /// This operation returns the [`DomainParticipantFactory`] singleton. The operation is idempotent, that is, it can be called multiple

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -579,11 +579,17 @@ impl DdsShared<DomainParticipantImpl> {
     }
 
     pub fn delete_contained_entities(&self) -> DdsResult<()> {
-        if !*self.enabled.read_lock() {
-            return Err(DdsError::NotEnabled);
+        for user_defined_publisher in self.user_defined_publisher_list.write_lock().drain(..) {
+            user_defined_publisher.delete_contained_entities()?;
         }
 
-        todo!()
+        for user_defined_subscriber in self.user_defined_subscriber_list.write_lock().drain(..) {
+            user_defined_subscriber.delete_contained_entities()?;
+        }
+
+        self.topic_list.write_lock().clear();
+
+        Ok(())
     }
 
     pub fn assert_liveliness(&self) -> DdsResult<()> {

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -239,6 +239,12 @@ impl DomainParticipantImpl {
 }
 
 impl DdsShared<DomainParticipantImpl> {
+    pub fn is_empty(&self) -> bool {
+        self.user_defined_publisher_list.read_lock().is_empty()
+            && self.user_defined_publisher_list.read_lock().is_empty()
+            && self.topic_list.read_lock().is_empty()
+    }
+
     pub fn is_enabled(&self) -> bool {
         *self.enabled.read_lock()
     }

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -246,11 +246,14 @@ impl DdsShared<UserDefinedSubscriber> {
     }
 
     pub fn delete_contained_entities(&self) -> DdsResult<()> {
-        if !*self.enabled.read_lock() {
-            return Err(DdsError::NotEnabled);
+        for data_reader in self.data_reader_list.write_lock().drain(..) {
+            if data_reader.is_enabled() {
+                self.get_participant()
+                    .announce_deleted_datareader(data_reader.as_discovered_reader_data())?;
+            }
         }
 
-        todo!()
+        Ok(())
     }
 
     pub fn set_default_datareader_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -339,3 +339,34 @@ fn allowed_to_delete_topic_with_created_and_deleted_reader() {
         .expect("Failed to delete datareader");
     assert_eq!(participant.delete_topic(&reader_topic), Ok(()));
 }
+
+#[test]
+fn allowed_to_delete_participant_after_delete_contained_entities() {
+    let domain_participant_factory = DomainParticipantFactory::get_instance();
+    let participant = domain_participant_factory
+        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<TestType>("Test", QosKind::Default, None, NO_STATUS)
+        .expect("Error creating topic");
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let _datareader = subscriber
+        .create_datareader::<TestType>(&topic, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let _datawriter = publisher
+        .create_datawriter(&topic, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    participant.delete_contained_entities().unwrap();
+
+    assert!(domain_participant_factory
+        .delete_participant(&participant)
+        .is_ok());
+}

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -339,34 +339,3 @@ fn allowed_to_delete_topic_with_created_and_deleted_reader() {
         .expect("Failed to delete datareader");
     assert_eq!(participant.delete_topic(&reader_topic), Ok(()));
 }
-
-#[test]
-fn allowed_to_delete_participant_after_delete_contained_entities() {
-    let domain_participant_factory = DomainParticipantFactory::get_instance();
-    let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
-        .unwrap();
-
-    let topic = participant
-        .create_topic::<TestType>("Test", QosKind::Default, None, NO_STATUS)
-        .expect("Error creating topic");
-    let subscriber = participant
-        .create_subscriber(QosKind::Default, None, NO_STATUS)
-        .unwrap();
-    let _datareader = subscriber
-        .create_datareader::<TestType>(&topic, QosKind::Default, None, NO_STATUS)
-        .unwrap();
-
-    let publisher = participant
-        .create_publisher(QosKind::Default, None, NO_STATUS)
-        .unwrap();
-    let _datawriter = publisher
-        .create_datawriter(&topic, QosKind::Default, None, NO_STATUS)
-        .unwrap();
-
-    participant.delete_contained_entities().unwrap();
-
-    assert!(domain_participant_factory
-        .delete_participant(&participant)
-        .is_ok());
-}

--- a/dds/tests/domain_participant_factory.rs
+++ b/dds/tests/domain_participant_factory.rs
@@ -85,6 +85,66 @@ fn default_participant_qos() {
 }
 
 #[test]
+fn not_allowed_to_delete_participant_with_entities() {
+    let domain_participant_factory = DomainParticipantFactory::get_instance();
+    let participant = domain_participant_factory
+        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>("Test", QosKind::Default, None, NO_STATUS)
+        .expect("Error creating topic");
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let _datareader = subscriber
+        .create_datareader::<KeyedData>(&topic, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let _datawriter = publisher
+        .create_datawriter(&topic, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    assert!(domain_participant_factory
+        .delete_participant(&participant)
+        .is_err());
+}
+
+#[test]
+fn allowed_to_delete_participant_after_delete_contained_entities() {
+    let domain_participant_factory = DomainParticipantFactory::get_instance();
+    let participant = domain_participant_factory
+        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>("Test", QosKind::Default, None, NO_STATUS)
+        .expect("Error creating topic");
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let _datareader = subscriber
+        .create_datareader::<KeyedData>(&topic, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let _datawriter = publisher
+        .create_datawriter(&topic, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    participant.delete_contained_entities().unwrap();
+
+    assert!(domain_participant_factory
+        .delete_participant(&participant)
+        .is_ok());
+}
+
+#[test]
 fn all_objects_are_dropped() {
     let domain_id = 0;
     let domain_participant_factory = DomainParticipantFactory::get_instance();


### PR DESCRIPTION
Add delete_contained_entities functionality and prevent the DomainParticipant from being deleted if it still contains any entity.