### PR TITLE
DDS-292 Add publishing of circle

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,9 +1,7 @@
-FROM cimg/rust:1.62.0
-RUN git clone --depth=1 https://github.com/eclipse-cyclonedds/cyclonedds.git \
-    && mkdir cyclonedds-build
-RUN cd cyclonedds-build \
-    && cmake ../cyclonedds \
-    && cmake --build . --parallel 5 \
-    && sudo cmake --build . --target install
-RUN rm -rf cyclonedds \
-    && rm -rf cyclonedds-build
+FROM cimg/rust:1.65.0 AS Builder
+RUN git clone --depth 1 --branch 0.10.2 --single-branch https://github.com/eclipse-cyclonedds/cyclonedds.git
+RUN cmake -B cyclonedds-build -S cyclonedds -DCMAKE_INSTALL_PREFIX=cyclonedds-install \
+    && cmake --build cyclonedds-build --parallel 5 --target install
+
+FROM cimg/rust:1.65.0
+COPY --from=Builder /home/circleci/project/cyclonedds-install /usr/local/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.62.0
+      - image: cimg/rust:1.65.0
     resource_class: large
     steps:
       - checkout
@@ -95,7 +95,7 @@ jobs:
 
   multi_machine_tests:
     docker:
-      - image: cimg/rust:1.62.0
+      - image: cimg/rust:1.65.0
     steps:
       - checkout
       - setup_remote_docker
@@ -108,12 +108,12 @@ jobs:
           name: Run 2 subscribers with different IPs
           command: |
             # create docker volume (since direct mapping is not possible)
-            docker create -v /var --name storage cimg/rust:1.62.0 /bin/true
+            docker create -v /var --name storage cimg/rust:1.65.0 /bin/true
             docker cp ./target/debug/multiple_subscriber_test_subscriber storage:/var
             docker cp ./target/debug/multiple_subscriber_test_publisher storage:/var
-            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/multiple_subscriber_test_subscriber
-            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/multiple_subscriber_test_subscriber
-            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/multiple_subscriber_test_publisher
+            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.65.0  /var/multiple_subscriber_test_subscriber
+            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.65.0  /var/multiple_subscriber_test_subscriber
+            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.65.0  /var/multiple_subscriber_test_publisher
             docker logs subscriber_1 | tee subscriber_1.out
             docker logs subscriber_2 | tee subscriber_2.out
             echo "Received: id: 8, msg: Hello world" | cmp subscriber_1.out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
   interoperability_tests:
     docker:
-      - image: s2esystems/dust_dds_interoperability
+      - image: s2esystems/dust_dds_interoperability:1.65.0
     steps:
       - checkout
       - run:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -8,7 +8,7 @@ parameters:
 jobs:
   build_and_push_docker_image:
     docker:
-      - image: cimg/base
+      - image: cimg/base:current
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -14,15 +14,15 @@ jobs:
       - setup_remote_docker
       - run:
           name: Build Docker image
-          command: docker build --file .circleci/Dockerfile --tag s2esystems/dust_dds_interoperability:1.62.0 .
+          command: docker build --file .circleci/Dockerfile --tag s2esystems/dust_dds_interoperability:1.65.0 .
       - run:
           name: Push image to DockerHub
           command: |
             echo $DOCKERHUB_ACCESS_TOKEN | docker login --username $DOCKERHUB_USERNAME --password-stdin
-            docker push s2esystems/dust_dds_interoperability:1.62.0
+            docker push s2esystems/dust_dds_interoperability:1.65.0
   build:
     docker:
-      - image: cimg/rust:1.62.0
+      - image: cimg/rust:1.65.0
     resource_class: large
     steps:
       - checkout
@@ -114,7 +114,7 @@ jobs:
 
   multi_machine_tests:
     docker:
-      - image: cimg/rust:1.62.0
+      - image: cimg/rust:1.65.0
     steps:
       - checkout
       - setup_remote_docker
@@ -127,12 +127,12 @@ jobs:
           name: Run 2 subscribers with different IPs
           command: |
             # create docker volume (since direct mapping is not possible)
-            docker create -v /var --name storage cimg/rust:1.62.0 /bin/true
+            docker create -v /var --name storage cimg/rust:1.65.0 /bin/true
             docker cp ./target/debug/multiple_subscriber_test_subscriber storage:/var
             docker cp ./target/debug/multiple_subscriber_test_publisher storage:/var
-            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.62.0  /var/multiple_subscriber_test_subscriber
-            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.62.0  /var/multiple_subscriber_test_subscriber
-            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.62.0  /var/multiple_subscriber_test_publisher
+            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.65.0  /var/multiple_subscriber_test_subscriber
+            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.65.0  /var/multiple_subscriber_test_subscriber
+            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.65.0  /var/multiple_subscriber_test_publisher
             docker logs subscriber_1 | tee subscriber_1.out
             docker logs subscriber_2 | tee subscriber_2.out
             echo "Received: id: 8, msg: Hello world" | cmp subscriber_1.out

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -8,7 +8,7 @@ parameters:
 jobs:
   build_and_push_docker_image:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base
     steps:
       - checkout
       - setup_remote_docker
@@ -69,7 +69,7 @@ jobs:
 
   interoperability_tests:
     docker:
-      - image: s2esystems/dust_dds_interoperability
+      - image: s2esystems/dust_dds_interoperability:1.65.0
     steps:
       - checkout
       - run:

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -17,8 +17,7 @@ categories = ["api-bindings", "network-programming"]
 
 [dependencies]
 dust_dds_derive = { path = "../dds_derive", version = "0.1" }
-
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "=1.0", default-features = false, features = ["derive"] }
 cdr = "=0.2.4"
 
 derive_more = "=0.99.16"

--- a/interoperability_tests/Cargo.toml
+++ b/interoperability_tests/Cargo.toml
@@ -19,7 +19,7 @@ dust_dds = { path = "../dds" }
 dust_dds_derive = { path = "../dds_derive", version = "0.1" }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-cdr = "0.2.4"
+cdr = "=0.2.4"
 
 [build-dependencies]
 dust_idlgen = {path = "../idlgen" }

--- a/shapes_demo/Cargo.toml
+++ b/shapes_demo/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["api-bindings", "network-programming"]
 [dependencies]
 dust_dds = { path = "../dds" }
 dust_dds_derive = { path = "../dds_derive", version = "0.1" }
-
+eframe = "0.21.3"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 cdr = "0.2.4"
 

--- a/shapes_demo/Cargo.toml
+++ b/shapes_demo/Cargo.toml
@@ -16,9 +16,9 @@ categories = ["api-bindings", "network-programming"]
 [dependencies]
 dust_dds = { path = "../dds" }
 dust_dds_derive = { path = "../dds_derive", version = "0.1" }
-eframe = "0.21.3"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-cdr = "0.2.4"
+eframe = "=0.19.0"
+serde = { version = "=1.0", default-features = false, features = ["derive"] }
+cdr = "=0.2.4"
 
 [build-dependencies]
 dust_idlgen = {path = "../idlgen" }

--- a/shapes_demo/Cargo.toml
+++ b/shapes_demo/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["api-bindings", "network-programming"]
 [dependencies]
 dust_dds = { path = "../dds" }
 dust_dds_derive = { path = "../dds_derive", version = "0.1" }
-eframe = "=0.19.0"
+eframe = "=0.21.0"
 serde = { version = "=1.0", default-features = false, features = ["derive"] }
 cdr = "=0.2.4"
 

--- a/shapes_demo/src/main.rs
+++ b/shapes_demo/src/main.rs
@@ -22,7 +22,7 @@ use eframe::{
     Theme,
 };
 
-fn main() -> Result<(), eframe::Error> {
+fn main() {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(500.0, 500.0)),
         default_theme: Theme::Light,
@@ -33,7 +33,7 @@ fn main() -> Result<(), eframe::Error> {
         "Dust DDS Shapes Demo",
         options,
         Box::new(|_cc| Box::new(MyApp::new())),
-    )
+    );
 }
 
 struct MyApp {

--- a/shapes_demo/src/main.rs
+++ b/shapes_demo/src/main.rs
@@ -22,7 +22,7 @@ use eframe::{
     Theme,
 };
 
-fn main() {
+fn main() -> Result<(), eframe::Error> {
     let options = eframe::NativeOptions {
         initial_window_size: Some(egui::vec2(500.0, 500.0)),
         default_theme: Theme::Light,
@@ -33,7 +33,7 @@ fn main() {
         "Dust DDS Shapes Demo",
         options,
         Box::new(|_cc| Box::new(MyApp::new())),
-    );
+    )
 }
 
 struct MyApp {

--- a/shapes_demo/src/main.rs
+++ b/shapes_demo/src/main.rs
@@ -1,65 +1,191 @@
-use dust_dds::{
-    domain::domain_participant_factory::DomainParticipantFactory,
-    infrastructure::{
-        qos::{DataWriterQos, QosKind},
-        qos_policy::{ReliabilityQosPolicy, ReliabilityQosPolicyKind},
-        status::{StatusKind, NO_STATUS},
-        time::Duration,
-        wait_set::{Condition, WaitSet},
-    },
-};
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 mod shapes_type;
 
-fn main() {
-    let domain_id = 0;
-    let participant_factory = DomainParticipantFactory::get_instance();
+use dust_dds::{
+    domain::{
+        domain_participant::DomainParticipant, domain_participant_factory::DomainParticipantFactory,
+    },
+    infrastructure::{
+        qos::{DataWriterQos, QosKind},
+        qos_policy::{ReliabilityQosPolicy, ReliabilityQosPolicyKind},
+        status::NO_STATUS,
+        time::Duration,
+    },
+    publication::{data_writer::DataWriter, publisher::Publisher},
+};
+use shapes_type::ShapeType;
 
-    let participant = participant_factory
-        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
-        .unwrap();
+use eframe::{
+    egui::{self, Rect},
+    epaint::{pos2, vec2, CircleShape, Color32, Pos2, Rounding, Shape, Stroke, Vec2},
+    Theme,
+};
 
-    let topic = participant
-        .create_topic::<shapes_type::ShapeType>("Circle", QosKind::Default, None, NO_STATUS)
-        .unwrap();
+fn main() -> Result<(), eframe::Error> {
+    let options = eframe::NativeOptions {
+        initial_window_size: Some(egui::vec2(500.0, 500.0)),
+        default_theme: Theme::Light,
 
-    let publisher = participant
-        .create_publisher(QosKind::Default, None, NO_STATUS)
-        .unwrap();
-
-    let writer_qos = DataWriterQos {
-        reliability: ReliabilityQosPolicy {
-            kind: ReliabilityQosPolicyKind::BestEffort,
-            max_blocking_time: Duration::new(1, 0),
-        },
         ..Default::default()
     };
-    let writer = publisher
-        .create_datawriter(&topic, QosKind::Specific(writer_qos), None, NO_STATUS)
-        .unwrap();
-    let writer_cond = writer.get_statuscondition().unwrap();
-    writer_cond
-        .set_enabled_statuses(&[StatusKind::PublicationMatched])
-        .unwrap();
-    let mut wait_set = WaitSet::new();
-    wait_set
-        .attach_condition(Condition::StatusCondition(writer_cond))
-        .unwrap();
+    eframe::run_native(
+        "Dust DDS Shapes Demo",
+        options,
+        Box::new(|_cc| Box::new(MyApp::new())),
+    )
+}
 
-    wait_set.wait(Duration::new(60, 0)).unwrap();
+struct MyApp {
+    moving_circle: MovingCircle,
+    participant: DomainParticipant,
+    publisher: Publisher,
+    writers: Vec<DataWriter<ShapeType>>,
+}
 
-    let data = shapes_type::ShapeType {
-        color: "BLUE".to_string(), //['B', 'L', 'U', 'E'].to_vec(),
-        x: 140,
-        y: 46,
-        shapesize: 30,
-    };
-    loop {
-        writer.write(&data, None).unwrap();
+impl MyApp {
+    fn new() -> Self {
+        let domain_id = 0;
+        let participant_factory = DomainParticipantFactory::get_instance();
+        let participant = participant_factory
+            .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+            .unwrap();
+        let publisher = participant
+            .create_publisher(QosKind::Default, None, NO_STATUS)
+            .unwrap();
 
-        // writer
-        //     .wait_for_acknowledgments(Duration::new(30, 0))
-        //     .unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        let moving_circle = MovingCircle::new(CircleShape {
+            center: pos2(360.0, 40.0),
+            radius: 15.0,
+            fill: Color32::BLUE,
+            stroke: Stroke::new(3.0, Color32::RED),
+        });
+
+        Self {
+            moving_circle,
+            participant,
+            publisher,
+            writers: vec![],
+        }
+    }
+
+    fn create_writer(&mut self, topic_name: &str) {
+        let topic = self
+            .participant
+            .create_topic::<ShapeType>(topic_name, QosKind::Default, None, NO_STATUS)
+            .unwrap();
+        let writer_qos = DataWriterQos {
+            reliability: ReliabilityQosPolicy {
+                kind: ReliabilityQosPolicyKind::Reliable,
+                max_blocking_time: Duration::new(1, 0),
+            },
+            ..Default::default()
+        };
+        let writer = self
+            .publisher
+            .create_datawriter(&topic, QosKind::Specific(writer_qos), None, NO_STATUS)
+            .unwrap();
+        self.writers.push(writer);
+    }
+
+    fn write_circle_data(&self, circle: &CircleShape, offset: &Pos2) {
+        if let Some(writer) = self.writers.first() {
+            let color = "BLUE".to_string();
+            let x = (circle.center.x - offset.x) as i32;
+            let y = (circle.center.y - offset.y) as i32;
+            let shapesize = (circle.radius * 2.0) as i32;
+            let data = ShapeType {
+                color,
+                x,
+                y,
+                shapesize,
+            };
+            writer.write(&data, None).expect("writing failed");
+            println!("written {:?}", data);
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        egui::SidePanel::left("left_panel").show(ctx, |ui| {
+            ui.heading("Publish");
+            if ui.button("Circle").clicked() {
+                self.create_writer("Circle");
+            };
+            ui.separator();
+            ui.heading("Subscribe");
+            if ui.button("Circle").clicked() {
+                println!("Subscribe Circle clicked")
+            };
+        });
+        egui::CentralPanel::default().show(ctx, |ui| {
+            let painter = ui.painter();
+            let rect = Rect::from_center_size(ui.max_rect().center(), vec2(235.0, 265.0));
+            painter.rect_filled(rect, Rounding::none(), Color32::WHITE);
+
+            if let Some(_writer) = self.writers.first() {
+                self.moving_circle.move_within_rect(rect);
+                self.write_circle_data(&self.moving_circle.circle, &rect.left_top());
+                painter.add(self.moving_circle.clone());
+            }
+            ctx.request_repaint_after(std::time::Duration::from_millis(40));
+        });
+    }
+}
+
+#[derive(Clone)]
+struct MovingCircle {
+    velocity: Vec2,
+    circle: CircleShape,
+}
+
+impl MovingCircle {
+    fn new(circle: CircleShape) -> Self {
+        Self {
+            circle,
+            velocity: vec2(2.0, 2.0),
+        }
+    }
+    fn left(&self) -> f32 {
+        self.circle.center.x - self.circle.radius
+    }
+    fn right(&self) -> f32 {
+        self.circle.center.x + self.circle.radius
+    }
+    fn top(&self) -> f32 {
+        self.circle.center.y - self.circle.radius
+    }
+    fn bottom(&self) -> f32 {
+        self.circle.center.y + self.circle.radius
+    }
+
+    fn move_within_rect(&mut self, rect: Rect) {
+        let normal = if self.left() < rect.left() {
+            self.circle.center.x = rect.left() + self.circle.radius;
+            Some(vec2(1.0, 0.0))
+        } else if self.right() > rect.right() {
+            self.circle.center.x = rect.right() - self.circle.radius;
+            Some(vec2(-1.0, 0.0))
+        } else if self.top() < rect.top() {
+            self.circle.center.y = rect.top() + self.circle.radius;
+            Some(vec2(0.0, 1.0))
+        } else if self.bottom() > rect.bottom() {
+            self.circle.center.y = rect.bottom() - self.circle.radius;
+            Some(vec2(0.0, -1.0))
+        } else {
+            None
+        };
+        if let Some(normal) = normal {
+            // reflect motion in respect to normal of surface
+            self.velocity = self.velocity - 2.0 * (self.velocity * normal) * normal;
+        }
+        self.circle.center += self.velocity;
+    }
+}
+
+impl From<MovingCircle> for Shape {
+    fn from(v: MovingCircle) -> Self {
+        v.circle.into()
     }
 }

--- a/shapes_demo/src/subscriber.rs
+++ b/shapes_demo/src/subscriber.rs
@@ -45,7 +45,7 @@ fn main() {
         .unwrap();
     let mut wait_set = WaitSet::new();
     wait_set
-        .attach_condition(Condition::StatusCondition(reader_cond.clone()))
+        .attach_condition(Condition::StatusCondition(reader_cond))
         .unwrap();
 
     loop {


### PR DESCRIPTION
Add a GUI and the publishing of a Circle. The RTI shapes demo can subscribe to that Circle data.
The Rust version is increased to 1.65 since the added egui dependency needs Rust 1.65. An enforced earlier egui version (0.19.0) does depend only on Rust 1.62, however this failed in compiling the sysfont dependency. 
To make this work also the docker image for the interoperability test docker image needed an upgrade.

![image](https://user-images.githubusercontent.com/54408686/222410008-af271fe6-0f1b-4f7e-bb93-40900dd0181d.png)
