### PR TITLE
DDS-300 Productize IDL parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tarpaulin-report.html
 interoperability_tests/build/
 interoperability_tests/hello_world.rs
 interoperability_tests/big_data.rs
+shapes_demo/src/shapes_type.rs

--- a/idlgen/src/idl/mod.rs
+++ b/idlgen/src/idl/mod.rs
@@ -72,6 +72,7 @@ pub enum UnaryOperator {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum Literal {
     Integer(i64),
     Float(f64),

--- a/idlgen/src/lib.rs
+++ b/idlgen/src/lib.rs
@@ -1,4 +1,18 @@
-pub mod idl;
-pub mod mappings;
-pub mod parser;
-pub mod syntax;
+use pest::Parser;
+use syntax::Analyser;
+
+mod idl;
+mod mappings;
+mod parser;
+mod syntax;
+
+pub fn compile_idl(idl_source: &str) -> Result<String, ()> {
+    let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, &idl_source).unwrap();
+    let idl_spec = syntax::specification().analyse(parsed_idl.into()).unwrap();
+
+    Ok(idl_spec
+        .value
+        .into_iter()
+        .flat_map(mappings::rust::definition)
+        .collect())
+}

--- a/idlgen/src/lib.rs
+++ b/idlgen/src/lib.rs
@@ -6,9 +6,12 @@ mod mappings;
 mod parser;
 mod syntax;
 
-pub fn compile_idl(idl_source: &str) -> Result<String, ()> {
-    let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, &idl_source).unwrap();
-    let idl_spec = syntax::specification().analyse(parsed_idl.into()).unwrap();
+pub fn compile_idl(idl_source: &str) -> Result<String, String> {
+    let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, &idl_source)
+        .map_err(|e| format!("Error parsing IDL string: {:?}", e))?;
+    let idl_spec = syntax::specification()
+        .analyse(parsed_idl.into())
+        .map_err(|e| format!("Error compiling IDL: {:?}", e.pretty_print()))?;
 
     Ok(idl_spec
         .value

--- a/idlgen/src/lib.rs
+++ b/idlgen/src/lib.rs
@@ -7,7 +7,7 @@ mod parser;
 mod syntax;
 
 pub fn compile_idl(idl_source: &str) -> Result<String, String> {
-    let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, &idl_source)
+    let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, idl_source)
         .map_err(|e| format!("Error parsing IDL string: {:?}", e))?;
     let idl_spec = syntax::specification()
         .analyse(parsed_idl.into())

--- a/idlgen/src/mappings/rust.rs
+++ b/idlgen/src/mappings/rust.rs
@@ -129,12 +129,12 @@ mod tests {
             })
             .collect::<Vec<String>>(),
             vec![
-                "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]",
-                "pub struct Toto {",
-                "    pub a: i64,",
-                "    pub b: char,",
-                "    pub c: f64,",
-                "}",
+                "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]\n",
+                "pub struct Toto {\n",
+                "    pub a: i64,\n",
+                "    pub b: char,\n",
+                "    pub c: f64,\n",
+                "}\n",
             ]
         )
     }
@@ -153,13 +153,13 @@ mod tests {
             })
             .collect::<Vec<String>>(),
             vec![
-                "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]",
-                "pub enum Suit {",
-                "    Spades,",
-                "    Hearts,",
-                "    Diamonds,",
-                "    Clubs,",
-                "}",
+                "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]\n",
+                "pub enum Suit {\n",
+                "    Spades,\n",
+                "    Hearts,\n",
+                "    Diamonds,\n",
+                "    Clubs,\n",
+                "}\n",
             ]
         )
     }
@@ -189,19 +189,19 @@ mod tests {
             })
             .collect::<Vec<String>>(),
             vec![
-                "mod M {",
-                "    #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]",
-                "    pub struct A {",
-                "        pub a: i16,",
-                "    }",
-                "    mod N {",
-                "        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]",
-                "        pub enum B {",
-                "            C,",
-                "            D,",
-                "        }",
-                "    }",
-                "}",
+                "mod M {\n",
+                "    #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]\n",
+                "    pub struct A {\n",
+                "        pub a: i16,\n",
+                "    }\n",
+                "    mod N {\n",
+                "        #[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]\n",
+                "        pub enum B {\n",
+                "            C,\n",
+                "            D,\n",
+                "        }\n",
+                "    }\n",
+                "}\n",
             ]
         )
     }

--- a/idlgen/src/mappings/rust.rs
+++ b/idlgen/src/mappings/rust.rs
@@ -40,44 +40,45 @@ pub fn type_spec(t: idl::Type) -> String {
 }
 
 pub fn struct_member(member: idl::StructMember) -> String {
-    let key_tag = if member.is_key {
-        "#[key] "
-    } else {
-        ""
-    };
-    format!("{}pub {}: {}", key_tag, member.name, type_spec(member.datatype))
+    let key_tag = if member.is_key { "#[key] " } else { "" };
+    format!(
+        "{}pub {}: {}",
+        key_tag,
+        member.name,
+        type_spec(member.datatype)
+    )
 }
 
 pub fn struct_def(def: idl::Struct) -> impl Iterator<Item = String> {
     [
-        "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]".to_string(),
-        format!("pub struct {} {{", def.name),
+        "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]\n".to_string(),
+        format!("pub struct {} {{\n", def.name),
     ]
         .into_iter()
         .chain(
             def.members
                 .into_iter()
-                .map(|member| format!("    {},", struct_member(member))),
+                .map(|member| format!("    {},\n", struct_member(member))),
         )
-        .chain(["}".to_string()].into_iter())
+        .chain(["}\n".to_string()].into_iter())
 }
 
 pub fn enum_def(def: idl::Enum) -> impl Iterator<Item = String> {
     [
-        "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]".to_string(),
-        format!("pub enum {} {{", def.name),
+        "#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]\n".to_string(),
+        format!("pub enum {} {{\n", def.name),
     ]
         .into_iter()
         .chain(
             def.variants
                 .into_iter()
-                .map(|variant| format!("    {},", variant)),
+                .map(|variant| format!("    {},\n", variant)),
         )
-        .chain(["}".to_string()].into_iter())
+        .chain(["}\n".to_string()].into_iter())
 }
 
 pub fn module_def(def: idl::Module) -> impl Iterator<Item = String> {
-    [format!("mod {} {{", def.name)]
+    [format!("mod {} {{\n", def.name)]
         .into_iter()
         .chain(
             def.definitions
@@ -86,7 +87,7 @@ pub fn module_def(def: idl::Module) -> impl Iterator<Item = String> {
                 .into_iter()
                 .map(|line| "    ".to_string() + &line),
         )
-        .chain(["}".to_string()].into_iter())
+        .chain(["}\n".to_string()].into_iter())
 }
 
 pub fn definition(def: idl::Definition) -> Box<dyn Iterator<Item = String>> {

--- a/idlgen/src/syntax/constants.rs
+++ b/idlgen/src/syntax/constants.rs
@@ -1,6 +1,6 @@
 use super::analyser::*;
 
-use crate::idl;
+use crate::idl::{self, Literal, UnaryOperator};
 use crate::parser::Rule;
 
 pub fn positive_int_const<'i>() -> AnalyserObject<'i, usize> {
@@ -28,21 +28,18 @@ pub fn primary_expr<'i>() -> AnalyserObject<'i, idl::Literal> {
 }
 
 pub fn unary_expr<'i>() -> AnalyserObject<'i, idl::Literal> {
-    use idl::Literal::*;
-    use idl::UnaryOperator::*;
-
     maybe(unary_operator())
         .zip(primary_expr())
         .and_then(|(op, l)| match (op, l) {
             (None, l) => pure(l),
 
-            (Some(Minus), Integer(n)) => pure(Integer(-n)),
-            (Some(Plus), Integer(n)) => pure(Integer(n)),
+            (Some(UnaryOperator::Minus), Literal::Integer(n)) => pure(Literal::Integer(-n)),
+            (Some(UnaryOperator::Plus), Literal::Integer(n)) => pure(Literal::Integer(n)),
 
-            (Some(Minus), Float(x)) => pure(Float(-x)),
-            (Some(Plus), Float(x)) => pure(Float(x)),
+            (Some(UnaryOperator::Minus), Literal::Float(x)) => pure(Literal::Float(-x)),
+            (Some(UnaryOperator::Plus), Literal::Float(x)) => pure(Literal::Float(x)),
 
-            (Some(Not), Bool(b)) => pure(Bool(!b)),
+            (Some(UnaryOperator::Not), Literal::Bool(b)) => pure(Literal::Bool(!b)),
 
             (Some(op), l) => fail(&format!("{:?} cannot be applied to {:?}", op, l)),
         })

--- a/idlgen/tests/examples.rs
+++ b/idlgen/tests/examples.rs
@@ -3,12 +3,7 @@ use std::{
     io::{BufRead, BufReader},
 };
 
-use dust_idlgen::{
-    parser,
-    syntax::{self, Analyser},
-    mappings::rust,
-};
-use pest::Parser;
+use dust_idlgen::compile_idl;
 
 #[test]
 fn verify_examples() {
@@ -34,18 +29,10 @@ fn verify_examples() {
 
         let idl_src = std::fs::read_to_string(idl_path.clone())
             .expect("(;_;) Couldn't read IDL source file!");
-        let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, &idl_src)
-            .expect(&format!("(;_;) Parse error in {:?}", idl_path));
-        let idl_spec = syntax::specification()
-            .analyse(parsed_idl.into())
-            .expect(&format!("(;_;) Syntax error in {:?}", idl_path));
-        let result_lines = idl_spec
-            .value
-            .into_iter()
-            .flat_map(rust::definition);
+        let compiled_idl = compile_idl(&idl_src).expect("Failed to parse IDL file");
 
         for (expected_line, result_line) in
-            expected_lines.zip(result_lines.chain(std::iter::repeat("".to_string())))
+            expected_lines.zip(compiled_idl.lines().chain(std::iter::repeat("")))
         {
             assert_eq!(result_line, expected_line.unwrap())
         }

--- a/interoperability_tests/Cargo.toml
+++ b/interoperability_tests/Cargo.toml
@@ -16,15 +16,12 @@ categories = ["api-bindings", "network-programming"]
 
 [dependencies]
 dust_dds = { path = "../dds" }
-dust_dds_derive = { path = "../dds_derive" }
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 cdr = "=0.2.4"
 
 [build-dependencies]
 dust_idlgen = {path = "../idlgen" }
-pest = "=2.5.3"
-pest_derive = "=2.5.3"
 
 [[bin]]
 name = "dust_dds_publisher"

--- a/interoperability_tests/build.rs
+++ b/interoperability_tests/build.rs
@@ -1,49 +1,13 @@
 use std::{fs::File, io::Write};
 
-use dust_idlgen::{
-    parser,
-    syntax::{self, Analyser},
-    mappings::rust,
-};
-use pest::Parser;
-
 fn main() {
     let idl_path = "HelloWorld.idl";
     let idl_src = std::fs::read_to_string(idl_path).expect("(;_;) Couldn't read IDL source file!");
 
-    let result = parser::IdlParser::parse(parser::Rule::specification, &idl_src)
-        .expect("Couldn't parse IDL file");
+    let compiled_idl = dust_idlgen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
 
     let mut file = File::create("hello_world.rs").expect("Failed to create file");
 
-    let spec = syntax::specification()
-        .analyse(result.into())
-        .expect("Couldn't analyse IDL syntax");
-
-    for def in spec.value {
-        for line in rust::definition(def) {
-            file.write_all(line.as_bytes())
-                .expect("Failed to write to file");
-        }
-    }
-
-
-    let idl_path = "BigData.idl";
-    let idl_src = std::fs::read_to_string(idl_path).expect("(;_;) Couldn't read IDL source file!");
-
-    let result = parser::IdlParser::parse(parser::Rule::specification, &idl_src)
-        .expect("Couldn't parse IDL file");
-
-    let mut file = File::create("big_data.rs").expect("Failed to create file");
-
-    let spec = syntax::specification()
-        .analyse(result.into())
-        .expect("Couldn't analyse IDL syntax");
-
-    for def in spec.value {
-        for line in rust::definition(def) {
-            file.write_all(line.as_bytes())
-                .expect("Failed to write to file");
-        }
-    }
+    file.write_all(compiled_idl.as_bytes())
+        .expect("Failed to write to file");
 }

--- a/interoperability_tests/build.rs
+++ b/interoperability_tests/build.rs
@@ -10,4 +10,14 @@ fn main() {
 
     file.write_all(compiled_idl.as_bytes())
         .expect("Failed to write to file");
+
+    let idl_path = "BigData.idl";
+    let idl_src = std::fs::read_to_string(idl_path).expect("(;_;) Couldn't read IDL source file!");
+
+    let compiled_idl = dust_idlgen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
+
+    let mut file = File::create("big_data.rs").expect("Failed to create file");
+
+    file.write_all(compiled_idl.as_bytes())
+        .expect("Failed to write to file");
 }

--- a/shapes_demo/Cargo.toml
+++ b/shapes_demo/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["api-bindings", "network-programming"]
 
 [dependencies]
 dust_dds = { path = "../dds" }
-dust_dds_derive = { path = "../dds_derive" }
 eframe = "=0.21.0"
 image = { version = "0.24", features = ["png"] }
 periodic = "0.1.1"

--- a/shapes_demo/Cargo.toml
+++ b/shapes_demo/Cargo.toml
@@ -24,8 +24,6 @@ cdr = "=0.2.4"
 
 [build-dependencies]
 dust_idlgen = {path = "../idlgen" }
-pest = "=2.5.3"
-pest_derive = "=2.5.3"
 
 [[bin]]
 name = "dust_dds_shapes_demo"

--- a/shapes_demo/build.rs
+++ b/shapes_demo/build.rs
@@ -1,29 +1,13 @@
 use std::{fs::File, io::Write};
 
-use dust_idlgen::{
-    mappings::rust,
-    parser,
-    syntax::{self, Analyser},
-};
-use pest::Parser;
-
 fn main() {
     let idl_path = "src/ShapeType.idl";
     let idl_src = std::fs::read_to_string(idl_path).expect("Couldn't read IDL source file!");
 
-    let result = parser::IdlParser::parse(parser::Rule::specification, &idl_src)
-        .expect("Couldn't parse IDL file");
+    let compiled_idl = dust_idlgen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
 
     let mut file = File::create("src/shapes_type.rs").expect("Failed to create file");
 
-    let spec = syntax::specification()
-        .analyse(result.into())
-        .expect("Couldn't analyse IDL syntax");
-
-    for def in spec.value {
-        for line in rust::definition(def) {
-            file.write_all(line.as_bytes())
-                .expect("Failed to write to file");
-        }
-    }
+    file.write_all(compiled_idl.as_bytes())
+        .expect("Failed to write to file");
 }

--- a/shapes_demo/src/shapes_type.rs
+++ b/shapes_demo/src/shapes_type.rs
@@ -1,1 +1,0 @@
-#[derive(Debug, serde::Deserialize, serde::Serialize, dust_dds::topic_definition::type_support::DdsSerde, dust_dds::topic_definition::type_support::DdsType)]pub struct ShapeType {    #[key] pub color: String,    pub x: i32,    pub y: i32,    pub shapesize: i32,}


### PR DESCRIPTION
Add an interface to the IDL parser such that the implementation details (e.g. Pest library) can be hidden away from the user and don't need to be imported throughout all the user crates.