### PR TITLE
DDS-297 Fix shapes dispose subscriber bugs

### DIFF
--- a/dds/src/implementation/data_representation_inline_qos/parameter_id_values.rs
+++ b/dds/src/implementation/data_representation_inline_qos/parameter_id_values.rs
@@ -6,5 +6,5 @@ pub const _PID_GROUP_COHERENT_SET: u16 = 0x0063;
 pub const _PID_GROUP_SEQ_NUM: u16 = 0x0064;
 pub const _PID_WRITER_GROUP_INFO: u16 = 0x0065;
 pub const _PID_SECURE_WRITER_GROUP_INFO: u16 = 0x0066;
-pub const _PID_KEY_HASH: u16 = 0x0070;
+pub const PID_KEY_HASH: u16 = 0x0070;
 pub const PID_STATUS_INFO: u16 = 0x0071;

--- a/dds/src/implementation/data_representation_inline_qos/types.rs
+++ b/dds/src/implementation/data_representation_inline_qos/types.rs
@@ -3,6 +3,7 @@ pub struct KeyHash(pub [u8; 16]);
 
 #[derive(Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct StatusInfo([u8; 4]);
-pub const STATUS_INFO_DISPOSED_FLAG: StatusInfo = StatusInfo([0, 0, 0, 0x0001 << 0]);
-pub const STATUS_INFO_UNREGISTERED_FLAG: StatusInfo = StatusInfo([0, 0, 0, 0x0001 << 1]);
-pub const _STATUS_INFO_FILTERED_FLAG: StatusInfo = StatusInfo([0, 0, 0, 0x0001 << 2]);
+pub const STATUS_INFO_DISPOSED: StatusInfo = StatusInfo([0, 0, 0, 0b00000001]);
+pub const STATUS_INFO_UNREGISTERED: StatusInfo = StatusInfo([0, 0, 0, 0b0000010]);
+pub const STATUS_INFO_DISPOSED_UNREGISTERED: StatusInfo = StatusInfo([0, 0, 0, 0b00000011]);
+pub const _STATUS_INFO_FILTERED: StatusInfo = StatusInfo([0, 0, 0, 0b0000100]);

--- a/dds/src/implementation/dds_impl/builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/builtin_subscriber.rs
@@ -230,15 +230,6 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
         message_receiver: &MessageReceiver,
     ) {
         if self
-            .spdp_builtin_participant_reader
-            .on_data_submessage_received(data_submessage, message_receiver)
-            == BuiltInStatelessReaderDataSubmessageReceivedResult::NewDataAvailable
-        {
-            self.spdp_builtin_participant_reader.on_data_available();
-            return;
-        }
-
-        if self
             .sedp_builtin_topics_reader
             .on_data_submessage_received(data_submessage, message_receiver)
             == BuiltInStatefulReaderDataSubmessageReceivedResult::NewDataAvailable
@@ -262,6 +253,15 @@ impl SubscriberSubmessageReceiver for DdsShared<BuiltInSubscriber> {
             == BuiltInStatefulReaderDataSubmessageReceivedResult::NewDataAvailable
         {
             self.sedp_builtin_subscriptions_reader.on_data_available();
+            return;
+        }
+
+        if self
+            .spdp_builtin_participant_reader
+            .on_data_submessage_received(data_submessage, message_receiver)
+            == BuiltInStatelessReaderDataSubmessageReceivedResult::NewDataAvailable
+        {
+            self.spdp_builtin_participant_reader.on_data_available();
         }
     }
 

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -48,6 +48,7 @@ pub struct RtpsReaderCacheChange {
     kind: ChangeKind,
     writer_guid: Guid,
     data: Vec<u8>,
+    inline_qos: Vec<RtpsParameter>,
     source_timestamp: Option<Time>,
     sample_state: SampleStateKind,
     disposed_generation_count: i32,
@@ -99,6 +100,7 @@ pub fn convert_data_frag_to_cache_change(
         kind: change_kind,
         writer_guid,
         data,
+        inline_qos,
         source_timestamp,
         sample_state: SampleStateKind::NotRead,
         disposed_generation_count: 0, // To be filled up only when getting stored
@@ -292,6 +294,7 @@ impl RtpsReader {
             kind: change_kind,
             writer_guid,
             data,
+            inline_qos,
             source_timestamp,
             sample_state: SampleStateKind::NotRead,
             disposed_generation_count: 0, // To be filled up only when getting stored

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -280,6 +280,7 @@ pub enum ChangeKind {
     AliveFiltered,
     NotAliveDisposed,
     NotAliveUnregistered,
+    NotAliveDisposedUnregistered,
 }
 
 /// ProtocolVersion_t

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use crate::{
     implementation::data_representation_inline_qos::{
         parameter_id_values::PID_STATUS_INFO,
-        types::{STATUS_INFO_DISPOSED_FLAG, STATUS_INFO_UNREGISTERED_FLAG},
+        types::{STATUS_INFO_DISPOSED, STATUS_INFO_UNREGISTERED},
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -157,7 +157,7 @@ impl RtpsWriter {
             let mut serialized_status_info = Vec::new();
             let mut serializer =
                 cdr::Serializer::<_, cdr::LittleEndian>::new(&mut serialized_status_info);
-            STATUS_INFO_DISPOSED_FLAG
+            STATUS_INFO_DISPOSED
                 .serialize(&mut serializer)
                 .unwrap();
 
@@ -222,7 +222,7 @@ impl RtpsWriter {
             let mut serialized_status_info = Vec::new();
             let mut serializer =
                 cdr::Serializer::<_, cdr::LittleEndian>::new(&mut serialized_status_info);
-            STATUS_INFO_UNREGISTERED_FLAG
+            STATUS_INFO_UNREGISTERED
                 .serialize(&mut serializer)
                 .unwrap();
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/parameter_list.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/parameter_list.rs
@@ -51,14 +51,16 @@ impl<'de: 'a, 'a> MappingReadByteOrdered<'de> for ParameterList<'a> {
 impl<'de: 'a, 'a> MappingReadByteOrdered<'de> for Parameter<'a> {
     fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
         let parameter_id = buf.read_u16::<B>()?;
-        let length = if parameter_id == PID_SENTINEL {
-            0
+        let length = buf.read_i16::<B>()?;
+
+        let value = if parameter_id == PID_SENTINEL {
+            &[]
         } else {
-            buf.read_i16::<B>()?
+            let (value, following) = buf.split_at(length as usize);
+            *buf = following;
+            value
         };
 
-        let (value, following) = buf.split_at(length as usize);
-        *buf = following;
         Ok(Self {
             parameter_id,
             length,

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/parameter_list.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/parameter_list.rs
@@ -51,7 +51,12 @@ impl<'de: 'a, 'a> MappingReadByteOrdered<'de> for ParameterList<'a> {
 impl<'de: 'a, 'a> MappingReadByteOrdered<'de> for Parameter<'a> {
     fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
         let parameter_id = buf.read_u16::<B>()?;
-        let length = buf.read_i16::<B>()?;
+        let length = if parameter_id == PID_SENTINEL {
+            0
+        } else {
+            buf.read_i16::<B>()?
+        };
+
         let (value, following) = buf.split_at(length as usize);
         *buf = following;
         Ok(Self {

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/parameter_list.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/parameter_list.rs
@@ -38,7 +38,7 @@ impl<'de: 'a, 'a> MappingReadByteOrdered<'de> for ParameterList<'a> {
             let parameter_i: Parameter =
                 MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
 
-            if parameter_i == SENTINEL {
+            if parameter_i.parameter_id == PID_SENTINEL {
                 break;
             } else {
                 parameter.push(parameter_i);

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data.rs
@@ -431,7 +431,7 @@ mod tests {
             10, 11, 12, 13, // inlineQos: value_1[length_1]
             7, 0, 4, 0, // inlineQos: parameterId_2, length_2
             20, 21, 22, 23, // inlineQos: value_2[length_2]
-            1, 0, 0, 0, // inlineQos: Sentinel
+            1, 0, 1, 0, // inlineQos: Sentinel
         ]).unwrap();
         assert_eq!(expected, result);
     }


### PR DESCRIPTION
This PR fixes a set of bugs preventing the Shapes demo from disposing the subscriber. The issues fixed are:
1. Wrong interpretation of the length in the sentinel parameter
2. Usage of KeyHash when the key is not explicitly transmitted in the Data submessage
3. SPDP stateless reader absorbing all the received messages with ENTITYID_UNKNOWN