### PR TITLE
DDS-283 Durability QoS policy on the reader side

### DIFF
--- a/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_reader.rs
@@ -9,7 +9,10 @@ use crate::{
     },
     infrastructure::qos::DataReaderQos,
     infrastructure::{
-        qos_policy::{HistoryQosPolicy, HistoryQosPolicyKind, ReliabilityQosPolicy},
+        qos_policy::{
+            DurabilityQosPolicy, DurabilityQosPolicyKind, HistoryQosPolicy, HistoryQosPolicyKind,
+            ReliabilityQosPolicy,
+        },
         status::StatusKind,
         time::DURATION_ZERO,
     },
@@ -72,9 +75,12 @@ impl BuiltinStatefulReader {
         Foo: DdsType + for<'de> DdsDeserialize<'de>,
     {
         let qos = DataReaderQos {
+            durability: DurabilityQosPolicy {
+                kind: DurabilityQosPolicyKind::TransientLocal,
+            },
             history: HistoryQosPolicy {
-                kind: HistoryQosPolicyKind::KeepAll,
-                depth: 0,
+                kind: HistoryQosPolicyKind::KeepLast,
+                depth: 1,
             },
             reliability: ReliabilityQosPolicy {
                 kind: ReliabilityQosPolicyKind::Reliable,

--- a/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
@@ -25,8 +25,11 @@ use crate::{
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::DataWriterQos,
-        qos_policy::ReliabilityQosPolicyKind,
-        time::Time,
+        qos_policy::{
+            DurabilityQosPolicy, DurabilityQosPolicyKind, HistoryQosPolicy, HistoryQosPolicyKind,
+            ReliabilityQosPolicy, ReliabilityQosPolicyKind,
+        },
+        time::{Time, DURATION_ZERO},
     },
     topic_definition::type_support::{DdsSerialize, DdsType},
 };
@@ -62,6 +65,20 @@ impl BuiltinStatefulWriter {
         let nack_response_delay = DEFAULT_NACK_RESPONSE_DELAY;
         let nack_suppression_duration = DEFAULT_NACK_SUPPRESSION_DURATION;
         let data_max_size_serialized = usize::MAX;
+        let qos = DataWriterQos {
+            durability: DurabilityQosPolicy {
+                kind: DurabilityQosPolicyKind::TransientLocal,
+            },
+            history: HistoryQosPolicy {
+                kind: HistoryQosPolicyKind::KeepLast,
+                depth: 1,
+            },
+            reliability: ReliabilityQosPolicy {
+                kind: ReliabilityQosPolicyKind::Reliable,
+                max_blocking_time: DURATION_ZERO,
+            },
+            ..Default::default()
+        };
         let rtps_writer = RtpsStatefulWriter::new(RtpsWriter::new(
             RtpsEndpoint::new(
                 guid,
@@ -74,7 +91,7 @@ impl BuiltinStatefulWriter {
             nack_response_delay,
             nack_suppression_duration,
             data_max_size_serialized,
-            DataWriterQos::default(),
+            qos,
         ));
 
         DdsShared::new(BuiltinStatefulWriter {

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -533,8 +533,10 @@ impl DdsShared<DomainParticipantImpl> {
                 );
             }
             // Block until timeout unless new topic is found or created
+            let duration_until_timeout =
+                Duration::from(self.get_current_time()? - start_time) - timeout;
             self.topic_find_condvar
-                .wait_timeout(self.get_current_time()? - start_time)
+                .wait_timeout(duration_until_timeout)
                 .ok();
         }
         Err(DdsError::Timeout)

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -533,8 +533,7 @@ impl DdsShared<DomainParticipantImpl> {
                 );
             }
             // Block until timeout unless new topic is found or created
-            let duration_until_timeout =
-                Duration::from(self.get_current_time()? - start_time) - timeout;
+            let duration_until_timeout = (self.get_current_time()? - start_time) - timeout;
             self.topic_find_condvar
                 .wait_timeout(duration_until_timeout)
                 .ok();

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -654,14 +654,14 @@ impl DdsShared<UserDefinedDataReader> {
         }?;
 
         let start_time = std::time::Instant::now();
-        let timeout: std::time::Duration = max_wait.into();
-        while std::time::Instant::now() - start_time < timeout {
-            if self.rtps_reader.read_lock().is_historical_data_received() {
-                return Ok(())
-            }
 
+        while start_time.elapsed() < std::time::Duration::from(max_wait) {
+            if self.rtps_reader.read_lock().is_historical_data_received() {
+                return Ok(());
+            }
+            let duration_until_timeout = Duration::from(start_time.elapsed()) - max_wait;
             self.wait_for_historical_data_condvar
-                .wait_timeout((std::time::Instant::now() - start_time).into())
+                .wait_timeout(duration_until_timeout)
                 .ok();
         }
         Err(DdsError::Timeout)

--- a/dds/src/implementation/rtps/stateful_reader.rs
+++ b/dds/src/implementation/rtps/stateful_reader.rs
@@ -324,4 +324,11 @@ impl RtpsStatefulReader {
             writer_proxy.send_message(&self.reader.guid(), header, transport)
         }
     }
+
+    pub fn is_historical_data_received(&self) -> bool {
+        !self
+            .matched_writers
+            .iter()
+            .any(|p| !p.is_historical_data_received())
+    }
 }

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -330,7 +330,8 @@ impl RtpsWriterProxy {
     }
 
     pub fn is_historical_data_received(&self) -> bool {
-        false
+        let at_least_one_heartbeat_received = self.last_received_heartbeat_count > Count::new(0);
+        at_least_one_heartbeat_received && self.missing_changes().is_empty()
     }
 }
 

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -328,6 +328,10 @@ impl RtpsWriterProxy {
             );
         }
     }
+
+    pub fn is_historical_data_received(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/dds/src/infrastructure/time.rs
+++ b/dds/src/infrastructure/time.rs
@@ -22,6 +22,22 @@ impl Duration {
     }
 }
 
+impl std::ops::Sub<Duration> for Duration {
+    type Output = Duration;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        let mut sec = self.sec - rhs.sec;
+        let nanosec_diff = (self.nanosec as i64) - (rhs.nanosec as i64);
+        let nanosec = if nanosec_diff < 0 {
+            sec -= 1;
+            (1_000_000_000 + nanosec_diff) as u32
+        } else {
+            self.nanosec - rhs.nanosec
+        };
+        Self { sec, nanosec }
+    }
+}
+
 impl From<std::time::Duration> for Duration {
     fn from(x: std::time::Duration) -> Self {
         Self::new(x.as_secs() as i32, x.subsec_nanos())


### PR DESCRIPTION
This PR implement the behavior of Volatile and TransientLocal Durability on the reader side. This mostly involves implementing the wait_for_historical_data function.

The QoS of the built-in types are also adjusted to better reflect the table on page 140 of the DDS standard.

I also corrected some bugs with other condvar waits when implementing a similar one for this purpose. Those wrong wait times were probably just causing the while loop to run too often (lower performance) so they were not really serious or visible on the tests.