### PR TITLE
DDS-277 Fix data frag submessage serialization and de-serialization

### DIFF
--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
@@ -120,7 +120,6 @@ impl<'de: 'a, 'a> MappingReadSubmessage<'de> for DataFragSubmessage<'a> {
         *buf = following;
         let serialized_payload = SerializedPayload::new(data);
 
-
         Ok(Self {
             endianness_flag,
             inline_qos_flag,
@@ -211,7 +210,7 @@ mod tests {
                     value: &[71, 72, 73, 74],
                 }],
             },
-            serialized_payload: SerializedPayload::new(&[1,2,3]),
+            serialized_payload: SerializedPayload::new(&[1, 2, 3]),
         };
         #[rustfmt::skip]
         assert_eq!(to_bytes(&submessage).unwrap(), vec![
@@ -285,7 +284,7 @@ mod tests {
                     value: &[71, 72, 73, 74],
                 }],
             },
-            serialized_payload: SerializedPayload::new(&[1,2,3,0]),
+            serialized_payload: SerializedPayload::new(&[1, 2, 3, 0]),
         };
         #[rustfmt::skip]
         let result = from_bytes(&[
@@ -305,7 +304,4 @@ mod tests {
         ]).unwrap();
         assert_eq!(expected, result);
     }
-
 }
-
-

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
@@ -2,9 +2,17 @@ use std::io::{Error, Write};
 
 use byteorder::ByteOrder;
 
-use crate::implementation::{rtps::messages::{
-    overall_structure::RtpsSubmessageHeader, submessages::DataFragSubmessage, types::{SubmessageKind, SerializedPayload}, submessage_elements::ParameterList,
-}, rtps_udp_psm::mapping_traits::{NumberOfBytes, MappingWriteByteOrdered, MappingReadByteOrdered}};
+use crate::implementation::{
+    rtps::messages::{
+        overall_structure::RtpsSubmessageHeader,
+        submessage_elements::ParameterList,
+        submessages::DataFragSubmessage,
+        types::{SerializedPayload, SubmessageKind},
+    },
+    rtps_udp_psm::mapping_traits::{
+        MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
+    },
+};
 
 use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
 
@@ -47,26 +55,30 @@ impl MappingWriteSubmessage for DataFragSubmessage<'_> {
             .mapping_write_byte_ordered::<_, B>(&mut writer)?;
         self.writer_sn
             .mapping_write_byte_ordered::<_, B>(&mut writer)?;
-        self.fragment_starting_num.mapping_write_byte_ordered::<_, B>(&mut writer)?;
-        self.fragments_in_submessage.mapping_write_byte_ordered::<_, B>(&mut writer)?;
-        self.fragment_size.mapping_write_byte_ordered::<_, B>(&mut writer)?;
-        self.data_size.mapping_write_byte_ordered::<_, B>(&mut writer)?;
+        self.fragment_starting_num
+            .mapping_write_byte_ordered::<_, B>(&mut writer)?;
+        self.fragments_in_submessage
+            .mapping_write_byte_ordered::<_, B>(&mut writer)?;
+        self.fragment_size
+            .mapping_write_byte_ordered::<_, B>(&mut writer)?;
+        self.data_size
+            .mapping_write_byte_ordered::<_, B>(&mut writer)?;
         if self.inline_qos_flag {
             self.inline_qos
                 .mapping_write_byte_ordered::<_, B>(&mut writer)?;
         }
-        if self.key_flag {
-            self.serialized_payload
-                .mapping_write_byte_ordered::<_, B>(&mut writer)?;
-            // Pad to 32bit boundary
-            let padding: &[u8] = match self.serialized_payload.number_of_bytes() % 4 {
-                1 => &[0; 3],
-                2 => &[0; 2],
-                3 => &[0; 1],
-                _ => &[],
-            };
-            writer.write_all(padding)?;
-        }
+
+        self.serialized_payload
+            .mapping_write_byte_ordered::<_, B>(&mut writer)?;
+        // Pad to 32bit boundary
+        let padding: &[u8] = match self.serialized_payload.number_of_bytes() % 4 {
+            1 => &[0; 3],
+            2 => &[0; 2],
+            3 => &[0; 1],
+            _ => &[],
+        };
+        writer.write_all(padding)?;
+
         Ok(())
     }
 }
@@ -76,8 +88,10 @@ impl<'de: 'a, 'a> MappingReadSubmessage<'de> for DataFragSubmessage<'a> {
         buf: &mut &'de [u8],
         header: RtpsSubmessageHeader,
     ) -> Result<Self, Error> {
+        let endianness_flag = header.flags[0];
         let inline_qos_flag = header.flags[1];
         let key_flag = header.flags[3];
+        let non_standard_payload_flag = header.flags[4];
         let _extra_flags: u16 = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
         let octets_to_inline_qos: u16 =
             MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
@@ -100,16 +114,12 @@ impl<'de: 'a, 'a> MappingReadSubmessage<'de> for DataFragSubmessage<'a> {
             0
         };
 
-        let serialized_payload_length = header.submessage_length as usize
-            - octets_to_inline_qos as usize
-            - 4
-            - inline_qos_len;
+        let serialized_payload_length =
+            header.submessage_length as usize - octets_to_inline_qos as usize - 4 - inline_qos_len;
         let (data, following) = buf.split_at(serialized_payload_length as usize);
         *buf = following;
         let serialized_payload = SerializedPayload::new(data);
 
-        let endianness_flag = header.flags[0];
-        let non_standard_payload_flag = header.flags[4];
 
         Ok(Self {
             endianness_flag,
@@ -135,7 +145,7 @@ mod tests {
     use crate::implementation::{
         rtps::{
             messages::{
-                submessage_elements::ParameterList,
+                submessage_elements::{Parameter, ParameterList},
                 types::{FragmentNumber, SerializedPayload, ULong, UShort},
             },
             types::{
@@ -181,6 +191,48 @@ mod tests {
     }
 
     #[test]
+    fn serialize_with_inline_qos_with_serialized_payload() {
+        let submessage = DataFragSubmessage {
+            endianness_flag: true,
+            inline_qos_flag: true,
+            non_standard_payload_flag: false,
+            key_flag: false,
+            reader_id: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
+            writer_id: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
+            writer_sn: SequenceNumber::new(6),
+            fragment_starting_num: FragmentNumber::new(2),
+            fragments_in_submessage: UShort::new(3),
+            data_size: ULong::new(8),
+            fragment_size: UShort::new(5),
+            inline_qos: ParameterList {
+                parameter: vec![Parameter {
+                    parameter_id: 8,
+                    length: 4,
+                    value: &[71, 72, 73, 74],
+                }],
+            },
+            serialized_payload: SerializedPayload::new(&[1,2,3]),
+        };
+        #[rustfmt::skip]
+        assert_eq!(to_bytes(&submessage).unwrap(), vec![
+                0x16_u8, 0b_0000_0011, 48, 0, // Submessage header
+                0, 0, 28, 0, // extraFlags | octetsToInlineQos
+                1, 2, 3, 4, // readerId
+                6, 7, 8, 9, // writerId
+                0, 0, 0, 0, // writerSN: high
+                6, 0, 0, 0, // writerSN: low
+                2, 0, 0, 0, // fragmentStartingNum
+                3, 0, 5, 0, // fragmentsInSubmessage | fragmentSize
+                8, 0, 0, 0, // sampleSize
+                8, 0, 4, 0, // inlineQos: parameterId, length
+                71, 72, 73, 74, // inlineQos: value[length]
+                1, 0, 0, 0, // inlineQos: Sentinel
+                1, 2, 3, 0, // serializedPayload
+            ]
+        );
+    }
+
+    #[test]
     fn deserialize_no_inline_qos_no_serialized_payload() {
         let expected = DataFragSubmessage {
             endianness_flag: true,
@@ -211,4 +263,49 @@ mod tests {
         ]).unwrap();
         assert_eq!(expected, result);
     }
+
+    #[test]
+    fn deserialize_with_inline_qos_with_serialized_payload() {
+        let expected = DataFragSubmessage {
+            endianness_flag: true,
+            inline_qos_flag: true,
+            non_standard_payload_flag: false,
+            key_flag: false,
+            reader_id: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
+            writer_id: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
+            writer_sn: SequenceNumber::new(6),
+            fragment_starting_num: FragmentNumber::new(2),
+            fragments_in_submessage: UShort::new(3),
+            data_size: ULong::new(8),
+            fragment_size: UShort::new(5),
+            inline_qos: ParameterList {
+                parameter: vec![Parameter {
+                    parameter_id: 8,
+                    length: 4,
+                    value: &[71, 72, 73, 74],
+                }],
+            },
+            serialized_payload: SerializedPayload::new(&[1,2,3,0]),
+        };
+        #[rustfmt::skip]
+        let result = from_bytes(&[
+            0x16_u8, 0b_0000_0011, 48, 0, // Submessage header
+            0, 0, 28, 0, // extraFlags | octetsToInlineQos
+            1, 2, 3, 4, // readerId
+            6, 7, 8, 9, // writerId
+            0, 0, 0, 0, // writerSN: high
+            6, 0, 0, 0, // writerSN: low
+            2, 0, 0, 0, // fragmentStartingNum
+            3, 0, 5, 0, // fragmentsInSubmessage | fragmentSize
+            8, 0, 0, 0, // sampleSize
+            8, 0, 4, 0, // inlineQos: parameterId, length
+            71, 72, 73, 74, // inlineQos: value[length]
+            1, 0, 0, 0, // inlineQos: Sentinel
+            1, 2, 3, 0, // serializedPayload
+        ]).unwrap();
+        assert_eq!(expected, result);
+    }
+
 }
+
+


### PR DESCRIPTION
Fix data-frag submessage. Add serialization and de-serialization test. 

Here is a Wireshark output for a data for id(u8) and value(Vec<u8;100000>) :

8045	\Device\NPF_Loopback		343.670031	192.168.1.5	192.168.1.5	RTPS	60120	7411	INFO_DST, INFO_TS, DATA_FRAG
8097	\Device\NPF_Loopback		343.671204	192.168.1.5	192.168.1.5	RTPS	40132	7411	INFO_DST, INFO_TS, DATA_FRAG