### PR TITLE
DDS-269 Fix access to builtin data and fix bugs on status condition waitset

### DIFF
--- a/dds/src/implementation/dds_impl/builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/builtin_subscriber.rs
@@ -206,7 +206,7 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
             == BuiltInStatelessReaderDataSubmessageReceivedResult::NewDataAvailable
         {
             self.spdp_builtin_participant_reader.on_data_available();
-            // return;
+            return;
         }
 
         if self
@@ -215,7 +215,7 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
             == BuiltInStatefulReaderDataSubmessageReceivedResult::NewDataAvailable
         {
             self.sedp_builtin_topics_reader.on_data_available();
-            // return;
+            return;
         }
 
         if self
@@ -224,7 +224,7 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
             == BuiltInStatefulReaderDataSubmessageReceivedResult::NewDataAvailable
         {
             self.sedp_builtin_publications_reader.on_data_available();
-            // return;
+            return;
         }
 
         if self

--- a/dds/src/implementation/dds_impl/builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/builtin_subscriber.rs
@@ -206,7 +206,7 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
             == BuiltInStatelessReaderDataSubmessageReceivedResult::NewDataAvailable
         {
             self.spdp_builtin_participant_reader.on_data_available();
-            return;
+            // return;
         }
 
         if self
@@ -214,8 +214,8 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
             .on_data_submessage_received(data_submessage, message_receiver)
             == BuiltInStatefulReaderDataSubmessageReceivedResult::NewDataAvailable
         {
-            self.sedp_builtin_publications_reader.on_data_available();
-            return;
+            self.sedp_builtin_topics_reader.on_data_available();
+            // return;
         }
 
         if self
@@ -224,7 +224,7 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
             == BuiltInStatefulReaderDataSubmessageReceivedResult::NewDataAvailable
         {
             self.sedp_builtin_publications_reader.on_data_available();
-            return;
+            // return;
         }
 
         if self

--- a/dds/src/implementation/dds_impl/status_condition_impl.rs
+++ b/dds/src/implementation/dds_impl/status_condition_impl.rs
@@ -68,10 +68,4 @@ impl StatusConditionImpl {
     pub fn push_cvar(&mut self, cvar: Arc<Condvar>) {
         self.cvar_list.push(cvar)
     }
-
-    pub fn clear_triggered_conditions(&mut self) {
-        let enabled_statuses = &self.enabled_statuses;
-        self.communication_status
-            .retain(|x| !enabled_statuses.contains(x));
-    }
 }

--- a/dds/src/implementation/dds_impl/status_condition_impl.rs
+++ b/dds/src/implementation/dds_impl/status_condition_impl.rs
@@ -55,7 +55,6 @@ impl StatusConditionImpl {
         self.communication_status.push(state);
 
         if self.get_trigger_value() {
-            self.communication_status.retain(|x| x != &state);
             for cvar in self.cvar_list.iter() {
                 cvar.notify_all();
             }
@@ -68,5 +67,11 @@ impl StatusConditionImpl {
 
     pub fn push_cvar(&mut self, cvar: Arc<Condvar>) {
         self.cvar_list.push(cvar)
+    }
+
+    pub fn clear_triggered_conditions(&mut self) {
+        let enabled_statuses = &self.enabled_statuses;
+        self.communication_status
+            .retain(|x| !enabled_statuses.contains(x));
     }
 }

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -527,10 +527,16 @@ impl DdsShared<UserDefinedDataReader> {
     }
 
     pub fn get_sample_rejected_status(&self) -> SampleRejectedStatus {
+        self.status_condition
+            .write_lock()
+            .remove_communication_state(StatusKind::SampleRejected);
         self.sample_rejected_status.write_lock().read_and_reset()
     }
 
     pub fn get_subscription_matched_status(&self) -> SubscriptionMatchedStatus {
+        self.status_condition
+            .write_lock()
+            .remove_communication_state(StatusKind::SubscriptionMatched);
         self.subscription_matched_status
             .write_lock()
             .read_and_reset(self.matched_publication_list.read_lock().len() as i32)

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -462,6 +462,9 @@ impl DdsShared<UserDefinedDataWriter> {
     }
 
     pub fn get_publication_matched_status(&self) -> PublicationMatchedStatus {
+        self.status_condition
+            .write_lock()
+            .remove_communication_state(StatusKind::PublicationMatched);
         self.publication_matched_status
             .write_lock()
             .read_and_reset(self.matched_subscription_list.read_lock().len() as i32)

--- a/dds/src/infrastructure/condition.rs
+++ b/dds/src/infrastructure/condition.rs
@@ -56,4 +56,8 @@ impl StatusCondition {
     pub(crate) fn push_cvar(&self, cvar: Arc<Condvar>) {
         self.0.write_lock().push_cvar(cvar)
     }
+
+    pub(crate) fn clear_triggered_conditions(&self) {
+        self.0.write_lock().clear_triggered_conditions()
+    }
 }

--- a/dds/src/infrastructure/condition.rs
+++ b/dds/src/infrastructure/condition.rs
@@ -56,8 +56,4 @@ impl StatusCondition {
     pub(crate) fn push_cvar(&self, cvar: Arc<Condvar>) {
         self.0.write_lock().push_cvar(cvar)
     }
-
-    pub(crate) fn clear_triggered_conditions(&self) {
-        self.0.write_lock().clear_triggered_conditions()
-    }
 }

--- a/dds/src/infrastructure/wait_set.rs
+++ b/dds/src/infrastructure/wait_set.rs
@@ -67,13 +67,6 @@ impl WaitSet {
             }
         }
 
-        // After waiting must remove all conditions that were already checked
-        for condition in self.conditions.iter().filter(|x| x.get_trigger_value()) {
-            match condition {
-                Condition::StatusCondition(c) => c.clear_triggered_conditions(),
-            }
-        }
-
         Ok(self
             .conditions
             .iter()

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -121,6 +121,7 @@ fn updated_readers_are_announced_to_writer() {
         .attach_condition(Condition::StatusCondition(cond.clone()))
         .unwrap();
     wait_set.wait(Duration::new(5, 0)).unwrap();
+    data_writer.get_publication_matched_status().unwrap();
 
     let user_data_qos_policy = UserDataQosPolicy {
         value: vec![1, 2, 3, 4],

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -82,6 +82,7 @@ fn deleted_readers_are_disposed_from_writer() {
         .attach_condition(Condition::StatusCondition(cond.clone()))
         .unwrap();
     wait_set.wait(Duration::new(5, 0)).unwrap();
+    data_writer.get_publication_matched_status().unwrap();
 
     subscriber.delete_datareader(&data_reader).unwrap();
 
@@ -207,6 +208,7 @@ fn deleted_writers_are_disposed_from_reader() {
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
     wait_set.wait(Duration::new(5, 0)).unwrap();
+    data_reader.get_subscription_matched_status().unwrap();
 
     publisher.delete_datawriter(&data_writer).unwrap();
 
@@ -246,6 +248,7 @@ fn updated_writers_are_announced_to_reader() {
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
     wait_set.wait(Duration::new(5, 0)).unwrap();
+    data_reader.get_subscription_matched_status().unwrap();
 
     let user_data_qos_policy = UserDataQosPolicy {
         value: vec![1, 2, 3, 4],
@@ -365,6 +368,7 @@ fn reader_discovers_disposed_writer_same_participant() {
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
     wait_set.wait(Duration::new(5, 0)).unwrap();
+    data_reader.get_subscription_matched_status().unwrap();
 
     publisher.delete_datawriter(&data_writer).unwrap();
 


### PR DESCRIPTION
This PR fixes the flaky test around the access to the built-in data. While fixing this I spotted two bugs on the WaitSet/StatusCondition combination. The first is that the WaitSet shouldn't wait if the condition is already true which wasn't happening. The second is that the conditions shouldn't be reset by the WaitSet but should only be reset when calling the corresponding get_*_status method.