### PR TITLE
DDS-283 Use durability of matched reader

### DIFF
--- a/dds/src/implementation/dds_impl/participant_discovery.rs
+++ b/dds/src/implementation/dds_impl/participant_discovery.rs
@@ -7,7 +7,7 @@ use crate::{
             reader_proxy::RtpsReaderProxy,
             stateful_reader::RtpsStatefulReader,
             stateful_writer::RtpsStatefulWriter,
-            types::{Guid, ReliabilityKind, ENTITYID_UNKNOWN},
+            types::{DurabilityKind, Guid, ReliabilityKind, ENTITYID_UNKNOWN},
             writer_proxy::RtpsWriterProxy,
         },
     },
@@ -76,6 +76,7 @@ impl<'a> ParticipantDiscovery<'a> {
                 expects_inline_qos,
                 true,
                 ReliabilityKind::Reliable,
+                DurabilityKind::TransientLocal,
             );
             writer.matched_reader_add(proxy);
         }
@@ -126,6 +127,7 @@ impl<'a> ParticipantDiscovery<'a> {
                 expects_inline_qos,
                 true,
                 ReliabilityKind::Reliable,
+                DurabilityKind::TransientLocal,
             );
             writer.matched_reader_add(proxy);
         }
@@ -175,6 +177,7 @@ impl<'a> ParticipantDiscovery<'a> {
                 expects_inline_qos,
                 true,
                 ReliabilityKind::Reliable,
+                DurabilityKind::TransientLocal,
             );
             writer.matched_reader_add(proxy);
         }

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -16,7 +16,8 @@ use crate::{
             stateful_writer::RtpsStatefulWriter,
             transport::TransportWrite,
             types::{
-                EntityId, EntityKey, Locator, ReliabilityKind, GUID_UNKNOWN, USER_DEFINED_UNKNOWN,
+                DurabilityKind, EntityId, EntityKey, Locator, ReliabilityKind, GUID_UNKNOWN,
+                USER_DEFINED_UNKNOWN,
             },
         },
         utils::{
@@ -28,7 +29,7 @@ use crate::{
         instance::InstanceHandle,
         qos::{PublisherQos, QosKind},
         qos_policy::{
-            QosPolicyId, ReliabilityQosPolicyKind, DEADLINE_QOS_POLICY_ID,
+            DurabilityQosPolicyKind, QosPolicyId, ReliabilityQosPolicyKind, DEADLINE_QOS_POLICY_ID,
             DESTINATIONORDER_QOS_POLICY_ID, DURABILITY_QOS_POLICY_ID, LATENCYBUDGET_QOS_POLICY_ID,
             LIVELINESS_QOS_POLICY_ID, PRESENTATION_QOS_POLICY_ID, RELIABILITY_QOS_POLICY_ID,
         },
@@ -739,6 +740,15 @@ fn add_discovered_reader(
             ReliabilityQosPolicyKind::Reliable => ReliabilityKind::Reliable,
         };
 
+        let proxy_durability = match discovered_reader_data
+            .subscription_builtin_topic_data
+            .durability
+            .kind
+        {
+            DurabilityQosPolicyKind::Volatile => DurabilityKind::Volatile,
+            DurabilityQosPolicyKind::TransientLocal => DurabilityKind::TransientLocal,
+        };
+
         let reader_proxy = RtpsReaderProxy::new(
             discovered_reader_data.reader_proxy.remote_reader_guid,
             discovered_reader_data.reader_proxy.remote_group_entity_id,
@@ -747,6 +757,7 @@ fn add_discovered_reader(
             discovered_reader_data.reader_proxy.expects_inline_qos,
             true,
             proxy_reliability,
+            proxy_durability,
         );
 
         writer.matched_reader_add(reader_proxy);

--- a/dds/src/implementation/rtps/history_cache.rs
+++ b/dds/src/implementation/rtps/history_cache.rs
@@ -53,7 +53,7 @@ impl RtpsWriterCacheChange {
             writer_id: self.writer_guid.entity_id(),
             gap_start: self.sequence_number,
             gap_list: SequenceNumberSet {
-                base: self.sequence_number,
+                base: self.sequence_number + 1,
                 set: vec![],
             },
         }

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -185,6 +185,10 @@ impl RtpsReaderProxy {
         &mut self.changes_for_reader
     }
 
+    pub fn durability(&self) -> DurabilityKind {
+        self.durability
+    }
+
     pub fn receive_acknack(&mut self, acknack_submessage: &AckNackSubmessage) {
         match self.reliability {
             ReliabilityKind::BestEffort => (),

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -16,7 +16,8 @@ use super::{
     },
     transport::TransportWrite,
     types::{
-        ChangeKind, Count, EntityId, Guid, GuidPrefix, Locator, ReliabilityKind, SequenceNumber,
+        ChangeKind, Count, DurabilityKind, EntityId, Guid, GuidPrefix, Locator, ReliabilityKind,
+        SequenceNumber,
     },
     utils::clock::{StdTimer, Timer, TimerConstructor},
 };
@@ -134,9 +135,11 @@ pub struct RtpsReaderProxy {
     heartbeat_machine: HeartbeatMachine,
     heartbeat_frag_machine: HeartbeatFragMachine,
     reliability: ReliabilityKind,
+    durability: DurabilityKind,
 }
 
 impl RtpsReaderProxy {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         remote_reader_guid: Guid,
         remote_group_entity_id: EntityId,
@@ -145,6 +148,7 @@ impl RtpsReaderProxy {
         expects_inline_qos: bool,
         is_active: bool,
         reliability: ReliabilityKind,
+        durability: DurabilityKind,
     ) -> Self {
         let heartbeat_machine = HeartbeatMachine::new(remote_reader_guid.entity_id());
         let heartbeat_frag_machine = HeartbeatFragMachine::new(remote_reader_guid.entity_id());
@@ -161,6 +165,7 @@ impl RtpsReaderProxy {
             heartbeat_machine,
             heartbeat_frag_machine,
             reliability,
+            durability,
         }
     }
 
@@ -744,6 +749,7 @@ mod tests {
             false,
             true,
             ReliabilityKind::Reliable,
+            DurabilityKind::TransientLocal,
         );
 
         let mut writer_cache = WriterHistoryCache::new();
@@ -793,6 +799,7 @@ mod tests {
             false,
             true,
             ReliabilityKind::Reliable,
+            DurabilityKind::TransientLocal,
         );
         let mut writer_cache = WriterHistoryCache::new();
         add_new_change_push_mode_true(&mut writer_cache, &mut reader_proxy, SequenceNumber::new(1));
@@ -819,6 +826,7 @@ mod tests {
             false,
             true,
             ReliabilityKind::Reliable,
+            DurabilityKind::TransientLocal,
         );
         let mut writer_cache = WriterHistoryCache::new();
         add_new_change_push_mode_true(&mut writer_cache, &mut reader_proxy, SequenceNumber::new(1));
@@ -850,6 +858,7 @@ mod tests {
             false,
             true,
             ReliabilityKind::Reliable,
+            DurabilityKind::TransientLocal,
         );
         let mut writer_cache = WriterHistoryCache::new();
         add_new_change_push_mode_false(

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -81,7 +81,7 @@ impl RtpsStatefulWriter {
                 .iter()
                 .find(|x| x.sequence_number() == a_change.sequence_number())
             {
-                if !(cc.is_relevant() || cc.status() == ChangeForReaderStatusKind::Acknowledged) {
+                if cc.is_relevant() && cc.status() != ChangeForReaderStatusKind::Acknowledged {
                     return false;
                 }
             } else {

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -455,3 +455,9 @@ pub enum ReliabilityKind {
     BestEffort,
     Reliable,
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DurabilityKind {
+    Volatile,
+    TransientLocal,
+}

--- a/dds/tests/domain_participant_factory.rs
+++ b/dds/tests/domain_participant_factory.rs
@@ -172,7 +172,7 @@ fn all_objects_are_dropped() {
         writer.write(&data3, None).unwrap();
 
         writer
-            .wait_for_acknowledgments(Duration::new(1, 0))
+            .wait_for_acknowledgments(Duration::new(10, 0))
             .unwrap();
 
         let _samples = reader

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1832,7 +1832,6 @@ fn data_reader_publication_handle_sample_info() {
 }
 
 #[test]
-#[ignore]
 fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1830,3 +1830,99 @@ fn data_reader_publication_handle_sample_info() {
         .get_matched_publication_data(samples[0].sample_info.publication_handle)
         .is_ok());
 }
+
+#[test]
+#[ignore]
+fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>("MyTopic", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        durability: DurabilityQosPolicy {
+            kind: DurabilityQosPolicyKind::Volatile,
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: Duration::new(1, 0),
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(&topic, QosKind::Specific(writer_qos), None, NO_STATUS)
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        durability: DurabilityQosPolicy {
+            kind: DurabilityQosPolicyKind::Volatile,
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: Duration::new(1, 0),
+        },
+        ..Default::default()
+    };
+    let _reader = subscriber
+        .create_datareader(
+            &topic,
+            QosKind::Specific(reader_qos.clone()),
+            None,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition().unwrap();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+    writer.get_publication_matched_status().unwrap(); // To reset wait_set for subsequent calls
+
+    let data1 = KeyedData { id: 1, value: 1 };
+    writer.write(&data1, None).unwrap();
+
+    writer
+        .wait_for_acknowledgments(Duration::new(3, 0))
+        .unwrap();
+
+    let reader_new = subscriber
+        .create_datareader(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let data2 = KeyedData { id: 2, value: 10 };
+    writer.write(&data2, None).unwrap();
+
+    writer
+        .wait_for_acknowledgments(Duration::new(5, 0))
+        .unwrap();
+
+    let samples = reader_new
+        .read(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data2);
+}


### PR DESCRIPTION
This PR adds the usage of the reader durability for the writer to decide which changes are relevant to send to each matched reader.