### PR TITLE
DDS-322 Use static type for reader operations

### DIFF
--- a/dds/src/dds/domain/dcps_service.rs
+++ b/dds/src/dds/domain/dcps_service.rs
@@ -877,7 +877,7 @@ fn discover_matched_writers(domain_participant: &DdsDomainParticipant) -> DdsRes
                                 h == &InstanceHandle::from(writer_parent_participant_guid)
                             })
                         {
-                            for subscriber in &domain_participant.user_defined_subscriber_list() {
+                            for subscriber in domain_participant.user_defined_subscriber_list() {
                                 subscriber_add_matched_writer(
                                     subscriber,
                                     &discovered_writer_data,
@@ -895,8 +895,8 @@ fn discover_matched_writers(domain_participant: &DdsDomainParticipant) -> DdsRes
                 }
             }
             InstanceStateKind::NotAliveDisposed => {
-                for subscriber in &domain_participant.user_defined_subscriber_list() {
-                    for data_reader in &subscriber.stateful_data_reader_list() {
+                for subscriber in domain_participant.user_defined_subscriber_list() {
+                    for data_reader in subscriber.stateful_data_reader_list() {
                         data_reader.remove_matched_writer(
                             discovered_writer_data_sample.sample_info.instance_handle,
                             &mut subscriber.get_status_listener_lock(),
@@ -955,7 +955,7 @@ pub fn subscriber_add_matched_writer(
         || is_subscriber_regex_matched_to_discovered_writer
         || is_partition_string_matched
     {
-        for data_reader in &user_defined_subscriber.stateful_data_reader_list() {
+        for data_reader in user_defined_subscriber.stateful_data_reader_list() {
             data_reader.add_matched_writer(
                 discovered_writer_data,
                 default_unicast_locator_list,
@@ -1445,8 +1445,8 @@ fn user_defined_communication_send(
         }
     }
 
-    for subscriber in &domain_participant.user_defined_subscriber_list() {
-        for data_reader in &subscriber.stateful_data_reader_list() {
+    for subscriber in domain_participant.user_defined_subscriber_list() {
+        for data_reader in subscriber.stateful_data_reader_list() {
             data_reader.send_message(header, default_unicast_transport_send)
         }
     }

--- a/dds/src/dds/domain/dcps_service.rs
+++ b/dds/src/dds/domain/dcps_service.rs
@@ -842,7 +842,7 @@ fn discover_matched_writers(domain_participant: &DdsDomainParticipant) -> DdsRes
     let samples = domain_participant
         .get_builtin_subscriber()
         .stateful_data_reader_list()
-        .into_iter()
+        .iter()
         .find(|x| x.get_topic_name() == DCPS_PUBLICATION)
         .unwrap()
         .read::<DiscoveredWriterData>(
@@ -975,7 +975,7 @@ fn discover_matched_participants(
     let spdp_builtin_participant_data_reader = domain_participant
         .get_builtin_subscriber()
         .stateless_data_reader_list()
-        .into_iter()
+        .iter()
         .find(|x| x.get_topic_name() == DCPS_PARTICIPANT)
         .unwrap()
         .clone();
@@ -1025,7 +1025,7 @@ fn add_discovered_participant(
             domain_participant
                 .get_builtin_subscriber()
                 .stateful_data_reader_list()
-                .into_iter()
+                .iter()
                 .find(|x| x.get_topic_name() == DCPS_PUBLICATION)
                 .unwrap(),
             &discovered_participant_data,
@@ -1045,7 +1045,7 @@ fn add_discovered_participant(
             domain_participant
                 .get_builtin_subscriber()
                 .stateful_data_reader_list()
-                .into_iter()
+                .iter()
                 .find(|x| x.get_topic_name() == DCPS_SUBSCRIPTION)
                 .unwrap(),
             &discovered_participant_data,
@@ -1065,7 +1065,7 @@ fn add_discovered_participant(
             domain_participant
                 .get_builtin_subscriber()
                 .stateful_data_reader_list()
-                .into_iter()
+                .iter()
                 .find(|x| x.get_topic_name() == DCPS_TOPIC)
                 .unwrap(),
             &discovered_participant_data,
@@ -1293,7 +1293,7 @@ fn receive_builtin_message(
         .process_message(
             domain_participant.guid().prefix(),
             core::slice::from_ref(domain_participant.get_builtin_publisher()),
-            core::slice::from_ref(&domain_participant.get_builtin_subscriber()),
+            core::slice::from_ref(domain_participant.get_builtin_subscriber()),
             locator,
             &message,
             &mut domain_participant.get_status_listener_lock(),
@@ -1365,7 +1365,6 @@ fn send_user_defined_message(
     for stateful_readers in domain_participant
         .get_builtin_subscriber()
         .stateful_data_reader_list()
-        .into_iter()
     {
         stateful_readers.send_message(header, metatraffic_unicast_transport_send)
     }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -100,7 +100,7 @@ impl DomainParticipant {
         a_listener: Option<Box<dyn SubscriberListener + Send + Sync>>,
         mask: &[StatusKind],
     ) -> DdsResult<Subscriber> {
-        self.call_participant_method(|dp| {
+        self.call_participant_mut_method(|dp| {
             Ok(Subscriber::new(SubscriberNodeKind::UserDefined(
                 self.0.create_subscriber(dp, qos, a_listener, mask)?,
             )))
@@ -114,7 +114,7 @@ impl DomainParticipant {
     /// it is called on a different [`DomainParticipant`], the operation will have no effect and it will return
     /// [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError).
     pub fn delete_subscriber(&self, a_subscriber: &Subscriber) -> DdsResult<()> {
-        self.call_participant_method(|dp| {
+        self.call_participant_mut_method(|dp| {
             self.0
                 .delete_subscriber(dp, a_subscriber.get_instance_handle()?)?;
             Ok(())

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -115,8 +115,12 @@ impl DomainParticipant {
     /// [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError).
     pub fn delete_subscriber(&self, a_subscriber: &Subscriber) -> DdsResult<()> {
         self.call_participant_mut_method(|dp| {
-            self.0
-                .delete_subscriber(dp, a_subscriber.get_instance_handle()?)?;
+            match &a_subscriber.0 {
+                SubscriberNodeKind::Builtin(_) => todo!(),
+                SubscriberNodeKind::UserDefined(s) => self.0.delete_subscriber(dp, s.guid()?)?,
+                SubscriberNodeKind::Listener(_) => todo!(),
+            }
+
             Ok(())
         })
     }

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -303,7 +303,7 @@ impl DomainParticipantFactory {
             |dp| {
                 let dp = dp.ok_or(DdsError::AlreadyDeleted)?;
                 Ok(dp.user_defined_publisher_list().iter().count() == 0
-                    && dp.user_defined_subscriber_list().into_iter().count() == 0
+                    && dp.user_defined_subscriber_list().iter().count() == 0
                     && dp.topic_list().iter().count() == 0)
             },
         )?;

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -125,13 +125,17 @@ where
                 instance_states,
                 None,
             ),
-            DataReaderNodeKind::UserDefined(r) => r.read(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                None,
-            ),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                        None,
+                    )
+                }),
             DataReaderNodeKind::Listener(r) => r.read(
                 max_samples,
                 sample_states,
@@ -155,13 +159,17 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
             DataReaderNodeKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
-            DataReaderNodeKind::UserDefined(r) => r.take(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                None,
-            ),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.take(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                        None,
+                    )
+                }),
             DataReaderNodeKind::Listener(r) => r.take(
                 max_samples,
                 sample_states,
@@ -195,13 +203,17 @@ where
                 ANY_INSTANCE_STATE,
                 None,
             )?,
-            DataReaderNodeKind::UserDefined(r) => r.read(
-                1,
-                &[SampleStateKind::NotRead],
-                ANY_VIEW_STATE,
-                ANY_INSTANCE_STATE,
-                None,
-            )?,
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        1,
+                        &[SampleStateKind::NotRead],
+                        ANY_VIEW_STATE,
+                        ANY_INSTANCE_STATE,
+                        None,
+                    )
+                })?,
             DataReaderNodeKind::Listener(r) => r.read(
                 1,
                 &[SampleStateKind::NotRead],
@@ -225,12 +237,18 @@ where
             DataReaderNodeKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
             DataReaderNodeKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
             DataReaderNodeKind::UserDefined(r) => {
-                let mut samples = r.take(
-                    1,
-                    &[SampleStateKind::NotRead],
-                    ANY_VIEW_STATE,
-                    ANY_INSTANCE_STATE,
-                    None,
+                let mut samples = THE_DDS_DOMAIN_PARTICIPANT_FACTORY.get_participant(
+                    &r.guid()?.prefix(),
+                    |dp| {
+                        r.take(
+                            dp.ok_or(DdsError::AlreadyDeleted)?,
+                            1,
+                            &[SampleStateKind::NotRead],
+                            ANY_VIEW_STATE,
+                            ANY_INSTANCE_STATE,
+                            None,
+                        )
+                    },
                 )?;
                 Ok(samples.pop().unwrap())
             }
@@ -278,13 +296,17 @@ where
                 instance_states,
                 Some(a_handle),
             ),
-            DataReaderNodeKind::UserDefined(r) => r.read(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                Some(a_handle),
-            ),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                        Some(a_handle),
+                    )
+                }),
             DataReaderNodeKind::Listener(r) => r.read(
                 max_samples,
                 sample_states,
@@ -314,13 +336,17 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
             DataReaderNodeKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
-            DataReaderNodeKind::UserDefined(r) => r.take(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                Some(a_handle),
-            ),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.take(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                        Some(a_handle),
+                    )
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -371,13 +397,17 @@ where
                 view_states,
                 instance_states,
             ),
-            DataReaderNodeKind::UserDefined(r) => r.read_next_instance(
-                max_samples,
-                previous_handle,
-                sample_states,
-                view_states,
-                instance_states,
-            ),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read_next_instance(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        previous_handle,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                    )
+                }),
             DataReaderNodeKind::Listener(r) => r.read_next_instance(
                 max_samples,
                 previous_handle,
@@ -402,13 +432,17 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => Err(DdsError::IllegalOperation),
             DataReaderNodeKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
-            DataReaderNodeKind::UserDefined(r) => r.take_next_instance(
-                max_samples,
-                previous_handle,
-                sample_states,
-                view_states,
-                instance_states,
-            ),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.take_next_instance(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        previous_handle,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                    )
+                }),
             DataReaderNodeKind::Listener(r) => r.take_next_instance(
                 max_samples,
                 previous_handle,
@@ -427,7 +461,10 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => todo!(),
-            DataReaderNodeKind::UserDefined(r) => r.get_key_value(key_holder, handle),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_key_value(dp.ok_or(DdsError::AlreadyDeleted)?, key_holder, handle)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -442,7 +479,10 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => todo!(),
-            DataReaderNodeKind::UserDefined(r) => r.lookup_instance(instance),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.lookup_instance(dp.ok_or(DdsError::AlreadyDeleted)?, instance)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -452,7 +492,10 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => todo!(),
-            DataReaderNodeKind::UserDefined(r) => r.get_liveliness_changed_status(),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_liveliness_changed_status(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -462,7 +505,10 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => todo!(),
-            DataReaderNodeKind::UserDefined(r) => r.get_requested_deadline_missed_status(),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_requested_deadline_missed_status(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -474,7 +520,10 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => todo!(),
-            DataReaderNodeKind::UserDefined(r) => r.get_requested_incompatible_qos_status(),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_requested_incompatible_qos_status(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -484,7 +533,10 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => todo!(),
-            DataReaderNodeKind::UserDefined(r) => r.get_sample_lost_status(),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_sample_lost_status(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -494,7 +546,10 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => todo!(),
-            DataReaderNodeKind::UserDefined(r) => r.get_sample_rejected_status(),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_sample_rejected_status(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -504,7 +559,10 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => todo!(),
-            DataReaderNodeKind::UserDefined(r) => r.get_subscription_matched_status(),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_subscription_matched_status(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -573,9 +631,13 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
-            DataReaderNodeKind::UserDefined(r) => {
-                r.get_matched_publication_data(publication_handle)
-            }
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_matched_publication_data(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        publication_handle,
+                    )
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -590,7 +652,10 @@ where
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => Err(DdsError::IllegalOperation),
-            DataReaderNodeKind::UserDefined(r) => r.get_matched_publications(),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_matched_publications(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }
@@ -627,7 +692,10 @@ impl<Foo> DataReader<Foo> {
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(r) => r.get_qos(),
             DataReaderNodeKind::BuiltinStateful(r) => r.get_qos(),
-            DataReaderNodeKind::UserDefined(r) => r.get_qos(),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_qos(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
             // DataReaderKind::BuiltinStateless(x) => x.upgrade()?.get_qos(),
             // DataReaderKind::BuiltinStateful(x) => x.upgrade()?.get_qos(),
@@ -646,9 +714,12 @@ impl<Foo> DataReader<Foo> {
             DataReaderNodeKind::BuiltinStateful(r) => {
                 Ok(StatusCondition::new(r.get_statuscondition()?))
             }
-            DataReaderNodeKind::UserDefined(r) => {
-                Ok(StatusCondition::new(r.get_statuscondition()?))
-            }
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    Ok(StatusCondition::new(r.get_statuscondition(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                    )?))
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
             // DataReaderKind::BuiltinStateless(x) => {
             //     StatusCondition::new(x.upgrade()?.get_statuscondition())
@@ -669,7 +740,10 @@ impl<Foo> DataReader<Foo> {
         match &self.0 {
             DataReaderNodeKind::BuiltinStateless(_) => todo!(),
             DataReaderNodeKind::BuiltinStateful(_) => todo!(),
-            DataReaderNodeKind::UserDefined(r) => r.get_status_changes(),
+            DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_status_changes(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::Listener(_) => todo!(),
         }
     }

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -111,20 +111,28 @@ where
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
         match &self.0 {
-            DataReaderNodeKind::BuiltinStateless(r) => r.read(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                None,
-            ),
-            DataReaderNodeKind::BuiltinStateful(r) => r.read(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                None,
-            ),
+            DataReaderNodeKind::BuiltinStateless(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                        None,
+                    )
+                }),
+            DataReaderNodeKind::BuiltinStateful(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                        None,
+                    )
+                }),
             DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
                 .get_participant(&r.guid()?.prefix(), |dp| {
                     r.read(
@@ -189,20 +197,28 @@ where
     /// sequences and specify states.
     pub fn read_next_sample(&self) -> DdsResult<Sample<Foo>> {
         let mut samples = match &self.0 {
-            DataReaderNodeKind::BuiltinStateless(r) => r.read(
-                1,
-                &[SampleStateKind::NotRead],
-                ANY_VIEW_STATE,
-                ANY_INSTANCE_STATE,
-                None,
-            )?,
-            DataReaderNodeKind::BuiltinStateful(r) => r.read(
-                1,
-                &[SampleStateKind::NotRead],
-                ANY_VIEW_STATE,
-                ANY_INSTANCE_STATE,
-                None,
-            )?,
+            DataReaderNodeKind::BuiltinStateless(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        1,
+                        &[SampleStateKind::NotRead],
+                        ANY_VIEW_STATE,
+                        ANY_INSTANCE_STATE,
+                        None,
+                    )
+                })?,
+            DataReaderNodeKind::BuiltinStateful(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        1,
+                        &[SampleStateKind::NotRead],
+                        ANY_VIEW_STATE,
+                        ANY_INSTANCE_STATE,
+                        None,
+                    )
+                })?,
             DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
                 .get_participant(&r.guid()?.prefix(), |dp| {
                     r.read(
@@ -282,20 +298,28 @@ where
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
         match &self.0 {
-            DataReaderNodeKind::BuiltinStateless(r) => r.read(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                Some(a_handle),
-            ),
-            DataReaderNodeKind::BuiltinStateful(r) => r.read(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                Some(a_handle),
-            ),
+            DataReaderNodeKind::BuiltinStateless(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                        Some(a_handle),
+                    )
+                }),
+            DataReaderNodeKind::BuiltinStateful(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                        Some(a_handle),
+                    )
+                }),
             DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
                 .get_participant(&r.guid()?.prefix(), |dp| {
                     r.read(
@@ -383,20 +407,28 @@ where
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
         match &self.0 {
-            DataReaderNodeKind::BuiltinStateless(r) => r.read_next_instance(
-                max_samples,
-                previous_handle,
-                sample_states,
-                view_states,
-                instance_states,
-            ),
-            DataReaderNodeKind::BuiltinStateful(r) => r.read_next_instance(
-                max_samples,
-                previous_handle,
-                sample_states,
-                view_states,
-                instance_states,
-            ),
+            DataReaderNodeKind::BuiltinStateless(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read_next_instance(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        previous_handle,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                    )
+                }),
+            DataReaderNodeKind::BuiltinStateful(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.read_next_instance(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        max_samples,
+                        previous_handle,
+                        sample_states,
+                        view_states,
+                        instance_states,
+                    )
+                }),
             DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
                 .get_participant(&r.guid()?.prefix(), |dp| {
                     r.read_next_instance(
@@ -690,8 +722,14 @@ impl<Foo> DataReader<Foo> {
     /// This operation allows access to the existing set of [`DataReaderQos`] policies.
     pub fn get_qos(&self) -> DdsResult<DataReaderQos> {
         match &self.0 {
-            DataReaderNodeKind::BuiltinStateless(r) => r.get_qos(),
-            DataReaderNodeKind::BuiltinStateful(r) => r.get_qos(),
+            DataReaderNodeKind::BuiltinStateless(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_qos(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
+            DataReaderNodeKind::BuiltinStateful(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    r.get_qos(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
                 .get_participant(&r.guid()?.prefix(), |dp| {
                     r.get_qos(dp.ok_or(DdsError::AlreadyDeleted)?)
@@ -708,12 +746,18 @@ impl<Foo> DataReader<Foo> {
     /// that affect the Entity.
     pub fn get_statuscondition(&self) -> DdsResult<StatusCondition> {
         match &self.0 {
-            DataReaderNodeKind::BuiltinStateless(r) => {
-                Ok(StatusCondition::new(r.get_statuscondition()?))
-            }
-            DataReaderNodeKind::BuiltinStateful(r) => {
-                Ok(StatusCondition::new(r.get_statuscondition()?))
-            }
+            DataReaderNodeKind::BuiltinStateless(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    Ok(StatusCondition::new(r.get_statuscondition(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                    )?))
+                }),
+            DataReaderNodeKind::BuiltinStateful(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&r.guid()?.prefix(), |dp| {
+                    Ok(StatusCondition::new(r.get_statuscondition(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                    )?))
+                }),
             DataReaderNodeKind::UserDefined(r) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
                 .get_participant(&r.guid()?.prefix(), |dp| {
                     Ok(StatusCondition::new(r.get_statuscondition(

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -100,7 +100,7 @@ impl Subscriber {
         match &self.0 {
             SubscriberNodeKind::Builtin(_) => Err(DdsError::IllegalOperation),
             SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
-                .get_participant(&s.guid()?.prefix(), |dp| {
+                .get_participant_mut(&s.guid()?.prefix(), |dp| {
                     s.delete_datareader(
                         dp.ok_or(DdsError::AlreadyDeleted)?,
                         a_datareader.get_instance_handle()?,
@@ -123,9 +123,15 @@ impl Subscriber {
             SubscriberNodeKind::Builtin(s) => Ok(s
                 .lookup_datareader::<Foo>(topic_name)?
                 .map(|x| DataReader::new(x))),
-            SubscriberNodeKind::UserDefined(s) => Ok(s
-                .lookup_datareader(Foo::type_name(), topic_name)?
-                .map(|x| DataReader::new(DataReaderNodeKind::UserDefined(x)))),
+            SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&s.guid()?.prefix(), |dp| {
+                    Ok(s.lookup_datareader(
+                        dp.ok_or(DdsError::AlreadyDeleted)?,
+                        Foo::type_name(),
+                        topic_name,
+                    )?
+                    .map(|x| DataReader::new(DataReaderNodeKind::UserDefined(x))))
+                }),
             SubscriberNodeKind::Listener(_) => todo!(),
         }
     }
@@ -186,7 +192,10 @@ impl Subscriber {
     pub fn set_default_datareader_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
         match &self.0 {
             SubscriberNodeKind::Builtin(_) => Err(DdsError::IllegalOperation),
-            SubscriberNodeKind::UserDefined(s) => s.set_default_datareader_qos(qos),
+            SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&s.guid()?.prefix(), |dp| {
+                    s.set_default_datareader_qos(dp.ok_or(DdsError::AlreadyDeleted)?, qos)
+                }),
             SubscriberNodeKind::Listener(_) => todo!(),
         }
     }
@@ -198,7 +207,10 @@ impl Subscriber {
     pub fn get_default_datareader_qos(&self) -> DdsResult<DataReaderQos> {
         match &self.0 {
             SubscriberNodeKind::Builtin(_) => Err(DdsError::IllegalOperation),
-            SubscriberNodeKind::UserDefined(s) => s.get_default_datareader_qos(),
+            SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&s.guid()?.prefix(), |dp| {
+                    s.get_default_datareader_qos(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             SubscriberNodeKind::Listener(_) => todo!(),
         }
     }
@@ -231,7 +243,10 @@ impl Subscriber {
     pub fn set_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
         match &self.0 {
             SubscriberNodeKind::Builtin(_) => Err(DdsError::IllegalOperation),
-            SubscriberNodeKind::UserDefined(s) => s.set_qos(qos),
+            SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&s.guid()?.prefix(), |dp| {
+                    s.set_qos(dp.ok_or(DdsError::AlreadyDeleted)?, qos)
+                }),
             SubscriberNodeKind::Listener(_) => todo!(),
         }
     }
@@ -240,7 +255,10 @@ impl Subscriber {
     pub fn get_qos(&self) -> DdsResult<SubscriberQos> {
         match &self.0 {
             SubscriberNodeKind::Builtin(s) => s.get_qos(),
-            SubscriberNodeKind::UserDefined(s) => s.get_qos(),
+            SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&s.guid()?.prefix(), |dp| {
+                    s.get_qos(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             SubscriberNodeKind::Listener(_) => todo!(),
         }
     }
@@ -269,7 +287,10 @@ impl Subscriber {
     pub fn get_statuscondition(&self) -> DdsResult<StatusCondition> {
         match &self.0 {
             SubscriberNodeKind::Builtin(s) => s.get_statuscondition(),
-            SubscriberNodeKind::UserDefined(s) => s.get_statuscondition(),
+            SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&s.guid()?.prefix(), |dp| {
+                    s.get_statuscondition(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             SubscriberNodeKind::Listener(_) => todo!(),
         }
     }
@@ -283,7 +304,10 @@ impl Subscriber {
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         match &self.0 {
             SubscriberNodeKind::Builtin(s) => s.get_status_changes(),
-            SubscriberNodeKind::UserDefined(s) => s.get_status_changes(),
+            SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
+                .get_participant(&s.guid()?.prefix(), |dp| {
+                    s.get_status_changes(dp.ok_or(DdsError::AlreadyDeleted)?)
+                }),
             SubscriberNodeKind::Listener(_) => todo!(),
         }
     }

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -176,7 +176,7 @@ impl Subscriber {
         match &self.0 {
             SubscriberNodeKind::Builtin(_) => Err(DdsError::IllegalOperation),
             SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
-                .get_participant(&s.guid()?.prefix(), |dp| {
+                .get_participant_mut(&s.guid()?.prefix(), |dp| {
                     s.delete_contained_entities(dp.ok_or(DdsError::AlreadyDeleted)?)
                 }),
             SubscriberNodeKind::Listener(_) => Err(DdsError::IllegalOperation),

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -31,7 +31,7 @@ use super::{
 /// A [`Subscriber`] acts on the behalf of one or several [`DataReader`] objects that are related to it. When it receives data (from the
 /// other parts of the system), it builds the list of concerned [`DataReader`] objects, and then indicates to the application that data is
 /// available, through its listener or by enabling related conditions.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Subscriber(pub(crate) SubscriberNodeKind);
 
 impl Subscriber {

--- a/dds/src/implementation/dds_impl/dds_domain_participant.rs
+++ b/dds/src/implementation/dds_impl/dds_domain_participant.rs
@@ -515,12 +515,12 @@ impl DdsDomainParticipant {
         );
         let guid = Guid::new(self.rtps_participant.guid().prefix(), entity_id);
         let rtps_group = RtpsGroup::new(guid);
-        let publisher_impl_shared = DdsPublisher::new(publisher_qos, rtps_group, a_listener, mask);
+        let publisher = DdsPublisher::new(publisher_qos, rtps_group, a_listener, mask);
         if self.is_enabled() && self.get_qos().entity_factory.autoenable_created_entities {
-            publisher_impl_shared.enable();
+            publisher.enable();
         }
 
-        self.user_defined_publisher_list.push(publisher_impl_shared);
+        self.user_defined_publisher_list.push(publisher);
 
         Ok(guid)
     }

--- a/dds/src/implementation/dds_impl/dds_domain_participant.rs
+++ b/dds/src/implementation/dds_impl/dds_domain_participant.rs
@@ -611,11 +611,11 @@ impl DdsDomainParticipant {
 
         if self
             .user_defined_subscriber_list()
-            .into_iter()
+            .iter()
             .find(|&x| x.guid() == subscriber_guid)
             .ok_or(DdsError::AlreadyDeleted)?
             .stateful_data_reader_list()
-            .into_iter()
+            .iter()
             .count()
             > 0
         {
@@ -715,7 +715,7 @@ impl DdsDomainParticipant {
         }
 
         for subscriber in self.user_defined_subscriber_list() {
-            if subscriber.stateful_data_reader_list().into_iter().any(|r| {
+            if subscriber.stateful_data_reader_list().iter().any(|r| {
                 r.get_type_name() == topic.get_type_name() && r.get_topic_name() == topic.get_name()
             }) {
                 return Err(DdsError::PreconditionNotMet(
@@ -853,10 +853,7 @@ impl DdsDomainParticipant {
         }
 
         for mut user_defined_subscriber in self.user_defined_subscriber_list.drain(..) {
-            for data_reader in user_defined_subscriber
-                .stateful_data_reader_drain()
-                .into_iter()
-            {
+            for data_reader in user_defined_subscriber.stateful_data_reader_drain() {
                 if data_reader.is_enabled() {
                     self.announce_sender
                         .send(AnnounceKind::DeletedDataReader(
@@ -1108,7 +1105,7 @@ impl DdsDomainParticipant {
         let samples = self
             .get_builtin_subscriber()
             .stateful_data_reader_list()
-            .into_iter()
+            .iter()
             .find(|x| x.get_topic_name() == DCPS_SUBSCRIPTION)
             .unwrap()
             .read::<DiscoveredReaderData>(
@@ -1223,7 +1220,7 @@ impl DdsDomainParticipant {
         while let Ok(samples) = self
             .get_builtin_subscriber()
             .stateful_data_reader_list()
-            .into_iter()
+            .iter()
             .find(|x| x.get_topic_name() == DCPS_TOPIC)
             .unwrap()
             .read::<DiscoveredTopicData>(

--- a/dds/src/implementation/dds_impl/dds_subscriber.rs
+++ b/dds/src/implementation/dds_impl/dds_subscriber.rs
@@ -30,7 +30,7 @@ use crate::{
 
 use super::{
     dds_data_reader::{DdsDataReader, UserDefinedReaderDataSubmessageReceivedResult},
-    message_receiver::{MessageReceiver, SubscriberSubmessageReceiver},
+    message_receiver::MessageReceiver,
     node_kind::SubscriberNodeKind,
     node_listener_subscriber::ListenerSubscriberNode,
     status_condition_impl::StatusConditionImpl,
@@ -56,8 +56,8 @@ impl DdsSubscriber {
         rtps_group: RtpsGroup,
         listener: Option<Box<dyn SubscriberListener + Send + Sync>>,
         mask: &[StatusKind],
-    ) -> DdsShared<Self> {
-        DdsShared::new(DdsSubscriber {
+    ) -> Self {
+        DdsSubscriber {
             qos: DdsRwLock::new(qos),
             rtps_group,
             stateless_data_reader_list: DdsRwLock::new(Vec::new()),
@@ -68,7 +68,7 @@ impl DdsSubscriber {
             status_listener: DdsRwLock::new(StatusListener::new(listener, mask)),
             user_defined_data_reader_counter: DdsRwLock::new(0),
             default_data_reader_qos: DdsRwLock::new(Default::default()),
-        })
+        }
     }
 
     pub fn guid(&self) -> Guid {
@@ -177,9 +177,7 @@ impl DdsSubscriber {
     pub fn get_default_datareader_qos(&self) -> DataReaderQos {
         self.default_data_reader_qos.read_lock().clone()
     }
-}
 
-impl DdsShared<DdsSubscriber> {
     pub fn update_communication_status(
         &self,
         now: Time,
@@ -287,10 +285,8 @@ impl DdsShared<DdsSubscriber> {
             }
         }
     }
-}
 
-impl SubscriberSubmessageReceiver for DdsShared<DdsSubscriber> {
-    fn on_heartbeat_submessage_received(
+    pub fn on_heartbeat_submessage_received(
         &self,
         heartbeat_submessage: &HeartbeatSubmessage,
         source_guid_prefix: GuidPrefix,
@@ -300,7 +296,7 @@ impl SubscriberSubmessageReceiver for DdsShared<DdsSubscriber> {
         }
     }
 
-    fn on_heartbeat_frag_submessage_received(
+    pub fn on_heartbeat_frag_submessage_received(
         &self,
         heartbeat_frag_submessage: &HeartbeatFragSubmessage,
         source_guid_prefix: GuidPrefix,
@@ -313,7 +309,7 @@ impl SubscriberSubmessageReceiver for DdsShared<DdsSubscriber> {
         }
     }
 
-    fn on_data_submessage_received(
+    pub fn on_data_submessage_received(
         &self,
         data_submessage: &DataSubmessage<'_>,
         message_receiver: &MessageReceiver,
@@ -344,7 +340,7 @@ impl SubscriberSubmessageReceiver for DdsShared<DdsSubscriber> {
         }
     }
 
-    fn on_data_frag_submessage_received(
+    pub fn on_data_frag_submessage_received(
         &self,
         data_frag_submessage: &DataFragSubmessage<'_>,
         message_receiver: &MessageReceiver,
@@ -371,7 +367,7 @@ impl SubscriberSubmessageReceiver for DdsShared<DdsSubscriber> {
         }
     }
 
-    fn on_gap_submessage_received(
+    pub fn on_gap_submessage_received(
         &self,
         gap_submessage: &GapSubmessage,
         message_receiver: &MessageReceiver,

--- a/dds/src/implementation/dds_impl/node_builtin_data_reader_stateful.rs
+++ b/dds/src/implementation/dds_impl/node_builtin_data_reader_stateful.rs
@@ -19,7 +19,7 @@ use super::{
     dds_domain_participant::DdsDomainParticipant, status_condition_impl::StatusConditionImpl,
 };
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct BuiltinDataReaderStatefulNode {
     this: Guid,
     parent_subcriber: Guid,

--- a/dds/src/implementation/dds_impl/node_builtin_data_reader_stateful.rs
+++ b/dds/src/implementation/dds_impl/node_builtin_data_reader_stateful.rs
@@ -1,12 +1,13 @@
 use crate::{
     implementation::{
-        rtps::{stateful_reader::RtpsStatefulReader, types::Guid},
-        utils::{
-            node::ChildNode,
-            shared_object::{DdsRwLock, DdsShared},
-        },
+        rtps::types::Guid,
+        utils::shared_object::{DdsRwLock, DdsShared},
     },
-    infrastructure::{error::DdsResult, instance::InstanceHandle, qos::DataReaderQos},
+    infrastructure::{
+        error::{DdsError, DdsResult},
+        instance::InstanceHandle,
+        qos::DataReaderQos,
+    },
     subscription::{
         data_reader::Sample,
         sample_info::{InstanceStateKind, SampleStateKind, ViewStateKind},
@@ -15,23 +16,32 @@ use crate::{
 };
 
 use super::{
-    dds_data_reader::DdsDataReader, dds_subscriber::DdsSubscriber,
-    status_condition_impl::StatusConditionImpl,
+    dds_domain_participant::DdsDomainParticipant, status_condition_impl::StatusConditionImpl,
 };
 
-type BuiltinDataReaderStatefulNodeType =
-    ChildNode<DdsDataReader<RtpsStatefulReader>, ChildNode<DdsSubscriber, Guid>>;
-
 #[derive(PartialEq, Debug)]
-pub struct BuiltinDataReaderStatefulNode(BuiltinDataReaderStatefulNodeType);
+pub struct BuiltinDataReaderStatefulNode {
+    this: Guid,
+    parent_subcriber: Guid,
+    parent_participant: Guid,
+}
 
 impl BuiltinDataReaderStatefulNode {
-    pub fn new(node: BuiltinDataReaderStatefulNodeType) -> Self {
-        Self(node)
+    pub fn new(this: Guid, parent_subcriber: Guid, parent_participant: Guid) -> Self {
+        Self {
+            this,
+            parent_subcriber,
+            parent_participant,
+        }
+    }
+
+    pub fn guid(&self) -> DdsResult<Guid> {
+        Ok(self.this)
     }
 
     pub fn read<Foo>(
         &self,
+        domain_participant: &DdsDomainParticipant,
         max_samples: i32,
         sample_states: &[SampleStateKind],
         view_states: &[ViewStateKind],
@@ -41,17 +51,22 @@ impl BuiltinDataReaderStatefulNode {
     where
         Foo: for<'de> DdsDeserialize<'de>,
     {
-        self.0.get()?.read(
-            max_samples,
-            sample_states,
-            view_states,
-            instance_states,
-            specific_instance_handle,
-        )
+        domain_participant
+            .get_builtin_subscriber()
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .read(
+                max_samples,
+                sample_states,
+                view_states,
+                instance_states,
+                specific_instance_handle,
+            )
     }
 
     pub fn read_next_instance<Foo>(
         &self,
+        domain_participant: &DdsDomainParticipant,
         max_samples: i32,
         previous_handle: Option<InstanceHandle>,
         sample_states: &[SampleStateKind],
@@ -61,24 +76,39 @@ impl BuiltinDataReaderStatefulNode {
     where
         Foo: for<'de> DdsDeserialize<'de>,
     {
-        self.0.get()?.read_next_instance(
-            max_samples,
-            previous_handle,
-            sample_states,
-            view_states,
-            instance_states,
-        )
+        domain_participant
+            .get_builtin_subscriber()
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .read_next_instance(
+                max_samples,
+                previous_handle,
+                sample_states,
+                view_states,
+                instance_states,
+            )
     }
 
-    pub fn get_qos(&self) -> DdsResult<DataReaderQos> {
-        Ok(self.0.get()?.get_qos())
+    pub fn get_qos(&self, domain_participant: &DdsDomainParticipant) -> DdsResult<DataReaderQos> {
+        Ok(domain_participant
+            .get_builtin_subscriber()
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_qos())
     }
 
-    pub fn get_statuscondition(&self) -> DdsResult<DdsShared<DdsRwLock<StatusConditionImpl>>> {
-        Ok(self.0.get()?.get_statuscondition())
+    pub fn get_statuscondition(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<DdsShared<DdsRwLock<StatusConditionImpl>>> {
+        Ok(domain_participant
+            .get_builtin_subscriber()
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_statuscondition())
     }
 
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        Ok(self.0.get()?.get_instance_handle())
+        Ok(self.this.into())
     }
 }

--- a/dds/src/implementation/dds_impl/node_builtin_data_reader_stateless.rs
+++ b/dds/src/implementation/dds_impl/node_builtin_data_reader_stateless.rs
@@ -19,7 +19,7 @@ use super::{
     dds_domain_participant::DdsDomainParticipant, status_condition_impl::StatusConditionImpl,
 };
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct BuiltinDataReaderStatelessNode {
     this: Guid,
     parent_subcriber: Guid,

--- a/dds/src/implementation/dds_impl/node_builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/node_builtin_subscriber.rs
@@ -1,5 +1,5 @@
 use crate::{
-    implementation::{rtps::types::Guid, utils::node::ChildNode},
+    implementation::rtps::types::Guid,
     infrastructure::{
         condition::StatusCondition, error::DdsResult, instance::InstanceHandle, qos::SubscriberQos,
         status::StatusKind,
@@ -8,51 +8,60 @@ use crate::{
 };
 
 use super::{
-    dds_subscriber::DdsSubscriber,
+    dds_domain_participant::DdsDomainParticipant,
     node_builtin_data_reader_stateful::BuiltinDataReaderStatefulNode,
     node_builtin_data_reader_stateless::BuiltinDataReaderStatelessNode,
     node_kind::DataReaderNodeKind,
 };
 
 #[derive(PartialEq, Debug)]
-pub struct BuiltinSubscriberNode(ChildNode<DdsSubscriber, Guid>);
+pub struct BuiltinSubscriberNode {
+    this: Guid,
+    parent: Guid,
+}
 
 impl BuiltinSubscriberNode {
-    pub fn new(node: ChildNode<DdsSubscriber, Guid>) -> Self {
-        Self(node)
+    pub fn new(this: Guid, parent: Guid) -> Self {
+        Self { this, parent }
     }
 
-    pub fn lookup_datareader<Foo>(&self, topic_name: &str) -> DdsResult<Option<DataReaderNodeKind>>
+    pub fn guid(&self) -> DdsResult<Guid> {
+        Ok(self.this)
+    }
+
+    pub fn lookup_datareader<Foo>(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+        topic_name: &str,
+    ) -> DdsResult<Option<DataReaderNodeKind>>
     where
         Foo: DdsType,
     {
-        if let Some(r) = self
-            .0
-            .get()?
+        if let Some(r) = domain_participant
+            .get_builtin_subscriber()
             .stateful_data_reader_list()
             .into_iter()
             .find(|x| x.get_type_name() == Foo::type_name() && x.get_topic_name() == topic_name)
         {
             Ok(Some(DataReaderNodeKind::BuiltinStateful(
-                BuiltinDataReaderStatefulNode::new(ChildNode::new(r.downgrade(), self.0.clone())),
+                BuiltinDataReaderStatefulNode::new(r.guid(), self.this, self.parent),
             )))
-        } else if let Some(r) = self
-            .0
-            .get()?
+        } else if let Some(r) = domain_participant
+            .get_builtin_subscriber()
             .stateless_data_reader_list()
             .into_iter()
             .find(|x| x.get_type_name() == Foo::type_name() && x.get_topic_name() == topic_name)
         {
             Ok(Some(DataReaderNodeKind::BuiltinStateless(
-                BuiltinDataReaderStatelessNode::new(ChildNode::new(r.downgrade(), self.0.clone())),
+                BuiltinDataReaderStatelessNode::new(r.guid(), self.this, self.parent),
             )))
         } else {
             Ok(None)
         }
     }
 
-    pub fn get_qos(&self) -> DdsResult<SubscriberQos> {
-        Ok(self.0.get()?.get_qos())
+    pub fn get_qos(&self, domain_participant: &DdsDomainParticipant) -> DdsResult<SubscriberQos> {
+        Ok(domain_participant.get_builtin_subscriber().get_qos())
     }
 
     pub fn get_statuscondition(&self) -> DdsResult<StatusCondition> {
@@ -64,6 +73,6 @@ impl BuiltinSubscriberNode {
     }
 
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        Ok(self.0.get()?.get_instance_handle())
+        Ok(self.this.into())
     }
 }

--- a/dds/src/implementation/dds_impl/node_builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/node_builtin_subscriber.rs
@@ -14,7 +14,7 @@ use super::{
     node_kind::DataReaderNodeKind,
 };
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct BuiltinSubscriberNode {
     this: Guid,
     parent: Guid,

--- a/dds/src/implementation/dds_impl/node_builtin_subscriber.rs
+++ b/dds/src/implementation/dds_impl/node_builtin_subscriber.rs
@@ -40,7 +40,7 @@ impl BuiltinSubscriberNode {
         if let Some(r) = domain_participant
             .get_builtin_subscriber()
             .stateful_data_reader_list()
-            .into_iter()
+            .iter()
             .find(|x| x.get_type_name() == Foo::type_name() && x.get_topic_name() == topic_name)
         {
             Ok(Some(DataReaderNodeKind::BuiltinStateful(
@@ -49,7 +49,7 @@ impl BuiltinSubscriberNode {
         } else if let Some(r) = domain_participant
             .get_builtin_subscriber()
             .stateless_data_reader_list()
-            .into_iter()
+            .iter()
             .find(|x| x.get_type_name() == Foo::type_name() && x.get_topic_name() == topic_name)
         {
             Ok(Some(DataReaderNodeKind::BuiltinStateless(

--- a/dds/src/implementation/dds_impl/node_domain_participant.rs
+++ b/dds/src/implementation/dds_impl/node_domain_participant.rs
@@ -127,7 +127,8 @@ impl DomainParticipantNode {
         let builtin_subcriber = Ok(domain_participant.get_builtin_subscriber())?;
 
         Ok(BuiltinSubscriberNode::new(ChildNode::new(
-            builtin_subcriber.downgrade(),
+            // builtin_subcriber.downgrade(),
+            todo!(),
             self.0,
         )))
     }

--- a/dds/src/implementation/dds_impl/node_domain_participant.rs
+++ b/dds/src/implementation/dds_impl/node_domain_participant.rs
@@ -55,19 +55,19 @@ impl DomainParticipantNode {
 
     pub fn create_subscriber(
         &self,
-        domain_participant: &DdsDomainParticipant,
+        domain_participant: &mut DdsDomainParticipant,
         qos: QosKind<SubscriberQos>,
         a_listener: Option<Box<dyn SubscriberListener + Send + Sync>>,
         mask: &[StatusKind],
     ) -> DdsResult<UserDefinedSubscriberNode> {
         domain_participant
             .create_subscriber(qos, a_listener, mask)
-            .map(|x| UserDefinedSubscriberNode::new(ChildNode::new(x.downgrade(), self.0)))
+            .map(|x| UserDefinedSubscriberNode::new(x, self.0))
     }
 
     pub fn delete_subscriber(
         &self,
-        domain_participant: &DdsDomainParticipant,
+        domain_participant: &mut DdsDomainParticipant,
         subscriber_handle: InstanceHandle,
     ) -> DdsResult<()> {
         domain_participant.delete_subscriber(subscriber_handle)

--- a/dds/src/implementation/dds_impl/node_domain_participant.rs
+++ b/dds/src/implementation/dds_impl/node_domain_participant.rs
@@ -68,9 +68,9 @@ impl DomainParticipantNode {
     pub fn delete_subscriber(
         &self,
         domain_participant: &mut DdsDomainParticipant,
-        subscriber_handle: InstanceHandle,
+        subscriber_guid: Guid,
     ) -> DdsResult<()> {
-        domain_participant.delete_subscriber(subscriber_handle)
+        domain_participant.delete_subscriber(subscriber_guid)
     }
 
     pub fn create_topic(
@@ -126,11 +126,7 @@ impl DomainParticipantNode {
     ) -> DdsResult<BuiltinSubscriberNode> {
         let builtin_subcriber = Ok(domain_participant.get_builtin_subscriber())?;
 
-        Ok(BuiltinSubscriberNode::new(ChildNode::new(
-            // builtin_subcriber.downgrade(),
-            todo!(),
-            self.0,
-        )))
+        Ok(BuiltinSubscriberNode::new(builtin_subcriber.guid(), self.0))
     }
 
     pub fn ignore_participant(

--- a/dds/src/implementation/dds_impl/node_kind.rs
+++ b/dds/src/implementation/dds_impl/node_kind.rs
@@ -11,7 +11,7 @@ use super::{
     node_user_defined_topic::UserDefinedTopicNode,
 };
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum SubscriberNodeKind {
     Builtin(BuiltinSubscriberNode),
     UserDefined(UserDefinedSubscriberNode),

--- a/dds/src/implementation/dds_impl/node_user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/node_user_defined_data_reader.rs
@@ -15,7 +15,6 @@ use crate::{
             LivelinessChangedStatus, RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus,
             SampleLostStatus, SampleRejectedStatus, StatusKind, SubscriptionMatchedStatus,
         },
-        time::Duration,
     },
     subscription::{
         data_reader::Sample,
@@ -284,9 +283,16 @@ impl UserDefinedDataReaderNode {
         UserDefinedSubscriberNode::new(self.parent_subcriber, self.parent_participant)
     }
 
-    pub fn wait_for_historical_data(&self, max_wait: Duration) -> DdsResult<()> {
-        todo!()
-        // self.0.get()?.wait_for_historical_data(max_wait)
+    pub fn is_historical_data_received(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<bool> {
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .is_historical_data_received()
     }
 
     pub fn get_matched_publication_data(

--- a/dds/src/implementation/dds_impl/node_user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/node_user_defined_data_reader.rs
@@ -356,8 +356,7 @@ impl UserDefinedDataReaderNode {
             let subscriber_qos = domain_participant
                 .get_subscriber(self.parent_subcriber)
                 .ok_or(DdsError::AlreadyDeleted)?
-                .get_qos()
-                .clone();
+                .get_qos();
             let discovered_reader_data = domain_participant
                 .get_subscriber(self.parent_subcriber)
                 .ok_or(DdsError::AlreadyDeleted)?
@@ -451,8 +450,7 @@ impl UserDefinedDataReaderNode {
         let subscriber_qos = domain_participant
             .get_subscriber(self.parent_subcriber)
             .ok_or(DdsError::AlreadyDeleted)?
-            .get_qos()
-            .clone();
+            .get_qos();
         let discovered_reader_data = domain_participant
             .get_subscriber(self.parent_subcriber)
             .ok_or(DdsError::AlreadyDeleted)?

--- a/dds/src/implementation/dds_impl/node_user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/node_user_defined_data_reader.rs
@@ -31,7 +31,7 @@ use super::{
     status_condition_impl::StatusConditionImpl,
 };
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct UserDefinedDataReaderNode {
     this: Guid,
     parent_subcriber: Guid,

--- a/dds/src/implementation/dds_impl/node_user_defined_data_reader.rs
+++ b/dds/src/implementation/dds_impl/node_user_defined_data_reader.rs
@@ -1,7 +1,7 @@
 use crate::{
     builtin_topics::PublicationBuiltinTopicData,
     implementation::{
-        rtps::{stateful_reader::RtpsStatefulReader, types::Guid},
+        rtps::types::Guid,
         utils::{
             node::ChildNode,
             shared_object::{DdsRwLock, DdsShared},
@@ -26,32 +26,35 @@ use crate::{
 
 use super::{
     any_data_reader_listener::AnyDataReaderListener,
-    dds_data_reader::DdsDataReader,
     dds_domain_participant::{AnnounceKind, DdsDomainParticipant},
-    dds_subscriber::DdsSubscriber,
     node_user_defined_subscriber::UserDefinedSubscriberNode,
     node_user_defined_topic::UserDefinedTopicNode,
     status_condition_impl::StatusConditionImpl,
-    status_listener::StatusListener,
 };
 
-type UserDefinedDataReaderNodeType =
-    ChildNode<DdsDataReader<RtpsStatefulReader>, ChildNode<DdsSubscriber, Guid>>;
-
 #[derive(PartialEq, Debug)]
-pub struct UserDefinedDataReaderNode(UserDefinedDataReaderNodeType);
+pub struct UserDefinedDataReaderNode {
+    this: Guid,
+    parent_subcriber: Guid,
+    parent_participant: Guid,
+}
 
 impl UserDefinedDataReaderNode {
-    pub fn new(node: UserDefinedDataReaderNodeType) -> Self {
-        Self(node)
+    pub fn new(this: Guid, parent_subcriber: Guid, parent_participant: Guid) -> Self {
+        Self {
+            this,
+            parent_subcriber,
+            parent_participant,
+        }
     }
 
     pub fn guid(&self) -> DdsResult<Guid> {
-        Ok(self.0.get()?.guid())
+        Ok(self.this)
     }
 
     pub fn read<Foo>(
         &self,
+        domain_participant: &DdsDomainParticipant,
         max_samples: i32,
         sample_states: &[SampleStateKind],
         view_states: &[ViewStateKind],
@@ -61,17 +64,23 @@ impl UserDefinedDataReaderNode {
     where
         Foo: for<'de> DdsDeserialize<'de>,
     {
-        self.0.get()?.read(
-            max_samples,
-            sample_states,
-            view_states,
-            instance_states,
-            specific_instance_handle,
-        )
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .read(
+                max_samples,
+                sample_states,
+                view_states,
+                instance_states,
+                specific_instance_handle,
+            )
     }
 
     pub fn take<Foo>(
         &self,
+        domain_participant: &DdsDomainParticipant,
         max_samples: i32,
         sample_states: &[SampleStateKind],
         view_states: &[ViewStateKind],
@@ -81,17 +90,23 @@ impl UserDefinedDataReaderNode {
     where
         Foo: for<'de> DdsDeserialize<'de>,
     {
-        self.0.get()?.take(
-            max_samples,
-            sample_states,
-            view_states,
-            instance_states,
-            specific_instance_handle,
-        )
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .take(
+                max_samples,
+                sample_states,
+                view_states,
+                instance_states,
+                specific_instance_handle,
+            )
     }
 
     pub fn read_next_instance<Foo>(
         &self,
+        domain_participant: &DdsDomainParticipant,
         max_samples: i32,
         previous_handle: Option<InstanceHandle>,
         sample_states: &[SampleStateKind],
@@ -101,17 +116,23 @@ impl UserDefinedDataReaderNode {
     where
         Foo: for<'de> DdsDeserialize<'de>,
     {
-        self.0.get()?.read_next_instance(
-            max_samples,
-            previous_handle,
-            sample_states,
-            view_states,
-            instance_states,
-        )
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .read_next_instance(
+                max_samples,
+                previous_handle,
+                sample_states,
+                view_states,
+                instance_states,
+            )
     }
 
     pub fn take_next_instance<Foo>(
         &self,
+        domain_participant: &DdsDomainParticipant,
         max_samples: i32,
         previous_handle: Option<InstanceHandle>,
         sample_states: &[SampleStateKind],
@@ -121,58 +142,128 @@ impl UserDefinedDataReaderNode {
     where
         Foo: for<'de> DdsDeserialize<'de>,
     {
-        self.0.get()?.take_next_instance(
-            max_samples,
-            previous_handle,
-            sample_states,
-            view_states,
-            instance_states,
-        )
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .take_next_instance(
+                max_samples,
+                previous_handle,
+                sample_states,
+                view_states,
+                instance_states,
+            )
     }
 
     pub fn get_key_value<Foo>(
         &self,
+        domain_participant: &DdsDomainParticipant,
         key_holder: &mut Foo,
         handle: InstanceHandle,
     ) -> DdsResult<()> {
-        self.0.get()?.get_key_value(key_holder, handle)
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_key_value(key_holder, handle)
     }
 
-    pub fn lookup_instance<Foo>(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
-        self.0.get()?.lookup_instance(instance)
+    pub fn lookup_instance<Foo>(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+        instance: &Foo,
+    ) -> DdsResult<Option<InstanceHandle>> {
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .lookup_instance(instance)
     }
 
-    pub fn get_liveliness_changed_status(&self) -> DdsResult<LivelinessChangedStatus> {
-        Ok(self.0.get()?.get_liveliness_changed_status())
+    pub fn get_liveliness_changed_status(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<LivelinessChangedStatus> {
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_liveliness_changed_status())
     }
 
-    pub fn get_requested_deadline_missed_status(&self) -> DdsResult<RequestedDeadlineMissedStatus> {
-        Ok(self.0.get()?.get_requested_deadline_missed_status())
+    pub fn get_requested_deadline_missed_status(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<RequestedDeadlineMissedStatus> {
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_requested_deadline_missed_status())
     }
 
     pub fn get_requested_incompatible_qos_status(
         &self,
+        domain_participant: &DdsDomainParticipant,
     ) -> DdsResult<RequestedIncompatibleQosStatus> {
-        Ok(self.0.get()?.get_requested_incompatible_qos_status())
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_requested_incompatible_qos_status())
     }
 
-    pub fn get_sample_lost_status(&self) -> DdsResult<SampleLostStatus> {
-        Ok(self.0.get()?.get_sample_lost_status())
+    pub fn get_sample_lost_status(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<SampleLostStatus> {
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_sample_lost_status())
     }
 
-    pub fn get_sample_rejected_status(&self) -> DdsResult<SampleRejectedStatus> {
-        Ok(self.0.get()?.get_sample_rejected_status())
+    pub fn get_sample_rejected_status(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<SampleRejectedStatus> {
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_sample_rejected_status())
     }
 
-    pub fn get_subscription_matched_status(&self) -> DdsResult<SubscriptionMatchedStatus> {
-        Ok(self.0.get()?.get_subscription_matched_status())
+    pub fn get_subscription_matched_status(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<SubscriptionMatchedStatus> {
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_subscription_matched_status())
     }
 
     pub fn get_topicdescription(
         &self,
         domain_participant: &DdsDomainParticipant,
     ) -> DdsResult<UserDefinedTopicNode> {
-        let data_reader = self.0.get()?;
+        let data_reader = domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?;
         let topic = domain_participant
             .topic_list()
             .iter()
@@ -185,29 +276,42 @@ impl UserDefinedDataReaderNode {
 
         Ok(UserDefinedTopicNode::new(ChildNode::new(
             topic.downgrade(),
-            *self.0.parent().parent(),
+            self.parent_participant,
         )))
     }
 
     pub fn get_subscriber(&self) -> UserDefinedSubscriberNode {
-        UserDefinedSubscriberNode::new(self.0.parent().clone())
+        UserDefinedSubscriberNode::new(self.parent_subcriber, self.parent_participant)
     }
 
     pub fn wait_for_historical_data(&self, max_wait: Duration) -> DdsResult<()> {
-        self.0.get()?.wait_for_historical_data(max_wait)
+        todo!()
+        // self.0.get()?.wait_for_historical_data(max_wait)
     }
 
     pub fn get_matched_publication_data(
         &self,
+        domain_participant: &DdsDomainParticipant,
         publication_handle: InstanceHandle,
     ) -> DdsResult<PublicationBuiltinTopicData> {
-        self.0
-            .get()?
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
             .get_matched_publication_data(publication_handle)
     }
 
-    pub fn get_matched_publications(&self) -> DdsResult<Vec<InstanceHandle>> {
-        Ok(self.0.get()?.get_matched_publications())
+    pub fn get_matched_publications(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<Vec<InstanceHandle>> {
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_matched_publications())
     }
 
     pub fn set_qos(
@@ -215,10 +319,25 @@ impl UserDefinedDataReaderNode {
         domain_participant: &DdsDomainParticipant,
         qos: QosKind<DataReaderQos>,
     ) -> DdsResult<()> {
-        self.0.get()?.set_qos(qos)?;
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .set_qos(qos)?;
 
-        let data_reader = self.0.get()?;
-        if self.0.get()?.is_enabled() {
+        let data_reader = domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?;
+        if domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .is_enabled()
+        {
             let topic = domain_participant
                 .topic_list()
                 .iter()
@@ -228,10 +347,17 @@ impl UserDefinedDataReaderNode {
                 })
                 .cloned()
                 .expect("Topic must exist");
-            let discovered_reader_data = self
-                .0
-                .get()?
-                .as_discovered_reader_data(&topic.get_qos(), &self.0.parent().get()?.get_qos());
+            let subscriber_qos = domain_participant
+                .get_subscriber(self.parent_subcriber)
+                .ok_or(DdsError::AlreadyDeleted)?
+                .get_qos()
+                .clone();
+            let discovered_reader_data = domain_participant
+                .get_subscriber(self.parent_subcriber)
+                .ok_or(DdsError::AlreadyDeleted)?
+                .get_stateful_data_reader(self.this)
+                .ok_or(DdsError::AlreadyDeleted)?
+                .as_discovered_reader_data(&topic.get_qos(), &subscriber_qos);
             domain_participant
                 .announce_sender()
                 .send(AnnounceKind::CreatedDataReader(discovered_reader_data))
@@ -241,37 +367,72 @@ impl UserDefinedDataReaderNode {
         Ok(())
     }
 
-    pub fn get_qos(&self) -> DdsResult<DataReaderQos> {
-        Ok(self.0.get()?.get_qos())
+    pub fn get_qos(&self, domain_participant: &DdsDomainParticipant) -> DdsResult<DataReaderQos> {
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_qos())
     }
 
     pub fn set_listener(
         &self,
-        a_listener: Option<Box<dyn AnyDataReaderListener + Send + Sync>>,
-        mask: &[StatusKind],
+        _a_listener: Option<Box<dyn AnyDataReaderListener + Send + Sync>>,
+        _mask: &[StatusKind],
     ) -> DdsResult<()> {
-        *self.0.get()?.get_status_listener_lock() = StatusListener::new(a_listener, mask);
-        Ok(())
+        todo!()
+        // *self.0.get()?.get_status_listener_lock() = StatusListener::new(a_listener, mask);
+        // Ok(())
     }
 
-    pub fn get_statuscondition(&self) -> DdsResult<DdsShared<DdsRwLock<StatusConditionImpl>>> {
-        Ok(self.0.get()?.get_statuscondition())
+    pub fn get_statuscondition(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<DdsShared<DdsRwLock<StatusConditionImpl>>> {
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_statuscondition())
     }
 
-    pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        Ok(self.0.get()?.get_status_changes())
+    pub fn get_status_changes(
+        &self,
+        domain_participant: &DdsDomainParticipant,
+    ) -> DdsResult<Vec<StatusKind>> {
+        Ok(domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_status_changes())
     }
 
     pub fn enable(&self, domain_participant: &mut DdsDomainParticipant) -> DdsResult<()> {
-        if !self.0.parent().get()?.is_enabled() {
+        if !domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .is_enabled()
+        {
             return Err(DdsError::PreconditionNotMet(
                 "Parent subscriber disabled".to_string(),
             ));
         }
 
-        self.0.get()?.enable()?;
+        domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .enable()?;
 
-        let data_reader = self.0.get()?;
+        let data_reader = domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?;
         let topic = domain_participant
             .topic_list()
             .iter()
@@ -281,10 +442,17 @@ impl UserDefinedDataReaderNode {
             })
             .cloned()
             .expect("Topic must exist");
-        let discovered_reader_data = self
-            .0
-            .get()?
-            .as_discovered_reader_data(&topic.get_qos(), &self.0.parent().get()?.get_qos());
+        let subscriber_qos = domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_qos()
+            .clone();
+        let discovered_reader_data = domain_participant
+            .get_subscriber(self.parent_subcriber)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .get_stateful_data_reader(self.this)
+            .ok_or(DdsError::AlreadyDeleted)?
+            .as_discovered_reader_data(&topic.get_qos(), &subscriber_qos);
         domain_participant
             .announce_sender()
             .send(AnnounceKind::CreatedDataReader(discovered_reader_data))
@@ -294,6 +462,6 @@ impl UserDefinedDataReaderNode {
     }
 
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        Ok(self.0.get()?.get_instance_handle())
+        Ok(self.this.into())
     }
 }

--- a/dds/src/implementation/dds_impl/node_user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/node_user_defined_subscriber.rs
@@ -28,7 +28,7 @@ use super::{
     node_user_defined_data_reader::UserDefinedDataReaderNode,
 };
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct UserDefinedSubscriberNode {
     this: Guid,
     parent: Guid,

--- a/dds/src/implementation/dds_impl/node_user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/node_user_defined_subscriber.rs
@@ -122,7 +122,7 @@ impl UserDefinedSubscriberNode {
         let data_reader = DdsDataReader::new(rtps_reader, type_name, topic_name, a_listener, mask);
 
         domain_participant
-            .get_subscriber(self.this)
+            .get_subscriber_mut(self.this)
             .ok_or(DdsError::AlreadyDeleted)?
             .stateful_data_reader_add(data_reader.clone());
 
@@ -164,7 +164,7 @@ impl UserDefinedSubscriberNode {
             .clone();
 
         domain_participant
-            .get_subscriber(self.this)
+            .get_subscriber_mut(self.this)
             .ok_or(DdsError::AlreadyDeleted)?
             .stateful_data_reader_delete(a_datareader_handle);
 
@@ -218,21 +218,22 @@ impl UserDefinedSubscriberNode {
 
     pub fn delete_contained_entities(
         &self,
-        domain_participant: &DdsDomainParticipant,
+        domain_participant: &mut DdsDomainParticipant,
     ) -> DdsResult<()> {
         for data_reader in domain_participant
-            .get_subscriber(self.this)
+            .get_subscriber_mut(self.this)
             .ok_or(DdsError::AlreadyDeleted)?
             .stateful_data_reader_drain()
             .into_iter()
         {
             if data_reader.is_enabled() {
-                domain_participant
-                    .announce_sender()
-                    .send(AnnounceKind::DeletedDataReader(
-                        data_reader.get_instance_handle(),
-                    ))
-                    .ok();
+                todo!()
+                // domain_participant
+                //     .announce_sender()
+                //     .send(AnnounceKind::DeletedDataReader(
+                //         data_reader.get_instance_handle(),
+                //     ))
+                //     .ok();
             }
         }
         Ok(())

--- a/dds/src/implementation/dds_impl/node_user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/node_user_defined_subscriber.rs
@@ -280,8 +280,8 @@ impl UserDefinedSubscriberNode {
 
     pub fn set_listener(
         &self,
-        a_listener: Option<Box<dyn SubscriberListener + Send + Sync>>,
-        mask: &[StatusKind],
+        _a_listener: Option<Box<dyn SubscriberListener + Send + Sync>>,
+        _mask: &[StatusKind],
     ) -> DdsResult<()> {
         todo!()
         // *self.0.get()?.get_status_listener_lock() = StatusListener::new(a_listener, mask);

--- a/dds/src/implementation/dds_impl/node_user_defined_subscriber.rs
+++ b/dds/src/implementation/dds_impl/node_user_defined_subscriber.rs
@@ -124,7 +124,7 @@ impl UserDefinedSubscriberNode {
         domain_participant
             .get_subscriber_mut(self.this)
             .ok_or(DdsError::AlreadyDeleted)?
-            .stateful_data_reader_add(data_reader.clone());
+            .stateful_data_reader_add(data_reader);
 
         let node = UserDefinedDataReaderNode::new(guid, self.this, self.parent);
 
@@ -154,7 +154,7 @@ impl UserDefinedSubscriberNode {
             .get_subscriber(self.this)
             .ok_or(DdsError::AlreadyDeleted)?
             .stateful_data_reader_list()
-            .into_iter()
+            .iter()
             .find(|x| x.get_instance_handle() == a_datareader_handle)
             .ok_or_else(|| {
                 DdsError::PreconditionNotMet(
@@ -190,7 +190,7 @@ impl UserDefinedSubscriberNode {
             .get_subscriber(self.this)
             .ok_or(DdsError::AlreadyDeleted)?
             .stateful_data_reader_list()
-            .into_iter()
+            .iter()
             .find(|data_reader| {
                 data_reader.get_topic_name() == topic_name
                     && data_reader.get_type_name() == type_name
@@ -224,7 +224,6 @@ impl UserDefinedSubscriberNode {
             .get_subscriber_mut(self.this)
             .ok_or(DdsError::AlreadyDeleted)?
             .stateful_data_reader_drain()
-            .into_iter()
         {
             if data_reader.is_enabled() {
                 todo!()


### PR DESCRIPTION
This PR replaces the usage of the DdsShared by getting the object from the static factory on the reader side.