### PR TITLE
DDS-308 Remove DdsSerde trait

### DIFF
--- a/dds/README.md
+++ b/dds/README.md
@@ -14,7 +14,7 @@ A basic example on how to use Dust DDS. The publisher side can be implemented as
     use dust_dds::{
         domain::domain_participant_factory::DomainParticipantFactory,
         infrastructure::{qos::QosKind, status::NO_STATUS},
-        topic_definition::type_support::DdsType,
+        DdsType,
     };
 
     use serde::{Deserialize, Serialize};
@@ -61,7 +61,7 @@ The subscriber side can be implemented as:
         domain::domain_participant_factory::DomainParticipantFactory,
         infrastructure::{qos::QosKind, status::NO_STATUS},
         subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-        topic_definition::type_support::DdsType,
+        DdsType,
     };
 
     use serde::{Deserialize, Serialize};

--- a/dds/README.md
+++ b/dds/README.md
@@ -14,12 +14,12 @@ A basic example on how to use Dust DDS. The publisher side can be implemented as
     use dust_dds::{
         domain::domain_participant_factory::DomainParticipantFactory,
         infrastructure::{qos::QosKind, status::NO_STATUS},
-        topic_definition::type_support::{DdsSerde, DdsType},
+        topic_definition::type_support::DdsType,
     };
 
     use serde::{Deserialize, Serialize};
 
-    #[derive(Deserialize, Serialize, DdsType, DdsSerde)]
+    #[derive(Deserialize, Serialize, DdsType)]
     struct HelloWorldType {
         #[key]
         id: u8,
@@ -61,12 +61,12 @@ The subscriber side can be implemented as:
         domain::domain_participant_factory::DomainParticipantFactory,
         infrastructure::{qos::QosKind, status::NO_STATUS},
         subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-        topic_definition::type_support::{DdsSerde, DdsType},
+        topic_definition::type_support::DdsType,
     };
 
     use serde::{Deserialize, Serialize};
 
-    #[derive(Debug, Deserialize, Serialize, DdsType, DdsSerde)]
+    #[derive(Debug, Deserialize, Serialize, DdsType)]
     struct HelloWorldType {
         #[key]
         id: u8,

--- a/dds/benches/benchmark.rs
+++ b/dds/benches/benchmark.rs
@@ -12,10 +12,10 @@ use dust_dds::{
         data_reader_listener::DataReaderListener,
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::DdsType,
 };
 
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType)]
 struct KeyedData {
     #[key]
     id: u8,

--- a/dds/examples/best_effort_publisher.rs
+++ b/dds/examples/best_effort_publisher.rs
@@ -6,7 +6,7 @@ use dust_dds::{
         time::Duration,
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::DdsType,
+    DdsType,
 };
 
 use serde::{Deserialize, Serialize};

--- a/dds/examples/best_effort_publisher.rs
+++ b/dds/examples/best_effort_publisher.rs
@@ -6,12 +6,12 @@ use dust_dds::{
         time::Duration,
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::DdsType,
 };
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, DdsType, DdsSerde, Debug)]
+#[derive(Deserialize, Serialize, DdsType, Debug)]
 struct BestEffortExampleType {
     id: i32,
 }

--- a/dds/examples/best_effort_subscriber.rs
+++ b/dds/examples/best_effort_subscriber.rs
@@ -14,12 +14,12 @@ use dust_dds::{
         data_reader_listener::DataReaderListener,
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::DdsType,
 };
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, DdsType, DdsSerde, Debug)]
+#[derive(Deserialize, Serialize, DdsType, Debug)]
 struct BestEffortExampleType {
     id: i32,
 }

--- a/dds/examples/best_effort_subscriber.rs
+++ b/dds/examples/best_effort_subscriber.rs
@@ -14,7 +14,7 @@ use dust_dds::{
         data_reader_listener::DataReaderListener,
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
     },
-    topic_definition::type_support::DdsType,
+    DdsType,
 };
 
 use serde::{Deserialize, Serialize};

--- a/dds/examples/hello_world_publisher.rs
+++ b/dds/examples/hello_world_publisher.rs
@@ -10,12 +10,12 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, DdsType, DdsSerde)]
+#[derive(Deserialize, Serialize, DdsType)]
 struct HelloWorldType {
     #[key]
     id: u8,

--- a/dds/examples/hello_world_publisher.rs
+++ b/dds/examples/hello_world_publisher.rs
@@ -10,7 +10,7 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::{DdsType},
+    DdsType,
 };
 
 use serde::{Deserialize, Serialize};

--- a/dds/examples/hello_world_subscriber.rs
+++ b/dds/examples/hello_world_subscriber.rs
@@ -11,12 +11,12 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, DdsType, DdsSerde)]
+#[derive(Debug, Deserialize, Serialize, DdsType)]
 struct HelloWorldType {
     #[key]
     id: u8,

--- a/dds/examples/hello_world_subscriber.rs
+++ b/dds/examples/hello_world_subscriber.rs
@@ -11,7 +11,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsType},
+    DdsType,
 };
 
 use serde::{Deserialize, Serialize};

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     topic_definition::{
         topic::Topic,
-        type_support::{DdsDeserialize, DdsType, DdsSerde},
+        type_support::{DdsDeserialize, DdsType},
     },
 };
 
@@ -88,7 +88,7 @@ impl Subscriber {
         mask: &[StatusKind],
     ) -> DdsResult<DataReader<Foo>>
     where
-        Foo: DdsSerde + DdsType + for<'de> serde::Deserialize<'de> + 'static,
+        Foo: DdsType + for<'de> serde::Deserialize<'de> + 'static,
     {
         match &self.0 {
             SubscriberNodeKind::Builtin(_) => Err(DdsError::IllegalOperation),

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -8,7 +8,7 @@ use crate::{
     infrastructure::error::{DdsError::PreconditionNotMet, DdsResult},
 };
 
-pub use dust_dds_derive::{DdsSerde, DdsType};
+pub use dust_dds_derive::DdsType;
 
 pub type RepresentationType = [u8; 2];
 pub type RepresentationOptions = [u8; 2];
@@ -18,8 +18,6 @@ pub const CDR_LE: RepresentationType = [0x00, 0x01];
 pub const PL_CDR_BE: RepresentationType = [0x00, 0x02];
 pub const PL_CDR_LE: RepresentationType = [0x00, 0x03];
 pub const REPRESENTATION_OPTIONS: RepresentationOptions = [0x00, 0x00];
-
-pub trait DdsSerde {}
 
 #[derive(Debug, PartialEq, Clone, Eq, serde::Serialize, serde::Deserialize)]
 pub struct DdsSerializedKey(Vec<u8>);
@@ -41,8 +39,6 @@ impl AsRef<[u8]> for DdsSerializedKey {
         self.0.as_slice()
     }
 }
-
-impl DdsSerde for DdsSerializedKey {}
 
 impl DdsType for DdsSerializedKey {
     fn type_name() -> &'static str {

--- a/dds/src/lib.rs
+++ b/dds/src/lib.rs
@@ -3,5 +3,5 @@
 #[forbid(unsafe_code)]
 mod dds;
 pub use dds::*;
-
+pub use topic_definition::type_support::DdsType;
 mod implementation;

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -7,13 +7,13 @@ use dust_dds::{
         time::Duration,
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 mod utils;
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
-#[derive(serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(serde::Serialize, serde::Deserialize, DdsType)]
 struct UserType(i32);
 
 #[test]

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -19,16 +19,16 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 mod utils;
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
-#[derive(serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(serde::Serialize, serde::Deserialize, DdsType)]
 struct TestType(u8);
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType)]
 struct MyData {
     #[key]
     id: u8,

--- a/dds/tests/domain_participant_factory.rs
+++ b/dds/tests/domain_participant_factory.rs
@@ -8,13 +8,13 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 mod utils;
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType)]
 struct KeyedData {
     #[key]
     id: u8,

--- a/dds/tests/listeners.rs
+++ b/dds/tests/listeners.rs
@@ -28,7 +28,7 @@ use dust_dds::{
         subscriber::Subscriber,
         subscriber_listener::SubscriberListener,
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 use mockall::mock;
@@ -36,7 +36,7 @@ use mockall::mock;
 mod utils;
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType)]
 struct MyData {
     #[key]
     id: u8,

--- a/dds/tests/publisher_api.rs
+++ b/dds/tests/publisher_api.rs
@@ -5,13 +5,13 @@ use dust_dds::{
         qos_policy::UserDataQosPolicy,
         status::NO_STATUS,
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 mod utils;
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
-#[derive(serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(serde::Serialize, serde::Deserialize, DdsType)]
 struct UserType(i32);
 
 #[test]

--- a/dds/tests/subscriber_api.rs
+++ b/dds/tests/subscriber_api.rs
@@ -5,13 +5,13 @@ use dust_dds::{
         qos_policy::UserDataQosPolicy,
         status::NO_STATUS,
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 mod utils;
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
-#[derive(serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(serde::Serialize, serde::Deserialize, DdsType)]
 struct UserType(i32);
 
 #[test]

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -21,23 +21,23 @@ use dust_dds::{
             ANY_SAMPLE_STATE, ANY_VIEW_STATE,
         },
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 mod utils;
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
-#[derive(Debug, PartialEq, DdsType, DdsSerde, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, DdsType, serde::Serialize, serde::Deserialize)]
 struct UserData(u8);
 
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType)]
 struct KeyedData {
     #[key]
     id: u8,
     value: u8,
 }
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType, DdsSerde)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, DdsType)]
 struct LargeData {
     #[key]
     id: u8,

--- a/dds_derive/README.md
+++ b/dds_derive/README.md
@@ -1,6 +1,6 @@
 # Derive macro for `DdsType`
 
-This package provides derive macros for `DdsType` and `DdsSerde` to support [dust-dds](https://github.com/s2e-systems/dust-dds).
+This package provides a derive macro for `DdsType` to support [dust-dds](https://github.com/s2e-systems/dust-dds).
 
 `DdsType` can only be derived for `struct`s, tuples and `enum`s. For `struct`s and tuples, the attribute `#[key]` can be specified either on the whole type or on a subset of fields. For `enum`s, the `#[key]` attribute can only be specified on the whole type.
 
@@ -9,10 +9,10 @@ This package provides derive macros for `DdsType` and `DdsSerde` to support [dus
 A typical user DDS type will look like this:
 
 ```rust
-use dust_dds::topic_definition::type_support::{DdsSerde, DdsType}
+use dust_dds::topic_definition::type_support::{DdsType}
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, DdsType, DdsSerde)]
+#[derive(Deserialize, Serialize, DdsType)]
 struct HelloWorldType {
     #[key]
     id: u8,

--- a/dds_derive/src/lib.rs
+++ b/dds_derive/src/lib.rs
@@ -183,15 +183,3 @@ fn has_key_attribute(attr_list: &[Attribute]) -> bool {
     })
 }
 
-#[proc_macro_derive(DdsSerde)]
-pub fn derive_dds_serde(input: TokenStream) -> TokenStream {
-    let input: DeriveInput = parse_macro_input!(input);
-    let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
-    let ident = input.ident;
-
-    let output = quote! {
-        impl #impl_generics dust_dds::topic_definition::type_support::DdsSerde for #ident #type_generics #where_clause  {}
-    };
-
-    output.into()
-}

--- a/dds_derive/tests/test_dds_type_derive.rs
+++ b/dds_derive/tests/test_dds_type_derive.rs
@@ -1,7 +1,7 @@
-use dust_dds::topic_definition::type_support::{DdsSerde, DdsType};
+use dust_dds::topic_definition::type_support::DdsType;
 use serde::{Deserialize, Serialize};
 
-#[derive(DdsType, DdsSerde)]
+#[derive(DdsType)]
 struct StructNoKey {
     a: i32,
     b: i32,
@@ -28,7 +28,7 @@ fn test_struct_no_key_set() {
     assert_eq!(snk2.b, 4);
 }
 
-#[derive(DdsType, DdsSerde)]
+#[derive(DdsType)]
 struct StructWithKey {
     a: i32,
     #[key]
@@ -56,7 +56,7 @@ fn test_struct_with_key_set() {
     assert_eq!(swk.b, 42)
 }
 
-#[derive(DdsType, DdsSerde)]
+#[derive(DdsType)]
 struct StructManyKeys {
     #[key]
     a: i32,
@@ -110,7 +110,7 @@ fn test_struct_many_keys_set() {
  * See: https://naftuli.wtf/2019/01/02/rust-derive-macros/
  */
 
-#[derive(DdsType, DdsSerde)]
+#[derive(DdsType)]
 struct TypeWithGeneric<T> {
     a: T,
     #[key]
@@ -144,7 +144,7 @@ fn test_dds_type_derive_with_generic_set() {
     assert_eq!(twg.b, 42);
 }
 
-#[derive(DdsType, DdsSerde)]
+#[derive(DdsType)]
 struct TupleNoKey(i32, i32);
 
 #[test]
@@ -168,7 +168,7 @@ fn test_tuple_no_key_set() {
     assert_eq!(twk.1, 2);
 }
 
-#[derive(DdsType, DdsSerde)]
+#[derive(DdsType)]
 struct TupleWithKeys(i32, #[key] i32, #[key] bool, char);
 
 #[test]
@@ -194,7 +194,7 @@ fn test_tuple_with_keys_set() {
     assert_eq!(twk.3, '\0');
 }
 
-#[derive(DdsType, DdsSerde, PartialEq, Eq, Debug)]
+#[derive(DdsType, PartialEq, Eq, Debug)]
 enum EnumNoKey {
     _One,
     _Two,
@@ -221,7 +221,7 @@ fn test_enum_no_key_set() {
     assert_eq!(enk, EnumNoKey::_Two);
 }
 
-#[derive(Serialize, Deserialize, DdsType, DdsSerde, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, DdsType, PartialEq, Eq, Debug)]
 #[key]
 enum EnumKey {
     _One,

--- a/interoperability_tests/Cargo.toml
+++ b/interoperability_tests/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 cdr = "=0.2.4"
 
 [build-dependencies]
-dust_dds_gen = {version = "0.1" }
+dust_dds_gen = {version = "0.2" }
 
 [[bin]]
 name = "dust_dds_publisher"

--- a/interoperability_tests/build.rs
+++ b/interoperability_tests/build.rs
@@ -1,22 +1,26 @@
-use std::{fs::File, io::Write};
+use std::{fs::{File, self}, io::Write, path::Path};
 
 fn main() {
-    let idl_path = "HelloWorld.idl";
+    let build_path = Path::new("./build/idl/");
+    fs::create_dir_all(build_path).expect("Creating build path failed");
+
+    let idl_path = Path::new("HelloWorld.idl");
     let idl_src = std::fs::read_to_string(idl_path).expect("(;_;) Couldn't read IDL source file!");
 
     let compiled_idl = dust_dds_gen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
-
-    let mut file = File::create("hello_world.rs").expect("Failed to create file");
+    let compiled_idl_path = build_path.join("hello_world.rs");
+    let mut file = File::create(compiled_idl_path).expect("Failed to create file");
 
     file.write_all(compiled_idl.as_bytes())
         .expect("Failed to write to file");
+
 
     let idl_path = "BigData.idl";
     let idl_src = std::fs::read_to_string(idl_path).expect("(;_;) Couldn't read IDL source file!");
 
     let compiled_idl = dust_dds_gen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
-
-    let mut file = File::create("big_data.rs").expect("Failed to create file");
+    let compiled_idl_path = build_path.join("big_data.rs");
+    let mut file = File::create(compiled_idl_path).expect("Failed to create file");
 
     file.write_all(compiled_idl.as_bytes())
         .expect("Failed to write to file");

--- a/interoperability_tests/dust_dds_big_data_publisher.rs
+++ b/interoperability_tests/dust_dds_big_data_publisher.rs
@@ -11,8 +11,9 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
 };
-
-mod big_data;
+mod big_data {
+    include!("build/idl/big_data.rs");
+}
 
 fn main() {
     let domain_id = 0;

--- a/interoperability_tests/dust_dds_big_data_subscriber.rs
+++ b/interoperability_tests/dust_dds_big_data_subscriber.rs
@@ -13,7 +13,9 @@ use dust_dds::{
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
 };
 
-mod big_data;
+mod big_data {
+    include!("build/idl/big_data.rs");
+}
 
 fn main() {
     let domain_id = 0;

--- a/interoperability_tests/dust_dds_publisher.rs
+++ b/interoperability_tests/dust_dds_publisher.rs
@@ -12,7 +12,9 @@ use dust_dds::{
     },
 };
 
-mod hello_world;
+mod hello_world {
+    include!("build/idl/hello_world.rs");
+}
 
 fn main() {
     let domain_id = 0;

--- a/interoperability_tests/dust_dds_subscriber.rs
+++ b/interoperability_tests/dust_dds_subscriber.rs
@@ -13,7 +13,9 @@ use dust_dds::{
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
 };
 
-mod hello_world;
+mod hello_world {
+    include!("build/idl/hello_world.rs");
+}
 
 fn main() {
     let domain_id = 0;

--- a/interoperability_tests/publisher_multi_machine.rs
+++ b/interoperability_tests/publisher_multi_machine.rs
@@ -10,12 +10,12 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, DdsType, DdsSerde)]
+#[derive(Deserialize, Serialize, DdsType)]
 struct HelloWorldType {
     #[key]
     id: u8,

--- a/interoperability_tests/subscriber_multi_machine.rs
+++ b/interoperability_tests/subscriber_multi_machine.rs
@@ -11,12 +11,12 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsSerde, DdsType},
+    topic_definition::type_support::{DdsType},
 };
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, DdsType, DdsSerde)]
+#[derive(Debug, Deserialize, Serialize, DdsType)]
 struct HelloWorldType {
     #[key]
     id: u8,


### PR DESCRIPTION
The DdsSerde marker trait could be used to mark DdsType that are meant to be serialized with CDR_LE encapsulation. This distinction can now be done directly within the  DdsType trait. As such the creation of serializable types is easier to explain.
This requires the dust-dds-gen crate to be updated as well. Since the dev dependencies of some of the crates here make use of dust-dds-gen this should be published first: https://github.com/s2e-systems/dust-dds-gen/pull/2