### PR TITLE
DDS-295 Fix reader factory bug

### DIFF
--- a/dds/src/implementation/dds_impl/data_writer_factory.rs
+++ b/dds/src/implementation/dds_impl/data_writer_factory.rs
@@ -1,0 +1,152 @@
+use crate::{
+    implementation::rtps::{
+        endpoint::RtpsEndpoint,
+        group::RtpsGroupImpl,
+        stateful_writer::RtpsStatefulWriter,
+        types::{
+            EntityId, EntityKey, Guid, Locator, TopicKind, USER_DEFINED_WRITER_NO_KEY,
+            USER_DEFINED_WRITER_WITH_KEY,
+        },
+        writer::RtpsWriter,
+    },
+    infrastructure::{
+        error::DdsResult,
+        qos::{DataWriterQos, QosKind},
+        time::{Duration, DURATION_ZERO},
+    },
+};
+
+pub struct DataWriterFactory {
+    user_defined_data_writer_counter: u8,
+    default_datawriter_qos: DataWriterQos,
+}
+
+impl DataWriterFactory {
+    pub fn new() -> Self {
+        Self {
+            user_defined_data_writer_counter: 0,
+            default_datawriter_qos: Default::default(),
+        }
+    }
+
+    pub fn get_default_datawriter_qos(&self) -> &DataWriterQos {
+        &self.default_datawriter_qos
+    }
+
+    pub fn set_default_datawriter_qos(&mut self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
+        match qos {
+            QosKind::Default => self.default_datawriter_qos = DataWriterQos::default(),
+            QosKind::Specific(q) => {
+                q.is_consistent()?;
+                self.default_datawriter_qos = q;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn create_datawriter(
+        &mut self,
+        rtps_group: &RtpsGroupImpl,
+        has_key: bool,
+        qos: QosKind<DataWriterQos>,
+        default_unicast_locator_list: &[Locator],
+        default_multicast_locator_list: &[Locator],
+        data_max_size_serialized: usize,
+    ) -> DdsResult<RtpsStatefulWriter> {
+        let guid = self.create_unique_writer_guid(rtps_group, has_key);
+
+        let qos = match qos {
+            QosKind::Default => self.default_datawriter_qos.clone(),
+            QosKind::Specific(q) => q,
+        };
+        qos.is_consistent()?;
+
+        let topic_kind = match has_key {
+            true => TopicKind::WithKey,
+            false => TopicKind::NoKey,
+        };
+
+        Ok(RtpsStatefulWriter::new(RtpsWriter::new(
+            RtpsEndpoint::new(
+                guid,
+                topic_kind,
+                default_unicast_locator_list,
+                default_multicast_locator_list,
+            ),
+            true,
+            Duration::new(0, 200_000_000),
+            DURATION_ZERO,
+            DURATION_ZERO,
+            data_max_size_serialized,
+            qos,
+        )))
+    }
+
+    fn create_unique_writer_guid(&mut self, rtps_group: &RtpsGroupImpl, has_key: bool) -> Guid {
+        let entity_kind = match has_key {
+            true => USER_DEFINED_WRITER_WITH_KEY,
+            false => USER_DEFINED_WRITER_NO_KEY,
+        };
+
+        let guid = Guid::new(
+            rtps_group.guid().prefix(),
+            EntityId::new(
+                EntityKey::new([
+                    <[u8; 3]>::from(rtps_group.guid().entity_id().entity_key())[0],
+                    self.user_defined_data_writer_counter,
+                    0,
+                ]),
+                entity_kind,
+            ),
+        );
+
+        self.user_defined_data_writer_counter += 1;
+
+        guid
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::implementation::rtps::types::{GuidPrefix, USER_DEFINED_WRITER_GROUP};
+
+    use super::*;
+
+    #[test]
+    fn each_created_writer_has_different_guid() {
+        let mut factory = DataWriterFactory::new();
+        let rtps_group = RtpsGroupImpl::new(Guid::new(
+            GuidPrefix::new([1; 12]),
+            EntityId::new(EntityKey::new([1; 3]), USER_DEFINED_WRITER_GROUP),
+        ));
+        let has_key = true;
+        let default_unicast_locator_list = &[];
+        let default_multicast_locator_list = &[];
+        let data_max_size_serialized = 5000;
+
+        let dw1 = factory
+            .create_datawriter(
+                &rtps_group,
+                has_key,
+                QosKind::Default,
+                default_unicast_locator_list,
+                default_multicast_locator_list,
+                data_max_size_serialized,
+            )
+            .unwrap();
+
+        let dw2 = factory
+            .create_datawriter(
+                &rtps_group,
+                has_key,
+                QosKind::Default,
+                default_unicast_locator_list,
+                default_multicast_locator_list,
+                data_max_size_serialized,
+            )
+            .unwrap();
+
+        assert_ne!(dw1.guid(), dw2.guid());
+    }
+}

--- a/dds/src/implementation/dds_impl/mod.rs
+++ b/dds/src/implementation/dds_impl/mod.rs
@@ -11,6 +11,7 @@ pub mod dcps_service;
 pub mod domain_participant_impl;
 pub mod message_receiver;
 pub mod participant_discovery;
+pub mod reader_factory;
 pub mod status_condition_impl;
 pub mod topic_impl;
 pub mod user_defined_data_reader;

--- a/dds/src/implementation/dds_impl/mod.rs
+++ b/dds/src/implementation/dds_impl/mod.rs
@@ -17,3 +17,4 @@ pub mod user_defined_data_reader;
 pub mod user_defined_data_writer;
 pub mod user_defined_publisher;
 pub mod user_defined_subscriber;
+pub mod data_writer_factory;

--- a/dds/src/implementation/dds_impl/mod.rs
+++ b/dds/src/implementation/dds_impl/mod.rs
@@ -17,4 +17,4 @@ pub mod user_defined_data_reader;
 pub mod user_defined_data_writer;
 pub mod user_defined_publisher;
 pub mod user_defined_subscriber;
-pub mod data_writer_factory;
+pub mod writer_factory;

--- a/dds/src/implementation/dds_impl/reader_factory.rs
+++ b/dds/src/implementation/dds_impl/reader_factory.rs
@@ -1,0 +1,104 @@
+use crate::{
+    implementation::rtps::{
+        endpoint::RtpsEndpoint,
+        group::RtpsGroupImpl,
+        reader::RtpsReader,
+        stateful_reader::RtpsStatefulReader,
+        types::{
+            EntityId, EntityKey, Guid, Locator, TopicKind, USER_DEFINED_READER_NO_KEY,
+            USER_DEFINED_READER_WITH_KEY,
+        },
+    },
+    infrastructure::{
+        error::DdsResult,
+        qos::{DataReaderQos, QosKind},
+        time::DURATION_ZERO,
+    },
+    topic_definition::type_support::{DdsDeserialize, DdsType},
+};
+
+pub struct ReaderFactory {
+    user_defined_data_reader_counter: u8,
+    default_data_reader_qos: DataReaderQos,
+}
+
+impl ReaderFactory {
+    pub fn new() -> Self {
+        Self {
+            user_defined_data_reader_counter: 0,
+            default_data_reader_qos: Default::default(),
+        }
+    }
+
+    pub fn get_default_datareader_qos(&self) -> &DataReaderQos {
+        &self.default_data_reader_qos
+    }
+
+    pub fn set_default_datareader_qos(&mut self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
+        match qos {
+            QosKind::Default => self.default_data_reader_qos = DataReaderQos::default(),
+            QosKind::Specific(q) => {
+                q.is_consistent()?;
+                self.default_data_reader_qos = q;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn create_reader<Foo>(
+        &mut self,
+        rtps_group: &RtpsGroupImpl,
+        has_key: bool,
+        qos: QosKind<DataReaderQos>,
+        default_unicast_locator_list: &[Locator],
+        default_multicast_locator_list: &[Locator],
+    ) -> DdsResult<RtpsStatefulReader>
+    where
+        Foo: DdsType + for<'de> DdsDeserialize<'de>,
+    {
+        let qos = match qos {
+            QosKind::Default => self.default_data_reader_qos.clone(),
+            QosKind::Specific(q) => q,
+        };
+        qos.is_consistent()?;
+
+        let guid = self.create_unique_reader_guid(rtps_group, has_key);
+
+        let topic_kind = match has_key {
+            true => TopicKind::WithKey,
+            false => TopicKind::NoKey,
+        };
+
+        Ok(RtpsStatefulReader::new(RtpsReader::new::<Foo>(
+            RtpsEndpoint::new(
+                guid,
+                topic_kind,
+                default_unicast_locator_list,
+                default_multicast_locator_list,
+            ),
+            DURATION_ZERO,
+            DURATION_ZERO,
+            false,
+            qos,
+        )))
+    }
+
+    fn create_unique_reader_guid(&mut self, rtps_group: &RtpsGroupImpl, has_key: bool) -> Guid {
+        let entity_kind = match has_key {
+            true => USER_DEFINED_READER_WITH_KEY,
+            false => USER_DEFINED_READER_NO_KEY,
+        };
+
+        let entity_key = EntityKey::new([
+            <[u8; 3]>::from(rtps_group.guid().entity_id().entity_key())[0],
+            self.user_defined_data_reader_counter,
+            0,
+        ]);
+
+        self.user_defined_data_reader_counter += 1;
+
+        let entity_id = EntityId::new(entity_key, entity_kind);
+
+        Guid::new(rtps_group.guid().prefix(), entity_id)
+    }
+}

--- a/dds/src/implementation/dds_impl/user_defined_publisher.rs
+++ b/dds/src/implementation/dds_impl/user_defined_publisher.rs
@@ -30,7 +30,7 @@ use crate::{
 
 use super::{
     any_data_writer_listener::AnyDataWriterListener,
-    data_writer_factory::DataWriterFactory,
+    writer_factory::WriterFactory,
     domain_participant_impl::DomainParticipantImpl,
     message_receiver::{MessageReceiver, PublisherMessageReceiver},
     status_condition_impl::StatusConditionImpl,
@@ -42,7 +42,7 @@ pub struct UserDefinedPublisher {
     qos: DdsRwLock<PublisherQos>,
     rtps_group: RtpsGroupImpl,
     data_writer_list: DdsRwLock<Vec<DdsShared<UserDefinedDataWriter>>>,
-    data_writer_factory: DdsRwLock<DataWriterFactory>,
+    data_writer_factory: DdsRwLock<WriterFactory>,
     enabled: DdsRwLock<bool>,
     user_defined_data_send_condvar: DdsCondvar,
     parent_participant: DdsWeak<DomainParticipantImpl>,
@@ -66,7 +66,7 @@ impl UserDefinedPublisher {
             qos: DdsRwLock::new(qos),
             rtps_group,
             data_writer_list: DdsRwLock::new(Vec::new()),
-            data_writer_factory: DdsRwLock::new(DataWriterFactory::new()),
+            data_writer_factory: DdsRwLock::new(WriterFactory::new()),
             enabled: DdsRwLock::new(false),
             user_defined_data_send_condvar,
             parent_participant,
@@ -97,7 +97,7 @@ impl DdsShared<UserDefinedPublisher> {
     where
         Foo: DdsType,
     {
-        let rtps_writer_impl = self.data_writer_factory.write_lock().create_datawriter(
+        let rtps_writer_impl = self.data_writer_factory.write_lock().create_writer(
             &self.rtps_group,
             Foo::has_key(),
             qos,

--- a/dds/src/implementation/dds_impl/user_defined_publisher.rs
+++ b/dds/src/implementation/dds_impl/user_defined_publisher.rs
@@ -1,24 +1,16 @@
-use std::sync::atomic::{self, AtomicU8};
-
 use fnmatch_regex::glob_to_regex;
 
 use crate::{
     implementation::{
         data_representation_builtin_endpoints::discovered_reader_data::DiscoveredReaderData,
         rtps::{
-            endpoint::RtpsEndpoint,
             group::RtpsGroupImpl,
             messages::{
                 overall_structure::RtpsMessageHeader,
                 submessages::{AckNackSubmessage, NackFragSubmessage},
             },
-            stateful_writer::RtpsStatefulWriter,
             transport::TransportWrite,
-            types::{
-                EntityId, EntityKey, Guid, Locator, TopicKind, USER_DEFINED_WRITER_NO_KEY,
-                USER_DEFINED_WRITER_WITH_KEY,
-            },
-            writer::RtpsWriter,
+            types::Locator,
         },
         utils::{
             condvar::DdsCondvar,
@@ -30,7 +22,7 @@ use crate::{
         instance::InstanceHandle,
         qos::{DataWriterQos, PublisherQos, QosKind, TopicQos},
         status::StatusKind,
-        time::{Duration, DURATION_ZERO},
+        time::Duration,
     },
     publication::publisher_listener::PublisherListener,
     topic_definition::type_support::DdsType,
@@ -38,6 +30,7 @@ use crate::{
 
 use super::{
     any_data_writer_listener::AnyDataWriterListener,
+    data_writer_factory::DataWriterFactory,
     domain_participant_impl::DomainParticipantImpl,
     message_receiver::{MessageReceiver, PublisherMessageReceiver},
     status_condition_impl::StatusConditionImpl,
@@ -49,8 +42,7 @@ pub struct UserDefinedPublisher {
     qos: DdsRwLock<PublisherQos>,
     rtps_group: RtpsGroupImpl,
     data_writer_list: DdsRwLock<Vec<DdsShared<UserDefinedDataWriter>>>,
-    user_defined_data_writer_counter: AtomicU8,
-    default_datawriter_qos: DdsRwLock<DataWriterQos>,
+    data_writer_factory: DdsRwLock<DataWriterFactory>,
     enabled: DdsRwLock<bool>,
     user_defined_data_send_condvar: DdsCondvar,
     parent_participant: DdsWeak<DomainParticipantImpl>,
@@ -74,8 +66,7 @@ impl UserDefinedPublisher {
             qos: DdsRwLock::new(qos),
             rtps_group,
             data_writer_list: DdsRwLock::new(Vec::new()),
-            user_defined_data_writer_counter: AtomicU8::new(0),
-            default_datawriter_qos: DdsRwLock::new(DataWriterQos::default()),
+            data_writer_factory: DdsRwLock::new(DataWriterFactory::new()),
             enabled: DdsRwLock::new(false),
             user_defined_data_send_condvar,
             parent_participant,
@@ -106,75 +97,27 @@ impl DdsShared<UserDefinedPublisher> {
     where
         Foo: DdsType,
     {
-        let topic_shared = a_topic;
+        let rtps_writer_impl = self.data_writer_factory.write_lock().create_datawriter(
+            &self.rtps_group,
+            Foo::has_key(),
+            qos,
+            self.get_participant().default_unicast_locator_list(),
+            self.get_participant().default_multicast_locator_list(),
+            self.data_max_size_serialized,
+        )?;
 
-        // /////// Build the GUID
-        let guid = {
-            let user_defined_data_writer_counter = self
-                .user_defined_data_writer_counter
-                .fetch_add(1, atomic::Ordering::SeqCst);
+        let data_writer_shared = UserDefinedDataWriter::new(
+            rtps_writer_impl,
+            a_listener,
+            mask,
+            a_topic.clone(),
+            self.downgrade(),
+            self.user_defined_data_send_condvar.clone(),
+        );
 
-            let entity_kind = match Foo::has_key() {
-                true => USER_DEFINED_WRITER_WITH_KEY,
-                false => USER_DEFINED_WRITER_NO_KEY,
-            };
-
-            Guid::new(
-                self.rtps_group.guid().prefix(),
-                EntityId::new(
-                    EntityKey::new([
-                        <[u8; 3]>::from(self.rtps_group.guid().entity_id().entity_key())[0],
-                        user_defined_data_writer_counter,
-                        0,
-                    ]),
-                    entity_kind,
-                ),
-            )
-        };
-
-        // /////// Create data writer
-        let data_writer_shared = {
-            let qos = match qos {
-                QosKind::Default => self.default_datawriter_qos.read_lock().clone(),
-                QosKind::Specific(q) => q,
-            };
-            qos.is_consistent()?;
-
-            let topic_kind = match Foo::has_key() {
-                true => TopicKind::WithKey,
-                false => TopicKind::NoKey,
-            };
-
-            let rtps_writer_impl = RtpsStatefulWriter::new(RtpsWriter::new(
-                RtpsEndpoint::new(
-                    guid,
-                    topic_kind,
-                    self.get_participant().default_unicast_locator_list(),
-                    self.get_participant().default_multicast_locator_list(),
-                ),
-                true,
-                Duration::new(0, 200_000_000),
-                DURATION_ZERO,
-                DURATION_ZERO,
-                self.data_max_size_serialized,
-                qos,
-            ));
-
-            let data_writer_shared = UserDefinedDataWriter::new(
-                rtps_writer_impl,
-                a_listener,
-                mask,
-                topic_shared.clone(),
-                self.downgrade(),
-                self.user_defined_data_send_condvar.clone(),
-            );
-
-            self.data_writer_list
-                .write_lock()
-                .push(data_writer_shared.clone());
-
-            data_writer_shared
-        };
+        self.data_writer_list
+            .write_lock()
+            .push(data_writer_shared.clone());
 
         if *self.enabled.read_lock()
             && self
@@ -286,21 +229,16 @@ impl DdsShared<UserDefinedPublisher> {
     }
 
     pub fn set_default_datawriter_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
-        match qos {
-            QosKind::Default => {
-                *self.default_datawriter_qos.write_lock() = DataWriterQos::default()
-            }
-            QosKind::Specific(q) => {
-                q.is_consistent()?;
-                *self.default_datawriter_qos.write_lock() = q;
-            }
-        }
-
-        Ok(())
+        self.data_writer_factory
+            .write_lock()
+            .set_default_datawriter_qos(qos)
     }
 
     pub fn get_default_datawriter_qos(&self) -> DataWriterQos {
-        self.default_datawriter_qos.read_lock().clone()
+        self.data_writer_factory
+            .read_lock()
+            .get_default_datawriter_qos()
+            .clone()
     }
 
     pub fn copy_from_topic_qos(

--- a/dds/src/implementation/dds_impl/writer_factory.rs
+++ b/dds/src/implementation/dds_impl/writer_factory.rs
@@ -16,12 +16,12 @@ use crate::{
     },
 };
 
-pub struct DataWriterFactory {
+pub struct WriterFactory {
     user_defined_data_writer_counter: u8,
     default_datawriter_qos: DataWriterQos,
 }
 
-impl DataWriterFactory {
+impl WriterFactory {
     pub fn new() -> Self {
         Self {
             user_defined_data_writer_counter: 0,
@@ -45,7 +45,7 @@ impl DataWriterFactory {
         Ok(())
     }
 
-    pub fn create_datawriter(
+    pub fn create_writer(
         &mut self,
         rtps_group: &RtpsGroupImpl,
         has_key: bool,
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn each_created_writer_has_different_guid() {
-        let mut factory = DataWriterFactory::new();
+        let mut factory = WriterFactory::new();
         let rtps_group = RtpsGroupImpl::new(Guid::new(
             GuidPrefix::new([1; 12]),
             EntityId::new(EntityKey::new([1; 3]), USER_DEFINED_WRITER_GROUP),
@@ -126,7 +126,7 @@ mod tests {
         let data_max_size_serialized = 5000;
 
         let dw1 = factory
-            .create_datawriter(
+            .create_writer(
                 &rtps_group,
                 has_key,
                 QosKind::Default,
@@ -137,7 +137,7 @@ mod tests {
             .unwrap();
 
         let dw2 = factory
-            .create_datawriter(
+            .create_writer(
                 &rtps_group,
                 has_key,
                 QosKind::Default,

--- a/dds/src/implementation/dds_impl/writer_factory.rs
+++ b/dds/src/implementation/dds_impl/writer_factory.rs
@@ -54,13 +54,13 @@ impl WriterFactory {
         default_multicast_locator_list: &[Locator],
         data_max_size_serialized: usize,
     ) -> DdsResult<RtpsStatefulWriter> {
-        let guid = self.create_unique_writer_guid(rtps_group, has_key);
-
         let qos = match qos {
             QosKind::Default => self.default_datawriter_qos.clone(),
             QosKind::Specific(q) => q,
         };
         qos.is_consistent()?;
+
+        let guid = self.create_unique_writer_guid(rtps_group, has_key);
 
         let topic_kind = match has_key {
             true => TopicKind::WithKey,
@@ -89,21 +89,17 @@ impl WriterFactory {
             false => USER_DEFINED_WRITER_NO_KEY,
         };
 
-        let guid = Guid::new(
-            rtps_group.guid().prefix(),
-            EntityId::new(
-                EntityKey::new([
-                    <[u8; 3]>::from(rtps_group.guid().entity_id().entity_key())[0],
-                    self.user_defined_data_writer_counter,
-                    0,
-                ]),
-                entity_kind,
-            ),
-        );
+        let entity_key = EntityKey::new([
+            <[u8; 3]>::from(rtps_group.guid().entity_id().entity_key())[0],
+            self.user_defined_data_writer_counter,
+            0,
+        ]);
 
         self.user_defined_data_writer_counter += 1;
 
-        guid
+        let entity_id = EntityId::new(entity_key, entity_kind);
+
+        Guid::new(rtps_group.guid().prefix(), entity_id)
     }
 }
 

--- a/dds/tests/publisher_api.rs
+++ b/dds/tests/publisher_api.rs
@@ -73,3 +73,41 @@ fn default_data_writer_qos() {
     );
     assert_eq!(&writer.get_qos().unwrap().user_data.value, &user_data);
 }
+
+#[test]
+fn different_writers_have_different_instance_handles() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let domain_participant_factory = DomainParticipantFactory::get_instance();
+    let participant = domain_participant_factory
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<UserType>("default_data_writer_qos", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let publisher1 = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let publisher2 = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let writer1_1 = publisher1
+        .create_datawriter(&topic, QosKind::Default, None, &[])
+        .unwrap();
+    let writer1_2 = publisher1
+        .create_datawriter(&topic, QosKind::Default, None, &[])
+        .unwrap();
+    let writer2_1 = publisher2
+        .create_datawriter(&topic, QosKind::Default, None, &[])
+        .unwrap();
+    let writer2_2 = publisher2
+        .create_datawriter(&topic, QosKind::Default, None, &[])
+        .unwrap();
+
+    assert_ne!(writer1_1.get_instance_handle(), writer1_2.get_instance_handle());
+    assert_ne!(writer1_2.get_instance_handle(), writer2_1.get_instance_handle());
+    assert_ne!(writer2_1.get_instance_handle(), writer2_2.get_instance_handle());
+}

--- a/dds/tests/subscriber_api.rs
+++ b/dds/tests/subscriber_api.rs
@@ -73,3 +73,50 @@ fn default_data_reader_qos() {
     );
     assert_eq!(&reader.get_qos().unwrap().user_data.value, &user_data);
 }
+
+#[test]
+fn different_readers_have_different_instance_handles() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let domain_participant_factory = DomainParticipantFactory::get_instance();
+    let participant = domain_participant_factory
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<UserType>("default_data_writer_qos", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let subscriber1 = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let subscriber2 = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let reader1_1 = subscriber1
+        .create_datareader(&topic, QosKind::Default, None, &[])
+        .unwrap();
+    let reader1_2 = subscriber1
+        .create_datareader(&topic, QosKind::Default, None, &[])
+        .unwrap();
+    let reader2_1 = subscriber2
+        .create_datareader(&topic, QosKind::Default, None, &[])
+        .unwrap();
+    let reader2_2 = subscriber2
+        .create_datareader(&topic, QosKind::Default, None, &[])
+        .unwrap();
+
+    assert_ne!(
+        reader1_1.get_instance_handle(),
+        reader1_2.get_instance_handle()
+    );
+    assert_ne!(
+        reader1_2.get_instance_handle(),
+        reader2_1.get_instance_handle()
+    );
+    assert_ne!(
+        reader2_1.get_instance_handle(),
+        reader2_2.get_instance_handle()
+    );
+}


### PR DESCRIPTION
This PR fixes a bug in which different readers were not being assigned unique ID's. The fix involves moving the code that create the user defined reader and writer into a dedicated factory class which can be more easily unit tested.