### PR TITLE
DDS-310 Refactor writer message sending to reduce lock usage

### DIFF
--- a/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
@@ -40,7 +40,7 @@ use super::{
         ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR,
         ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR,
     },
-    iterators::ReaderProxyListIntoIter,
+    iterators::{ReaderProxyListIntoIter, WriterChangeListIntoIter},
     message_receiver::MessageReceiver,
     participant_discovery::ParticipantDiscovery,
     topic_impl::TopicImpl,
@@ -143,9 +143,8 @@ impl BuiltinStatefulWriter {
             .new_change(kind, data, inline_qos, handle, timestamp)
     }
 
-    pub fn change_list(&self) -> &[RtpsWriterCacheChange] {
-        todo!()
-        // self.rtps_writer.read_lock().change_list()
+    pub fn change_list(&self) -> WriterChangeListIntoIter {
+        WriterChangeListIntoIter::new(self.rtps_writer.read_lock())
     }
 
     pub fn add_change(&self, change: RtpsWriterCacheChange) {

--- a/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
@@ -207,8 +207,9 @@ impl DdsShared<BuiltinStatefulWriter> {
         transport: &mut impl TransportWrite,
         now: Time,
     ) {
-        self.rtps_writer
-            .write_lock()
-            .send_message(header, transport, now);
+        todo!()
+        // self.rtps_writer
+        //     .write_lock()
+        //     .send_message(header, transport, now);
     }
 }

--- a/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
@@ -107,18 +107,18 @@ impl BuiltinStatefulWriter {
         self.rtps_writer.read_lock().guid()
     }
 
-    pub fn unicast_locator_list(&self) -> Vec<Locator> {
+    pub fn _unicast_locator_list(&self) -> Vec<Locator> {
         self.rtps_writer.read_lock().unicast_locator_list().to_vec()
     }
 
-    pub fn multicast_locator_list(&self) -> Vec<Locator> {
+    pub fn _multicast_locator_list(&self) -> Vec<Locator> {
         self.rtps_writer
             .read_lock()
             .multicast_locator_list()
             .to_vec()
     }
 
-    pub fn push_mode(&self) -> bool {
+    pub fn _push_mode(&self) -> bool {
         self.rtps_writer.read_lock().push_mode()
     }
 
@@ -130,7 +130,7 @@ impl BuiltinStatefulWriter {
         self.rtps_writer.read_lock().data_max_size_serialized()
     }
 
-    pub fn new_change(
+    pub fn _new_change(
         &mut self,
         kind: ChangeKind,
         data: Vec<u8>,
@@ -147,24 +147,24 @@ impl BuiltinStatefulWriter {
         WriterChangeListIntoIter::new(self.rtps_writer.read_lock())
     }
 
-    pub fn add_change(&self, change: RtpsWriterCacheChange) {
+    pub fn _add_change(&self, change: RtpsWriterCacheChange) {
         self.rtps_writer.write_lock().add_change(change)
     }
 
-    pub fn remove_change<F>(&self, f: F)
+    pub fn _remove_change<F>(&self, f: F)
     where
         F: FnMut(&RtpsWriterCacheChange) -> bool,
     {
         self.rtps_writer.write_lock().remove_change(f)
     }
 
-    pub fn matched_reader_add(&self, mut a_reader_proxy: RtpsReaderProxy) {
+    pub fn _matched_reader_add(&self, a_reader_proxy: RtpsReaderProxy) {
         self.rtps_writer
             .write_lock()
             .matched_reader_add(a_reader_proxy)
     }
 
-    pub fn matched_reader_remove(&self, a_reader_guid: Guid) {
+    pub fn _matched_reader_remove(&self, a_reader_guid: Guid) {
         self.rtps_writer
             .write_lock()
             .matched_reader_remove(a_reader_guid)
@@ -174,14 +174,8 @@ impl BuiltinStatefulWriter {
         ReaderProxyListIntoIter::new(self.rtps_writer.write_lock())
     }
 
-    pub fn is_acked_by_all(&self, a_change: &RtpsWriterCacheChange) -> bool {
-        todo!()
-    }
-
-    pub fn enable(&self) -> DdsResult<()> {
-        *self.enabled.write_lock() = true;
-
-        Ok(())
+    pub fn _is_acked_by_all(&self, a_change: &RtpsWriterCacheChange) -> bool {
+        self.rtps_writer.read_lock().is_acked_by_all(a_change)
     }
 }
 

--- a/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
+++ b/dds/src/implementation/dds_impl/builtin_stateful_writer.rs
@@ -7,13 +7,14 @@ use crate::{
         },
         rtps::{
             endpoint::RtpsEndpoint,
-            messages::{overall_structure::RtpsMessageHeader, submessages::AckNackSubmessage},
+            history_cache::{RtpsParameter, RtpsWriterCacheChange},
+            messages::submessages::AckNackSubmessage,
+            reader_proxy::RtpsReaderProxy,
             stateful_writer::{
                 RtpsStatefulWriter, DEFAULT_HEARTBEAT_PERIOD, DEFAULT_NACK_RESPONSE_DELAY,
                 DEFAULT_NACK_SUPPRESSION_DURATION,
             },
-            transport::TransportWrite,
-            types::{Guid, GuidPrefix, TopicKind},
+            types::{ChangeKind, Guid, GuidPrefix, Locator, TopicKind},
             writer::RtpsWriter,
         },
         utils::{
@@ -29,7 +30,7 @@ use crate::{
             DurabilityQosPolicy, DurabilityQosPolicyKind, HistoryQosPolicy, HistoryQosPolicyKind,
             ReliabilityQosPolicy, ReliabilityQosPolicyKind,
         },
-        time::{DurationKind, Time, DURATION_ZERO},
+        time::{Duration, DurationKind, Time, DURATION_ZERO},
     },
     topic_definition::type_support::{DdsSerializedKey, DdsType},
 };
@@ -39,6 +40,7 @@ use super::{
         ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR,
         ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR,
     },
+    iterators::ReaderProxyListIntoIter,
     message_receiver::MessageReceiver,
     participant_discovery::ParticipantDiscovery,
     topic_impl::TopicImpl,
@@ -99,6 +101,88 @@ impl BuiltinStatefulWriter {
             enabled: DdsRwLock::new(false),
             sedp_condvar,
         })
+    }
+
+    pub fn guid(&self) -> Guid {
+        self.rtps_writer.read_lock().guid()
+    }
+
+    pub fn unicast_locator_list(&self) -> Vec<Locator> {
+        self.rtps_writer.read_lock().unicast_locator_list().to_vec()
+    }
+
+    pub fn multicast_locator_list(&self) -> Vec<Locator> {
+        self.rtps_writer
+            .read_lock()
+            .multicast_locator_list()
+            .to_vec()
+    }
+
+    pub fn push_mode(&self) -> bool {
+        self.rtps_writer.read_lock().push_mode()
+    }
+
+    pub fn heartbeat_period(&self) -> Duration {
+        self.rtps_writer.read_lock().heartbeat_period()
+    }
+
+    pub fn data_max_size_serialized(&self) -> usize {
+        self.rtps_writer.read_lock().data_max_size_serialized()
+    }
+
+    pub fn new_change(
+        &mut self,
+        kind: ChangeKind,
+        data: Vec<u8>,
+        inline_qos: Vec<RtpsParameter>,
+        handle: InstanceHandle,
+        timestamp: Time,
+    ) -> RtpsWriterCacheChange {
+        self.rtps_writer
+            .write_lock()
+            .new_change(kind, data, inline_qos, handle, timestamp)
+    }
+
+    pub fn change_list(&self) -> &[RtpsWriterCacheChange] {
+        todo!()
+        // self.rtps_writer.read_lock().change_list()
+    }
+
+    pub fn add_change(&self, change: RtpsWriterCacheChange) {
+        self.rtps_writer.write_lock().add_change(change)
+    }
+
+    pub fn remove_change<F>(&self, f: F)
+    where
+        F: FnMut(&RtpsWriterCacheChange) -> bool,
+    {
+        self.rtps_writer.write_lock().remove_change(f)
+    }
+
+    pub fn matched_reader_add(&self, mut a_reader_proxy: RtpsReaderProxy) {
+        self.rtps_writer
+            .write_lock()
+            .matched_reader_add(a_reader_proxy)
+    }
+
+    pub fn matched_reader_remove(&self, a_reader_guid: Guid) {
+        self.rtps_writer
+            .write_lock()
+            .matched_reader_remove(a_reader_guid)
+    }
+
+    pub fn matched_reader_list(&self) -> ReaderProxyListIntoIter {
+        ReaderProxyListIntoIter::new(self.rtps_writer.write_lock())
+    }
+
+    pub fn is_acked_by_all(&self, a_change: &RtpsWriterCacheChange) -> bool {
+        todo!()
+    }
+
+    pub fn enable(&self) -> DdsResult<()> {
+        *self.enabled.write_lock() = true;
+
+        Ok(())
     }
 }
 
@@ -199,17 +283,5 @@ impl DdsShared<BuiltinStatefulWriter> {
         *self.enabled.write_lock() = true;
 
         Ok(())
-    }
-
-    pub fn send_message(
-        &self,
-        header: RtpsMessageHeader,
-        transport: &mut impl TransportWrite,
-        now: Time,
-    ) {
-        todo!()
-        // self.rtps_writer
-        //     .write_lock()
-        //     .send_message(header, transport, now);
     }
 }

--- a/dds/src/implementation/dds_impl/dcps_service.rs
+++ b/dds/src/implementation/dds_impl/dcps_service.rs
@@ -499,12 +499,12 @@ fn send_message_best_effort_reader_proxy(
         let change = reader_proxy.next_unsent_change();
 
         if change.is_relevant() {
-            let timestamp = change.timestamp();
+            let cache_change = change.cache_change();
+            let timestamp = cache_change.timestamp();
 
-            if change.data_value().len() > data_max_size_serialized {
-                let data_frag_submessage_list = change
-                    .cache_change()
-                    .as_data_frag_submessages(data_max_size_serialized, reader_id);
+            if cache_change.data_value().len() > data_max_size_serialized {
+                let data_frag_submessage_list =
+                    cache_change.as_data_frag_submessages(data_max_size_serialized, reader_id);
                 for data_frag_submessage in data_frag_submessage_list {
                     let info_dst =
                         info_destination_submessage(reader_proxy.remote_reader_guid().prefix());
@@ -522,7 +522,7 @@ fn send_message_best_effort_reader_proxy(
             } else {
                 submessages.push(info_timestamp_submessage(timestamp));
                 submessages.push(RtpsSubmessageKind::Data(
-                    change.cache_change().as_data_submessage(reader_id),
+                    cache_change.as_data_submessage(reader_id),
                 ))
             }
         } else {
@@ -571,7 +571,8 @@ fn send_message_reliable_reader_proxy(
             // "( a_change BELONGS-TO the_reader_proxy.unsent_changes() ) == FALSE"
             // should be full-filled by next_unsent_change()
             if change.is_relevant() {
-                if change.data_value().len() > data_max_size_serialized {
+                let cache_change = change.cache_change();
+                if cache_change.data_value().len() > data_max_size_serialized {
                     todo!();
                     // directly_send_data_frag(
                     //     change.cache_change(),
@@ -583,9 +584,9 @@ fn send_message_reliable_reader_proxy(
                     // );
                     return;
                 } else {
-                    submessages.push(info_timestamp_submessage(change.timestamp()));
+                    submessages.push(info_timestamp_submessage(cache_change.timestamp()));
                     submessages.push(RtpsSubmessageKind::Data(
-                        change.cache_change().as_data_submessage(reader_id),
+                        cache_change.as_data_submessage(reader_id),
                     ))
                 }
             } else {
@@ -623,7 +624,8 @@ fn send_message_reliable_reader_proxy(
             // a_change BELONGS-TO the_reader_proxy.requested_changes() ) == FALSE
             // should be full-filled by next_requested_change()
             if change_for_reader.is_relevant() {
-                if change_for_reader.data_value().len() > data_max_size_serialized {
+                let cache_change = change_for_reader.cache_change();
+                if cache_change.data_value().len() > data_max_size_serialized {
                     todo!();
                     // directly_send_data_frag(
                     //     change_for_reader.cache_change(),
@@ -635,11 +637,9 @@ fn send_message_reliable_reader_proxy(
                     // );
                     return;
                 } else {
-                    submessages.push(info_timestamp_submessage(change_for_reader.timestamp()));
+                    submessages.push(info_timestamp_submessage(cache_change.timestamp()));
                     submessages.push(RtpsSubmessageKind::Data(
-                        change_for_reader
-                            .cache_change()
-                            .as_data_submessage(reader_id),
+                        cache_change.as_data_submessage(reader_id),
                     ))
                 }
             } else {

--- a/dds/src/implementation/dds_impl/dcps_service.rs
+++ b/dds/src/implementation/dds_impl/dcps_service.rs
@@ -189,7 +189,7 @@ impl DcpsService {
                     .send_message(header, &mut metatraffic_unicast_transport_send);
 
                 builtin_stateful_writer_send_message(
-                    &domain_participant
+                    domain_participant
                         .get_builtin_publisher()
                         .sedp_builtin_publications_writer(),
                     header,
@@ -197,7 +197,7 @@ impl DcpsService {
                 );
 
                 builtin_stateful_writer_send_message(
-                    &domain_participant
+                    domain_participant
                         .get_builtin_publisher()
                         .sedp_builtin_subscriptions_writer(),
                     header,
@@ -205,7 +205,7 @@ impl DcpsService {
                 );
 
                 builtin_stateful_writer_send_message(
-                    &domain_participant
+                    domain_participant
                         .get_builtin_publisher()
                         .sedp_builtin_topics_writer(),
                     header,
@@ -560,6 +560,7 @@ fn send_message_best_effort_reader_proxy(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn send_message_reliable_reader_proxy(
     reader_proxy: &mut WriterAssociatedReaderProxy,
     data_max_size_serialized: usize,
@@ -700,6 +701,7 @@ fn info_destination_submessage<'a>(guid_prefix: GuidPrefix) -> RtpsSubmessageKin
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn directly_send_data_frag(
     reader_proxy: &mut WriterAssociatedReaderProxy,
     cache_change: &RtpsWriterCacheChange,

--- a/dds/src/implementation/dds_impl/dcps_service.rs
+++ b/dds/src/implementation/dds_impl/dcps_service.rs
@@ -15,19 +15,32 @@ use crate::{
             discovered_topic_data::DiscoveredTopicData,
             discovered_writer_data::{DiscoveredWriterData, WriterProxy},
         },
-        rtps::messages::{overall_structure::RtpsMessageHeader, types::ProtocolId},
-        rtps_udp_psm::udp_transport::UdpTransport,
+        rtps::{
+            messages::{
+                overall_structure::RtpsMessageHeader,
+                submessages::{GapSubmessage, InfoDestinationSubmessage, InfoTimestampSubmessage},
+                types::ProtocolId,
+                RtpsMessage, RtpsSubmessageKind,
+            },
+            reader_proxy::{self, WriterAssociatedReaderProxy},
+            transport::TransportWrite,
+            types::{GuidPrefix, ReliabilityKind},
+        },
+        rtps_udp_psm::{mapping_rtps_messages::submessages::data, udp_transport::UdpTransport},
         utils::{condvar::DdsCondvar, shared_object::DdsShared},
     },
     infrastructure::{
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
-        time::Duration,
+        time::{Duration, DurationKind, Time},
     },
     topic_definition::type_support::{DdsSerialize, DdsSerializedKey, DdsType, LittleEndian},
 };
 
-use super::domain_participant_impl::{AnnounceKind, DomainParticipantImpl};
+use super::{
+    domain_participant_impl::{AnnounceKind, DomainParticipantImpl},
+    user_defined_data_writer::UserDefinedDataWriter,
+};
 
 pub struct DcpsService {
     participant: DdsShared<DomainParticipantImpl>,
@@ -235,8 +248,20 @@ impl DcpsService {
                 for publisher in domain_participant.publisher_list() {
                     for data_writer in publisher.data_writer_list() {
                         {
-                            for reader_proxy in &mut data_writer.matched_reader_list() {
-                                // todo!()
+                            let data_max_size_serialized = data_writer.data_max_size_serialized();
+                            remove_stale_writer_changes(&data_writer, now);
+                            for mut reader_proxy in &mut data_writer.matched_reader_list() {
+                                match reader_proxy.reliability() {
+                                    ReliabilityKind::BestEffort => {
+                                        send_message_best_effort_reader_proxy(
+                                            &mut reader_proxy,
+                                            data_max_size_serialized,
+                                            header,
+                                            &mut default_unicast_transport_send,
+                                        )
+                                    }
+                                    ReliabilityKind::Reliable => (),
+                                }
                             }
                         }
 
@@ -436,4 +461,120 @@ fn announce_deleted_writer(
         .sedp_builtin_publications_writer()
         .dispose_w_timestamp(instance_serialized_key, writer_handle, timestamp)
         .expect("Should not fail to write built-in message");
+}
+
+fn send_user_defined_data_writer_writer_message(
+    writer: &UserDefinedDataWriter,
+    header: RtpsMessageHeader,
+    transport: &mut impl TransportWrite,
+    now: Time,
+) {
+    for reader_proxy in &mut writer.matched_reader_list() {
+        match reader_proxy.reliability() {
+            ReliabilityKind::BestEffort => todo!(), //send_message_best_effort_reader_proxy(reader_proxy),
+            ReliabilityKind::Reliable => todo!(), //send_message_reliable_reader_proxy(reader_proxy),
+        }
+        todo!()
+        // reader_proxy.send_message(
+        //     self.writer.writer_cache(),
+        //     self.writer.guid().entity_id(),
+        //     self.writer.data_max_size_serialized(),
+        //     self.writer.heartbeat_period(),
+        //     header,
+        //     transport,
+        // );
+    }
+}
+
+fn remove_stale_writer_changes(writer: &UserDefinedDataWriter, now: Time) {
+    let timespan_duration = writer.get_qos().lifespan.duration;
+    writer.remove_change(|cc| DurationKind::Finite(now - cc.timestamp()) > timespan_duration);
+}
+
+fn send_message_reader_proxy(
+    reader_proxy: &mut WriterAssociatedReaderProxy,
+    data_max_size_serialized: usize,
+    header: RtpsMessageHeader,
+    transport: &mut impl TransportWrite,
+) {
+}
+
+fn send_message_best_effort_reader_proxy(
+    reader_proxy: &mut WriterAssociatedReaderProxy,
+    data_max_size_serialized: usize,
+    header: RtpsMessageHeader,
+    transport: &mut impl TransportWrite,
+) {
+    let info_dst = info_destination_submessage(reader_proxy.remote_reader_guid().prefix());
+    let mut submessages = vec![info_dst];
+
+    while !reader_proxy.unsent_changes().is_empty() {
+        // Note: The readerId is set to the remote reader ID as described in 8.4.9.2.12 Transition T12
+        // in confront to ENTITYID_UNKNOWN as described in 8.4.9.2.4 Transition T4
+        let reader_id = reader_proxy.remote_reader_guid().entity_id();
+        let change = reader_proxy.next_unsent_change();
+
+        if change.is_relevant() {
+            let timestamp = change.timestamp();
+
+            if change.data_value().len() > data_max_size_serialized {
+                let data_frag_submessage_list = change
+                    .cache_change()
+                    .as_data_frag_submessages(data_max_size_serialized, reader_id);
+                for data_frag_submessage in data_frag_submessage_list {
+                    let info_dst =
+                        info_destination_submessage(reader_proxy.remote_reader_guid().prefix());
+
+                    let into_timestamp = info_timestamp_submessage(timestamp);
+                    let data_frag = RtpsSubmessageKind::DataFrag(data_frag_submessage);
+
+                    let submessages = vec![info_dst, into_timestamp, data_frag];
+
+                    transport.write(
+                        &RtpsMessage::new(header, submessages),
+                        reader_proxy.unicast_locator_list(),
+                    )
+                }
+            } else {
+                submessages.push(info_timestamp_submessage(timestamp));
+                submessages.push(RtpsSubmessageKind::Data(
+                    change.cache_change().as_data_submessage(reader_id),
+                ))
+            }
+        } else {
+            let gap_submessage: GapSubmessage = change
+                .cache_change()
+                .as_gap_message(reader_proxy.remote_reader_guid().entity_id());
+            submessages.push(RtpsSubmessageKind::Gap(gap_submessage));
+        }
+    }
+
+    // Send messages only if more than INFO_DST is added
+    if submessages.len() > 1 {
+        transport.write(
+            &RtpsMessage::new(header, submessages),
+            reader_proxy.unicast_locator_list(),
+        )
+    }
+}
+
+fn send_message_reliable_reader_proxy(reader_proxy: &mut WriterAssociatedReaderProxy) {
+    todo!()
+}
+
+fn info_timestamp_submessage<'a>(timestamp: Time) -> RtpsSubmessageKind<'a> {
+    RtpsSubmessageKind::InfoTimestamp(InfoTimestampSubmessage {
+        endianness_flag: true,
+        invalidate_flag: false,
+        timestamp: crate::implementation::rtps::messages::types::Time::new(
+            timestamp.sec(),
+            timestamp.nanosec(),
+        ),
+    })
+}
+fn info_destination_submessage<'a>(guid_prefix: GuidPrefix) -> RtpsSubmessageKind<'a> {
+    RtpsSubmessageKind::InfoDestination(InfoDestinationSubmessage {
+        endianness_flag: true,
+        guid_prefix,
+    })
 }

--- a/dds/src/implementation/dds_impl/dcps_service.rs
+++ b/dds/src/implementation/dds_impl/dcps_service.rs
@@ -234,6 +234,13 @@ impl DcpsService {
 
                 for publisher in domain_participant.publisher_list() {
                     for data_writer in publisher.data_writer_list() {
+                        {
+                            let mut reader_proxy_list = data_writer.matched_reader_list();
+                            while let Some(mut reader_proxy) = reader_proxy_list.next() {
+                                // reader_proxy.next_unsent_change();
+                            }
+                        }
+
                         data_writer.send_message(header, &mut default_unicast_transport_send, now)
                     }
                 }

--- a/dds/src/implementation/dds_impl/dcps_service.rs
+++ b/dds/src/implementation/dds_impl/dcps_service.rs
@@ -235,9 +235,8 @@ impl DcpsService {
                 for publisher in domain_participant.publisher_list() {
                     for data_writer in publisher.data_writer_list() {
                         {
-                            let mut reader_proxy_list = data_writer.matched_reader_list();
-                            while let Some(mut reader_proxy) = reader_proxy_list.next() {
-                                // reader_proxy.next_unsent_change();
+                            for reader_proxy in &mut data_writer.matched_reader_list() {
+                                // todo!()
                             }
                         }
 

--- a/dds/src/implementation/dds_impl/dcps_service.rs
+++ b/dds/src/implementation/dds_impl/dcps_service.rs
@@ -22,11 +22,11 @@ use crate::{
                 types::ProtocolId,
                 RtpsMessage, RtpsSubmessageKind,
             },
-            reader_proxy::{self, WriterAssociatedReaderProxy},
+            reader_proxy::WriterAssociatedReaderProxy,
             transport::TransportWrite,
-            types::{GuidPrefix, ReliabilityKind},
+            types::{EntityId, GuidPrefix, ReliabilityKind, SequenceNumber},
         },
-        rtps_udp_psm::{mapping_rtps_messages::submessages::data, udp_transport::UdpTransport},
+        rtps_udp_psm::udp_transport::UdpTransport,
         utils::{condvar::DdsCondvar, shared_object::DdsShared},
     },
     infrastructure::{
@@ -247,25 +247,40 @@ impl DcpsService {
 
                 for publisher in domain_participant.publisher_list() {
                     for data_writer in publisher.data_writer_list() {
-                        {
-                            let data_max_size_serialized = data_writer.data_max_size_serialized();
-                            remove_stale_writer_changes(&data_writer, now);
-                            for mut reader_proxy in &mut data_writer.matched_reader_list() {
-                                match reader_proxy.reliability() {
-                                    ReliabilityKind::BestEffort => {
-                                        send_message_best_effort_reader_proxy(
-                                            &mut reader_proxy,
-                                            data_max_size_serialized,
-                                            header,
-                                            &mut default_unicast_transport_send,
-                                        )
-                                    }
-                                    ReliabilityKind::Reliable => (),
+                        let writer_id = data_writer.guid().entity_id();
+                        let data_max_size_serialized = data_writer.data_max_size_serialized();
+                        let heartbeat_period = data_writer.heartbeat_period();
+                        let first_sn = SequenceNumber::new(1);
+                        // data_writer.change_list() writer_cache
+                        // .get_seq_num_min()
+                        // .unwrap_or(SequenceNumber::new(1));
+                        let last_sn = SequenceNumber::new(0);
+                        // writer_cache
+                        //     .get_seq_num_max()
+                        //     .unwrap_or_else(|| SequenceNumber::new(0)),
+                        remove_stale_writer_changes(&data_writer, now);
+                        for mut reader_proxy in &mut data_writer.matched_reader_list() {
+                            match reader_proxy.reliability() {
+                                ReliabilityKind::BestEffort => {
+                                    send_message_best_effort_reader_proxy(
+                                        &mut reader_proxy,
+                                        data_max_size_serialized,
+                                        header,
+                                        &mut default_unicast_transport_send,
+                                    )
                                 }
+                                ReliabilityKind::Reliable => send_message_reliable_reader_proxy(
+                                    &mut reader_proxy,
+                                    data_max_size_serialized,
+                                    header,
+                                    &mut default_unicast_transport_send,
+                                    writer_id,
+                                    first_sn,
+                                    last_sn,
+                                    heartbeat_period,
+                                ),
                             }
                         }
-
-                        data_writer.send_message(header, &mut default_unicast_transport_send, now)
                     }
                 }
 
@@ -463,40 +478,9 @@ fn announce_deleted_writer(
         .expect("Should not fail to write built-in message");
 }
 
-fn send_user_defined_data_writer_writer_message(
-    writer: &UserDefinedDataWriter,
-    header: RtpsMessageHeader,
-    transport: &mut impl TransportWrite,
-    now: Time,
-) {
-    for reader_proxy in &mut writer.matched_reader_list() {
-        match reader_proxy.reliability() {
-            ReliabilityKind::BestEffort => todo!(), //send_message_best_effort_reader_proxy(reader_proxy),
-            ReliabilityKind::Reliable => todo!(), //send_message_reliable_reader_proxy(reader_proxy),
-        }
-        todo!()
-        // reader_proxy.send_message(
-        //     self.writer.writer_cache(),
-        //     self.writer.guid().entity_id(),
-        //     self.writer.data_max_size_serialized(),
-        //     self.writer.heartbeat_period(),
-        //     header,
-        //     transport,
-        // );
-    }
-}
-
 fn remove_stale_writer_changes(writer: &UserDefinedDataWriter, now: Time) {
     let timespan_duration = writer.get_qos().lifespan.duration;
     writer.remove_change(|cc| DurationKind::Finite(now - cc.timestamp()) > timespan_duration);
-}
-
-fn send_message_reader_proxy(
-    reader_proxy: &mut WriterAssociatedReaderProxy,
-    data_max_size_serialized: usize,
-    header: RtpsMessageHeader,
-    transport: &mut impl TransportWrite,
-) {
 }
 
 fn send_message_best_effort_reader_proxy(
@@ -558,8 +542,125 @@ fn send_message_best_effort_reader_proxy(
     }
 }
 
-fn send_message_reliable_reader_proxy(reader_proxy: &mut WriterAssociatedReaderProxy) {
-    todo!()
+fn send_message_reliable_reader_proxy(
+    reader_proxy: &mut WriterAssociatedReaderProxy,
+    data_max_size_serialized: usize,
+    header: RtpsMessageHeader,
+    transport: &mut impl TransportWrite,
+    writer_id: EntityId,
+    first_sn: SequenceNumber,
+    last_sn: SequenceNumber,
+    heartbeat_period: Duration,
+) {
+    let reader_id = reader_proxy.remote_reader_guid().entity_id();
+
+    let info_dst = info_destination_submessage(reader_proxy.remote_reader_guid().prefix());
+
+    let mut submessages = vec![info_dst];
+
+    // Top part of the state machine - Figure 8.19 RTPS standard
+    if !reader_proxy.unsent_changes().is_empty() {
+        // Note: The readerId is set to the remote reader ID as described in 8.4.9.2.12 Transition T12
+        // in confront to ENTITYID_UNKNOWN as described in 8.4.9.2.4 Transition T4
+
+        while !reader_proxy.unsent_changes().is_empty() {
+            let change = reader_proxy.next_unsent_change();
+            // "a_change.status := UNDERWAY;" should be done by next_requested_change() as
+            // it's not done here to avoid the change being a mutable reference
+            // Also the post-condition:
+            // "( a_change BELONGS-TO the_reader_proxy.unsent_changes() ) == FALSE"
+            // should be full-filled by next_unsent_change()
+            if change.is_relevant() {
+                if change.data_value().len() > data_max_size_serialized {
+                    todo!();
+                    // directly_send_data_frag(
+                    //     change.cache_change(),
+                    //     writer_cache,
+                    //     writer_id,
+                    //     data_max_size_serialized,
+                    //     header,
+                    //     transport,
+                    // );
+                    return;
+                } else {
+                    submessages.push(info_timestamp_submessage(change.timestamp()));
+                    submessages.push(RtpsSubmessageKind::Data(
+                        change.cache_change().as_data_submessage(reader_id),
+                    ))
+                }
+            } else {
+                let gap_submessage: GapSubmessage = change.cache_change().as_gap_message(reader_id);
+
+                submessages.push(RtpsSubmessageKind::Gap(gap_submessage));
+            }
+        }
+
+        let heartbeat = reader_proxy
+            .heartbeat_machine()
+            .submessage(writer_id, first_sn, last_sn);
+        submessages.push(heartbeat);
+    } else if reader_proxy.unacked_changes().is_empty() {
+        // Idle
+    } else if reader_proxy
+        .heartbeat_machine()
+        .is_time_for_heartbeat(heartbeat_period)
+    {
+        let heartbeat = reader_proxy
+            .heartbeat_machine()
+            .submessage(writer_id, first_sn, last_sn);
+        submessages.push(heartbeat);
+    }
+
+    // Middle-part of the state-machine - Figure 8.19 RTPS standard
+    if !reader_proxy.requested_changes().is_empty() {
+        let reader_id = reader_proxy.remote_reader_guid().entity_id();
+
+        while !reader_proxy.requested_changes().is_empty() {
+            let change_for_reader = reader_proxy.next_requested_change();
+            // "a_change.status := UNDERWAY;" should be done by next_requested_change() as
+            // it's not done here to avoid the change being a mutable reference
+            // Also the post-condition:
+            // a_change BELONGS-TO the_reader_proxy.requested_changes() ) == FALSE
+            // should be full-filled by next_requested_change()
+            if change_for_reader.is_relevant() {
+                if change_for_reader.data_value().len() > data_max_size_serialized {
+                    todo!();
+                    // directly_send_data_frag(
+                    //     change_for_reader.cache_change(),
+                    //     writer_cache,
+                    //     writer_id,
+                    //     data_max_size_serialized,
+                    //     header,
+                    //     transport,
+                    // );
+                    return;
+                } else {
+                    submessages.push(info_timestamp_submessage(change_for_reader.timestamp()));
+                    submessages.push(RtpsSubmessageKind::Data(
+                        change_for_reader
+                            .cache_change()
+                            .as_data_submessage(reader_id),
+                    ))
+                }
+            } else {
+                let gap_submessage: GapSubmessage =
+                    change_for_reader.cache_change().as_gap_message(reader_id);
+
+                submessages.push(RtpsSubmessageKind::Gap(gap_submessage));
+            }
+        }
+        let heartbeat = reader_proxy
+            .heartbeat_machine()
+            .submessage(writer_id, first_sn, last_sn);
+        submessages.push(heartbeat);
+    }
+    // Send messages only if more or equal than INFO_DST and HEARTBEAT is added
+    if submessages.len() >= 2 {
+        transport.write(
+            &RtpsMessage::new(header, submessages),
+            reader_proxy.unicast_locator_list(),
+        )
+    }
 }
 
 fn info_timestamp_submessage<'a>(timestamp: Time) -> RtpsSubmessageKind<'a> {
@@ -577,4 +678,49 @@ fn info_destination_submessage<'a>(guid_prefix: GuidPrefix) -> RtpsSubmessageKin
         endianness_flag: true,
         guid_prefix,
     })
+}
+
+fn directly_send_data_frag(// &mut self,
+    // cache_change: &RtpsWriterCacheChange,
+    // writer_cache: &WriterHistoryCache,
+    // writer_id: EntityId,
+    // data_max_size_serialized: usize,
+    // header: RtpsMessageHeader,
+    // transport: &mut impl TransportWrite,
+) {
+    // let reader_id = self.remote_reader_guid().entity_id();
+    // let timestamp = cache_change.timestamp();
+
+    // let mut data_frag_submessage_list = cache_change
+    //     .as_data_frag_submessages(data_max_size_serialized, reader_id)
+    //     .into_iter()
+    //     .peekable();
+
+    // while let Some(data_frag_submessage) = data_frag_submessage_list.next() {
+    //     let writer_sn = data_frag_submessage.writer_sn;
+    //     let last_fragment_num = FragmentNumber::new(
+    //         u32::from(data_frag_submessage.fragment_starting_num)
+    //             + u16::from(data_frag_submessage.fragments_in_submessage) as u32
+    //             - 1,
+    //     );
+
+    //     let info_dst = info_destination_submessage(self.remote_reader_guid().prefix());
+    //     let into_timestamp = info_timestamp_submessage(timestamp);
+    //     let data_frag = RtpsSubmessageKind::DataFrag(data_frag_submessage);
+
+    //     let is_last_fragment = data_frag_submessage_list.peek().is_none();
+    //     let submessages = if is_last_fragment {
+    //         let heartbeat_frag =
+    //             self.heartbeat_frag_machine
+    //                 .submessage(writer_id, writer_sn, last_fragment_num);
+    //         vec![info_dst, into_timestamp, data_frag, heartbeat_frag]
+    //     } else {
+    //         let heartbeat = self.heartbeat_machine.submessage(writer_id, writer_cache);
+    //         vec![info_dst, into_timestamp, data_frag, heartbeat]
+    //     };
+    //     transport.write(
+    //         &RtpsMessage::new(header, submessages),
+    //         self.unicast_locator_list(),
+    //     )
+    // }
 }

--- a/dds/src/implementation/dds_impl/iterators.rs
+++ b/dds/src/implementation/dds_impl/iterators.rs
@@ -1,0 +1,38 @@
+use std::sync::RwLockWriteGuard;
+
+use crate::implementation::rtps::{
+    reader_proxy::WriterAssociatedReaderProxy, stateful_writer::RtpsStatefulWriter,
+};
+
+pub struct ReaderProxyListIntoIter<'a> {
+    writer_lock: RwLockWriteGuard<'a, RtpsStatefulWriter>,
+}
+
+impl<'a> IntoIterator for &'a mut ReaderProxyListIntoIter<'_> {
+    type Item = WriterAssociatedReaderProxy<'a>;
+    type IntoIter = ReaderProxyListIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ReaderProxyListIter {
+            list: self.writer_lock.matched_reader_list().into_iter(),
+        }
+    }
+}
+
+impl<'a> ReaderProxyListIntoIter<'a> {
+    pub fn new(writer_lock: RwLockWriteGuard<'a, RtpsStatefulWriter>) -> Self {
+        Self { writer_lock }
+    }
+}
+
+pub struct ReaderProxyListIter<'a> {
+    list: std::vec::IntoIter<WriterAssociatedReaderProxy<'a>>,
+}
+
+impl<'a> Iterator for ReaderProxyListIter<'a> {
+    type Item = WriterAssociatedReaderProxy<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.list.next()
+    }
+}

--- a/dds/src/implementation/dds_impl/iterators.rs
+++ b/dds/src/implementation/dds_impl/iterators.rs
@@ -1,7 +1,8 @@
-use std::sync::RwLockWriteGuard;
+use std::sync::{RwLockReadGuard, RwLockWriteGuard};
 
 use crate::implementation::rtps::{
-    reader_proxy::WriterAssociatedReaderProxy, stateful_writer::RtpsStatefulWriter,
+    history_cache::RtpsWriterCacheChange, reader_proxy::WriterAssociatedReaderProxy,
+    stateful_writer::RtpsStatefulWriter,
 };
 
 pub struct ReaderProxyListIntoIter<'a> {
@@ -34,5 +35,25 @@ impl<'a> Iterator for ReaderProxyListIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.list.next()
+    }
+}
+
+pub struct WriterChangeListIntoIter<'a> {
+    lock: RwLockReadGuard<'a, RtpsStatefulWriter>,
+}
+
+impl<'a> WriterChangeListIntoIter<'a> {
+    pub fn new(lock: RwLockReadGuard<'a, RtpsStatefulWriter>) -> Self {
+        Self { lock }
+    }
+}
+
+impl<'a> IntoIterator for &'a WriterChangeListIntoIter<'_> {
+    type Item = &'a RtpsWriterCacheChange;
+
+    type IntoIter = std::slice::Iter<'a, RtpsWriterCacheChange>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.lock.change_list().iter()
     }
 }

--- a/dds/src/implementation/dds_impl/mod.rs
+++ b/dds/src/implementation/dds_impl/mod.rs
@@ -9,6 +9,7 @@ pub mod builtin_stateless_writer;
 pub mod builtin_subscriber;
 pub mod dcps_service;
 pub mod domain_participant_impl;
+pub mod iterators;
 pub mod message_receiver;
 pub mod node_builtin_data_reader_stateful;
 pub mod node_builtin_data_reader_stateless;

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -189,18 +189,18 @@ impl UserDefinedDataWriter {
         self.rtps_writer.read_lock().guid()
     }
 
-    pub fn unicast_locator_list(&self) -> Vec<Locator> {
+    pub fn _unicast_locator_list(&self) -> Vec<Locator> {
         self.rtps_writer.read_lock().unicast_locator_list().to_vec()
     }
 
-    pub fn multicast_locator_list(&self) -> Vec<Locator> {
+    pub fn _multicast_locator_list(&self) -> Vec<Locator> {
         self.rtps_writer
             .read_lock()
             .multicast_locator_list()
             .to_vec()
     }
 
-    pub fn push_mode(&self) -> bool {
+    pub fn _push_mode(&self) -> bool {
         self.rtps_writer.read_lock().push_mode()
     }
 
@@ -212,7 +212,7 @@ impl UserDefinedDataWriter {
         self.rtps_writer.read_lock().data_max_size_serialized()
     }
 
-    pub fn new_change(
+    pub fn _new_change(
         &mut self,
         kind: ChangeKind,
         data: Vec<u8>,
@@ -229,7 +229,7 @@ impl UserDefinedDataWriter {
         WriterChangeListIntoIter::new(self.rtps_writer.read_lock())
     }
 
-    pub fn add_change(&self, change: RtpsWriterCacheChange) {
+    pub fn _add_change(&self, change: RtpsWriterCacheChange) {
         self.rtps_writer.write_lock().add_change(change)
     }
 
@@ -240,13 +240,13 @@ impl UserDefinedDataWriter {
         self.rtps_writer.write_lock().remove_change(f)
     }
 
-    pub fn matched_reader_add(&self, mut a_reader_proxy: RtpsReaderProxy) {
+    pub fn _matched_reader_add(&self, a_reader_proxy: RtpsReaderProxy) {
         self.rtps_writer
             .write_lock()
             .matched_reader_add(a_reader_proxy)
     }
 
-    pub fn matched_reader_remove(&self, a_reader_guid: Guid) {
+    pub fn _matched_reader_remove(&self, a_reader_guid: Guid) {
         self.rtps_writer
             .write_lock()
             .matched_reader_remove(a_reader_guid)
@@ -256,8 +256,8 @@ impl UserDefinedDataWriter {
         ReaderProxyListIntoIter::new(self.rtps_writer.write_lock())
     }
 
-    pub fn is_acked_by_all(&self, a_change: &RtpsWriterCacheChange) -> bool {
-        todo!()
+    pub fn _is_acked_by_all(&self, a_change: &RtpsWriterCacheChange) -> bool {
+        self.rtps_writer.read_lock().is_acked_by_all(a_change)
     }
 
     pub fn get_topic_name(&self) -> &str {

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -222,14 +222,15 @@ impl UserDefinedDataWriter {
         self.rtps_writer.read_lock().guid()
     }
 
-    pub fn unicast_locator_list(&self) -> &[Locator] {
-        todo!()
-        // self.rtps_writer.read_lock().unicast_locator_list()
+    pub fn unicast_locator_list(&self) -> Vec<Locator> {
+        self.rtps_writer.read_lock().unicast_locator_list().to_vec()
     }
 
-    pub fn multicast_locator_list(&self) -> &[Locator] {
-        todo!()
-        // self.rtps_writer.read_lock().multicast_locator_list()
+    pub fn multicast_locator_list(&self) -> Vec<Locator> {
+        self.rtps_writer
+            .read_lock()
+            .multicast_locator_list()
+            .to_vec()
     }
 
     pub fn push_mode(&self) -> bool {

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -49,9 +49,12 @@ use crate::{
 };
 
 use super::{
-    any_data_writer_listener::AnyDataWriterListener, domain_participant_impl::AnnounceKind,
-    iterators::ReaderProxyListIntoIter, message_receiver::MessageReceiver,
-    node_listener_data_writer::ListenerDataWriterNode, status_condition_impl::StatusConditionImpl,
+    any_data_writer_listener::AnyDataWriterListener,
+    domain_participant_impl::AnnounceKind,
+    iterators::{ReaderProxyListIntoIter, WriterChangeListIntoIter},
+    message_receiver::MessageReceiver,
+    node_listener_data_writer::ListenerDataWriterNode,
+    status_condition_impl::StatusConditionImpl,
     status_listener::StatusListener,
 };
 
@@ -222,9 +225,8 @@ impl UserDefinedDataWriter {
             .new_change(kind, data, inline_qos, handle, timestamp)
     }
 
-    pub fn change_list(&self) -> &[RtpsWriterCacheChange] {
-        todo!()
-        // self.rtps_writer.read_lock().change_list()
+    pub fn change_list(&self) -> WriterChangeListIntoIter {
+        WriterChangeListIntoIter::new(self.rtps_writer.read_lock())
     }
 
     pub fn add_change(&self, change: RtpsWriterCacheChange) {

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::{mpsc::SyncSender, RwLockWriteGuard},
-    time::Instant,
-};
+use std::{collections::HashMap, sync::mpsc::SyncSender, time::Instant};
 
 use crate::{
     builtin_topics::BuiltInTopicKey,
@@ -15,7 +11,7 @@ use crate::{
         rtps::{
             history_cache::{RtpsParameter, RtpsWriterCacheChange},
             messages::submessages::{AckNackSubmessage, NackFragSubmessage},
-            reader_proxy::{RtpsReaderProxy, WriterAssociatedReaderProxy},
+            reader_proxy::RtpsReaderProxy,
             stateful_writer::RtpsStatefulWriter,
             types::{
                 ChangeKind, DurabilityKind, EntityId, EntityKey, Guid, Locator, ReliabilityKind,
@@ -54,8 +50,9 @@ use crate::{
 
 use super::{
     any_data_writer_listener::AnyDataWriterListener, domain_participant_impl::AnnounceKind,
-    message_receiver::MessageReceiver, node_listener_data_writer::ListenerDataWriterNode,
-    status_condition_impl::StatusConditionImpl, status_listener::StatusListener,
+    iterators::ReaderProxyListIntoIter, message_receiver::MessageReceiver,
+    node_listener_data_writer::ListenerDataWriterNode, status_condition_impl::StatusConditionImpl,
+    status_listener::StatusListener,
 };
 
 impl PublicationMatchedStatus {
@@ -137,39 +134,6 @@ impl OfferedIncompatibleQosStatus {
         self.total_count_change = 0;
 
         status
-    }
-}
-
-pub struct ReaderProxyListIntoIter<'a> {
-    writer_lock: RwLockWriteGuard<'a, RtpsStatefulWriter>,
-}
-
-impl<'a> IntoIterator for &'a mut ReaderProxyListIntoIter<'_> {
-    type Item = WriterAssociatedReaderProxy<'a>;
-    type IntoIter = ReaderProxyListIter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        ReaderProxyListIter {
-            list: self.writer_lock.matched_reader_list().into_iter(),
-        }
-    }
-}
-
-impl<'a> ReaderProxyListIntoIter<'a> {
-    pub fn new(writer_lock: RwLockWriteGuard<'a, RtpsStatefulWriter>) -> Self {
-        Self { writer_lock }
-    }
-}
-
-pub struct ReaderProxyListIter<'a> {
-    list: std::vec::IntoIter<WriterAssociatedReaderProxy<'a>>,
-}
-
-impl<'a> Iterator for ReaderProxyListIter<'a> {
-    type Item = WriterAssociatedReaderProxy<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.list.next()
     }
 }
 

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -436,7 +436,7 @@ impl DdsShared<UserDefinedDataWriter> {
                 // This is done in an inner scope such that the lock can be dropped and new acknowledgements
                 // can be processed when received
                 let rtps_writer_lock = self.rtps_writer.write_lock();
-                let changes = rtps_writer_lock.writer_cache().change_list();
+                let changes = rtps_writer_lock.change_list();
 
                 if changes
                     .iter()

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -14,13 +14,9 @@ use crate::{
         },
         rtps::{
             history_cache::{RtpsParameter, RtpsWriterCacheChange},
-            messages::{
-                overall_structure::RtpsMessageHeader,
-                submessages::{AckNackSubmessage, NackFragSubmessage},
-            },
+            messages::submessages::{AckNackSubmessage, NackFragSubmessage},
             reader_proxy::{RtpsReaderProxy, WriterAssociatedReaderProxy},
             stateful_writer::RtpsStatefulWriter,
-            transport::TransportWrite,
             types::{
                 ChangeKind, DurabilityKind, EntityId, EntityKey, Guid, Locator, ReliabilityKind,
                 GUID_UNKNOWN, USER_DEFINED_UNKNOWN,
@@ -216,7 +212,6 @@ impl UserDefinedDataWriter {
             enabled: DdsRwLock::new(false),
             status_listener: DdsRwLock::new(StatusListener::new(listener, mask)),
             status_condition: DdsShared::new(DdsRwLock::new(StatusConditionImpl::default())),
-
             user_defined_data_send_condvar,
             acked_by_all_condvar: DdsCondvar::new(),
             announce_sender,
@@ -735,17 +730,6 @@ impl DdsShared<UserDefinedDataWriter> {
         }
     }
 
-    pub fn send_message(
-        &self,
-        header: RtpsMessageHeader,
-        transport: &mut impl TransportWrite,
-        now: Time,
-    ) {
-        self.rtps_writer
-            .write_lock()
-            .send_message(header, transport, now);
-    }
-
     fn on_offered_incompatible_qos(
         &self,
         incompatible_qos_policy_list: Vec<QosPolicyId>,
@@ -981,6 +965,7 @@ mod test {
         implementation::rtps::{
             endpoint::RtpsEndpoint,
             messages::RtpsMessage,
+            transport::TransportWrite,
             types::{TopicKind, GUID_UNKNOWN},
             writer::RtpsWriter,
         },

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -18,11 +18,8 @@ use crate::{
                 overall_structure::RtpsMessageHeader,
                 submessages::{AckNackSubmessage, NackFragSubmessage},
             },
-            reader_proxy::RtpsReaderProxy,
-            stateful_writer::{
-                RtpsStatefulWriter, WriterAssociatedReaderProxy,
-                WriterAssociatedReaderProxyIterator,
-            },
+            reader_proxy::{RtpsReaderProxy, WriterAssociatedReaderProxy},
+            stateful_writer::RtpsStatefulWriter,
             transport::TransportWrite,
             types::{
                 ChangeKind, DurabilityKind, EntityId, EntityKey, Guid, Locator, ReliabilityKind,

--- a/dds/src/implementation/dds_impl/user_defined_data_writer.rs
+++ b/dds/src/implementation/dds_impl/user_defined_data_writer.rs
@@ -436,7 +436,7 @@ impl DdsShared<UserDefinedDataWriter> {
                 // This is done in an inner scope such that the lock can be dropped and new acknowledgements
                 // can be processed when received
                 let rtps_writer_lock = self.rtps_writer.write_lock();
-                let changes = rtps_writer_lock.writer_cache().changes();
+                let changes = rtps_writer_lock.writer_cache().change_list();
 
                 if changes
                     .iter()

--- a/dds/src/implementation/rtps/history_cache.rs
+++ b/dds/src/implementation/rtps/history_cache.rs
@@ -223,7 +223,7 @@ impl WriterHistoryCache {
         }
     }
 
-    pub fn changes(&self) -> &[RtpsWriterCacheChange] {
+    pub fn change_list(&self) -> &[RtpsWriterCacheChange] {
         &self.changes
     }
 
@@ -270,7 +270,7 @@ mod tests {
         );
         hc.add_change(change);
         hc.remove_change(|cc| cc.sequence_number() == SequenceNumber::new(1));
-        assert!(hc.changes().is_empty());
+        assert!(hc.change_list().is_empty());
     }
 
     #[test]

--- a/dds/src/implementation/rtps/reader_locator.rs
+++ b/dds/src/implementation/rtps/reader_locator.rs
@@ -72,7 +72,7 @@ impl RtpsReaderLocator {
         self.unsent_changes.retain(|c| *c != next_seq_num);
 
         let cache_change = writer_cache
-            .changes()
+            .change_list()
             .iter()
             .find(|c| c.sequence_number() == next_seq_num);
 

--- a/dds/src/implementation/rtps/reader_locator.rs
+++ b/dds/src/implementation/rtps/reader_locator.rs
@@ -51,6 +51,10 @@ impl RtpsReaderLocator {
         }
     }
 
+    pub fn _locator(&self) -> Locator {
+        self.locator
+    }
+
     pub fn unsent_changes_mut(&mut self) -> &mut Vec<SequenceNumber> {
         &mut self.unsent_changes
     }

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -67,7 +67,7 @@ impl HeartbeatFragMachine {
             reader_id,
         }
     }
-    fn submessage<'a>(
+    pub fn submessage<'a>(
         &mut self,
         writer_id: EntityId,
         writer_sn: SequenceNumber,
@@ -350,6 +350,10 @@ impl<'a> WriterAssociatedReaderProxy<'a> {
 
     pub fn heartbeat_machine(&mut self) -> &mut HeartbeatMachine {
         &mut self.reader_proxy.heartbeat_machine
+    }
+
+    pub fn heartbeat_frag_machine(&mut self) -> &mut HeartbeatFragMachine {
+        &mut self.reader_proxy.heartbeat_frag_machine
     }
 
     // //////////////   ReaderProxy operations defined in the Rtps Standard

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -19,7 +19,8 @@ use super::{
         ChangeKind, Count, DurabilityKind, EntityId, Guid, GuidPrefix, Locator, ReliabilityKind,
         SequenceNumber,
     },
-    utils::clock::{StdTimer, Timer, TimerConstructor}, writer::RtpsWriter,
+    utils::clock::{StdTimer, Timer, TimerConstructor},
+    writer::RtpsWriter,
 };
 
 fn info_timestamp_submessage<'a>(timestamp: Time) -> RtpsSubmessageKind<'a> {
@@ -604,6 +605,18 @@ impl<'a> WriterAssociatedReaderProxy<'a> {
             writer,
             reader_proxy,
         }
+    }
+
+    pub fn remote_reader_guid(&self) -> Guid {
+        self.reader_proxy.remote_reader_guid()
+    }
+
+    pub fn unicast_locator_list(&self) -> &[Locator] {
+        self.reader_proxy.unicast_locator_list()
+    }
+
+    pub fn reliability(&self) -> ReliabilityKind {
+        self.reader_proxy.reliability
     }
 
     pub fn unsent_changes(&self) -> Vec<SequenceNumber> {

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -548,10 +548,6 @@ impl<'a> RtpsChangeForReaderCacheChange<'a> {
         self.cache_change
     }
 
-    pub fn _status(&self) -> ChangeForReaderStatusKind {
-        self.change_for_reader.status
-    }
-
     pub fn is_relevant(&self) -> bool {
         self.change_for_reader.is_relevant
     }

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -636,7 +636,7 @@ impl<'a> RtpsChangeForReaderCacheChange<'a> {
         writer_cache: &'a WriterHistoryCache,
     ) -> Self {
         let cache_change = writer_cache
-            .changes()
+            .change_list()
             .iter()
             .find(|cc| cc.sequence_number() == change_for_reader.sequence_number)
             .unwrap();

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -1,10 +1,7 @@
-use crate::infrastructure::{
-    instance::InstanceHandle,
-    time::{Duration, Time},
-};
+use crate::infrastructure::time::Duration;
 
 use super::{
-    history_cache::{RtpsParameter, RtpsWriterCacheChange, WriterHistoryCache},
+    history_cache::{RtpsWriterCacheChange, WriterHistoryCache},
     messages::{
         submessages::{
             AckNackSubmessage, HeartbeatFragSubmessage, HeartbeatSubmessage, NackFragSubmessage,
@@ -12,9 +9,7 @@ use super::{
         types::FragmentNumber,
         RtpsSubmessageKind,
     },
-    types::{
-        ChangeKind, Count, DurabilityKind, EntityId, Guid, Locator, ReliabilityKind, SequenceNumber,
-    },
+    types::{Count, DurabilityKind, EntityId, Guid, Locator, ReliabilityKind, SequenceNumber},
     utils::clock::{StdTimer, Timer, TimerConstructor},
     writer::RtpsWriter,
 };
@@ -357,7 +352,8 @@ impl<'a> WriterAssociatedReaderProxy<'a> {
         &mut self.reader_proxy.heartbeat_machine
     }
 
-    // ReaderProxy operations defined in the Rtps Standard
+    // //////////////   ReaderProxy operations defined in the Rtps Standard
+
     pub fn acked_changes_set(&mut self, committed_seq_num: SequenceNumber) {
         // "FOR_EACH change in this.changes_for_reader
         // SUCH-THAT (change.sequenceNumber <= committed_seq_num) DO
@@ -559,34 +555,6 @@ impl<'a> RtpsChangeForReaderCacheChange<'a> {
     pub fn is_relevant(&self) -> bool {
         self.change_for_reader.is_relevant
     }
-
-    pub fn _kind(&self) -> ChangeKind {
-        self.cache_change.kind()
-    }
-
-    pub fn _writer_guid(&self) -> Guid {
-        self.cache_change.writer_guid()
-    }
-
-    pub fn _instance_handle(&self) -> InstanceHandle {
-        self.cache_change._instance_handle()
-    }
-
-    pub fn _sequence_number(&self) -> SequenceNumber {
-        self.cache_change.sequence_number()
-    }
-
-    pub fn data_value(&self) -> &[u8] {
-        self.cache_change.data_value()
-    }
-
-    pub fn _inline_qos(&self) -> &[RtpsParameter] {
-        self.cache_change.inline_qos()
-    }
-
-    pub fn timestamp(&self) -> Time {
-        self.cache_change.timestamp()
-    }
 }
 
 #[cfg(test)]
@@ -596,7 +564,7 @@ mod tests {
     use crate::{
         implementation::rtps::{
             history_cache::RtpsWriterCacheChange,
-            types::{ENTITYID_UNKNOWN, GUID_UNKNOWN},
+            types::{ChangeKind, ENTITYID_UNKNOWN, GUID_UNKNOWN},
         },
         infrastructure::{instance::HANDLE_NIL, time::TIME_INVALID},
     };

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -616,6 +616,10 @@ impl RtpsChangeForReader {
         self.status
     }
 
+    pub fn set_status(&mut self, status: ChangeForReaderStatusKind) {
+        self.status = status;
+    }
+
     pub fn is_relevant(&self) -> bool {
         self.is_relevant
     }
@@ -686,8 +690,6 @@ impl<'a> RtpsChangeForReaderCacheChange<'a> {
         self.cache_change.timestamp()
     }
 }
-
-impl RtpsReaderProxy {}
 
 #[cfg(test)]
 mod tests {

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -64,7 +64,7 @@ impl RtpsStatefulWriter {
                 DurabilityKind::TransientLocal => true,
             };
 
-            for change in self.writer.writer_cache().changes() {
+            for change in self.writer.writer_cache().change_list() {
                 a_reader_proxy
                     .changes_for_reader_mut()
                     .push(RtpsChangeForReader::new(

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -107,12 +107,14 @@ impl<'a> WriterAssociatedReaderProxyIterator<'a> {
             matched_reader_iter,
         }
     }
-}
 
-impl<'a> Iterator for WriterAssociatedReaderProxyIterator<'a> {
-    type Item = WriterAssociatedReaderProxy<'a>;
+    pub fn get(&'a mut self, index: usize) -> Option<WriterAssociatedReaderProxy<'a>> {
+        self.matched_reader_iter
+            .nth(index)
+            .map(|x| WriterAssociatedReaderProxy::new(self.writer, x))
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
+    pub fn next(&'a mut self) -> Option<WriterAssociatedReaderProxy<'a>> {
         self.matched_reader_iter
             .next()
             .map(|x| WriterAssociatedReaderProxy::new(self.writer, x))
@@ -240,8 +242,8 @@ impl RtpsStatefulWriter {
             .retain(|x| x.remote_reader_guid() != a_reader_guid)
     }
 
-    pub fn matched_reader_list(&mut self) -> WriterAssociatedReaderProxyIterator {
-        WriterAssociatedReaderProxyIterator::new(&self.writer, self.matched_readers.iter_mut())
+    pub fn matched_reader_list(&mut self) -> (&RtpsWriter, &mut Vec<RtpsReaderProxy>) {
+        (&self.writer, &mut self.matched_readers)
     }
 
     pub fn is_acked_by_all(&self, a_change: &RtpsWriterCacheChange) -> bool {

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::{
-    history_cache::{RtpsParameter, RtpsWriterCacheChange, WriterHistoryCache},
+    history_cache::{RtpsParameter, RtpsWriterCacheChange},
     messages::{
         overall_structure::RtpsMessageHeader,
         submessages::{AckNackSubmessage, NackFragSubmessage},

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -1,3 +1,5 @@
+use std::slice::IterMut;
+
 use serde::Serialize;
 
 use crate::{
@@ -24,15 +26,98 @@ use super::{
         submessages::{AckNackSubmessage, NackFragSubmessage},
         types::ParameterId,
     },
-    reader_proxy::{ChangeForReaderStatusKind, RtpsChangeForReader, RtpsReaderProxy},
+    reader_proxy::{
+        ChangeForReaderStatusKind, RtpsChangeForReader, RtpsChangeForReaderCacheChange,
+        RtpsReaderProxy,
+    },
     transport::TransportWrite,
-    types::{ChangeKind, DurabilityKind, Guid, GuidPrefix, Locator},
+    types::{ChangeKind, DurabilityKind, Guid, GuidPrefix, Locator, SequenceNumber},
     writer::RtpsWriter,
 };
 
 pub const DEFAULT_HEARTBEAT_PERIOD: Duration = Duration::new(2, 0);
 pub const DEFAULT_NACK_RESPONSE_DELAY: Duration = Duration::new(0, 200);
 pub const DEFAULT_NACK_SUPPRESSION_DURATION: Duration = DURATION_ZERO;
+
+pub struct WriterAssociatedReaderProxy<'a> {
+    writer: &'a RtpsWriter,
+    reader_proxy: &'a mut RtpsReaderProxy,
+}
+
+impl<'a> WriterAssociatedReaderProxy<'a> {
+    pub fn new(writer: &'a RtpsWriter, reader_proxy: &'a mut RtpsReaderProxy) -> Self {
+        Self {
+            writer,
+            reader_proxy,
+        }
+    }
+
+    pub fn unsent_changes(&self) -> Vec<SequenceNumber> {
+        // "return change IN this.changes_for_reader SUCH-THAT (change.status == UNSENT);"
+        self.reader_proxy
+            .changes_for_reader()
+            .iter()
+            .filter_map(|cc| {
+                if cc.status() == ChangeForReaderStatusKind::Unsent {
+                    Some(cc.sequence_number())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub fn next_unsent_change(&mut self) -> RtpsChangeForReaderCacheChange<'a> {
+        // "next_seq_num := MIN { change.sequenceNumber
+        //     SUCH-THAT change IN this.unsent_changes() };
+        // return change IN this.unsent_changes()
+        //     SUCH-THAT (change.sequenceNumber == next_seq_num);"
+        let next_seq_num = self.unsent_changes().iter().min().cloned().unwrap();
+
+        let change = self
+            .reader_proxy
+            .changes_for_reader_mut()
+            .iter_mut()
+            .find(|c| c.sequence_number() == next_seq_num)
+            .unwrap();
+
+        // Following 8.4.9.1.4 Transition T14 of BestEffort Stateful Writer Behavior:
+        // a_change := the_reader_proxy.next_unsent_change();
+        // a_change.status := UNDERWAY;
+        // Note this is the only usage in the standard of next_unsent_change() as such
+        // the modification of the status is done always.
+        change.set_status(ChangeForReaderStatusKind::Underway);
+
+        // After ackNackSuppressionDuration = 0
+        change.set_status(ChangeForReaderStatusKind::Unacknowledged);
+
+        RtpsChangeForReaderCacheChange::new(change.clone(), self.writer.writer_cache())
+    }
+}
+
+pub struct WriterAssociatedReaderProxyIterator<'a> {
+    writer: &'a RtpsWriter,
+    matched_reader_iter: IterMut<'a, RtpsReaderProxy>,
+}
+
+impl<'a> WriterAssociatedReaderProxyIterator<'a> {
+    pub fn new(writer: &'a RtpsWriter, matched_reader_iter: IterMut<'a, RtpsReaderProxy>) -> Self {
+        Self {
+            writer,
+            matched_reader_iter,
+        }
+    }
+}
+
+impl<'a> Iterator for WriterAssociatedReaderProxyIterator<'a> {
+    type Item = WriterAssociatedReaderProxy<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.matched_reader_iter
+            .next()
+            .map(|x| WriterAssociatedReaderProxy::new(self.writer, x))
+    }
+}
 
 pub struct RtpsStatefulWriter {
     writer: RtpsWriter,
@@ -153,6 +238,10 @@ impl RtpsStatefulWriter {
     pub fn matched_reader_remove(&mut self, a_reader_guid: Guid) {
         self.matched_readers
             .retain(|x| x.remote_reader_guid() != a_reader_guid)
+    }
+
+    pub fn matched_reader_list(&mut self) -> WriterAssociatedReaderProxyIterator {
+        WriterAssociatedReaderProxyIterator::new(&self.writer, self.matched_readers.iter_mut())
     }
 
     pub fn is_acked_by_all(&self, a_change: &RtpsWriterCacheChange) -> bool {

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -201,8 +201,6 @@ impl RtpsStatefulWriter {
     where
         F: FnMut(&RtpsWriterCacheChange) -> bool,
     {
-        todo!();
-
         self.writer.remove_change(f)
     }
 
@@ -242,8 +240,12 @@ impl RtpsStatefulWriter {
             .retain(|x| x.remote_reader_guid() != a_reader_guid)
     }
 
-    pub fn matched_reader_list(&mut self) -> (&RtpsWriter, &mut Vec<RtpsReaderProxy>) {
-        (&self.writer, &mut self.matched_readers)
+    pub fn matched_reader_list(&mut self) -> Vec<WriterAssociatedReaderProxy> {
+        let writer = &self.writer;
+        self.matched_readers
+            .iter_mut()
+            .map(|x| WriterAssociatedReaderProxy::new(writer, x))
+            .collect()
     }
 
     pub fn is_acked_by_all(&self, a_change: &RtpsWriterCacheChange) -> bool {

--- a/dds/src/implementation/rtps/stateless_writer.rs
+++ b/dds/src/implementation/rtps/stateless_writer.rs
@@ -36,7 +36,7 @@ impl RtpsStatelessWriter {
         *a_locator.unsent_changes_mut() = self
             .writer
             .writer_cache()
-            .changes()
+            .change_list()
             .iter()
             .map(|c| c.sequence_number())
             .collect();

--- a/dds/src/implementation/rtps/stateless_writer.rs
+++ b/dds/src/implementation/rtps/stateless_writer.rs
@@ -13,14 +13,13 @@ use super::{
     messages::overall_structure::RtpsMessageHeader,
     reader_locator::RtpsReaderLocator,
     transport::TransportWrite,
-    types::{ChangeKind, Count, Guid, Locator},
+    types::{ChangeKind, Guid, Locator},
     writer::RtpsWriter,
 };
 
 pub struct RtpsStatelessWriter {
     writer: RtpsWriter,
     reader_locators: Vec<RtpsReaderLocator>,
-    _heartbeat_count: Count,
 }
 
 impl RtpsStatelessWriter {
@@ -28,35 +27,34 @@ impl RtpsStatelessWriter {
         Self {
             writer,
             reader_locators: Vec::new(),
-            _heartbeat_count: Count::new(0),
         }
     }
 
-    pub fn guid(&self) -> Guid {
+    pub fn _guid(&self) -> Guid {
         self.writer.guid()
     }
 
-    pub fn unicast_locator_list(&self) -> &[Locator] {
+    pub fn _unicast_locator_list(&self) -> &[Locator] {
         self.writer.unicast_locator_list()
     }
 
-    pub fn multicast_locator_list(&self) -> &[Locator] {
+    pub fn _multicast_locator_list(&self) -> &[Locator] {
         self.writer.multicast_locator_list()
     }
 
-    pub fn push_mode(&self) -> bool {
+    pub fn _push_mode(&self) -> bool {
         self.writer.push_mode()
     }
 
-    pub fn heartbeat_period(&self) -> Duration {
+    pub fn _heartbeat_period(&self) -> Duration {
         self.writer.heartbeat_period()
     }
 
-    pub fn data_max_size_serialized(&self) -> usize {
+    pub fn _data_max_size_serialized(&self) -> usize {
         self.writer.data_max_size_serialized()
     }
 
-    pub fn new_change(
+    pub fn _new_change(
         &mut self,
         kind: ChangeKind,
         data: Vec<u8>,
@@ -68,7 +66,7 @@ impl RtpsStatelessWriter {
             .new_change(kind, data, inline_qos, handle, timestamp)
     }
 
-    pub fn change_list(&self) -> &[RtpsWriterCacheChange] {
+    pub fn _change_list(&self) -> &[RtpsWriterCacheChange] {
         self.writer.change_list()
     }
 
@@ -81,12 +79,10 @@ impl RtpsStatelessWriter {
         self.writer.add_change(change);
     }
 
-    pub fn remove_change<F>(&mut self, f: F)
+    pub fn _remove_change<F>(&mut self, f: F)
     where
         F: FnMut(&RtpsWriterCacheChange) -> bool,
     {
-        todo!();
-
         self.writer.remove_change(f)
     }
 
@@ -100,8 +96,9 @@ impl RtpsStatelessWriter {
         self.reader_locators.push(a_locator);
     }
 
-    pub fn reader_locator_remove(&mut self, a_locator: Locator) {
-        todo!()
+    pub fn _reader_locator_remove(&mut self, a_locator: Locator) {
+        self.reader_locators
+            .retain(|l| !(l._locator() == a_locator))
     }
 
     pub fn write_w_timestamp(

--- a/dds/src/implementation/rtps/stateless_writer.rs
+++ b/dds/src/implementation/rtps/stateless_writer.rs
@@ -35,7 +35,6 @@ impl RtpsStatelessWriter {
     pub fn reader_locator_add(&mut self, mut a_locator: RtpsReaderLocator) {
         *a_locator.unsent_changes_mut() = self
             .writer
-            .writer_cache()
             .change_list()
             .iter()
             .map(|c| c.sequence_number())
@@ -49,7 +48,7 @@ impl RtpsStatelessWriter {
                 .unsent_changes_mut()
                 .push(change.sequence_number());
         }
-        self.writer.writer_cache_mut().add_change(change);
+        self.writer.add_change(change);
     }
 
     pub fn write_w_timestamp(

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -1,14 +1,6 @@
 use std::collections::HashMap;
 
-use serde::Serialize;
-
 use crate::{
-    implementation::data_representation_inline_qos::{
-        parameter_id_values::PID_STATUS_INFO,
-        types::{
-            STATUS_INFO_DISPOSED, STATUS_INFO_DISPOSED_UNREGISTERED, STATUS_INFO_UNREGISTERED,
-        },
-    },
     infrastructure::{
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
@@ -21,7 +13,6 @@ use crate::{
 use super::{
     endpoint::RtpsEndpoint,
     history_cache::{RtpsParameter, RtpsWriterCacheChange, WriterHistoryCache},
-    messages::types::ParameterId,
     types::{ChangeKind, Guid, Locator, SequenceNumber},
 };
 
@@ -82,6 +73,10 @@ impl RtpsWriter {
         self.heartbeat_period
     }
 
+    pub fn data_max_size_serialized(&self) -> usize {
+        self.data_max_size_serialized
+    }
+
     pub fn writer_cache(&self) -> &WriterHistoryCache {
         &self.writer_cache
     }
@@ -108,66 +103,6 @@ impl RtpsWriter {
             data,
             inline_qos,
         )
-    }
-
-    pub fn new_dispose_change(
-        &mut self,
-        instance_serialized_key: Vec<u8>,
-        handle: InstanceHandle,
-        timestamp: Time,
-    ) -> DdsResult<RtpsWriterCacheChange> {
-        let mut serialized_status_info = Vec::new();
-        let mut serializer =
-            cdr::Serializer::<_, cdr::LittleEndian>::new(&mut serialized_status_info);
-        STATUS_INFO_DISPOSED.serialize(&mut serializer).unwrap();
-
-        let inline_qos = vec![RtpsParameter::new(
-            ParameterId(PID_STATUS_INFO),
-            serialized_status_info,
-        )];
-
-        Ok(self.new_change(
-            ChangeKind::NotAliveDisposed,
-            instance_serialized_key,
-            inline_qos,
-            handle,
-            timestamp,
-        ))
-    }
-
-    pub fn new_unregister_change(
-        &mut self,
-        instance_serialized_key: Vec<u8>,
-        handle: InstanceHandle,
-        timestamp: Time,
-    ) -> DdsResult<RtpsWriterCacheChange> {
-        let mut serialized_status_info = Vec::new();
-        let mut serializer =
-            cdr::Serializer::<_, cdr::LittleEndian>::new(&mut serialized_status_info);
-        if self
-            .qos
-            .writer_data_lifecycle
-            .autodispose_unregistered_instances
-        {
-            STATUS_INFO_DISPOSED_UNREGISTERED
-                .serialize(&mut serializer)
-                .unwrap();
-        } else {
-            STATUS_INFO_UNREGISTERED.serialize(&mut serializer).unwrap();
-        }
-
-        let inline_qos = vec![RtpsParameter::new(
-            ParameterId(PID_STATUS_INFO),
-            serialized_status_info,
-        )];
-
-        Ok(self.new_change(
-            ChangeKind::NotAliveUnregistered,
-            instance_serialized_key,
-            inline_qos,
-            handle,
-            timestamp,
-        ))
     }
 
     pub fn get_qos(&self) -> &DataWriterQos {
@@ -212,10 +147,6 @@ impl RtpsWriter {
         } else {
             None
         }
-    }
-
-    pub fn data_max_size_serialized(&self) -> usize {
-        self.data_max_size_serialized
     }
 
     pub fn remove_stale_changes(&mut self, now: Time) {

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     infrastructure::{
         error::{DdsError, DdsResult},
-        instance::{InstanceHandle, HANDLE_NIL},
+        instance::InstanceHandle,
         qos::DataWriterQos,
         time::{Duration, DurationKind, Time},
     },
@@ -90,25 +90,24 @@ impl RtpsWriter {
         &mut self.writer_cache
     }
 
-    pub fn new_write_change(
+    pub fn new_change(
         &mut self,
-        serialized_data: Vec<u8>,
-        instance_serialized_key: DdsSerializedKey,
-        _handle: Option<InstanceHandle>,
+        kind: ChangeKind,
+        data: Vec<u8>,
+        inline_qos: Vec<RtpsParameter>,
+        handle: InstanceHandle,
         timestamp: Time,
-    ) -> DdsResult<RtpsWriterCacheChange> {
-        let handle = self
-            .register_instance_w_timestamp(instance_serialized_key, timestamp)?
-            .unwrap_or(HANDLE_NIL);
-        let change = self.new_change(
-            ChangeKind::Alive,
-            serialized_data,
-            vec![],
+    ) -> RtpsWriterCacheChange {
+        self.last_change_sequence_number += 1;
+        RtpsWriterCacheChange::new(
+            kind,
+            self.guid(),
             handle,
+            self.last_change_sequence_number,
             timestamp,
-        );
-
-        Ok(change)
+            data,
+            inline_qos,
+        )
     }
 
     pub fn new_dispose_change(
@@ -169,26 +168,6 @@ impl RtpsWriter {
             handle,
             timestamp,
         ))
-    }
-
-    fn new_change(
-        &mut self,
-        kind: ChangeKind,
-        data: Vec<u8>,
-        inline_qos: Vec<RtpsParameter>,
-        handle: InstanceHandle,
-        timestamp: Time,
-    ) -> RtpsWriterCacheChange {
-        self.last_change_sequence_number += 1;
-        RtpsWriterCacheChange::new(
-            kind,
-            self.guid(),
-            handle,
-            self.last_change_sequence_number,
-            timestamp,
-            data,
-            inline_qos,
-        )
     }
 
     pub fn get_qos(&self) -> &DataWriterQos {

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -601,7 +601,7 @@ fn get_discovery_data_from_builtin_reader() {
     wait_set
         .attach_condition(Condition::StatusCondition(topics_reader_cond))
         .unwrap();
-    wait_set.wait(Duration::new(4, 0)).unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 
     let topic_samples = topics_reader
         .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
@@ -615,7 +615,7 @@ fn get_discovery_data_from_builtin_reader() {
     wait_set
         .attach_condition(Condition::StatusCondition(subscriptions_reader_cond))
         .unwrap();
-    wait_set.wait(Duration::new(4, 0)).unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 
     let subscription_samples = subscriptions_reader
         .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
@@ -629,7 +629,7 @@ fn get_discovery_data_from_builtin_reader() {
     wait_set
         .attach_condition(Condition::StatusCondition(publications_reader_cond))
         .unwrap();
-    wait_set.wait(Duration::new(100, 0)).unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 
     let publication_samples = publications_reader
         .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)


### PR DESCRIPTION
This refactor makes the message sending on the stateful writer become an external behavior rather than a member function of a class. This is a step to reduce the scope of the locks and reduce the chances of getting into deadlock situations.