### PR TITLE
DDS-278 Add inconsistent topic detection and status condition

### DIFF
--- a/dds/src/domain/domain_participant.rs
+++ b/dds/src/domain/domain_participant.rs
@@ -457,7 +457,9 @@ impl DomainParticipant {
     /// condition can then be added to a [`WaitSet`](crate::infrastructure::wait_set::WaitSet) so that the application can wait for specific status changes
     /// that affect the Entity.
     pub fn get_statuscondition(&self) -> DdsResult<StatusCondition> {
-        self.0.upgrade()?.get_statuscondition()
+        Ok(StatusCondition::new(
+            self.0.upgrade()?.get_statuscondition(),
+        ))
     }
 
     /// This operation retrieves the list of communication statuses in the Entity that are ‘triggered.’ That is, the list of statuses whose
@@ -467,7 +469,7 @@ impl DomainParticipant {
     /// The list of statuses returned by the [`Self::get_status_changes`] operation refers to the status that are triggered on the Entity itself
     /// and does not include statuses that apply to contained entities.
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        self.0.upgrade()?.get_status_changes()
+        Ok(self.0.upgrade()?.get_status_changes())
     }
 
     /// This operation enables the Entity. Entity objects can be created either enabled or disabled. This is controlled by the value of

--- a/dds/src/implementation/dds_impl/any_topic_listener.rs
+++ b/dds/src/implementation/dds_impl/any_topic_listener.rs
@@ -1,7 +1,7 @@
 use crate::{
     implementation::utils::shared_object::DdsShared,
     infrastructure::status::InconsistentTopicStatus,
-    topic_definition::topic_listener::TopicListener,
+    topic_definition::{topic::Topic, topic_listener::TopicListener},
 };
 
 use super::topic_impl::TopicImpl;
@@ -17,9 +17,9 @@ pub trait AnyTopicListener {
 impl<Foo> AnyTopicListener for Box<dyn TopicListener<Foo = Foo> + Send + Sync> {
     fn trigger_on_inconsistent_topic(
         &mut self,
-        _the_topic: &DdsShared<TopicImpl>,
-        _status: InconsistentTopicStatus,
+        the_topic: &DdsShared<TopicImpl>,
+        status: InconsistentTopicStatus,
     ) {
-        todo!()
+        self.on_inconsistent_topic(&Topic::new(the_topic.downgrade()), status)
     }
 }

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -63,8 +63,8 @@ use crate::{
 use super::{
     any_topic_listener::AnyTopicListener, builtin_publisher::BuiltinPublisher,
     builtin_subscriber::BuiltInSubscriber, message_receiver::MessageReceiver,
-    participant_discovery::ParticipantDiscovery, topic_impl::TopicImpl,
-    user_defined_data_reader::UserDefinedDataReader,
+    participant_discovery::ParticipantDiscovery, status_condition_impl::StatusConditionImpl,
+    topic_impl::TopicImpl, user_defined_data_reader::UserDefinedDataReader,
     user_defined_data_writer::UserDefinedDataWriter, user_defined_publisher::UserDefinedPublisher,
     user_defined_subscriber::UserDefinedSubscriber,
 };
@@ -125,6 +125,7 @@ pub struct DomainParticipantImpl {
     data_max_size_serialized: usize,
     timer_factory: TimerFactory,
     timer: DdsShared<DdsRwLock<Timer>>,
+    status_condition: DdsShared<DdsRwLock<StatusConditionImpl>>,
 }
 
 impl DomainParticipantImpl {
@@ -244,6 +245,7 @@ impl DomainParticipantImpl {
             data_max_size_serialized,
             timer_factory,
             timer,
+            status_condition: DdsShared::new(DdsRwLock::new(StatusConditionImpl::default())),
         })
     }
 }
@@ -774,14 +776,12 @@ impl DdsShared<DomainParticipantImpl> {
         *self.listener_status_mask.write_lock() = mask.to_vec();
     }
 
-    pub fn get_statuscondition(
-        &self,
-    ) -> DdsResult<crate::infrastructure::condition::StatusCondition> {
-        todo!()
+    pub fn get_statuscondition(&self) -> DdsShared<DdsRwLock<StatusConditionImpl>> {
+        self.status_condition.clone()
     }
 
-    pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        todo!()
+    pub fn get_status_changes(&self) -> Vec<StatusKind> {
+        self.status_condition.read_lock().get_status_changes()
     }
 
     pub fn enable(&self) -> DdsResult<()> {

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -1190,7 +1190,7 @@ impl DdsShared<DomainParticipantImpl> {
             for sample in samples {
                 if let Some(topic_data) = sample.data.as_ref() {
                     for topic in self.topic_list.read_lock().iter() {
-                        topic.process_discovered_topic(&topic_data);
+                        topic.process_discovered_topic(topic_data);
                     }
 
                     self.discovered_topic_list.write_lock().insert(

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -1189,10 +1189,15 @@ impl DdsShared<DomainParticipantImpl> {
         ) {
             for sample in samples {
                 if let Some(topic_data) = sample.data.as_ref() {
+                    for topic in self.topic_list.read_lock().iter() {
+                        topic.process_discovered_topic(&topic_data);
+                    }
+
                     self.discovered_topic_list.write_lock().insert(
                         topic_data.get_serialized_key().into(),
                         topic_data.topic_builtin_topic_data.clone(),
                     );
+
                     self.topic_find_condvar.notify_all();
                 }
             }

--- a/dds/src/implementation/dds_impl/status_condition_impl.rs
+++ b/dds/src/implementation/dds_impl/status_condition_impl.rs
@@ -4,7 +4,7 @@ use crate::infrastructure::{error::DdsResult, status::StatusKind};
 
 pub struct StatusConditionImpl {
     enabled_statuses: Vec<StatusKind>,
-    communication_status: Vec<StatusKind>,
+    status_changes: Vec<StatusKind>,
     cvar_list: Vec<Arc<Condvar>>,
 }
 
@@ -26,7 +26,7 @@ impl Default for StatusConditionImpl {
                 StatusKind::PublicationMatched,
                 StatusKind::SubscriptionMatched,
             ],
-            communication_status: Vec::new(),
+            status_changes: Vec::new(),
             cvar_list: Vec::new(),
         }
     }
@@ -43,7 +43,7 @@ impl StatusConditionImpl {
     }
 
     pub fn get_trigger_value(&self) -> bool {
-        for status in &self.communication_status {
+        for status in &self.status_changes {
             if self.enabled_statuses.contains(status) {
                 return true;
             }
@@ -52,7 +52,7 @@ impl StatusConditionImpl {
     }
 
     pub fn add_communication_state(&mut self, state: StatusKind) {
-        self.communication_status.push(state);
+        self.status_changes.push(state);
 
         if self.get_trigger_value() {
             for cvar in self.cvar_list.iter() {
@@ -62,10 +62,14 @@ impl StatusConditionImpl {
     }
 
     pub fn remove_communication_state(&mut self, state: StatusKind) {
-        self.communication_status.retain(|x| x != &state);
+        self.status_changes.retain(|x| x != &state);
     }
 
     pub fn push_cvar(&mut self, cvar: Arc<Condvar>) {
         self.cvar_list.push(cvar)
+    }
+
+    pub fn get_status_changes(&self) -> Vec<StatusKind> {
+        self.status_changes.clone()
     }
 }

--- a/dds/src/implementation/dds_impl/topic_impl.rs
+++ b/dds/src/implementation/dds_impl/topic_impl.rs
@@ -6,7 +6,6 @@ use crate::{
         utils::shared_object::{DdsRwLock, DdsShared, DdsWeak},
     },
     infrastructure::{
-        condition::StatusCondition,
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{QosKind, TopicQos},
@@ -14,7 +13,10 @@ use crate::{
     },
 };
 
-use super::{any_topic_listener::AnyTopicListener, domain_participant_impl::DomainParticipantImpl};
+use super::{
+    any_topic_listener::AnyTopicListener, domain_participant_impl::DomainParticipantImpl,
+    status_condition_impl::StatusConditionImpl,
+};
 
 impl InconsistentTopicStatus {
     fn increment(&mut self) {
@@ -39,6 +41,7 @@ pub struct TopicImpl {
     listener: DdsRwLock<Option<Box<dyn AnyTopicListener + Send + Sync>>>,
     listener_status_mask: DdsRwLock<Vec<StatusKind>>,
     inconsistent_topic_status: DdsRwLock<InconsistentTopicStatus>,
+    status_condition: DdsShared<DdsRwLock<StatusConditionImpl>>,
 }
 
 impl TopicImpl {
@@ -61,6 +64,7 @@ impl TopicImpl {
             listener: DdsRwLock::new(listener),
             listener_status_mask: DdsRwLock::new(mask.to_vec()),
             inconsistent_topic_status: DdsRwLock::new(InconsistentTopicStatus::default()),
+            status_condition: DdsShared::new(DdsRwLock::new(StatusConditionImpl::default())),
         })
     }
 }
@@ -113,9 +117,8 @@ impl DdsShared<TopicImpl> {
         *self.listener_status_mask.write_lock() = mask.to_vec();
     }
 
-    pub fn get_statuscondition(&self) -> DdsResult<StatusCondition> {
-        // rtps_shared_read_lock(&rtps_weak_upgrade(&self.topic_impl)?).get_statuscondition()
-        todo!()
+    pub fn get_statuscondition(&self) -> DdsShared<DdsRwLock<StatusConditionImpl>> {
+        self.status_condition.clone()
     }
 
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
@@ -170,15 +173,58 @@ impl DdsShared<TopicImpl> {
         if discovered_topic_data.topic_builtin_topic_data.type_name == self.type_name
             && discovered_topic_data.topic_builtin_topic_data.name == self.topic_name
         {
-            if !self.is_discovered_topic_consistent(discovered_topic_data) {
+            if !is_discovered_topic_consistent(&self.qos.read_lock(), discovered_topic_data) {
                 self.inconsistent_topic_status.write_lock().increment();
-                todo!("Trigger listener if enabled")
+                if self
+                    .listener_status_mask
+                    .read_lock()
+                    .contains(&StatusKind::InconsistentTopic)
+                {
+                    if let Some(listener) = self.listener.write_lock().as_mut() {
+                        listener.trigger_on_inconsistent_topic(
+                            self,
+                            self.inconsistent_topic_status.write_lock().read_and_reset(),
+                        )
+                    }
+                }
+                self.status_condition.write_lock().add_communication_state(StatusKind::InconsistentTopic);
             }
         }
     }
+}
 
-    fn is_discovered_topic_consistent(&self, discovered_topic_data: &DiscoveredTopicData) -> bool {
-        todo!()
+fn is_discovered_topic_consistent(
+    topic_qos: &TopicQos,
+    discovered_topic_data: &DiscoveredTopicData,
+) -> bool {
+    if topic_qos.topic_data == discovered_topic_data.topic_builtin_topic_data.topic_data
+        && topic_qos.durability == discovered_topic_data.topic_builtin_topic_data.durability
+        && topic_qos.deadline == discovered_topic_data.topic_builtin_topic_data.deadline
+        && topic_qos.latency_budget
+            == discovered_topic_data
+                .topic_builtin_topic_data
+                .latency_budget
+        && topic_qos.liveliness == discovered_topic_data.topic_builtin_topic_data.liveliness
+        && topic_qos.reliability == discovered_topic_data.topic_builtin_topic_data.reliability
+        && topic_qos.destination_order
+            == discovered_topic_data
+                .topic_builtin_topic_data
+                .destination_order
+        && topic_qos.history == discovered_topic_data.topic_builtin_topic_data.history
+        && topic_qos.resource_limits
+            == discovered_topic_data
+                .topic_builtin_topic_data
+                .resource_limits
+        && topic_qos.transport_priority
+            == discovered_topic_data
+                .topic_builtin_topic_data
+                .transport_priority
+        && topic_qos.lifespan == discovered_topic_data.topic_builtin_topic_data.lifespan
+        && topic_qos.ownership == discovered_topic_data.topic_builtin_topic_data.ownership
+    {
+        true
+    } else {
+        false
     }
 }
 

--- a/dds/src/implementation/dds_impl/topic_impl.rs
+++ b/dds/src/implementation/dds_impl/topic_impl.rs
@@ -125,7 +125,7 @@ impl DdsShared<TopicImpl> {
     }
 
     pub fn get_status_changes(&self) -> Vec<StatusKind> {
-        self.status_condition.read_lock().get_enabled_statuses()
+        self.status_condition.read_lock().get_status_changes()
     }
 
     pub fn enable(&self) -> DdsResult<()> {

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -262,11 +262,11 @@ impl DdsShared<UserDefinedDataReader> {
                     .period;
                 let duration = std::time::Duration::new(duration.sec() as u64, duration.nanosec());
                 let me = self.clone();
-                self.timer.write_lock().start_timer(
-                    duration,
-                    instance_handle,
-                    move || me.on_requested_deadline_missed(instance_handle),
-                );
+                self.timer
+                    .write_lock()
+                    .start_timer(duration, instance_handle, move || {
+                        me.on_requested_deadline_missed(instance_handle)
+                    });
                 UserDefinedReaderDataSubmessageReceivedResult::NewDataAvailable
             }
             StatefulReaderDataReceivedResult::NewSampleAddedAndSamplesLost(instance_handle) => {
@@ -704,7 +704,7 @@ impl DdsShared<UserDefinedDataReader> {
     }
 
     pub fn get_status_changes(&self) -> Vec<StatusKind> {
-        self.status_condition.write_lock().get_enabled_statuses()
+        self.status_condition.read_lock().get_status_changes()
     }
 
     pub fn is_enabled(&self) -> bool {

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -576,8 +576,8 @@ impl DdsShared<UserDefinedDataWriter> {
         self.status_condition.clone()
     }
 
-    pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        todo!()
+    pub fn get_status_changes(&self) -> Vec<StatusKind> {
+        self.status_condition.read_lock().get_status_changes()
     }
 
     pub fn enable(&self) -> DdsResult<()> {

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -164,10 +164,7 @@ impl DdsShared<UserDefinedSubscriber> {
                 qos,
             ));
 
-            let timer = self
-                .get_participant()
-                .timer_factory()
-                .create_timer();
+            let timer = self.get_participant().timer_factory().create_timer();
 
             let data_reader_shared = UserDefinedDataReader::new(
                 rtps_reader,
@@ -324,8 +321,8 @@ impl DdsShared<UserDefinedSubscriber> {
         self.status_condition.clone()
     }
 
-    pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        todo!()
+    pub fn get_status_changes(&self) -> Vec<StatusKind> {
+        self.status_condition.read_lock().get_status_changes()
     }
 
     pub fn enable(&self) -> DdsResult<()> {

--- a/dds/src/publication/data_writer.rs
+++ b/dds/src/publication/data_writer.rs
@@ -407,7 +407,7 @@ where
     /// The list of statuses returned by the [`Self::get_status_changes`] operation refers to the status that are triggered on the Entity itself
     /// and does not include statuses that apply to contained entities.
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        self.0.upgrade()?.get_status_changes()
+        Ok(self.0.upgrade()?.get_status_changes())
     }
 
     /// This operation enables the Entity. Entity objects can be created either enabled or disabled. This is controlled by the value of

--- a/dds/src/publication/publisher.rs
+++ b/dds/src/publication/publisher.rs
@@ -262,7 +262,9 @@ impl Publisher {
     /// condition can then be added to a [`WaitSet`](crate::infrastructure::wait_set::WaitSet) so that the application can wait for specific status changes
     /// that affect the Entity.
     pub fn get_statuscondition(&self) -> DdsResult<StatusCondition> {
-        self.0.upgrade()?.get_statuscondition()
+        Ok(StatusCondition::new(
+            self.0.upgrade()?.get_statuscondition(),
+        ))
     }
 
     /// This operation retrieves the list of communication statuses in the Entity that are ‘triggered.’ That is, the list of statuses whose
@@ -272,7 +274,7 @@ impl Publisher {
     /// The list of statuses returned by the [`Self::get_status_changes`] operation refers to the status that are triggered on the Entity itself
     /// and does not include statuses that apply to contained entities.
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        self.0.upgrade()?.get_status_changes()
+        Ok(self.0.upgrade()?.get_status_changes())
     }
 
     /// This operation enables the Entity. Entity objects can be created either enabled or disabled. This is controlled by the value of

--- a/dds/src/subscription/subscriber.rs
+++ b/dds/src/subscription/subscriber.rs
@@ -301,7 +301,7 @@ impl Subscriber {
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         match &self.0 {
             SubscriberKind::BuiltIn(s) => s.upgrade()?.get_status_changes(),
-            SubscriberKind::UserDefined(s) => s.upgrade()?.get_status_changes(),
+            SubscriberKind::UserDefined(s) => Ok(s.upgrade()?.get_status_changes()),
         }
     }
 

--- a/dds/src/topic_definition/topic.rs
+++ b/dds/src/topic_definition/topic.rs
@@ -41,7 +41,7 @@ impl<Foo> Drop for Topic<Foo> {
 impl<Foo> Topic<Foo> {
     /// This method allows the application to retrieve the [`InconsistentTopicStatus`] of the [`Topic`].
     pub fn get_inconsistent_topic_status(&self) -> DdsResult<InconsistentTopicStatus> {
-        self.0.upgrade()?.get_inconsistent_topic_status()
+        Ok(self.0.upgrade()?.get_inconsistent_topic_status())
     }
 }
 

--- a/dds/src/topic_definition/topic.rs
+++ b/dds/src/topic_definition/topic.rs
@@ -126,7 +126,7 @@ where
     /// The list of statuses returned by the [`Self::get_status_changes`] operation refers to the status that are triggered on the Entity itself
     /// and does not include statuses that apply to contained entities.
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        self.0.upgrade()?.get_status_changes()
+        Ok(self.0.upgrade()?.get_status_changes())
     }
 
     /// This operation enables the Entity. Entity objects can be created either enabled or disabled. This is controlled by the value of

--- a/dds/src/topic_definition/topic.rs
+++ b/dds/src/topic_definition/topic.rs
@@ -114,7 +114,9 @@ where
     /// condition can then be added to a [`WaitSet`](crate::infrastructure::wait_set::WaitSet) so that the application can wait for specific status changes
     /// that affect the Entity.
     pub fn get_statuscondition(&self) -> DdsResult<StatusCondition> {
-        self.0.upgrade()?.get_statuscondition()
+        Ok(StatusCondition::new(
+            self.0.upgrade()?.get_statuscondition(),
+        ))
     }
 
     /// This operation retrieves the list of communication statuses in the Entity that are ‘triggered.’ That is, the list of statuses whose

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -1191,7 +1191,7 @@ fn write_read_sample_view_state() {
 }
 
 #[test]
-fn inconsistent_topic_notification() {
+fn inconsistent_topic_status_condition() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let participant_factory = DomainParticipantFactory::get_instance();
 
@@ -1208,7 +1208,7 @@ fn inconsistent_topic_notification() {
     };
     let topic_best_effort = participant
         .create_topic::<KeyedData>(
-            "OtherTopic",
+            "Topic",
             QosKind::Specific(best_effort_topic_qos),
             None,
             NO_STATUS,
@@ -1220,25 +1220,25 @@ fn inconsistent_topic_notification() {
         .set_enabled_statuses(&[StatusKind::InconsistentTopic])
         .unwrap();
 
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(status_cond))
+        .unwrap();
+
     let reliable_topic_qos = TopicQos {
         reliability: ReliabilityQosPolicy {
-            kind: ReliabilityQosPolicyKind::BestEffort,
+            kind: ReliabilityQosPolicyKind::Reliable,
             max_blocking_time: Duration::new(1, 0),
         },
         ..Default::default()
     };
     let _topic_reliable = participant
         .create_topic::<KeyedData>(
-            "OtherTopic",
+            "Topic",
             QosKind::Specific(reliable_topic_qos),
             None,
             NO_STATUS,
         )
-        .unwrap();
-
-    let mut wait_set = WaitSet::new();
-    wait_set
-        .attach_condition(Condition::StatusCondition(status_cond))
         .unwrap();
 
     wait_set.wait(Duration::new(2, 0)).unwrap();

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -2,7 +2,7 @@ use dust_dds::{
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{
         error::DdsError,
-        qos::{DataReaderQos, DataWriterQos, QosKind},
+        qos::{DataReaderQos, DataWriterQos, QosKind, TopicQos},
         qos_policy::{
             HistoryQosPolicy, HistoryQosPolicyKind, ReliabilityQosPolicy, ReliabilityQosPolicyKind,
         },
@@ -96,9 +96,9 @@ fn large_data_should_be_fragmented() {
         .unwrap();
     let mut reader_wait_set = WaitSet::new();
     reader_wait_set
-            .attach_condition(Condition::StatusCondition(cond))
-            .unwrap();
-            reader_wait_set.wait(Duration::new(5, 0)).unwrap();
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    reader_wait_set.wait(Duration::new(5, 0)).unwrap();
 
     let samples = reader
         .take(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
@@ -165,7 +165,9 @@ fn large_data_should_be_fragmented_reliable() {
 
     writer.write(&data, None).unwrap();
 
-    writer.wait_for_acknowledgments(Duration::new(5, 0)).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(5, 0))
+        .unwrap();
 
     let samples = reader
         .take(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
@@ -174,8 +176,6 @@ fn large_data_should_be_fragmented_reliable() {
     assert_eq!(samples.len(), 1);
     assert_eq!(samples[0].data.as_ref().unwrap(), &data);
 }
-
-
 
 #[test]
 fn samples_are_taken() {
@@ -1188,4 +1188,66 @@ fn write_read_sample_view_state() {
     assert_eq!(samples.len(), 2);
     assert_eq!(samples[0].sample_info.view_state, ViewStateKind::NotNew);
     assert_eq!(samples[1].sample_info.view_state, ViewStateKind::New);
+}
+
+#[test]
+fn inconsistent_topic_notification() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let participant_factory = DomainParticipantFactory::get_instance();
+
+    let participant = participant_factory
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let best_effort_topic_qos = TopicQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::BestEffort,
+            max_blocking_time: Duration::new(1, 0),
+        },
+        ..Default::default()
+    };
+    let topic_best_effort = participant
+        .create_topic::<KeyedData>(
+            "OtherTopic",
+            QosKind::Specific(best_effort_topic_qos),
+            None,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let status_cond = topic_best_effort.get_statuscondition().unwrap();
+    status_cond
+        .set_enabled_statuses(&[StatusKind::InconsistentTopic])
+        .unwrap();
+
+    let reliable_topic_qos = TopicQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::BestEffort,
+            max_blocking_time: Duration::new(1, 0),
+        },
+        ..Default::default()
+    };
+    let _topic_reliable = participant
+        .create_topic::<KeyedData>(
+            "OtherTopic",
+            QosKind::Specific(reliable_topic_qos),
+            None,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(status_cond))
+        .unwrap();
+
+    wait_set.wait(Duration::new(2, 0)).unwrap();
+
+    assert_eq!(
+        topic_best_effort
+            .get_inconsistent_topic_status()
+            .unwrap()
+            .total_count,
+        1
+    );
 }


### PR DESCRIPTION
This PR adds the inconsistent topic detection. To enable testing the status condition is added to the Topic and other entities where it is missing.