### PR TITLE
DDS-268 Use get publication matched status for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,6 @@ jobs:
             cargo build --bin multiple_subscriber_test_publisher
       - run:
           name: Run 2 subscribers with different IPs
-          no_output_timeout: 60s
           command: |
             # create docker volume (since direct mapping is not possible)
             docker create -v /var --name storage cimg/rust:1.62.0 /bin/true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
             cargo test --jobs 4
       - run:
           name: Hello world example
-          no_output_timeout: 30s
           command: |
             export RUSTFLAGS="-Cinstrument-coverage -Dwarnings"
             export LLVM_PROFILE_FILE="test-%p-%m.profraw"
@@ -33,7 +32,6 @@ jobs:
             wait $pid
       - run:
           name: BestEffort example
-          no_output_timeout: 30s
           command: |
             export RUSTFLAGS="-Cinstrument-coverage -Dwarnings"
             export LLVM_PROFILE_FILE="test-%p-%m.profraw"
@@ -68,7 +66,6 @@ jobs:
             cargo build
       - run:
           name: Hello world subscriber interoperability test
-          no_output_timeout: 30s
           command: |
             cargo run --bin dust_dds_subscriber &
             pid=$!
@@ -76,7 +73,6 @@ jobs:
             wait $pid
       - run:
           name: Hello world publisher interoperability test
-          no_output_timeout: 30s
           command: |
             build/CycloneDdsSubscriber &
             pid=$!
@@ -84,7 +80,6 @@ jobs:
             wait $pid
       - run:
           name: Big data publisher interoperability test
-          no_output_timeout: 30s
           command: |
             build/CycloneDdsBigDataSubscriber &
             pid=$!
@@ -92,7 +87,6 @@ jobs:
             wait $pid
       - run:
           name: Big data subscriber interoperability test
-          no_output_timeout: 30s
           command: |
             build/CycloneDdsBigDataPublisher &
             pid=$!

--- a/dds/tests/executables/publisher.rs
+++ b/dds/tests/executables/publisher.rs
@@ -61,11 +61,9 @@ fn main() {
         .attach_condition(Condition::StatusCondition(writer_cond)).unwrap();
 
     let number_of_subscribers_to_find = 2;
-    loop {
+    for _ in 0..number_of_subscribers_to_find {
         wait_set.wait(Duration::new(60, 0)).unwrap();
-        if writer.get_publication_matched_status().unwrap().current_count == number_of_subscribers_to_find {
-            break
-        }
+        writer.get_publication_matched_status().unwrap();
     }
 
     let hello_world = HelloWorldType {

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -1417,8 +1417,8 @@ fn transient_local_writer_reader_wait_for_historical_data() {
         .create_datareader(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
         .unwrap();
 
-    let cond = writer.get_statuscondition().unwrap();
-    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+    let cond = reader.get_statuscondition().unwrap();
+    cond.set_enabled_statuses(&[StatusKind::SubscriptionMatched])
         .unwrap();
 
     let mut wait_set = WaitSet::new();


### PR DESCRIPTION
Use a finite loop in the multi subscriber tests. 
Also make the transient_local_writer_reader_wait_for_historical_data test stable (due to a similar cause)