### PR TITLE
DDS-286 Add time based filter qos policy

### DIFF
--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -368,11 +368,7 @@ impl RtpsReader {
         if let Some(Some(t)) = closest_timestamp_before_received_sample {
             if let Some(sample_source_time) = change.source_timestamp {
                 let sample_separation = sample_source_time - t;
-                if sample_separation >= self.qos.time_based_filter.minimum_separation {
-                    true
-                } else {
-                    false
-                }
+                sample_separation >= self.qos.time_based_filter.minimum_separation
             } else {
                 true
             }

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -346,6 +346,41 @@ impl RtpsReader {
         total_samples_of_instance == self.qos.resource_limits.max_samples_per_instance
     }
 
+    fn is_sample_of_interest_based_on_time(
+        &self,
+        change: &RtpsReaderCacheChange,
+        change_instance_handle: &InstanceHandle,
+    ) -> bool {
+        let closest_timestamp_before_received_sample = self
+            .changes
+            .iter()
+            .filter(|cc| {
+                &self
+                    .instance_handle_builder
+                    .build_instance_handle(cc.kind, &cc.data)
+                    .expect("Change in cache must have valid instance handle")
+                    == change_instance_handle
+            })
+            .filter(|cc| cc.source_timestamp <= change.source_timestamp)
+            .map(|cc| cc.source_timestamp)
+            .max();
+
+        if let Some(Some(t)) = closest_timestamp_before_received_sample {
+            if let Some(sample_source_time) = change.source_timestamp {
+                let sample_separation = sample_source_time - t;
+                if sample_separation >= self.qos.time_based_filter.minimum_separation {
+                    true
+                } else {
+                    false
+                }
+            } else {
+                true
+            }
+        } else {
+            true
+        }
+    }
+
     pub fn add_change(
         &mut self,
         mut change: RtpsReaderCacheChange,
@@ -353,82 +388,86 @@ impl RtpsReader {
         let change_instance_handle = self
             .instance_handle_builder
             .build_instance_handle(change.kind, &change.data)?;
-
-        if self.is_max_samples_limit_reached(&change_instance_handle) {
-            Err(RtpsReaderError::Rejected(
-                change_instance_handle,
-                SampleRejectedStatusKind::RejectedBySamplesLimit,
-            ))
-        } else if self.is_max_instances_limit_reached(&change_instance_handle) {
-            Err(RtpsReaderError::Rejected(
-                change_instance_handle,
-                SampleRejectedStatusKind::RejectedByInstancesLimit,
-            ))
-        } else if self.is_max_samples_per_instance_limit_reached(&change_instance_handle) {
-            Err(RtpsReaderError::Rejected(
-                change_instance_handle,
-                SampleRejectedStatusKind::RejectedBySamplesPerInstanceLimit,
-            ))
-        } else {
-            let num_alive_samples_of_instance = self
-                .changes
-                .iter()
-                .filter(|cc| {
-                    self.instance_handle_builder
-                        .build_instance_handle(cc.kind, cc.data.as_slice())
-                        .unwrap()
-                        == change_instance_handle
-                        && cc.kind == ChangeKind::Alive
-                })
-                .count() as i32;
-
-            if self.qos.history.kind == HistoryQosPolicyKind::KeepLast
-                && self.qos.history.depth == num_alive_samples_of_instance
-            {
-                let index_sample_to_remove = self
+        if self.is_sample_of_interest_based_on_time(&change, &change_instance_handle) {
+            if self.is_max_samples_limit_reached(&change_instance_handle) {
+                Err(RtpsReaderError::Rejected(
+                    change_instance_handle,
+                    SampleRejectedStatusKind::RejectedBySamplesLimit,
+                ))
+            } else if self.is_max_instances_limit_reached(&change_instance_handle) {
+                Err(RtpsReaderError::Rejected(
+                    change_instance_handle,
+                    SampleRejectedStatusKind::RejectedByInstancesLimit,
+                ))
+            } else if self.is_max_samples_per_instance_limit_reached(&change_instance_handle) {
+                Err(RtpsReaderError::Rejected(
+                    change_instance_handle,
+                    SampleRejectedStatusKind::RejectedBySamplesPerInstanceLimit,
+                ))
+            } else {
+                let num_alive_samples_of_instance = self
                     .changes
                     .iter()
-                    .position(|cc| {
+                    .filter(|cc| {
                         self.instance_handle_builder
                             .build_instance_handle(cc.kind, cc.data.as_slice())
                             .unwrap()
                             == change_instance_handle
                             && cc.kind == ChangeKind::Alive
                     })
-                    .expect("Samples must exist");
-                self.changes.remove(index_sample_to_remove);
-            }
+                    .count() as i32;
 
-            let instance_entry = self
-                .instances
-                .entry(change_instance_handle)
-                .or_insert_with(Instance::new);
-
-            instance_entry.update_state(change.kind);
-
-            change.disposed_generation_count = instance_entry.most_recent_disposed_generation_count;
-            change.no_writers_generation_count =
-                instance_entry.most_recent_no_writers_generation_count;
-            self.changes.push(change);
-
-            match self.qos.destination_order.kind {
-                DestinationOrderQosPolicyKind::BySourceTimestamp => {
-                    self.changes.sort_by(|a, b| {
-                        a.source_timestamp
-                            .as_ref()
-                            .expect("Missing source timestamp")
-                            .cmp(
-                                b.source_timestamp
-                                    .as_ref()
-                                    .expect("Missing source timestamp"),
-                            )
-                    });
+                if self.qos.history.kind == HistoryQosPolicyKind::KeepLast
+                    && self.qos.history.depth == num_alive_samples_of_instance
+                {
+                    let index_sample_to_remove = self
+                        .changes
+                        .iter()
+                        .position(|cc| {
+                            self.instance_handle_builder
+                                .build_instance_handle(cc.kind, cc.data.as_slice())
+                                .unwrap()
+                                == change_instance_handle
+                                && cc.kind == ChangeKind::Alive
+                        })
+                        .expect("Samples must exist");
+                    self.changes.remove(index_sample_to_remove);
                 }
-                DestinationOrderQosPolicyKind::ByReceptionTimestamp => self
-                    .changes
-                    .sort_by(|a, b| a.reception_timestamp.cmp(&b.reception_timestamp)),
-            }
 
+                let instance_entry = self
+                    .instances
+                    .entry(change_instance_handle)
+                    .or_insert_with(Instance::new);
+
+                instance_entry.update_state(change.kind);
+
+                change.disposed_generation_count =
+                    instance_entry.most_recent_disposed_generation_count;
+                change.no_writers_generation_count =
+                    instance_entry.most_recent_no_writers_generation_count;
+                self.changes.push(change);
+
+                match self.qos.destination_order.kind {
+                    DestinationOrderQosPolicyKind::BySourceTimestamp => {
+                        self.changes.sort_by(|a, b| {
+                            a.source_timestamp
+                                .as_ref()
+                                .expect("Missing source timestamp")
+                                .cmp(
+                                    b.source_timestamp
+                                        .as_ref()
+                                        .expect("Missing source timestamp"),
+                                )
+                        });
+                    }
+                    DestinationOrderQosPolicyKind::ByReceptionTimestamp => self
+                        .changes
+                        .sort_by(|a, b| a.reception_timestamp.cmp(&b.reception_timestamp)),
+                }
+
+                Ok(change_instance_handle)
+            }
+        } else {
             Ok(change_instance_handle)
         }
     }

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -1345,12 +1345,12 @@ fn reader_with_minimum_time_separation_qos() {
         .unwrap();
 
     let samples = reader
-        .read(5, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .read(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
 
     assert_eq!(samples.len(), 4);
     assert_eq!(samples[0].data.as_ref().unwrap(), &data1_1);
     assert_eq!(samples[1].data.as_ref().unwrap(), &data1_3);
     assert_eq!(samples[2].data.as_ref().unwrap(), &data2_1);
-    assert_eq!(samples[2].data.as_ref().unwrap(), &data2_3);
+    assert_eq!(samples[3].data.as_ref().unwrap(), &data2_3);
 }

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -1269,6 +1269,10 @@ fn reader_with_minimum_time_separation_qos() {
         .create_publisher(QosKind::Default, None, NO_STATUS)
         .unwrap();
     let writer_qos = DataWriterQos {
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+            depth: 1,
+        },
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::Reliable,
             max_blocking_time: Duration::new(1, 0),
@@ -1283,6 +1287,10 @@ fn reader_with_minimum_time_separation_qos() {
         .create_subscriber(QosKind::Default, None, NO_STATUS)
         .unwrap();
     let reader_qos = DataReaderQos {
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+            depth: 1,
+        },
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::Reliable,
             max_blocking_time: Duration::new(1, 0),
@@ -1306,26 +1314,30 @@ fn reader_with_minimum_time_separation_qos() {
         .unwrap();
     wait_set.wait(Duration::new(5, 0)).unwrap();
 
-    let data1 = KeyedData { id: 1, value: 0 };
-    let data2 = KeyedData { id: 1, value: 10 };
-    let data3 = KeyedData { id: 1, value: 20 };
-    let data4 = KeyedData { id: 1, value: 30 };
-    let data5 = KeyedData { id: 1, value: 40 };
+    let data1_1 = KeyedData { id: 1, value: 1 };
+    let data1_2 = KeyedData { id: 1, value: 2 };
+    let data1_3 = KeyedData { id: 1, value: 3 };
+    let data2_1 = KeyedData { id: 2, value: 10 };
+    let data2_2 = KeyedData { id: 2, value: 20 };
+    let data2_3 = KeyedData { id: 2, value: 30 };
 
     writer
-        .write_w_timestamp(&data1, None, Time::new(1, 0))
+        .write_w_timestamp(&data1_1, None, Time::new(1, 0))
         .unwrap();
     writer
-        .write_w_timestamp(&data2, None, Time::new(2, 0))
+        .write_w_timestamp(&data1_2, None, Time::new(2, 0))
         .unwrap();
     writer
-        .write_w_timestamp(&data3, None, Time::new(3, 0))
+        .write_w_timestamp(&data1_3, None, Time::new(3, 0))
         .unwrap();
     writer
-        .write_w_timestamp(&data4, None, Time::new(4, 0))
+        .write_w_timestamp(&data2_1, None, Time::new(4, 0))
         .unwrap();
     writer
-        .write_w_timestamp(&data5, None, Time::new(5, 0))
+        .write_w_timestamp(&data2_2, None, Time::new(5, 0))
+        .unwrap();
+    writer
+        .write_w_timestamp(&data2_3, None, Time::new(6, 0))
         .unwrap();
 
     writer
@@ -1336,8 +1348,9 @@ fn reader_with_minimum_time_separation_qos() {
         .read(5, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
 
-    assert_eq!(samples.len(), 3);
-    assert_eq!(samples[0].data.as_ref().unwrap(), &data1);
-    assert_eq!(samples[1].data.as_ref().unwrap(), &data3);
-    assert_eq!(samples[2].data.as_ref().unwrap(), &data5);
+    assert_eq!(samples.len(), 4);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data1_1);
+    assert_eq!(samples[1].data.as_ref().unwrap(), &data1_3);
+    assert_eq!(samples[2].data.as_ref().unwrap(), &data2_1);
+    assert_eq!(samples[2].data.as_ref().unwrap(), &data2_3);
 }


### PR DESCRIPTION
This PR adds the Time-Based Filter qos policy functionality. By standard this applies to the reader samples only.