### PR TITLE
Refactor: Reduce parent dependencies on object implementations

### DIFF
--- a/dds/src/domain/domain_participant_factory.rs
+++ b/dds/src/domain/domain_participant_factory.rs
@@ -227,6 +227,7 @@ impl DomainParticipantFactory {
         );
         let sedp_condvar = DdsCondvar::new();
         let user_defined_data_send_condvar = DdsCondvar::new();
+        let (announce_sender, announce_receiver) = std::sync::mpsc::sync_channel(1);
         let participant = DomainParticipantImpl::new(
             rtps_participant,
             domain_id,
@@ -238,6 +239,7 @@ impl DomainParticipantFactory {
             sedp_condvar,
             user_defined_data_send_condvar,
             configuration.fragment_size,
+            announce_sender.clone(),
         );
 
         let dcps_service = DcpsService::new(
@@ -245,6 +247,8 @@ impl DomainParticipantFactory {
             metatraffic_multicast_transport,
             metatraffic_unicast_transport,
             default_unicast_transport,
+            announce_sender,
+            announce_receiver,
         )?;
 
         let participant = DomainParticipant::new(dcps_service.participant().downgrade());

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -387,6 +387,7 @@ impl DdsShared<DomainParticipantImpl> {
             mask,
             self.downgrade(),
             self.user_defined_data_send_condvar.clone(),
+            self.announce_sender.clone(),
         );
         if *self.enabled.read_lock()
             && self

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -284,7 +284,7 @@ impl DdsShared<DomainParticipantImpl> {
         *self.enabled.read_lock()
     }
 
-    pub fn announce_topic(&self, sedp_discovered_topic_data: DiscoveredTopicData) -> DdsResult<()> {
+    fn announce_topic(&self, sedp_discovered_topic_data: DiscoveredTopicData) -> DdsResult<()> {
         self.builtin_publisher
             .sedp_builtin_topics_writer()
             .write_w_timestamp(
@@ -858,7 +858,7 @@ impl DdsShared<DomainParticipantImpl> {
         Ok(self.rtps_participant.guid().into())
     }
 
-    pub fn announce_participant(&self) -> DdsResult<()> {
+    fn announce_participant(&self) -> DdsResult<()> {
         let spdp_discovered_participant_data = SpdpDiscoveredParticipantData {
             dds_participant_data: ParticipantBuiltinTopicData {
                 key: BuiltInTopicKey {
@@ -1236,7 +1236,7 @@ impl DdsShared<DomainParticipantImpl> {
         Ok(())
     }
 
-    pub fn announce_created_datawriter(
+    fn announce_created_datawriter(
         &self,
         sedp_discovered_writer_data: DiscoveredWriterData,
     ) -> DdsResult<()> {
@@ -1254,7 +1254,7 @@ impl DdsShared<DomainParticipantImpl> {
             .write_w_timestamp(writer_data, None, self.get_current_time()?)
     }
 
-    pub fn announce_deleted_datawriter(
+    fn announce_deleted_datawriter(
         &self,
         sedp_discovered_writer_data: DiscoveredWriterData,
     ) -> DdsResult<()> {
@@ -1263,7 +1263,7 @@ impl DdsShared<DomainParticipantImpl> {
             .dispose_w_timestamp(&sedp_discovered_writer_data, None, self.get_current_time()?)
     }
 
-    pub fn announce_created_datareader(
+    fn announce_created_datareader(
         &self,
         sedp_discovered_reader_data: DiscoveredReaderData,
     ) -> DdsResult<()> {
@@ -1281,7 +1281,7 @@ impl DdsShared<DomainParticipantImpl> {
             .write_w_timestamp(reader_data, None, self.get_current_time().unwrap())
     }
 
-    pub fn announce_deleted_datareader(
+    fn announce_deleted_datareader(
         &self,
         sedp_discovered_reader_data: DiscoveredReaderData,
     ) -> DdsResult<()> {

--- a/dds/src/implementation/dds_impl/domain_participant_impl.rs
+++ b/dds/src/implementation/dds_impl/domain_participant_impl.rs
@@ -173,6 +173,7 @@ impl DomainParticipantImpl {
             None,
             &[],
             DdsWeak::new(),
+            announce_sender.clone(),
         );
 
         let sedp_topics_entity_id = EntityId::new(EntityKey::new([0, 0, 1]), BUILT_IN_TOPIC);
@@ -185,6 +186,7 @@ impl DomainParticipantImpl {
             None,
             &[],
             DdsWeak::new(),
+            announce_sender.clone(),
         );
 
         let sedp_publications_entity_id = EntityId::new(EntityKey::new([0, 0, 2]), BUILT_IN_TOPIC);
@@ -197,6 +199,7 @@ impl DomainParticipantImpl {
             None,
             &[],
             DdsWeak::new(),
+            announce_sender.clone(),
         );
 
         let sedp_subscriptions_entity_id = EntityId::new(EntityKey::new([0, 0, 2]), BUILT_IN_TOPIC);
@@ -209,6 +212,7 @@ impl DomainParticipantImpl {
             None,
             &[],
             DdsWeak::new(),
+            announce_sender.clone(),
         );
 
         let builtin_subscriber = BuiltInSubscriber::new(
@@ -462,6 +466,7 @@ impl DdsShared<DomainParticipantImpl> {
             a_listener,
             mask,
             self.downgrade(),
+            self.announce_sender.clone(),
         );
         if *self.enabled.read_lock()
             && self

--- a/dds/src/implementation/dds_impl/topic_impl.rs
+++ b/dds/src/implementation/dds_impl/topic_impl.rs
@@ -6,7 +6,7 @@ use crate::{
         utils::shared_object::{DdsRwLock, DdsShared, DdsWeak},
     },
     infrastructure::{
-        error::{DdsError, DdsResult},
+        error::DdsResult,
         instance::InstanceHandle,
         qos::{QosKind, TopicQos},
         status::{InconsistentTopicStatus, StatusKind},
@@ -129,12 +129,6 @@ impl DdsShared<TopicImpl> {
     }
 
     pub fn enable(&self) -> DdsResult<()> {
-        if !self.get_participant().is_enabled() {
-            return Err(DdsError::PreconditionNotMet(
-                "Parent participant is disabled".to_string(),
-            ));
-        }
-
         self.get_participant()
             .announce_topic(self.as_discovered_topic_data());
 

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -198,6 +198,7 @@ pub struct UserDefinedDataReader {
 }
 
 impl UserDefinedDataReader {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         rtps_reader: RtpsStatefulReader,
         topic: DdsShared<TopicImpl>,

--- a/dds/src/implementation/dds_impl/user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_reader.rs
@@ -753,12 +753,6 @@ impl DdsShared<UserDefinedDataReader> {
     }
 
     pub fn enable(&self) -> DdsResult<()> {
-        if !self.get_subscriber().is_enabled() {
-            return Err(DdsError::PreconditionNotMet(
-                "Parent subscriber disabled".to_string(),
-            ));
-        }
-
         self.get_subscriber()
             .get_participant()
             .announce_created_datareader(self.as_discovered_reader_data());

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -855,6 +855,7 @@ mod test {
             None,
             &[],
             DdsWeak::new(),
+            sender.clone(),
         );
 
         let rtps_writer = RtpsStatefulWriter::new(RtpsWriter::new(

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -539,12 +539,6 @@ impl DdsShared<UserDefinedDataWriter> {
     }
 
     pub fn enable(&self) -> DdsResult<()> {
-        if !self.get_publisher().is_enabled() {
-            return Err(DdsError::PreconditionNotMet(
-                "Parent publisher disabled".to_string(),
-            ));
-        }
-
         self.get_publisher()
             .get_participant()
             .announce_created_datawriter(self.as_discovered_writer_data())?;

--- a/dds/src/implementation/dds_impl/user_defined_publisher.rs
+++ b/dds/src/implementation/dds_impl/user_defined_publisher.rs
@@ -151,8 +151,11 @@ impl DdsShared<UserDefinedPublisher> {
 
         // The writer creation is announced only on enabled so its deletion must be announced only if it is enabled
         if data_writer.is_enabled() {
-            self.get_participant()
-                .announce_deleted_datawriter(data_writer.as_discovered_writer_data())?;
+            self.announce_sender
+                .send(AnnounceKind::DeletedDataWriter(
+                    data_writer.as_discovered_writer_data(),
+                ))
+                .ok();
         }
 
         Ok(())
@@ -226,8 +229,11 @@ impl DdsShared<UserDefinedPublisher> {
         for data_writer in self.data_writer_list.write_lock().drain(..) {
             // The writer creation is announced only on enabled so its deletion must be announced only if it is enabled
             if data_writer.is_enabled() {
-                self.get_participant()
-                    .announce_deleted_datawriter(data_writer.as_discovered_writer_data())?;
+                self.announce_sender
+                    .send(AnnounceKind::DeletedDataWriter(
+                        data_writer.as_discovered_writer_data(),
+                    ))
+                    .ok();
             }
         }
 

--- a/dds/src/implementation/dds_impl/user_defined_publisher.rs
+++ b/dds/src/implementation/dds_impl/user_defined_publisher.rs
@@ -56,6 +56,7 @@ pub struct UserDefinedPublisher {
 }
 
 impl UserDefinedPublisher {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         qos: PublisherQos,
         rtps_group: RtpsGroupImpl,

--- a/dds/src/implementation/dds_impl/user_defined_publisher.rs
+++ b/dds/src/implementation/dds_impl/user_defined_publisher.rs
@@ -292,12 +292,6 @@ impl DdsShared<UserDefinedPublisher> {
     }
 
     pub fn enable(&self) -> DdsResult<()> {
-        if !self.get_participant().is_enabled() {
-            return Err(DdsError::PreconditionNotMet(
-                "Parent participant is disabled".to_string(),
-            ));
-        }
-
         *self.enabled.write_lock() = true;
 
         if self

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -1,3 +1,5 @@
+use std::sync::mpsc::SyncSender;
+
 use fnmatch_regex::glob_to_regex;
 
 use crate::{
@@ -36,7 +38,7 @@ use crate::{
 
 use super::{
     any_data_reader_listener::AnyDataReaderListener,
-    domain_participant_impl::DomainParticipantImpl,
+    domain_participant_impl::{AnnounceKind, DomainParticipantImpl},
     message_receiver::{MessageReceiver, SubscriberSubmessageReceiver},
     reader_factory::ReaderFactory,
     status_condition_impl::StatusConditionImpl,
@@ -58,6 +60,7 @@ pub struct UserDefinedSubscriber {
     data_on_readers_status_changed_flag: DdsRwLock<bool>,
     listener: DdsRwLock<Option<Box<dyn SubscriberListener + Send + Sync>>>,
     listener_status_mask: DdsRwLock<Vec<StatusKind>>,
+    announce_sender: SyncSender<AnnounceKind>,
 }
 
 impl UserDefinedSubscriber {
@@ -68,6 +71,7 @@ impl UserDefinedSubscriber {
         mask: &[StatusKind],
         parent_participant: DdsWeak<DomainParticipantImpl>,
         user_defined_data_send_condvar: DdsCondvar,
+        announce_sender: SyncSender<AnnounceKind>,
     ) -> DdsShared<Self> {
         DdsShared::new(UserDefinedSubscriber {
             qos: DdsRwLock::new(qos),
@@ -81,6 +85,7 @@ impl UserDefinedSubscriber {
             data_on_readers_status_changed_flag: DdsRwLock::new(false),
             listener: DdsRwLock::new(listener),
             listener_status_mask: DdsRwLock::new(mask.to_vec()),
+            announce_sender,
         })
     }
 
@@ -135,6 +140,7 @@ impl DdsShared<UserDefinedSubscriber> {
             self.downgrade(),
             self.user_defined_data_send_condvar.clone(),
             timer,
+            self.announce_sender.clone(),
         );
 
         self.data_reader_list
@@ -169,8 +175,11 @@ impl DdsShared<UserDefinedSubscriber> {
         data_reader.cancel_timers();
 
         if data_reader.is_enabled() {
-            self.get_participant()
-                .announce_deleted_datareader(data_reader.as_discovered_reader_data())?;
+            self.announce_sender
+                .send(AnnounceKind::DeletedDataReader(
+                    data_reader.as_discovered_reader_data(),
+                ))
+                .ok();
         }
 
         Ok(())
@@ -216,8 +225,11 @@ impl DdsShared<UserDefinedSubscriber> {
     pub fn delete_contained_entities(&self) -> DdsResult<()> {
         for data_reader in self.data_reader_list.write_lock().drain(..) {
             if data_reader.is_enabled() {
-                self.get_participant()
-                    .announce_deleted_datareader(data_reader.as_discovered_reader_data())?;
+                self.announce_sender
+                    .send(AnnounceKind::DeletedDataReader(
+                        data_reader.as_discovered_reader_data(),
+                    ))
+                    .ok();
             }
         }
 

--- a/dds/src/implementation/dds_impl/user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/user_defined_subscriber.rs
@@ -280,12 +280,6 @@ impl DdsShared<UserDefinedSubscriber> {
     }
 
     pub fn enable(&self) -> DdsResult<()> {
-        if !self.get_participant().is_enabled() {
-            return Err(DdsError::PreconditionNotMet(
-                "Parent participant is disabled".to_string(),
-            ));
-        }
-
         *self.enabled.write_lock() = true;
 
         if self

--- a/dds/src/publication/data_writer.rs
+++ b/dds/src/publication/data_writer.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     infrastructure::{
         condition::StatusCondition,
-        error::DdsResult,
+        error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{DataWriterQos, QosKind},
         status::{
@@ -431,6 +431,12 @@ where
     /// The Listeners associated with an entity are not called until the entity is enabled. Conditions associated with an entity that is not
     /// enabled are “inactive,” that is, the operation [`StatusCondition::get_trigger_value()`] will always return `false`.
     pub fn enable(&self) -> DdsResult<()> {
+        if !self.0.upgrade()?.get_publisher().is_enabled() {
+            return Err(DdsError::PreconditionNotMet(
+                "Parent publisher disabled".to_string(),
+            ));
+        }
+
         self.0.upgrade()?.enable()
     }
 

--- a/dds/src/publication/publisher.rs
+++ b/dds/src/publication/publisher.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     infrastructure::{
         condition::StatusCondition,
-        error::DdsResult,
+        error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{DataWriterQos, PublisherQos, QosKind, TopicQos},
         status::StatusKind,
@@ -298,6 +298,12 @@ impl Publisher {
     /// The Listeners associated with an entity are not called until the entity is enabled. Conditions associated with an entity that is not
     /// enabled are “inactive”, that is, the operation [`StatusCondition::get_trigger_value()`] will always return `false`.
     pub fn enable(&self) -> DdsResult<()> {
+        if !self.0.upgrade()?.get_participant().is_enabled() {
+            return Err(DdsError::PreconditionNotMet(
+                "Parent participant is disabled".to_string(),
+            ));
+        }
+
         self.0.upgrade()?.enable()
     }
 

--- a/dds/src/subscription/data_reader.rs
+++ b/dds/src/subscription/data_reader.rs
@@ -676,7 +676,14 @@ where
         match &self.0 {
             DataReaderKind::BuiltinStateless(_) => todo!(),
             DataReaderKind::BuiltinStateful(_) => todo!(),
-            DataReaderKind::UserDefined(x) => x.upgrade()?.enable(),
+            DataReaderKind::UserDefined(x) => {
+                if !x.upgrade()?.get_subscriber().is_enabled() {
+                    return Err(DdsError::PreconditionNotMet(
+                        "Parent subscriber disabled".to_string(),
+                    ));
+                }
+                x.upgrade()?.enable()
+            }
         }
     }
 

--- a/dds/src/subscription/subscriber.rs
+++ b/dds/src/subscription/subscriber.rs
@@ -328,7 +328,15 @@ impl Subscriber {
     pub fn enable(&self) -> DdsResult<()> {
         match &self.0 {
             SubscriberKind::BuiltIn(_) => Err(DdsError::IllegalOperation),
-            SubscriberKind::UserDefined(s) => s.upgrade()?.enable(),
+            SubscriberKind::UserDefined(s) => {
+                if !s.upgrade()?.get_participant().is_enabled() {
+                    return Err(DdsError::PreconditionNotMet(
+                        "Parent participant is disabled".to_string(),
+                    ));
+                }
+
+                s.upgrade()?.enable()
+            }
         }
     }
 

--- a/dds/src/topic_definition/topic.rs
+++ b/dds/src/topic_definition/topic.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     infrastructure::{
         condition::StatusCondition,
-        error::DdsResult,
+        error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{QosKind, TopicQos},
         status::{InconsistentTopicStatus, StatusKind},
@@ -150,6 +150,12 @@ where
     /// The Listeners associated with an entity are not called until the entity is enabled. Conditions associated with an entity that is not
     /// enabled are “inactive,” that is, the operation [`StatusCondition::get_trigger_value()`] will always return `false`.
     pub fn enable(&self) -> DdsResult<()> {
+        if !self.0.upgrade()?.get_participant().is_enabled() {
+            return Err(DdsError::PreconditionNotMet(
+                "Parent participant is disabled".to_string(),
+            ));
+        }
+
         self.0.upgrade()?.enable()
     }
 

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -173,7 +173,7 @@ fn reader_discovers_writer_in_same_participant() {
     wait_set
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
-    wait_set.wait(Duration::new(5, 0)).unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 
     assert_eq!(data_reader.get_matched_publications().unwrap().len(), 1);
 }

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -368,7 +368,7 @@ fn reader_discovers_disposed_writer_same_participant() {
     wait_set
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
-    wait_set.wait(Duration::new(5, 0)).unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
     data_reader.get_subscription_matched_status().unwrap();
 
     publisher.delete_datawriter(&data_writer).unwrap();

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1818,7 +1818,7 @@ fn data_reader_publication_handle_sample_info() {
     writer.write(&UserData(1), None).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(1, 0))
+        .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
     let samples = reader


### PR DESCRIPTION
In the current architecture the implementation objects are too big which is hindering the implementation of the missing QoS functionality. As a way to reduce this complexity, this change reduces (but does not yet totally eliminate) dependencies on the parent objects.