### PR TITLE
DDS-292 Add shapes demo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "dds_derive",
     "idlgen",
     "interoperability_tests",
+    "shapes_demo",
 ]

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -885,7 +885,7 @@ impl DdsShared<DomainParticipantImpl> {
     ) {
         if let Ok(participant_discovery) = ParticipantDiscovery::new(
             &discovered_participant_data,
-            self.domain_id as i32,
+            self.domain_id,
             &self.domain_tag,
         ) {
             if !self

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data.rs
@@ -105,7 +105,7 @@ impl<'de: 'a, 'a> MappingReadSubmessage<'de> for DataSubmessage<'a> {
                 - octets_to_inline_qos as usize
                 - 4
                 - inline_qos_len;
-            let (data, following) = buf.split_at(serialized_payload_length as usize);
+            let (data, following) = buf.split_at(serialized_payload_length);
             *buf = following;
             SerializedPayload::new(data)
         } else {

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
@@ -116,7 +116,7 @@ impl<'de: 'a, 'a> MappingReadSubmessage<'de> for DataFragSubmessage<'a> {
 
         let serialized_payload_length =
             header.submessage_length as usize - octets_to_inline_qos as usize - 4 - inline_qos_len;
-        let (data, following) = buf.split_at(serialized_payload_length as usize);
+        let (data, following) = buf.split_at(serialized_payload_length);
         *buf = following;
         let serialized_payload = SerializedPayload::new(data);
 

--- a/dds/tests/write_read_keyed_topic.rs
+++ b/dds/tests/write_read_keyed_topic.rs
@@ -817,7 +817,7 @@ fn take_next_instance() {
     wait_set
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
-    wait_set.wait(Duration::new(5, 0)).unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 
     let data1 = KeyedData { id: 1, value: 1 };
     let data2 = KeyedData { id: 2, value: 10 };
@@ -828,7 +828,7 @@ fn take_next_instance() {
     writer.write(&data3, None).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(1, 0))
+        .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
     let samples1 = reader
@@ -999,7 +999,7 @@ fn take_specific_unknown_instance() {
     wait_set
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
-    wait_set.wait(Duration::new(5, 0)).unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 
     let data1 = KeyedData { id: 1, value: 1 };
     let data2 = KeyedData { id: 2, value: 10 };
@@ -1010,7 +1010,7 @@ fn take_specific_unknown_instance() {
     writer.write(&data3, None).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(1, 0))
+        .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
     assert_eq!(
@@ -1242,7 +1242,7 @@ fn inconsistent_topic_status_condition() {
         )
         .unwrap();
 
-    wait_set.wait(Duration::new(2, 0)).unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 
     assert_eq!(
         topic_best_effort

--- a/dds_derive/src/lib.rs
+++ b/dds_derive/src/lib.rs
@@ -40,7 +40,7 @@ pub fn derive_dds_type(input: TokenStream) -> TokenStream {
 
     if is_key {
         quote! {
-            impl #impl_generics DdsType for #ident #type_generics #where_clause {
+            impl #impl_generics dust_dds::topic_definition::type_support::DdsType for #ident #type_generics #where_clause {
                 fn type_name() -> &'static str {
                     #type_name
                 }
@@ -70,7 +70,7 @@ pub fn derive_dds_type(input: TokenStream) -> TokenStream {
         let set_key = struct_set_key(&struct_data);
 
         quote! {
-            impl #impl_generics DdsType for #ident #type_generics #where_clause {
+            impl #impl_generics dust_dds::topic_definition::type_support::DdsType for #ident #type_generics #where_clause {
                 fn type_name() -> &'static str {
                     #type_name
                 }
@@ -129,7 +129,7 @@ fn struct_build_key(struct_data: &DataStruct) -> TokenStream2 {
             .map(|field| field.into_token_stream())
             .unwrap_or_else(|| syn::Index::from(i).into_token_stream());
 
-        field_list_ts.extend(quote! {self.#field_ident,});
+        field_list_ts.extend(quote! {&self.#field_ident,});
     }
 
     quote! {

--- a/idlgen/src/mappings/rust.rs
+++ b/idlgen/src/mappings/rust.rs
@@ -24,10 +24,10 @@ pub fn template_type(t: idl::TemplateType) -> String {
         }
         idl::TemplateType::Sequence(t, None) => format!("Vec<{}>", type_spec(*t)),
 
-        idl::TemplateType::String(Some(size)) => format!("[char; {}]", size),
+        idl::TemplateType::String(Some(_size)) => format!("String"),
         idl::TemplateType::String(None) => "String".to_string(),
 
-        idl::TemplateType::WideString(Some(size)) => format!("[char; {}]", size),
+        idl::TemplateType::WideString(Some(_size)) => format!("String"),
         idl::TemplateType::WideString(None) => "String".to_string(),
     }
 }

--- a/idlgen/src/mappings/rust.rs
+++ b/idlgen/src/mappings/rust.rs
@@ -24,10 +24,10 @@ pub fn template_type(t: idl::TemplateType) -> String {
         }
         idl::TemplateType::Sequence(t, None) => format!("Vec<{}>", type_spec(*t)),
 
-        idl::TemplateType::String(Some(_size)) => format!("String"),
+        idl::TemplateType::String(Some(_size)) => "String".to_string(),
         idl::TemplateType::String(None) => "String".to_string(),
 
-        idl::TemplateType::WideString(Some(_size)) => format!("String"),
+        idl::TemplateType::WideString(Some(_size)) => "String".to_string(),
         idl::TemplateType::WideString(None) => "String".to_string(),
     }
 }

--- a/idlgen/tests/examples/structs.rs
+++ b/idlgen/tests/examples/structs.rs
@@ -20,5 +20,5 @@ pub struct Sentence {
 }
 #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]
 pub struct User {
-    pub name: [char; 8],
+    pub name: String,
 }

--- a/shapes_demo/Cargo.toml
+++ b/shapes_demo/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "dust_dds_shapes_demo"
+version = "0.1.0"
+authors = [
+	"Joao Rebelo <jrebelo@s2e-systems.com>",
+	"Stefan Kimmer <skimmer@s2e-systems.com>",
+]
+license = "Apache-2.0"
+edition = "2021"
+description = "Dust DDS Shapes Demo"
+homepage = "https://s2e-systems.com/products/dust-dds"
+repository = "https://github.com/s2e-systems/dust-dds"
+keywords = ["dds", "rtps", "middleware", "network", "udp"]
+categories = ["api-bindings", "network-programming"]
+
+[dependencies]
+dust_dds = { path = "../dds" }
+dust_dds_derive = { path = "../dds_derive", version = "0.1" }
+
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+cdr = "0.2.4"
+
+[build-dependencies]
+dust_idlgen = {path = "../idlgen" }
+pest = "=2.5.3"
+pest_derive = "=2.5.3"
+
+[[bin]]
+name = "dust_dds_shapes_demo"
+path = "src/main.rs"
+
+[[bin]]
+name = "subscriber"
+path = "src/subscriber.rs"

--- a/shapes_demo/build.rs
+++ b/shapes_demo/build.rs
@@ -1,0 +1,29 @@
+use std::{fs::File, io::Write};
+
+use dust_idlgen::{
+    mappings::rust,
+    parser,
+    syntax::{self, Analyser},
+};
+use pest::Parser;
+
+fn main() {
+    let idl_path = "src/ShapeType.idl";
+    let idl_src = std::fs::read_to_string(idl_path).expect("Couldn't read IDL source file!");
+
+    let result = parser::IdlParser::parse(parser::Rule::specification, &idl_src)
+        .expect("Couldn't parse IDL file");
+
+    let mut file = File::create("src/shapes_type.rs").expect("Failed to create file");
+
+    let spec = syntax::specification()
+        .analyse(result.into())
+        .expect("Couldn't analyse IDL syntax");
+
+    for def in spec.value {
+        for line in rust::definition(def) {
+            file.write_all(line.as_bytes())
+                .expect("Failed to write to file");
+        }
+    }
+}

--- a/shapes_demo/src/ShapeType.idl
+++ b/shapes_demo/src/ShapeType.idl
@@ -1,0 +1,7 @@
+struct ShapeType
+{
+    @key string color;
+    long x;
+    long y;
+    long shapesize;
+};

--- a/shapes_demo/src/main.rs
+++ b/shapes_demo/src/main.rs
@@ -1,0 +1,65 @@
+use dust_dds::{
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        qos::{DataWriterQos, QosKind},
+        qos_policy::{ReliabilityQosPolicy, ReliabilityQosPolicyKind},
+        status::{StatusKind, NO_STATUS},
+        time::Duration,
+        wait_set::{Condition, WaitSet},
+    },
+};
+
+mod shapes_type;
+
+fn main() {
+    let domain_id = 0;
+    let participant_factory = DomainParticipantFactory::get_instance();
+
+    let participant = participant_factory
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<shapes_type::ShapeType>("Circle", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::BestEffort,
+            max_blocking_time: Duration::new(1, 0),
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(&topic, QosKind::Specific(writer_qos), None, NO_STATUS)
+        .unwrap();
+    let writer_cond = writer.get_statuscondition().unwrap();
+    writer_cond
+        .set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(writer_cond))
+        .unwrap();
+
+    wait_set.wait(Duration::new(60, 0)).unwrap();
+
+    let data = shapes_type::ShapeType {
+        color: "BLUE".to_string(), //['B', 'L', 'U', 'E'].to_vec(),
+        x: 140,
+        y: 46,
+        shapesize: 30,
+    };
+    loop {
+        writer.write(&data, None).unwrap();
+
+        // writer
+        //     .wait_for_acknowledgments(Duration::new(30, 0))
+        //     .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+}

--- a/shapes_demo/src/shapes_type.rs
+++ b/shapes_demo/src/shapes_type.rs
@@ -1,0 +1,1 @@
+#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]pub struct ShapeType {    #[key] pub color: String,    pub x: i32,    pub y: i32,    pub shapesize: i32,}

--- a/shapes_demo/src/subscriber.rs
+++ b/shapes_demo/src/subscriber.rs
@@ -1,0 +1,75 @@
+use dust_dds::{
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        qos::{DataReaderQos, QosKind},
+        qos_policy::{
+            DurabilityQosPolicy, DurabilityQosPolicyKind, ReliabilityQosPolicy,
+            ReliabilityQosPolicyKind,
+        },
+        status::{StatusKind, NO_STATUS},
+        time::Duration,
+        wait_set::{Condition, WaitSet},
+    },
+    subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+};
+
+mod shapes_type;
+
+fn main() {
+    let domain_id = 0;
+    let participant_factory = DomainParticipantFactory::get_instance();
+
+    let participant = participant_factory
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<shapes_type::ShapeType>(
+            "Circle",
+            QosKind::Default,
+            None,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: Duration::new(1, 0),
+        },
+        durability: DurabilityQosPolicy {
+            kind: DurabilityQosPolicyKind::TransientLocal,
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
+        .unwrap();
+
+    let reader_cond = reader.get_statuscondition().unwrap();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond.clone()))
+        .unwrap();
+
+    wait_set.wait(Duration::new(60, 0)).unwrap();
+
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::DataAvailable])
+        .unwrap();
+    wait_set.wait(Duration::new(30, 0)).unwrap();
+
+    let samples = reader
+        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    let sample = samples[0].data.as_ref().unwrap();
+    println!("Received: {:?}", sample);
+}


### PR DESCRIPTION
Add shapes demo skeleton. A subscriber bin is added for development purposes.
- Some Clippy warnings are fixed and some timeouts in the tests are increased.
- The key value macro for non copy types is fixed in the derive crate.
- The idl gen generates now Strings from size limited templates such as string<128> gets a String now. 