### PR TITLE
DDS-268 Add multiple subscriber integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,10 @@ jobs:
               docker cp ./target/debug/examples/hello_world_subscriber storage:/var
               docker cp ./target/debug/examples/hello_world_publisher storage:/var
               docker run --detach --name hello_world_subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/hello_world_subscriber
-              docker run --name hello_world_publisher --volumes-from storage  cimg/rust:1.62.0  /var/hello_world_publisher
+              docker run --detach --name hello_world_subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/hello_world_subscriber
+              docker run --rm --name hello_world_publisher --volumes-from storage  cimg/rust:1.62.0  /var/hello_world_publisher
+              docker logs hello_world_subscriber_1
+              docker logs hello_world_subscriber_2
   build:
     docker:
       - image: cimg/rust:1.62.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,11 @@ jobs:
       - run:
             name: "Run hello_world_subscriber"
             command: |
+              echo mytest > test.txt
               docker run --detach --name hello_world_subscriber_1 --volume `pwd`:/tmp --workdir /tmp  cimg/rust:1.62.0  cargo run --example hello_world_subscriber > log_1.txt
               docker run --detach --name hello_world_publisher --volume `pwd`:/tmp --workdir /tmp  cimg/rust:1.62.0  cargo run --example hello_world_publisher > log.txt
+              cat test.txt
+              cat log_1.txt
               cat log.txt
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
             name: "Run hello_world_subscriber"
             command: |
-              docker run --detach --name hello_world_subscriber_1 --volume ./target/debug/examples:/tmp  cimg/rust:1.62.0  /tmp/hello_world_subscriber
+              docker run --detach --name hello_world_subscriber_1 --volume `pwd`/target/debug/examples:/tmp  cimg/rust:1.62.0  /tmp/hello_world_subscriber
   build:
     docker:
       - image: cimg/rust:1.62.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/publisher
             docker logs subscriber_1 | tee subscriber_1.out
             docker logs subscriber_2 | tee subscriber_2.out
-            cmp echo "Received: id: 8, msg: Hello world" | subscriber_1.out
+            echo "Received: id: 8, msg: Hello world" | cmp subscriber_1.out
             cmp subscriber_1.out subscriber_2.out
 build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,21 +11,22 @@ jobs:
       - run:
           name: Hello world example
           command: |
-            cargo build --example hello_world_subscriber
-            cargo build --example hello_world_publisher
+            cargo build --bin subscriber
+            cargo build --bin publisher
       - run:
-            name: "Run hello_world"
-            command: |
-              # create docker volume (since direct mapping is not possible)
-              docker create -v /var --name storage alpine:3.4 /bin/true
-              docker cp ./target/debug/examples/hello_world_subscriber storage:/var
-              docker cp ./target/debug/examples/hello_world_publisher storage:/var
-              docker run --detach --name hello_world_subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/hello_world_subscriber
-              docker run --detach --name hello_world_subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/hello_world_subscriber
-              docker run --rm --name hello_world_publisher --volumes-from storage  cimg/rust:1.62.0  /var/hello_world_publisher
-              docker logs hello_world_subscriber_1
-              docker logs hello_world_subscriber_2
-  build:
+          name: "Run two subscribers on two machines"
+          command: |
+            # create docker volume (since direct mapping is not possible)
+            docker create -v /var --name storage alpine:3.4 /bin/true
+            docker cp ./target/debug/subscriber storage:/var
+            docker cp ./target/debug/publisher storage:/var
+            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
+            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
+            docker run --rm --name hello_world_publisher --volumes-from storage  cimg/rust:1.62.0  /var/publisher
+            docker logs subscriber_1 | tee subscriber_1.out
+            docker logs subscriber_2 | tee subscriber_2.out
+            cmp subscriber_1.out subscriber_2.out
+build:
     docker:
       - image: cimg/rust:1.62.0
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,19 +108,19 @@ jobs:
       - run:
           name: Build executables
           command: |
-            cargo build --bin subscriber
-            cargo build --bin publisher
+            cargo build --bin multiple_subscriber_test_subscriber
+            cargo build --bin multiple_subscriber_test_publisher
       - run:
           name: Run 2 subscribers with different IPs
           no_output_timeout: 60s
           command: |
             # create docker volume (since direct mapping is not possible)
             docker create -v /var --name storage cimg/rust:1.62.0 /bin/true
-            docker cp ./target/debug/subscriber storage:/var
-            docker cp ./target/debug/publisher storage:/var
-            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
-            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
-            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/publisher
+            docker cp ./target/debug/multiple_subscriber_test_subscriber storage:/var
+            docker cp ./target/debug/multiple_subscriber_test_publisher storage:/var
+            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/multiple_subscriber_test_subscriber
+            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/multiple_subscriber_test_subscriber
+            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/multiple_subscriber_test_publisher
             docker logs subscriber_1 | tee subscriber_1.out
             docker logs subscriber_2 | tee subscriber_2.out
             echo "Received: id: 8, msg: Hello world" | cmp subscriber_1.out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
             cargo build --bin publisher
       - run:
           name: Run two subscribers on two machines
+          no_output_timeout: 60s
           command: |
             # create docker volume (since direct mapping is not possible)
             docker create -v /var --name storage cimg/rust:1.62.0 /bin/true
@@ -25,6 +26,7 @@ jobs:
             docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/publisher
             docker logs subscriber_1 | tee subscriber_1.out
             docker logs subscriber_2 | tee subscriber_2.out
+            cmp echo "Received: id: 8, msg: Hello world" | subscriber_1.out
             cmp subscriber_1.out subscriber_2.out
 build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ jobs:
       - run:
             name: "Run hello_world_subscriber"
             command: |
-              pwd
-              cd `pwd`
-              docker run --detach --name hello_world_subscriber_1 --volume `pwd`:/tmp --workdir /tmp  cimg/rust:1.62.0  cargo run --example hello_world_subscriber
+              docker run --detach --name hello_world_subscriber_1 --volume `pwd`:/tmp --workdir /tmp  cimg/rust:1.62.0  cargo run --example hello_world_subscriber > log_1.txt
+              docker run --detach --name hello_world_publisher --volume `pwd`:/tmp --workdir /tmp  cimg/rust:1.62.0  cargo run --example hello_world_publisher > log.txt
+              cat log.txt
   build:
     docker:
       - image: cimg/rust:1.62.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
             docker create -v /var --name storage cimg/rust:1.62.0 /bin/true
             docker cp ./target/debug/subscriber storage:/var
             docker cp ./target/debug/publisher storage:/var
-            docker run --rm --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
-            docker run --rm --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
+            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
+            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
             docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/publisher
             docker logs subscriber_1 | tee subscriber_1.out
             docker logs subscriber_2 | tee subscriber_2.out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
             name: "Run hello_world_subscriber"
             command: |
-              docker run --detach --name hello_world_subscriber_1 --volume `pwd`/target/debug/examples:/tmp  cimg/rust:1.62.0  /tmp/hello_world_subscriber
+              docker run --detach --name hello_world_subscriber_1 --volume `pwd`:/tmp --workdir /tmp  cimg/rust:1.62.0  cargo run --example hello_world_subscriber
   build:
     docker:
       - image: cimg/rust:1.62.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,5 +120,4 @@ workflows:
   version: 2
   all:
     jobs:
-      - build
-      - interoperability_tests
+      - build_extented

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,22 @@
 version: 2.1
 
 jobs:
+  build_extented:
+    docker:
+        - image: cimg/rust:1.62.0
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Hello world example
+          command: |
+            cargo build --example hello_world_subscriber
+            cargo build --example hello_world_publisher
+            # target\debug\examples\hello_world_subscriber.exe
+      - run:
+            name: "Run hello_world_subscriber"
+            command: |
+              docker run --detach --name hello_world_subscriber_1 --volume ./target/debug/examples:/tmp  cimg/rust:1.62.0  /tmp/hello_world_subscriber
   build:
     docker:
       - image: cimg/rust:1.62.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,7 @@
 version: 2.1
 
 jobs:
-  build_extented:
-    docker:
-      - image: cimg/rust:1.62.0
-    resource_class: large
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Hello world example
-          command: |
-            cargo build --bin subscriber
-            cargo build --bin publisher
-      - run:
-          name: Run two subscribers on two machines
-          no_output_timeout: 60s
-          command: |
-            # create docker volume (since direct mapping is not possible)
-            docker create -v /var --name storage cimg/rust:1.62.0 /bin/true
-            docker cp ./target/debug/subscriber storage:/var
-            docker cp ./target/debug/publisher storage:/var
-            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
-            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
-            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/publisher
-            docker logs subscriber_1 | tee subscriber_1.out
-            docker logs subscriber_2 | tee subscriber_2.out
-            echo "Received: id: 8, msg: Hello world" | cmp subscriber_1.out
-            cmp subscriber_1.out subscriber_2.out
-build:
+  build:
     docker:
       - image: cimg/rust:1.62.0
     resource_class: large
@@ -77,7 +50,7 @@ build:
       - store_artifacts:
           path: /tmp/coverage
 
-interoperability_tests:
+  interoperability_tests:
     docker:
       - image: s2esystems/dust_dds_interoperability
     resource_class: large
@@ -127,8 +100,38 @@ interoperability_tests:
             cargo run --bin dust_dds_big_data_subscriber
             wait $pid
 
+  multi_machine_tests:
+    docker:
+      - image: cimg/rust:1.62.0
+    resource_class: large
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build executables
+          command: |
+            cargo build --bin subscriber
+            cargo build --bin publisher
+      - run:
+          name: Run 2 subscribers with different IPs
+          no_output_timeout: 60s
+          command: |
+            # create docker volume (since direct mapping is not possible)
+            docker create -v /var --name storage cimg/rust:1.62.0 /bin/true
+            docker cp ./target/debug/subscriber storage:/var
+            docker cp ./target/debug/publisher storage:/var
+            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
+            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
+            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/publisher
+            docker logs subscriber_1 | tee subscriber_1.out
+            docker logs subscriber_2 | tee subscriber_2.out
+            echo "Received: id: 8, msg: Hello world" | cmp subscriber_1.out
+            cmp subscriber_1.out subscriber_2.out
+
 workflows:
   version: 2
   all:
     jobs:
-      - build_extented
+      - build
+      - interoperability_tests
+      - multi_machine_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ jobs:
   interoperability_tests:
     docker:
       - image: s2esystems/dust_dds_interoperability
-    resource_class: large
     steps:
       - checkout
       - run:
@@ -103,7 +102,6 @@ jobs:
   multi_machine_tests:
     docker:
       - image: cimg/rust:1.62.0
-    resource_class: large
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: Hello world example
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,16 +13,15 @@ jobs:
           command: |
             cargo build --example hello_world_subscriber
             cargo build --example hello_world_publisher
-            # target\debug\examples\hello_world_subscriber.exe
       - run:
-            name: "Run hello_world_subscriber"
+            name: "Run hello_world"
             command: |
-              echo mytest > test.txt
-              docker run --detach --name hello_world_subscriber_1 --volume `pwd`:/tmp --workdir /tmp  cimg/rust:1.62.0  cargo run --example hello_world_subscriber > log_1.txt
-              docker run --detach --name hello_world_publisher --volume `pwd`:/tmp --workdir /tmp  cimg/rust:1.62.0  cargo run --example hello_world_publisher > log.txt
-              cat test.txt
-              cat log_1.txt
-              cat log.txt
+              # create docker volume (since direct mapping is not possible)
+              docker create -v /var --name storage alpine:3.4 /bin/true
+              docker cp ./target/debug/examples/hello_world_subscriber storage:/var
+              docker cp ./target/debug/examples/hello_world_publisher storage:/var
+              docker run --detach --name hello_world_subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/hello_world_subscriber
+              docker run --name hello_world_publisher --volumes-from storage  cimg/rust:1.62.0  /var/hello_world_publisher
   build:
     docker:
       - image: cimg/rust:1.62.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,8 @@ jobs:
       - run:
             name: "Run hello_world_subscriber"
             command: |
+              pwd
+              cd `pwd`
               docker run --detach --name hello_world_subscriber_1 --volume `pwd`:/tmp --workdir /tmp  cimg/rust:1.62.0  cargo run --example hello_world_subscriber
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,12 @@ jobs:
           name: "Run two subscribers on two machines"
           command: |
             # create docker volume (since direct mapping is not possible)
-            docker create -v /var --name storage alpine:3.4 /bin/true
+            docker create -v /var --name storage cimg/rust:1.62.0 /bin/true
             docker cp ./target/debug/subscriber storage:/var
             docker cp ./target/debug/publisher storage:/var
-            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
-            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
-            docker run --rm --name hello_world_publisher --volumes-from storage  cimg/rust:1.62.0  /var/publisher
+            docker run --rm --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
+            docker run --rm --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/subscriber
+            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/publisher
             docker logs subscriber_1 | tee subscriber_1.out
             docker logs subscriber_2 | tee subscriber_2.out
             cmp subscriber_1.out subscriber_2.out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build_extented:
     docker:
-        - image: cimg/rust:1.62.0
+      - image: cimg/rust:1.62.0
     resource_class: large
     steps:
       - checkout
@@ -14,7 +14,7 @@ jobs:
             cargo build --bin subscriber
             cargo build --bin publisher
       - run:
-          name: "Run two subscribers on two machines"
+          name: Run two subscribers on two machines
           command: |
             # create docker volume (since direct mapping is not possible)
             docker create -v /var --name storage cimg/rust:1.62.0 /bin/true
@@ -75,7 +75,7 @@ build:
       - store_artifacts:
           path: /tmp/coverage
 
-  interoperability_tests:
+interoperability_tests:
     docker:
       - image: s2esystems/dust_dds_interoperability
     resource_class: large

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -31,7 +31,7 @@ socket2 = "=0.4"
 ifcfg = "=0.1"
 mac_address = "=1.1"
 
-jsonschema = {version = "=0.16", default-features = false}
+jsonschema = {version = "=0.12.0", default-features = false}
 serde_json = "=1.0.87"
 schemars = "=0.8.11"
 

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -41,3 +41,11 @@ path = "src/implementation/configuration_schema_generator.rs"
 
 [dev-dependencies]
 mockall = { version = "0.11" }
+
+[[bin]]
+name = "subscriber"
+path = "tests/executables/subscriber.rs"
+
+[[bin]]
+name = "publisher"
+path = "tests/executables/publisher.rs"

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -45,9 +45,9 @@ path = "src/implementation/configuration_schema_generator.rs"
 mockall = { version = "0.11" }
 
 [[bin]]
-name = "subscriber"
+name = "multiple_subscriber_test_subscriber"
 path = "tests/executables/subscriber.rs"
 
 [[bin]]
-name = "publisher"
+name = "multiple_subscriber_test_publisher"
 path = "tests/executables/publisher.rs"

--- a/dds/examples/hello_world_publisher.rs
+++ b/dds/examples/hello_world_publisher.rs
@@ -55,12 +55,19 @@ fn main() {
     writer_cond
         .set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
+
     let mut wait_set = WaitSet::new();
     wait_set
-        .attach_condition(Condition::StatusCondition(writer_cond))
-        .unwrap();
+        .attach_condition(Condition::StatusCondition(writer_cond)).unwrap();
 
-    wait_set.wait(Duration::new(60, 0)).unwrap();
+
+    loop {
+        wait_set.wait(Duration::new(60, 0)).unwrap();
+        let conditions = writer.get_matched_subscriptions().unwrap();
+        if conditions.len() == 2 {
+            break;
+        }
+    }
 
     let hello_world = HelloWorldType {
         id: 8,

--- a/dds/tests/executables/publisher.rs
+++ b/dds/tests/executables/publisher.rs
@@ -60,18 +60,14 @@ fn main() {
     wait_set
         .attach_condition(Condition::StatusCondition(writer_cond)).unwrap();
 
-    // let number_of_subscribers_to_find = 2;
-    // for _ in 0..number_of_subscribers_to_find {
-    //     wait_set.wait(Duration::new(60, 0)).unwrap();
-    // }
-
-    loop {
+    let number_of_subscribers_to_find = 2;
+    for _ in 0..number_of_subscribers_to_find {
         wait_set.wait(Duration::new(60, 0)).unwrap();
-        let conditions = writer.get_matched_subscriptions().unwrap();
-        if conditions.len() == 2 {
-            break;
-        }
+
     }
+
+    let number_of_matched_readers = writer.get_publication_matched_status().unwrap().current_count;
+    assert_eq!(number_of_subscribers_to_find, number_of_matched_readers);
 
     let hello_world = HelloWorldType {
         id: 8,

--- a/dds/tests/executables/publisher.rs
+++ b/dds/tests/executables/publisher.rs
@@ -55,12 +55,15 @@ fn main() {
     writer_cond
         .set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
+
     let mut wait_set = WaitSet::new();
     wait_set
-        .attach_condition(Condition::StatusCondition(writer_cond))
-        .unwrap();
+        .attach_condition(Condition::StatusCondition(writer_cond)).unwrap();
 
-    wait_set.wait(Duration::new(60, 0)).unwrap();
+    let number_of_subscribers_to_find = 2;
+    for _ in 0..number_of_subscribers_to_find {
+        wait_set.wait(Duration::new(60, 0)).unwrap();
+    }
 
     let hello_world = HelloWorldType {
         id: 8,

--- a/dds/tests/executables/publisher.rs
+++ b/dds/tests/executables/publisher.rs
@@ -60,9 +60,17 @@ fn main() {
     wait_set
         .attach_condition(Condition::StatusCondition(writer_cond)).unwrap();
 
-    let number_of_subscribers_to_find = 2;
-    for _ in 0..number_of_subscribers_to_find {
+    // let number_of_subscribers_to_find = 2;
+    // for _ in 0..number_of_subscribers_to_find {
+    //     wait_set.wait(Duration::new(60, 0)).unwrap();
+    // }
+
+    loop {
         wait_set.wait(Duration::new(60, 0)).unwrap();
+        let conditions = writer.get_matched_subscriptions().unwrap();
+        if conditions.len() == 2 {
+            break;
+        }
     }
 
     let hello_world = HelloWorldType {

--- a/dds/tests/executables/publisher.rs
+++ b/dds/tests/executables/publisher.rs
@@ -61,17 +61,16 @@ fn main() {
         .attach_condition(Condition::StatusCondition(writer_cond)).unwrap();
 
     let number_of_subscribers_to_find = 2;
-    for _ in 0..number_of_subscribers_to_find {
+    loop {
         wait_set.wait(Duration::new(60, 0)).unwrap();
-
+        if writer.get_publication_matched_status().unwrap().current_count == number_of_subscribers_to_find {
+            break
+        }
     }
-
-    let number_of_matched_readers = writer.get_publication_matched_status().unwrap().current_count;
-    assert_eq!(number_of_subscribers_to_find, number_of_matched_readers);
 
     let hello_world = HelloWorldType {
         id: 8,
-        msg: "Hello world!".to_string(),
+        msg: "Hello world".to_string(),
     };
     writer.write(&hello_world, None).unwrap();
 

--- a/dds/tests/executables/subscriber.rs
+++ b/dds/tests/executables/subscriber.rs
@@ -1,0 +1,75 @@
+use dust_dds::{
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        qos::{DataReaderQos, QosKind},
+        qos_policy::{ReliabilityQosPolicy, ReliabilityQosPolicyKind, DurabilityQosPolicy, DurabilityQosPolicyKind},
+        status::{StatusKind, NO_STATUS},
+        time::Duration,
+        wait_set::{Condition, WaitSet},
+    },
+    subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+    topic_definition::type_support::{DdsSerde, DdsType},
+};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, DdsType, DdsSerde)]
+struct HelloWorldType {
+    #[key]
+    id: u8,
+    msg: String,
+}
+
+fn main() {
+    let domain_id = 0;
+    let participant_factory = DomainParticipantFactory::get_instance();
+
+    let participant = participant_factory
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<HelloWorldType>("HelloWorld", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: Duration::new(1, 0),
+        },
+        durability: DurabilityQosPolicy {
+            kind: DurabilityQosPolicyKind::TransientLocal,
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
+        .unwrap();
+
+    let reader_cond = reader.get_statuscondition().unwrap();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond.clone()))
+        .unwrap();
+
+    wait_set.wait(Duration::new(60, 0)).unwrap();
+
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::DataAvailable])
+        .unwrap();
+    wait_set.wait(Duration::new(30, 0)).unwrap();
+
+    let samples = reader
+        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    let hello_world = samples[0].data.as_ref().unwrap();
+    println!("Received: {:?}", hello_world);
+}

--- a/dds/tests/executables/subscriber.rs
+++ b/dds/tests/executables/subscriber.rs
@@ -71,5 +71,5 @@ fn main() {
         .unwrap();
 
     let hello_world = samples[0].data.as_ref().unwrap();
-    println!("Received: {:?}", hello_world);
+    println!("Received: id: {}, msg: {}", hello_world.id, hello_world.msg);
 }

--- a/dds_derive/src/lib.rs
+++ b/dds_derive/src/lib.rs
@@ -54,7 +54,7 @@ pub fn derive_dds_type(input: TokenStream) -> TokenStream {
                 }
 
                 fn set_key_fields_from_serialized_key(&mut self, key: &dust_dds::topic_definition::type_support::DdsSerializedKey) -> dust_dds::infrastructure::error::DdsResult<()> {
-                    *self = cdr::de::deserialize_data::<_, cdr::LittleEndian>(&mut key.as_ref()).map_err(|e| dust_dds::infrastructure::error::DdsError::PreconditionNotMet(e.to_string()))?;
+                    *self = cdr::de::deserialize_data::<_, cdr::LittleEndian>(&key.as_ref()).map_err(|e| dust_dds::infrastructure::error::DdsError::PreconditionNotMet(e.to_string()))?;
                     Ok(())
                 }
             }
@@ -155,7 +155,7 @@ fn struct_set_key(struct_data: &DataStruct) -> TokenStream2 {
     }
 
     let mut token_stream = quote! {
-        let (#identifier_list_ts) = cdr::de::deserialize_data::<_,cdr::LittleEndian>(&mut key.as_ref()).map_err(|e| dust_dds::infrastructure::error::DdsError::PreconditionNotMet(e.to_string()))?;
+        let (#identifier_list_ts) = cdr::de::deserialize_data::<_,cdr::LittleEndian>(&key.as_ref()).map_err(|e| dust_dds::infrastructure::error::DdsError::PreconditionNotMet(e.to_string()))?;
     };
 
     for (&(i, field), ident) in indexed_key_fields.iter().zip(identifiers.iter()) {


### PR DESCRIPTION
Add multi-machine tests to allow testing for multiple subscribers to verify that multiple IPs are working. 
Note that the publisher needs to wait for the 2 subscribtions beeing matched. This is done using an infinite loop here. Ans implementation of that kind: 
```
let number_of_subscribers_to_find = 2;
for _ in 0..number_of_subscribers_to_find {
    wait_set.wait(Duration::new(60, 0)).unwrap();
}

let number_of_matched_readers = writer.get_matched_subscriptions().unwrap().len();
// Or: let number_of_matched_readers = writer.get_publication_matched_status().unwrap().current_count;
// Or: let number_of_matched_readers = writer.get_publication_matched_status().unwrap().total_count;
assert_eq!(number_of_subscribers_to_find, number_of_matched_readers);
```
resulted mostly in only 1 matched reader. There is probably an issue. I suggest fixing this elsewhere and refactor this test after. 

Note also that the dds_derive is changed, this is due to clippy gave an error, since the executables were pulled into clippy's catchment area.  

ALSO jsonschema is degraded because its dependency on the "time" crate keeps increasing the rust compiler version 