### PR TITLE
DDS-267 Parallelize integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             export RUSTFLAGS="-Cinstrument-coverage -Dwarnings"
             export LLVM_PROFILE_FILE="test-%p-%m.profraw"
-            cargo test --jobs 4 -- --test-threads=1
+            cargo test --jobs 4
       - run:
           name: Hello world example
           no_output_timeout: 30s

--- a/dds/tests/data_available_listeners.rs
+++ b/dds/tests/data_available_listeners.rs
@@ -16,6 +16,9 @@ use dust_dds::{
 
 use mockall::mock;
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct MyData {
     #[key]
@@ -38,7 +41,7 @@ fn on_data_available_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -125,7 +128,7 @@ fn data_on_readers_listener() {
 
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -222,7 +225,7 @@ fn data_available_listener_not_called_when_data_on_readers_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory

--- a/dds/tests/data_reader_listener.rs
+++ b/dds/tests/data_reader_listener.rs
@@ -19,6 +19,9 @@ use dust_dds::{
 
 use mockall::mock;
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct MyData {
     #[key]
@@ -42,7 +45,7 @@ fn deadline_missed_listener() {
         }
 
     }
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -142,7 +145,7 @@ fn sample_rejected_listener() {
 
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -256,7 +259,7 @@ fn subscription_matched_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -347,7 +350,7 @@ fn requested_incompatible_qos_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory

--- a/dds/tests/data_writer_listener.rs
+++ b/dds/tests/data_writer_listener.rs
@@ -14,6 +14,9 @@ use dust_dds::{
 };
 use mockall::mock;
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct MyData {
     #[key]
@@ -37,7 +40,7 @@ fn publication_matched_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -128,7 +131,7 @@ fn offered_incompatible_qos_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -10,12 +10,15 @@ use dust_dds::{
     topic_definition::type_support::{DdsSerde, DdsType},
 };
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct UserType(i32);
 
 #[test]
 fn writer_discovers_reader_in_same_participant() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
@@ -50,7 +53,7 @@ fn writer_discovers_reader_in_same_participant() {
 
 #[test]
 fn deleted_readers_are_disposed_from_writer() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
@@ -89,7 +92,7 @@ fn deleted_readers_are_disposed_from_writer() {
 
 #[test]
 fn updated_readers_are_announced_to_writer() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
@@ -139,7 +142,7 @@ fn updated_readers_are_announced_to_writer() {
 
 #[test]
 fn reader_discovers_writer_in_same_participant() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
@@ -174,7 +177,7 @@ fn reader_discovers_writer_in_same_participant() {
 
 #[test]
 fn deleted_writers_are_disposed_from_reader() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
@@ -213,7 +216,7 @@ fn deleted_writers_are_disposed_from_reader() {
 
 #[test]
 fn updated_writers_are_announced_to_reader() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
@@ -264,8 +267,7 @@ fn updated_writers_are_announced_to_reader() {
 
 #[test]
 fn participant_records_discovered_topics() {
-    let domain_id = 0;
-
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
 
     let participant1 = domain_participant_factory
@@ -303,8 +305,7 @@ fn participant_records_discovered_topics() {
 
 #[test]
 fn participant_announces_updated_qos() {
-    let domain_id = 0;
-
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
 
     let participant1 = domain_participant_factory
@@ -332,12 +333,9 @@ fn participant_announces_updated_qos() {
     std::thread::sleep(std::time::Duration::from_secs(5));
 }
 
-
-
-
 #[test]
 fn reader_discovers_disposed_writer_same_participant() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -11,6 +11,9 @@ use dust_dds::{
     topic_definition::type_support::{DdsDeserialize, DdsSerialize, DdsType, Endianness},
 };
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 struct TestType;
 
 impl DdsType for TestType {
@@ -37,9 +40,10 @@ impl<'de> DdsDeserialize<'de> for TestType {
 
 #[test]
 fn create_delete_publisher() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let publisher = participant
@@ -56,9 +60,10 @@ fn create_delete_publisher() {
 
 #[test]
 fn create_delete_subscriber() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let subscriber = participant
@@ -75,9 +80,10 @@ fn create_delete_subscriber() {
 
 #[test]
 fn create_delete_topic() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let topic = participant
@@ -94,12 +100,13 @@ fn create_delete_topic() {
 
 #[test]
 fn not_allowed_to_delete_publisher_from_different_participant() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
     let other_participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let publisher = participant
@@ -115,12 +122,13 @@ fn not_allowed_to_delete_publisher_from_different_participant() {
 
 #[test]
 fn not_allowed_to_delete_subscriber_from_different_participant() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
     let other_participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let subscriber = participant
@@ -136,12 +144,13 @@ fn not_allowed_to_delete_subscriber_from_different_participant() {
 
 #[test]
 fn not_allowed_to_delete_topic_from_different_participant() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
     let other_participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let topic = participant
@@ -157,9 +166,10 @@ fn not_allowed_to_delete_topic_from_different_participant() {
 
 #[test]
 fn not_allowed_to_delete_publisher_with_writer() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let writer_topic = participant
@@ -182,9 +192,10 @@ fn not_allowed_to_delete_publisher_with_writer() {
 
 #[test]
 fn not_allowed_to_delete_subscriber_with_reader() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let reader_topic = participant
@@ -207,9 +218,10 @@ fn not_allowed_to_delete_subscriber_with_reader() {
 
 #[test]
 fn not_allowed_to_delete_topic_attached_to_reader() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let reader_topic = participant
@@ -232,9 +244,10 @@ fn not_allowed_to_delete_topic_attached_to_reader() {
 
 #[test]
 fn not_allowed_to_delete_topic_attached_to_writer() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let writer_topic = participant
@@ -257,9 +270,10 @@ fn not_allowed_to_delete_topic_attached_to_writer() {
 
 #[test]
 fn allowed_to_delete_publisher_with_created_and_deleted_writer() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let writer_topic = participant
@@ -279,9 +293,10 @@ fn allowed_to_delete_publisher_with_created_and_deleted_writer() {
 
 #[test]
 fn allowed_to_delete_subscriber_with_created_and_deleted_reader() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let reader_topic = participant
@@ -301,9 +316,10 @@ fn allowed_to_delete_subscriber_with_created_and_deleted_reader() {
 
 #[test]
 fn allowed_to_delete_topic_with_created_and_deleted_writer() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let writer_topic = participant
@@ -323,9 +339,10 @@ fn allowed_to_delete_topic_with_created_and_deleted_writer() {
 
 #[test]
 fn allowed_to_delete_topic_with_created_and_deleted_reader() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let reader_topic = participant
@@ -345,9 +362,10 @@ fn allowed_to_delete_topic_with_created_and_deleted_reader() {
 
 #[test]
 fn default_publisher_qos() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let group_data = vec![1, 2, 3];

--- a/dds/tests/domain_participant_factory.rs
+++ b/dds/tests/domain_participant_factory.rs
@@ -1,16 +1,8 @@
 use dust_dds::{
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{
-        error::DdsError,
-        instance::HANDLE_NIL,
-        qos::{
-            DataReaderQos, DataWriterQos, DomainParticipantFactoryQos, DomainParticipantQos,
-            QosKind,
-        },
-        qos_policy::{
-            EntityFactoryQosPolicy, ReliabilityQosPolicy, ReliabilityQosPolicyKind,
-            UserDataQosPolicy,
-        },
+        qos::{DataReaderQos, DataWriterQos, DomainParticipantQos, QosKind},
+        qos_policy::{ReliabilityQosPolicy, ReliabilityQosPolicyKind, UserDataQosPolicy},
         status::{StatusKind, NO_STATUS},
         time::Duration,
         wait_set::{Condition, WaitSet},
@@ -27,36 +19,6 @@ struct KeyedData {
     #[key]
     id: u8,
     value: u8,
-}
-
-#[test]
-fn create_not_enabled_entities() {
-    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
-    let domain_participant_factory = DomainParticipantFactory::get_instance();
-
-    let qos = DomainParticipantFactoryQos {
-        entity_factory: EntityFactoryQosPolicy {
-            autoenable_created_entities: false,
-        },
-    };
-
-    domain_participant_factory
-        .set_qos(QosKind::Specific(qos))
-        .unwrap();
-
-    let participant = domain_participant_factory
-        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
-        .unwrap();
-
-    // Call an operation that should return a NotEnabled error as a check the QoS is taken
-    let result = participant.ignore_topic(HANDLE_NIL);
-
-    // Teardown before assert: Set qos back to original to prevent it affecting other test
-    domain_participant_factory
-        .set_qos(QosKind::Default)
-        .unwrap();
-
-    assert_eq!(result, Err(DdsError::NotEnabled));
 }
 
 #[test]

--- a/dds/tests/domain_participant_factory.rs
+++ b/dds/tests/domain_participant_factory.rs
@@ -19,6 +19,9 @@ use dust_dds::{
     topic_definition::type_support::{DdsSerde, DdsType},
 };
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct KeyedData {
     #[key]
@@ -28,7 +31,7 @@ struct KeyedData {
 
 #[test]
 fn create_not_enabled_entities() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
 
     let qos = DomainParticipantFactoryQos {
@@ -58,7 +61,7 @@ fn create_not_enabled_entities() {
 
 #[test]
 fn default_participant_qos() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
 
     let user_data = vec![1, 2, 3];
@@ -86,9 +89,10 @@ fn default_participant_qos() {
 
 #[test]
 fn not_allowed_to_delete_participant_with_entities() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let topic = participant
@@ -115,9 +119,10 @@ fn not_allowed_to_delete_participant_with_entities() {
 
 #[test]
 fn allowed_to_delete_participant_after_delete_contained_entities() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let topic = participant
@@ -146,7 +151,7 @@ fn allowed_to_delete_participant_after_delete_contained_entities() {
 
 #[test]
 fn all_objects_are_dropped() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
 
     {

--- a/dds/tests/domain_participant_factory_qos.rs
+++ b/dds/tests/domain_participant_factory_qos.rs
@@ -1,0 +1,43 @@
+use dust_dds::{
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        error::DdsError,
+        instance::HANDLE_NIL,
+        qos::{DomainParticipantFactoryQos, QosKind},
+        qos_policy::EntityFactoryQosPolicy,
+        status::NO_STATUS,
+    },
+};
+
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
+#[test]
+fn create_not_enabled_entities() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let domain_participant_factory = DomainParticipantFactory::get_instance();
+
+    let qos = DomainParticipantFactoryQos {
+        entity_factory: EntityFactoryQosPolicy {
+            autoenable_created_entities: false,
+        },
+    };
+
+    domain_participant_factory
+        .set_qos(QosKind::Specific(qos))
+        .unwrap();
+
+    let participant = domain_participant_factory
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    // Call an operation that should return a NotEnabled error as a check the QoS is taken
+    let result = participant.ignore_topic(HANDLE_NIL);
+
+    // Teardown before assert: Set qos back to original to prevent it affecting other test
+    domain_participant_factory
+        .set_qos(QosKind::Default)
+        .unwrap();
+
+    assert_eq!(result, Err(DdsError::NotEnabled));
+}

--- a/dds/tests/domain_participant_listener.rs
+++ b/dds/tests/domain_participant_listener.rs
@@ -23,6 +23,9 @@ use dust_dds::{
 };
 use mockall::mock;
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct MyData {
     #[key]
@@ -44,7 +47,7 @@ fn deadline_missed_listener() {
         }
 
     }
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let mut participant_listener = MockDeadlineMissedListener::new();
     participant_listener
@@ -142,7 +145,7 @@ fn sample_rejected_listener() {
 
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let mut participant_listener = MockSampleRejectedListener::new();
@@ -254,7 +257,7 @@ fn subscription_matched_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let mut participant_listener = MockSubscriptionMatchedListener::new();
@@ -343,7 +346,7 @@ fn requested_incompatible_qos_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let mut participant_listener = MockRequestedIncompatibleQosListener::new();
@@ -432,7 +435,7 @@ fn publication_matched_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let mut participant_listener = MockPublicationMatchedListener::new();
@@ -522,7 +525,7 @@ fn offered_incompatible_qos_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let mut participant_listener = MockOfferedIncompatibleQosListener::new();

--- a/dds/tests/publisher_api.rs
+++ b/dds/tests/publisher_api.rs
@@ -8,14 +8,18 @@ use dust_dds::{
     topic_definition::type_support::{DdsSerde, DdsType},
 };
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct UserType(i32);
 
 #[test]
 fn get_publisher_parent_participant() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let publisher = participant
@@ -29,9 +33,10 @@ fn get_publisher_parent_participant() {
 
 #[test]
 fn default_data_writer_qos() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let topic = participant

--- a/dds/tests/publisher_listener.rs
+++ b/dds/tests/publisher_listener.rs
@@ -14,6 +14,9 @@ use dust_dds::{
 };
 use mockall::mock;
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct MyData {
     #[key]
@@ -35,7 +38,7 @@ fn publication_matched_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -124,7 +127,7 @@ fn offered_incompatible_qos_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory

--- a/dds/tests/subscriber_api.rs
+++ b/dds/tests/subscriber_api.rs
@@ -8,14 +8,18 @@ use dust_dds::{
     topic_definition::type_support::{DdsSerde, DdsType},
 };
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct UserType(i32);
 
 #[test]
 fn get_subscriber_parent_participant() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let subscriber = participant
@@ -29,9 +33,10 @@ fn get_subscriber_parent_participant() {
 
 #[test]
 fn default_data_reader_qos() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory = DomainParticipantFactory::get_instance();
     let participant = domain_participant_factory
-        .create_participant(0, QosKind::Default, None, NO_STATUS)
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
     let topic = participant

--- a/dds/tests/subscriber_listener.rs
+++ b/dds/tests/subscriber_listener.rs
@@ -18,6 +18,9 @@ use dust_dds::{
 };
 use mockall::mock;
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct MyData {
     #[key]
@@ -41,7 +44,7 @@ fn deadline_missed_listener() {
         }
 
     }
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -138,7 +141,7 @@ fn sample_rejected_listener() {
 
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -249,7 +252,7 @@ fn subscription_matched_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -337,7 +340,7 @@ fn requested_incompatible_qos_listener() {
         }
     }
 
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory

--- a/dds/tests/utils/domain_id_generator.rs
+++ b/dds/tests/utils/domain_id_generator.rs
@@ -1,0 +1,21 @@
+use std::sync::atomic::AtomicI32;
+
+use dust_dds::domain::domain_participant_factory::DomainId;
+
+pub static TEST_DOMAIN_ID_GENERATOR: DomainIdGenerator = DomainIdGenerator::new();
+
+pub struct DomainIdGenerator {
+    id: AtomicI32,
+}
+
+impl DomainIdGenerator {
+    pub const fn new() -> Self {
+        Self {
+            id: AtomicI32::new(0),
+        }
+    }
+
+    pub fn generate_unique_domain_id(&self) -> DomainId {
+        self.id.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+    }
+}

--- a/dds/tests/utils/mod.rs
+++ b/dds/tests/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod domain_id_generator;

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -15,6 +15,9 @@ use dust_dds::{
     topic_definition::type_support::{DdsSerde, DdsType},
 };
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
 struct KeyedData {
     #[key]
@@ -24,7 +27,7 @@ struct KeyedData {
 
 #[test]
 fn each_key_sample_is_read() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -110,7 +113,7 @@ fn each_key_sample_is_read() {
 
 #[test]
 fn write_read_disposed_samples() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -194,7 +197,7 @@ fn write_read_disposed_samples() {
 
 #[test]
 fn write_read_sample_view_state() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -29,7 +29,7 @@ struct KeyedData {
 
 #[test]
 fn samples_are_taken() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -113,7 +113,7 @@ fn samples_are_taken() {
 
 #[test]
 fn read_only_unread_samples() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -216,7 +216,7 @@ fn read_only_unread_samples() {
 
 #[test]
 fn read_next_sample() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -284,7 +284,7 @@ fn read_next_sample() {
 
 #[test]
 fn take_next_sample() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -438,7 +438,7 @@ fn each_key_sample_is_read() {
 
 #[test]
 fn read_specific_instance() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -514,7 +514,7 @@ fn read_specific_instance() {
 
 #[test]
 fn read_next_instance() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -620,7 +620,7 @@ fn read_next_instance() {
 
 #[test]
 fn take_next_instance() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -726,7 +726,7 @@ fn take_next_instance() {
 
 #[test]
 fn take_specific_instance() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
@@ -802,7 +802,7 @@ fn take_specific_instance() {
 
 #[test]
 fn take_specific_unknown_instance() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)

--- a/dds/tests/write_read_unkeyed_topic.rs
+++ b/dds/tests/write_read_unkeyed_topic.rs
@@ -15,12 +15,15 @@ use dust_dds::{
     topic_definition::type_support::{DdsSerde, DdsType},
 };
 
+mod utils;
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
 #[derive(Debug, PartialEq, DdsType, DdsSerde, serde::Serialize, serde::Deserialize)]
 struct UserData(u8);
 
 #[test]
 fn write_read_unkeyed_topic() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -87,7 +90,7 @@ fn write_read_unkeyed_topic() {
 
 #[test]
 fn data_reader_resource_limits() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -177,7 +180,7 @@ fn data_reader_resource_limits() {
 
 #[test]
 fn data_reader_order_by_source_timestamp() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
@@ -265,7 +268,7 @@ fn data_reader_order_by_source_timestamp() {
 
 #[test]
 fn data_reader_publication_handle_sample_info() {
-    let domain_id = 0;
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory


### PR DESCRIPTION
This PR allows the test suite to run in parallel with the default "cargo test" command. This is achieved by having a static domain_id generator that can be used to ensure that each test gets a unique domain id.

Running in parallel however didn't affect the overall performance of the tests given that a lot of time was spent in shutting down the tasks. To increase the performance the condvar are now all triggered when shutting down the tasks to make sure that the loops stop as fast as possible.