### PR TITLE
DDS-269 Access built-in reader data

### DIFF
--- a/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
@@ -47,7 +47,7 @@ use crate::{
 
 use super::{
     message_receiver::MessageReceiver, participant_discovery::ParticipantDiscovery,
-    topic_impl::TopicImpl,
+    status_condition_impl::StatusConditionImpl, topic_impl::TopicImpl,
 };
 
 pub struct BuiltinStatefulReader {
@@ -60,6 +60,7 @@ pub struct BuiltinStatefulReader {
     _subscription_matched_status: DdsRwLock<SubscriptionMatchedStatus>,
     _matched_publication_list: DdsRwLock<HashMap<InstanceHandle, PublicationBuiltinTopicData>>,
     enabled: DdsRwLock<bool>,
+    status_condition: DdsShared<DdsRwLock<StatusConditionImpl>>,
 }
 
 impl BuiltinStatefulReader {
@@ -133,6 +134,7 @@ impl BuiltinStatefulReader {
             }),
             _matched_publication_list: DdsRwLock::new(HashMap::new()),
             enabled: DdsRwLock::new(false),
+            status_condition: DdsShared::new(DdsRwLock::new(StatusConditionImpl::default())),
         })
     }
 }
@@ -242,5 +244,13 @@ impl DdsShared<BuiltinStatefulReader> {
 
     pub fn get_qos(&self) -> DataReaderQos {
         self.rtps_reader.read_lock().reader().get_qos().clone()
+    }
+
+    pub fn get_instance_handle(&self) -> InstanceHandle {
+        self.rtps_reader.read_lock().reader().guid().into()
+    }
+
+    pub fn get_statuscondition(&self) -> DdsShared<DdsRwLock<StatusConditionImpl>> {
+        self.status_condition.clone()
     }
 }

--- a/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
@@ -9,6 +9,7 @@ use crate::{
     infrastructure::qos::DataReaderQos,
     infrastructure::{
         qos_policy::{HistoryQosPolicy, HistoryQosPolicyKind, ReliabilityQosPolicy},
+        status::StatusKind,
         time::DURATION_ZERO,
     },
     subscription::data_reader::Sample,
@@ -45,6 +46,7 @@ use super::{
     status_condition_impl::StatusConditionImpl, topic_impl::TopicImpl,
 };
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum BuiltInStatefulReaderDataSubmessageReceivedResult {
     NoChange,
     NewDataAvailable,
@@ -224,5 +226,11 @@ impl DdsShared<BuiltinStatefulReader> {
 
     pub fn get_statuscondition(&self) -> DdsShared<DdsRwLock<StatusConditionImpl>> {
         self.status_condition.clone()
+    }
+
+    pub fn on_data_available(&self) {
+        self.status_condition
+            .write_lock()
+            .add_communication_state(StatusKind::DataAvailable);
     }
 }

--- a/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
@@ -229,18 +229,18 @@ impl DdsShared<BuiltinStatefulReader> {
                 instance_states,
             )
     }
-}
 
-impl DdsShared<BuiltinStatefulReader> {
     pub fn enable(&self) -> DdsResult<()> {
         *self.enabled.write_lock() = true;
 
         Ok(())
     }
-}
 
-impl DdsShared<BuiltinStatefulReader> {
     pub fn send_message(&self, transport: &mut impl TransportWrite) {
         self.rtps_reader.write_lock().send_message(transport);
+    }
+
+    pub fn get_qos(&self) -> DataReaderQos {
+        self.rtps_reader.read_lock().reader().get_qos().clone()
     }
 }

--- a/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
@@ -229,29 +229,6 @@ impl DdsShared<BuiltinStatefulReader> {
                 instance_states,
             )
     }
-
-    pub fn take<Foo>(
-        &self,
-        max_samples: i32,
-        sample_states: &[SampleStateKind],
-        view_states: &[ViewStateKind],
-        instance_states: &[InstanceStateKind],
-    ) -> DdsResult<Vec<Sample<Foo>>>
-    where
-        Foo: for<'de> DdsDeserialize<'de>,
-    {
-        if !*self.enabled.read_lock() {
-            return Err(DdsError::NotEnabled);
-        }
-
-        self.rtps_reader.write_lock().reader_mut().take(
-            max_samples,
-            sample_states,
-            view_states,
-            instance_states,
-            None,
-        )
-    }
 }
 
 impl DdsShared<BuiltinStatefulReader> {

--- a/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
@@ -179,6 +179,57 @@ impl DdsShared<BuiltinStatefulReader> {
 }
 
 impl DdsShared<BuiltinStatefulReader> {
+    pub fn read<Foo>(
+        &self,
+        max_samples: i32,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
+        specific_instance_handle: Option<InstanceHandle>,
+    ) -> DdsResult<Vec<Sample<Foo>>>
+    where
+        Foo: for<'de> DdsDeserialize<'de>,
+    {
+        if !*self.enabled.read_lock() {
+            return Err(DdsError::NotEnabled);
+        }
+
+        self.rtps_reader.write_lock().reader_mut().read(
+            max_samples,
+            sample_states,
+            view_states,
+            instance_states,
+            specific_instance_handle,
+        )
+    }
+
+    pub fn read_next_instance<Foo>(
+        &self,
+        max_samples: i32,
+        previous_handle: Option<InstanceHandle>,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
+    ) -> DdsResult<Vec<Sample<Foo>>>
+    where
+        Foo: for<'de> DdsDeserialize<'de>,
+    {
+        if !*self.enabled.read_lock() {
+            return Err(DdsError::NotEnabled);
+        }
+
+        self.rtps_reader
+            .write_lock()
+            .reader_mut()
+            .read_next_instance(
+                max_samples,
+                previous_handle,
+                sample_states,
+                view_states,
+                instance_states,
+            )
+    }
+
     pub fn take<Foo>(
         &self,
         max_samples: i32,

--- a/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
@@ -143,12 +143,14 @@ impl DdsShared<BuiltinStatelessReader> {
                 instance_states,
             )
     }
-}
 
-impl DdsShared<BuiltinStatelessReader> {
     pub fn enable(&self) -> DdsResult<()> {
         *self.enabled.write_lock() = true;
 
         Ok(())
+    }
+
+    pub fn get_qos(&self) -> DataReaderQos {
+        self.rtps_reader.read_lock().reader().get_qos().clone()
     }
 }

--- a/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
@@ -23,12 +23,16 @@ use crate::{
     topic_definition::type_support::DdsDeserialize,
 };
 
-use super::{message_receiver::MessageReceiver, topic_impl::TopicImpl};
+use super::{
+    message_receiver::MessageReceiver, status_condition_impl::StatusConditionImpl,
+    topic_impl::TopicImpl,
+};
 
 pub struct BuiltinStatelessReader {
     rtps_reader: DdsRwLock<RtpsStatelessReader>,
     _topic: DdsShared<TopicImpl>,
     enabled: DdsRwLock<bool>,
+    status_condition: DdsShared<DdsRwLock<StatusConditionImpl>>,
 }
 
 impl BuiltinStatelessReader {
@@ -63,6 +67,7 @@ impl BuiltinStatelessReader {
             rtps_reader: DdsRwLock::new(rtps_reader),
             _topic: topic,
             enabled: DdsRwLock::new(false),
+            status_condition: DdsShared::new(DdsRwLock::new(StatusConditionImpl::default())),
         })
     }
 }
@@ -152,5 +157,13 @@ impl DdsShared<BuiltinStatelessReader> {
 
     pub fn get_qos(&self) -> DataReaderQos {
         self.rtps_reader.read_lock().reader().get_qos().clone()
+    }
+
+    pub fn get_instance_handle(&self) -> InstanceHandle {
+        self.rtps_reader.read_lock().reader().guid().into()
+    }
+
+    pub fn get_statuscondition(&self) -> DdsShared<DdsRwLock<StatusConditionImpl>> {
+        self.status_condition.clone()
     }
 }

--- a/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
@@ -7,7 +7,7 @@ use crate::{
     infrastructure::{
         instance::InstanceHandle,
         qos_policy::{HistoryQosPolicy, HistoryQosPolicyKind},
-        time::DURATION_ZERO,
+        time::DURATION_ZERO, status::StatusKind,
     },
     subscription::data_reader::Sample,
     topic_definition::type_support::DdsType,
@@ -30,6 +30,7 @@ use super::{
     topic_impl::TopicImpl,
 };
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum BuiltInStatelessReaderDataSubmessageReceivedResult {
     NoChange,
     NewDataAvailable,
@@ -169,5 +170,9 @@ impl DdsShared<BuiltinStatelessReader> {
 
     pub fn get_statuscondition(&self) -> DdsShared<DdsRwLock<StatusConditionImpl>> {
         self.status_condition.clone()
+    }
+
+    pub fn on_data_available(&self) {
+        self.status_condition.write_lock().add_communication_state(StatusKind::DataAvailable);
     }
 }

--- a/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
@@ -2,6 +2,7 @@ use crate::{
     implementation::rtps::{endpoint::RtpsEndpoint, reader::RtpsReader, types::TopicKind},
     infrastructure::qos::DataReaderQos,
     infrastructure::{
+        instance::InstanceHandle,
         qos_policy::{HistoryQosPolicy, HistoryQosPolicyKind},
         time::DURATION_ZERO,
     },
@@ -92,6 +93,57 @@ impl DdsShared<BuiltinStatelessReader> {
 }
 
 impl DdsShared<BuiltinStatelessReader> {
+    pub fn read<Foo>(
+        &self,
+        max_samples: i32,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
+        specific_instance_handle: Option<InstanceHandle>,
+    ) -> DdsResult<Vec<Sample<Foo>>>
+    where
+        Foo: for<'de> DdsDeserialize<'de>,
+    {
+        if !*self.enabled.read_lock() {
+            return Err(DdsError::NotEnabled);
+        }
+
+        self.rtps_reader.write_lock().reader_mut().read(
+            max_samples,
+            sample_states,
+            view_states,
+            instance_states,
+            specific_instance_handle,
+        )
+    }
+
+    pub fn read_next_instance<Foo>(
+        &self,
+        max_samples: i32,
+        previous_handle: Option<InstanceHandle>,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
+    ) -> DdsResult<Vec<Sample<Foo>>>
+    where
+        Foo: for<'de> DdsDeserialize<'de>,
+    {
+        if !*self.enabled.read_lock() {
+            return Err(DdsError::NotEnabled);
+        }
+
+        self.rtps_reader
+            .write_lock()
+            .reader_mut()
+            .read_next_instance(
+                max_samples,
+                previous_handle,
+                sample_states,
+                view_states,
+                instance_states,
+            )
+    }
+
     pub fn take<Foo>(
         &self,
         max_samples: i32,

--- a/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
@@ -12,9 +12,8 @@ use crate::{
 use crate::{
     implementation::{
         rtps::{
-            messages::submessages::DataSubmessage,
-            stateless_reader::RtpsStatelessReader,
-            types::{EntityId, Guid, ENTITYID_UNKNOWN},
+            messages::submessages::DataSubmessage, stateless_reader::RtpsStatelessReader,
+            types::Guid,
         },
         utils::shared_object::{DdsRwLock, DdsShared},
     },
@@ -78,22 +77,9 @@ impl DdsShared<BuiltinStatelessReader> {
         data_submessage: &DataSubmessage<'_>,
         message_receiver: &MessageReceiver,
     ) {
-        let mut rtps_reader = self.rtps_reader.write_lock();
-
-        let data_reader_id: EntityId = data_submessage.reader_id;
-        if data_reader_id == ENTITYID_UNKNOWN
-            || data_reader_id == rtps_reader.reader().guid().entity_id()
-        {
-            rtps_reader
-                .reader_mut()
-                .add_change(
-                    data_submessage,
-                    Some(message_receiver.timestamp()),
-                    message_receiver.source_guid_prefix(),
-                    message_receiver.reception_timestamp(),
-                )
-                .ok();
-        }
+        self.rtps_reader
+            .write_lock()
+            .on_data_submessage_received(data_submessage, message_receiver);
     }
 }
 

--- a/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateless_reader.rs
@@ -143,29 +143,6 @@ impl DdsShared<BuiltinStatelessReader> {
                 instance_states,
             )
     }
-
-    pub fn take<Foo>(
-        &self,
-        max_samples: i32,
-        sample_states: &[SampleStateKind],
-        view_states: &[ViewStateKind],
-        instance_states: &[InstanceStateKind],
-    ) -> DdsResult<Vec<Sample<Foo>>>
-    where
-        Foo: for<'de> DdsDeserialize<'de>,
-    {
-        if !*self.enabled.read_lock() {
-            return Err(DdsError::NotEnabled);
-        }
-
-        self.rtps_reader.write_lock().reader_mut().take(
-            max_samples,
-            sample_states,
-            view_states,
-            instance_states,
-            None,
-        )
-    }
 }
 
 impl DdsShared<BuiltinStatelessReader> {

--- a/dds/src/implementation/dds_impl/builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/builtin_subscriber.rs
@@ -233,7 +233,6 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
             == BuiltInStatefulReaderDataSubmessageReceivedResult::NewDataAvailable
         {
             self.sedp_builtin_subscriptions_reader.on_data_available();
-            return;
         }
     }
 

--- a/dds/src/implementation/dds_impl/builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/builtin_subscriber.rs
@@ -153,9 +153,7 @@ impl DdsShared<BuiltInSubscriber> {
             _ => Err(DdsError::BadParameter),
         }
     }
-}
 
-impl DdsShared<BuiltInSubscriber> {
     pub fn get_qos(&self) -> SubscriberQos {
         self.qos.read_lock().clone()
     }
@@ -181,6 +179,14 @@ impl DdsShared<BuiltInSubscriber> {
 
     pub fn get_instance_handle(&self) -> InstanceHandle {
         self.rtps_group.guid().into()
+    }
+
+    pub fn send_message(&self, transport: &mut impl TransportWrite) {
+        self.sedp_builtin_topics_reader.send_message(transport);
+        self.sedp_builtin_publications_reader
+            .send_message(transport);
+        self.sedp_builtin_subscriptions_reader
+            .send_message(transport);
     }
 }
 
@@ -211,15 +217,5 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
             .on_heartbeat_submessage_received(heartbeat_submessage, source_guid_prefix);
         self.sedp_builtin_subscriptions_reader
             .on_heartbeat_submessage_received(heartbeat_submessage, source_guid_prefix);
-    }
-}
-
-impl DdsShared<BuiltInSubscriber> {
-    pub fn send_message(&self, transport: &mut impl TransportWrite) {
-        self.sedp_builtin_topics_reader.send_message(transport);
-        self.sedp_builtin_publications_reader
-            .send_message(transport);
-        self.sedp_builtin_subscriptions_reader
-            .send_message(transport);
     }
 }

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -45,7 +45,7 @@ use crate::{
     },
     publication::publisher_listener::PublisherListener,
     subscription::{
-        sample_info::{InstanceStateKind, ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+        sample_info::{InstanceStateKind, SampleStateKind, ANY_INSTANCE_STATE, ANY_VIEW_STATE},
         subscriber_listener::SubscriberListener,
     },
     topic_definition::type_support::DdsType,
@@ -940,11 +940,12 @@ impl DdsShared<DomainParticipantImpl> {
         let spdp_builtin_participant_data_reader =
             self.builtin_subscriber.spdp_builtin_participant_reader();
 
-        while let Ok(samples) = spdp_builtin_participant_data_reader.take(
+        while let Ok(samples) = spdp_builtin_participant_data_reader.read(
             1,
-            ANY_SAMPLE_STATE,
+            &[SampleStateKind::NotRead],
             ANY_VIEW_STATE,
             ANY_INSTANCE_STATE,
+            None,
         ) {
             for discovered_participant_data_sample in samples.into_iter() {
                 if let Some(discovered_participant_data) = discovered_participant_data_sample.data {
@@ -960,11 +961,12 @@ impl DdsShared<DomainParticipantImpl> {
         while let Ok(samples) = self
             .builtin_subscriber
             .sedp_builtin_publications_reader()
-            .take::<DiscoveredWriterData>(
+            .read::<DiscoveredWriterData>(
             1,
-            ANY_SAMPLE_STATE,
+            &[SampleStateKind::NotRead],
             ANY_VIEW_STATE,
             ANY_INSTANCE_STATE,
+            None,
         ) {
             for discovered_writer_data_sample in samples.into_iter() {
                 match discovered_writer_data_sample.sample_info.instance_state {
@@ -1014,11 +1016,12 @@ impl DdsShared<DomainParticipantImpl> {
         while let Ok(samples) = self
             .builtin_subscriber
             .sedp_builtin_subscriptions_reader()
-            .take::<DiscoveredReaderData>(
+            .read::<DiscoveredReaderData>(
             1,
-            ANY_SAMPLE_STATE,
+            &[SampleStateKind::NotRead],
             ANY_VIEW_STATE,
             ANY_INSTANCE_STATE,
+            None,
         ) {
             for discovered_reader_data_sample in samples.into_iter() {
                 match discovered_reader_data_sample.sample_info.instance_state {
@@ -1068,11 +1071,12 @@ impl DdsShared<DomainParticipantImpl> {
         while let Ok(samples) = self
             .builtin_subscriber
             .sedp_builtin_topics_reader()
-            .take::<DiscoveredTopicData>(
+            .read::<DiscoveredTopicData>(
             1,
-            ANY_SAMPLE_STATE,
+            &[SampleStateKind::NotRead],
             ANY_VIEW_STATE,
             ANY_INSTANCE_STATE,
+            None,
         ) {
             for sample in samples {
                 if let Some(topic_data) = sample.data.as_ref() {

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -602,8 +602,8 @@ impl DdsShared<UserDefinedDataReader> {
         Ok(())
     }
 
-    pub fn get_qos(&self) -> DdsResult<DataReaderQos> {
-        Ok(self.rtps_reader.read_lock().reader().get_qos().clone())
+    pub fn get_qos(&self) -> DataReaderQos {
+        self.rtps_reader.read_lock().reader().get_qos().clone()
     }
 
     pub fn set_listener(

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -48,7 +48,7 @@ use super::{
     user_defined_subscriber::UserDefinedSubscriber,
 };
 
-pub enum DataSubmessageReceivedResult {
+pub enum UserDefinedReaderDataSubmessageReceivedResult {
     NoChange,
     NewDataAvailable,
 }
@@ -223,7 +223,7 @@ impl DdsShared<UserDefinedDataReader> {
         &self,
         data_submessage: &DataSubmessage<'_>,
         message_receiver: &MessageReceiver,
-    ) -> DataSubmessageReceivedResult {
+    ) -> UserDefinedReaderDataSubmessageReceivedResult {
         let data_submessage_received_result = self
             .rtps_reader
             .write_lock()
@@ -231,17 +231,17 @@ impl DdsShared<UserDefinedDataReader> {
 
         match data_submessage_received_result {
             StatefulReaderDataReceivedResult::NoMatchedWriterProxy => {
-                DataSubmessageReceivedResult::NoChange
+                UserDefinedReaderDataSubmessageReceivedResult::NoChange
             }
             StatefulReaderDataReceivedResult::UnexpectedDataSequenceNumber => {
-                DataSubmessageReceivedResult::NoChange
+                UserDefinedReaderDataSubmessageReceivedResult::NoChange
             }
             StatefulReaderDataReceivedResult::NewSampleAdded(instance_handle) => {
                 self.instance_reception_time
                     .write_lock()
                     .insert(instance_handle, message_receiver.reception_timestamp());
                 *self.data_available_status_changed_flag.write_lock() = true;
-                DataSubmessageReceivedResult::NewDataAvailable
+                UserDefinedReaderDataSubmessageReceivedResult::NewDataAvailable
             }
             StatefulReaderDataReceivedResult::NewSampleAddedAndSamplesLost(instance_handle) => {
                 self.instance_reception_time
@@ -249,14 +249,14 @@ impl DdsShared<UserDefinedDataReader> {
                     .insert(instance_handle, message_receiver.reception_timestamp());
                 *self.data_available_status_changed_flag.write_lock() = true;
                 self.on_sample_lost();
-                DataSubmessageReceivedResult::NewDataAvailable
+                UserDefinedReaderDataSubmessageReceivedResult::NewDataAvailable
             }
             StatefulReaderDataReceivedResult::SampleRejected(instance_handle, rejected_reason) => {
                 self.on_sample_rejected(instance_handle, rejected_reason);
-                DataSubmessageReceivedResult::NoChange
+                UserDefinedReaderDataSubmessageReceivedResult::NoChange
             }
             StatefulReaderDataReceivedResult::InvalidData(_) => {
-                DataSubmessageReceivedResult::NoChange
+                UserDefinedReaderDataSubmessageReceivedResult::NoChange
             }
         }
     }

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -38,7 +38,7 @@ use super::{
     message_receiver::{MessageReceiver, SubscriberSubmessageReceiver},
     status_condition_impl::StatusConditionImpl,
     topic_impl::TopicImpl,
-    user_defined_data_reader::{DataSubmessageReceivedResult, UserDefinedDataReader},
+    user_defined_data_reader::{UserDefinedReaderDataSubmessageReceivedResult, UserDefinedDataReader},
 };
 
 pub struct UserDefinedSubscriber {
@@ -467,8 +467,8 @@ impl SubscriberSubmessageReceiver for DdsShared<UserDefinedSubscriber> {
             let data_submessage_received_result =
                 data_reader.on_data_submessage_received(data_submessage, message_receiver);
             match data_submessage_received_result {
-                DataSubmessageReceivedResult::NoChange => (),
-                DataSubmessageReceivedResult::NewDataAvailable => {
+                UserDefinedReaderDataSubmessageReceivedResult::NoChange => (),
+                UserDefinedReaderDataSubmessageReceivedResult::NewDataAvailable => {
                     *self.data_on_readers_status_changed_flag.write_lock() = true
                 }
             }

--- a/dds/src/implementation/rtps/stateless_reader.rs
+++ b/dds/src/implementation/rtps/stateless_reader.rs
@@ -1,8 +1,25 @@
-use crate::infrastructure::qos_policy::ReliabilityQosPolicyKind;
+use crate::{
+    implementation::dds_impl::message_receiver::MessageReceiver,
+    infrastructure::{
+        instance::InstanceHandle, qos_policy::ReliabilityQosPolicyKind,
+        status::SampleRejectedStatusKind,
+    },
+};
 
-use super::reader::RtpsReader;
+use super::{
+    messages::submessages::DataSubmessage,
+    reader::{RtpsReader, RtpsReaderError},
+    types::ENTITYID_UNKNOWN,
+};
 
 pub struct RtpsStatelessReader(RtpsReader);
+
+pub enum StatelessReaderDataReceivedResult {
+    NotForThisReader,
+    NewSampleAdded(InstanceHandle),
+    SampleRejected(InstanceHandle, SampleRejectedStatusKind),
+    InvalidData(&'static str),
+}
 
 impl RtpsStatelessReader {
     pub fn new(reader: RtpsReader) -> Self {
@@ -19,5 +36,36 @@ impl RtpsStatelessReader {
 
     pub fn reader_mut(&mut self) -> &mut RtpsReader {
         &mut self.0
+    }
+
+    pub fn on_data_submessage_received(
+        &mut self,
+        data_submessage: &DataSubmessage<'_>,
+        message_receiver: &MessageReceiver,
+    ) -> StatelessReaderDataReceivedResult {
+        if data_submessage.reader_id == ENTITYID_UNKNOWN
+            || data_submessage.reader_id == self.0.guid().entity_id()
+        {
+            let add_change_result = self.0.add_change(
+                data_submessage,
+                Some(message_receiver.timestamp()),
+                message_receiver.source_guid_prefix(),
+                message_receiver.reception_timestamp(),
+            );
+
+            match add_change_result {
+                Ok(h) => StatelessReaderDataReceivedResult::NewSampleAdded(h),
+                Err(e) => match e {
+                    RtpsReaderError::InvalidData(s) => {
+                        StatelessReaderDataReceivedResult::InvalidData(s)
+                    }
+                    RtpsReaderError::Rejected(h, k) => {
+                        StatelessReaderDataReceivedResult::SampleRejected(h, k)
+                    }
+                },
+            }
+        } else {
+            StatelessReaderDataReceivedResult::NotForThisReader
+        }
     }
 }

--- a/dds/src/subscription/data_reader.rs
+++ b/dds/src/subscription/data_reader.rs
@@ -580,19 +580,19 @@ where
     /// modified to match the current default for the Entity’s factory.
     pub fn set_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
+            DataReaderKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
             DataReaderKind::UserDefined(x) => x.upgrade()?.set_qos(qos),
         }
     }
 
     /// This operation allows access to the existing set of [`DataReaderQos`] policies.
     pub fn get_qos(&self) -> DdsResult<DataReaderQos> {
-        match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+        Ok(match &self.0 {
+            DataReaderKind::BuiltinStateless(x) => x.upgrade()?.get_qos(),
+            DataReaderKind::BuiltinStateful(x) => x.upgrade()?.get_qos(),
             DataReaderKind::UserDefined(x) => x.upgrade()?.get_qos(),
-        }
+        })
     }
 
     /// This operation installs a Listener on the Entity. The listener will only be invoked on the changes of communication status

--- a/dds/src/subscription/data_reader.rs
+++ b/dds/src/subscription/data_reader.rs
@@ -8,7 +8,9 @@ use crate::{
         },
         utils::shared_object::DdsWeak,
     },
-    infrastructure::{instance::InstanceHandle, qos::QosKind, status::StatusKind, time::Duration},
+    infrastructure::{
+        error::DdsError, instance::InstanceHandle, qos::QosKind, status::StatusKind, time::Duration,
+    },
     topic_definition::type_support::{DdsDeserialize, DdsType},
 };
 use crate::{
@@ -140,8 +142,20 @@ where
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(x) => x.upgrade()?.read(
+                max_samples,
+                sample_states,
+                view_states,
+                instance_states,
+                None,
+            ),
+            DataReaderKind::BuiltinStateful(x) => x.upgrade()?.read(
+                max_samples,
+                sample_states,
+                view_states,
+                instance_states,
+                None,
+            ),
             DataReaderKind::UserDefined(x) => x.upgrade()?.read(
                 max_samples,
                 sample_states,
@@ -163,8 +177,8 @@ where
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
+            DataReaderKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
             DataReaderKind::UserDefined(x) => x.upgrade()?.take(
                 max_samples,
                 sample_states,
@@ -183,20 +197,30 @@ where
     /// This operation provides a simplified API to ‘read’ samples avoiding the need for the application to manage
     /// sequences and specify states.
     pub fn read_next_sample(&self) -> DdsResult<Sample<Foo>> {
-        match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
-            DataReaderKind::UserDefined(x) => {
-                let mut samples = x.upgrade()?.read(
-                    1,
-                    &[SampleStateKind::NotRead],
-                    ANY_VIEW_STATE,
-                    ANY_INSTANCE_STATE,
-                    None,
-                )?;
-                Ok(samples.pop().unwrap())
-            }
-        }
+        let mut samples = match &self.0 {
+            DataReaderKind::BuiltinStateless(x) => x.upgrade()?.read(
+                1,
+                &[SampleStateKind::NotRead],
+                ANY_VIEW_STATE,
+                ANY_INSTANCE_STATE,
+                None,
+            )?,
+            DataReaderKind::BuiltinStateful(x) => x.upgrade()?.read(
+                1,
+                &[SampleStateKind::NotRead],
+                ANY_VIEW_STATE,
+                ANY_INSTANCE_STATE,
+                None,
+            )?,
+            DataReaderKind::UserDefined(x) => x.upgrade()?.read(
+                1,
+                &[SampleStateKind::NotRead],
+                ANY_VIEW_STATE,
+                ANY_INSTANCE_STATE,
+                None,
+            )?,
+        };
+        Ok(samples.pop().unwrap())
     }
 
     /// This operation takes the next, non-previously accessed [`Sample`] value from the [`DataReader`].
@@ -208,8 +232,8 @@ where
     /// sequences and specify states.
     pub fn take_next_sample(&self) -> DdsResult<Sample<Foo>> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
+            DataReaderKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
             DataReaderKind::UserDefined(x) => {
                 let mut samples = x.upgrade()?.take(
                     1,
@@ -240,8 +264,20 @@ where
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(x) => x.upgrade()?.read(
+                max_samples,
+                sample_states,
+                view_states,
+                instance_states,
+                Some(a_handle),
+            ),
+            DataReaderKind::BuiltinStateful(x) => x.upgrade()?.read(
+                max_samples,
+                sample_states,
+                view_states,
+                instance_states,
+                Some(a_handle),
+            ),
             DataReaderKind::UserDefined(x) => x.upgrade()?.read(
                 max_samples,
                 sample_states,
@@ -269,8 +305,8 @@ where
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
+            DataReaderKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
             DataReaderKind::UserDefined(x) => x.upgrade()?.take(
                 max_samples,
                 sample_states,
@@ -313,8 +349,20 @@ where
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(x) => x.upgrade()?.read_next_instance(
+                max_samples,
+                previous_handle,
+                sample_states,
+                view_states,
+                instance_states,
+            ),
+            DataReaderKind::BuiltinStateful(x) => x.upgrade()?.read_next_instance(
+                max_samples,
+                previous_handle,
+                sample_states,
+                view_states,
+                instance_states,
+            ),
             DataReaderKind::UserDefined(x) => x.upgrade()?.read_next_instance(
                 max_samples,
                 previous_handle,
@@ -337,8 +385,8 @@ where
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
+            DataReaderKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
             DataReaderKind::UserDefined(x) => x.upgrade()?.take_next_instance(
                 max_samples,
                 previous_handle,

--- a/dds/src/subscription/data_reader.rs
+++ b/dds/src/subscription/data_reader.rs
@@ -538,8 +538,8 @@ where
         publication_handle: InstanceHandle,
     ) -> DdsResult<PublicationBuiltinTopicData> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
+            DataReaderKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
             DataReaderKind::UserDefined(x) => x
                 .upgrade()?
                 .get_matched_publication_data(publication_handle),
@@ -554,8 +554,8 @@ where
     /// [`SampleInfo::instance_handle`](crate::subscription::sample_info::SampleInfo) when reading the “DCPSPublications” builtin topic.
     pub fn get_matched_publications(&self) -> DdsResult<Vec<InstanceHandle>> {
         match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
+            DataReaderKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
+            DataReaderKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
             DataReaderKind::UserDefined(x) => Ok(x.upgrade()?.get_matched_publications()),
         }
     }
@@ -632,13 +632,17 @@ where
     /// condition can then be added to a [`WaitSet`](crate::infrastructure::wait_set::WaitSet) so that the application can wait for specific status changes
     /// that affect the Entity.
     pub fn get_statuscondition(&self) -> DdsResult<StatusCondition> {
-        match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
-            DataReaderKind::UserDefined(x) => {
-                Ok(StatusCondition::new(x.upgrade()?.get_statuscondition()))
+        Ok(match &self.0 {
+            DataReaderKind::BuiltinStateless(x) => {
+                StatusCondition::new(x.upgrade()?.get_statuscondition())
             }
-        }
+            DataReaderKind::BuiltinStateful(x) => {
+                StatusCondition::new(x.upgrade()?.get_statuscondition())
+            }
+            DataReaderKind::UserDefined(x) => {
+                StatusCondition::new(x.upgrade()?.get_statuscondition())
+            }
+        })
     }
 
     /// This operation retrieves the list of communication statuses in the Entity that are ‘triggered.’ That is, the list of statuses whose
@@ -685,11 +689,11 @@ where
 
     /// This operation returns the [`InstanceHandle`] that represents the Entity.
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        match &self.0 {
-            DataReaderKind::BuiltinStateless(_) => todo!(),
-            DataReaderKind::BuiltinStateful(_) => todo!(),
-            DataReaderKind::UserDefined(x) => Ok(x.upgrade()?.get_instance_handle()),
-        }
+        Ok(match &self.0 {
+            DataReaderKind::BuiltinStateless(x) => x.upgrade()?.get_instance_handle(),
+            DataReaderKind::BuiltinStateful(x) => x.upgrade()?.get_instance_handle(),
+            DataReaderKind::UserDefined(x) => x.upgrade()?.get_instance_handle(),
+        })
     }
 }
 

--- a/dds/tests/builtin_readers.rs
+++ b/dds/tests/builtin_readers.rs
@@ -5,15 +5,23 @@ use dust_dds::{
     },
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{
-        qos::{DomainParticipantQos, QosKind},
-        qos_policy::UserDataQosPolicy,
+        qos::{DataReaderQos, DataWriterQos, DomainParticipantQos, QosKind, TopicQos},
+        qos_policy::{TopicDataQosPolicy, UserDataQosPolicy},
         status::NO_STATUS,
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+    topic_definition::type_support::{DdsSerde, DdsType},
 };
 
 mod utils;
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+struct MyData {
+    #[key]
+    id: u8,
+    value: u8,
+}
 
 #[test]
 fn builtin_reader_access() {
@@ -45,13 +53,16 @@ fn builtin_reader_access() {
 #[test]
 fn get_discovery_data_from_builtin_reader() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
-    let participant_user_data = vec![1, 2, 3, 4];
+    let participant_user_data = vec![1, 2];
+    let topic_user_data = vec![3, 4];
+    let reader_user_data = vec![5, 6];
+    let writer_user_data = vec![7, 8];
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
 
-    let _participant2 = DomainParticipantFactory::get_instance()
+    let participant2 = DomainParticipantFactory::get_instance()
         .create_participant(
             domain_id,
             QosKind::Specific(DomainParticipantQos {
@@ -65,6 +76,55 @@ fn get_discovery_data_from_builtin_reader() {
         )
         .unwrap();
 
+    let topic = participant2
+        .create_topic::<MyData>(
+            "topic_name",
+            QosKind::Specific(TopicQos {
+                topic_data: TopicDataQosPolicy {
+                    value: topic_user_data.clone(),
+                },
+                ..Default::default()
+            }),
+            None,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant2
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let _data_writer = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(DataWriterQos {
+                user_data: UserDataQosPolicy {
+                    value: writer_user_data.clone(),
+                },
+                ..Default::default()
+            }),
+            None,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant2
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let _data_reader = subscriber
+        .create_datareader(
+            &topic,
+            QosKind::Specific(DataReaderQos {
+                user_data: UserDataQosPolicy {
+                    value: reader_user_data.clone(),
+                },
+                ..Default::default()
+            }),
+            None,
+            NO_STATUS,
+        )
+        .unwrap();
     let builtin_subscriber = participant.get_builtin_subscriber().unwrap();
 
     let participants_reader = builtin_subscriber
@@ -72,17 +132,17 @@ fn get_discovery_data_from_builtin_reader() {
         .unwrap()
         .unwrap();
 
-    let _topics_reader = builtin_subscriber
+    let topics_reader = builtin_subscriber
         .lookup_datareader::<TopicBuiltinTopicData>("DCPSTopic")
         .unwrap()
         .unwrap();
 
-    let _publications_reader = builtin_subscriber
+    let publications_reader = builtin_subscriber
         .lookup_datareader::<PublicationBuiltinTopicData>("DCPSPublication")
         .unwrap()
         .unwrap();
 
-    let _subscriptions_reader = builtin_subscriber
+    let subscriptions_reader = builtin_subscriber
         .lookup_datareader::<SubscriptionBuiltinTopicData>("DCPSSubscription")
         .unwrap()
         .unwrap();
@@ -90,6 +150,18 @@ fn get_discovery_data_from_builtin_reader() {
     std::thread::sleep(std::time::Duration::from_millis(2000));
 
     let participant_samples = participants_reader
+        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    let topic_samples = topics_reader
+        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    let subscription_samples = subscriptions_reader
+        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    let publication_samples = publications_reader
         .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
 
@@ -101,5 +173,30 @@ fn get_discovery_data_from_builtin_reader() {
             .user_data
             .value,
         &participant_user_data
+    );
+
+    assert_eq!(
+        &topic_samples[0].data.as_ref().unwrap().topic_data.value,
+        &topic_user_data
+    );
+
+    assert_eq!(
+        &subscription_samples[0]
+            .data
+            .as_ref()
+            .unwrap()
+            .user_data
+            .value,
+        &reader_user_data
+    );
+
+    assert_eq!(
+        &publication_samples[0]
+            .data
+            .as_ref()
+            .unwrap()
+            .user_data
+            .value,
+        &writer_user_data
     );
 }

--- a/dds/tests/builtin_readers.rs
+++ b/dds/tests/builtin_readers.rs
@@ -5,6 +5,7 @@ use dust_dds::{
     },
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{qos::QosKind, status::NO_STATUS},
+    subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
 };
 
 mod utils;
@@ -35,4 +36,42 @@ fn builtin_reader_access() {
     assert!(builtin_subscriber
         .lookup_datareader::<SubscriptionBuiltinTopicData>("DCPSSubscription")
         .is_ok());
+}
+
+#[test]
+fn get_discovery_data_from_builtin_reader() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let _participant2 = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let builtin_subscriber = participant.get_builtin_subscriber().unwrap();
+
+    let participants_reader = builtin_subscriber
+        .lookup_datareader::<ParticipantBuiltinTopicData>("DCPSParticipant")
+        .unwrap()
+        .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(2000));
+
+    let participant_samples = participants_reader
+        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    let topics_reader = builtin_subscriber
+        .lookup_datareader::<TopicBuiltinTopicData>("DCPSTopic")
+        .unwrap();
+
+    let publications_reader = builtin_subscriber
+        .lookup_datareader::<PublicationBuiltinTopicData>("DCPSPublication")
+        .unwrap();
+
+    let subscriptions_reader = builtin_subscriber
+        .lookup_datareader::<SubscriptionBuiltinTopicData>("DCPSSubscription")
+        .unwrap();
 }

--- a/dds/tests/builtin_readers.rs
+++ b/dds/tests/builtin_readers.rs
@@ -149,8 +149,9 @@ fn get_discovery_data_from_builtin_reader() {
 
     std::thread::sleep(std::time::Duration::from_millis(2000));
 
+    // Note: Participant also discovers itself
     let participant_samples = participants_reader
-        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .read(2, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
 
     let topic_samples = topics_reader
@@ -165,15 +166,10 @@ fn get_discovery_data_from_builtin_reader() {
         .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
 
-    assert_eq!(
-        &participant_samples[0]
-            .data
-            .as_ref()
-            .unwrap()
-            .user_data
-            .value,
-        &participant_user_data
-    );
+    assert!(participant_samples
+        .iter()
+        .find(|x| &x.data.as_ref().unwrap().user_data.value == &participant_user_data)
+        .is_some());
 
     assert_eq!(
         &topic_samples[0].data.as_ref().unwrap().topic_data.value,

--- a/dds/tests/builtin_readers.rs
+++ b/dds/tests/builtin_readers.rs
@@ -8,6 +8,8 @@ use dust_dds::{
         qos::{DataReaderQos, DataWriterQos, DomainParticipantQos, QosKind, TopicQos},
         qos_policy::{TopicDataQosPolicy, UserDataQosPolicy},
         status::NO_STATUS,
+        time::Duration,
+        wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
     topic_definition::type_support::{DdsSerde, DdsType},
@@ -147,7 +149,12 @@ fn get_discovery_data_from_builtin_reader() {
         .unwrap()
         .unwrap();
 
-    std::thread::sleep(std::time::Duration::from_millis(2000));
+    let subscriptions_reader_cond = subscriptions_reader.get_statuscondition().unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(subscriptions_reader_cond))
+        .unwrap();
+    wait_set.wait(Duration::new(2, 0)).unwrap();
 
     // Note: Participant also discovers itself
     let participant_samples = participants_reader

--- a/dds/tests/builtin_readers.rs
+++ b/dds/tests/builtin_readers.rs
@@ -154,7 +154,7 @@ fn get_discovery_data_from_builtin_reader() {
     wait_set
         .attach_condition(Condition::StatusCondition(subscriptions_reader_cond))
         .unwrap();
-    wait_set.wait(Duration::new(2, 0)).unwrap();
+    wait_set.wait(Duration::new(4, 0)).unwrap();
 
     // Note: Participant also discovers itself
     let participant_samples = participants_reader


### PR DESCRIPTION
This PR adds the possibility for the user to access the data stored in the built-in readers. To make that data available to the outside the internal access was replace from a take, which was consuming the data, into a read with a filter on unread samples. I have also decided to provide only the read API to the user and not the take. This is to prevent data from disappearing from the built-in readers. Therefore calling take on a built-in reader will result in an IllegalOperation error. 

To keep the test free of sleep usages, the status conditions is also added to the built-in reader. According to the standard (chapter 2.2.5) the user should be able to use listeners, conditions and wait-sets. These mechanisms still need to be extended but for now it seems enough to show the ability to access the built-in data.