### PR TITLE
DDS-328 Use u8 as rep invariant for rtps message read

### DIFF
--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -37,8 +37,11 @@ use crate::{
             messages::{
                 overall_structure::RtpsMessageHeader,
                 submessage_elements::SequenceNumberSet,
-                submessages::{InfoTimestampSubmessage, GapSubmessageWrite, InfoDestinationSubmessageWrite},
-                types::{FragmentNumber, ProtocolId}, RtpsSubmessageWriteKind, RtpsMessageWrite, RtpsMessageRead,
+                submessages::{
+                    GapSubmessageWrite, InfoDestinationSubmessageWrite, InfoTimestampSubmessage,
+                },
+                types::{FragmentNumber, ProtocolId},
+                RtpsMessageRead, RtpsMessageWrite, RtpsSubmessageWriteKind,
             },
             reader_locator::WriterAssociatedReaderLocator,
             reader_proxy::{RtpsReaderProxy, WriterAssociatedReaderProxy},
@@ -1995,7 +1998,8 @@ fn send_message_reliable_reader_proxy(
                     ))
                 }
             } else {
-                let gap_submessage: GapSubmessageWrite = change.cache_change().as_gap_message(reader_id);
+                let gap_submessage: GapSubmessageWrite =
+                    change.cache_change().as_gap_message(reader_id);
 
                 submessages.push(RtpsSubmessageWriteKind::Gap(gap_submessage));
             }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -37,7 +37,7 @@ use crate::{
             messages::{
                 overall_structure::RtpsMessageHeader,
                 submessage_elements::SequenceNumberSet,
-                submessages::{GapSubmessage, InfoDestinationSubmessage, InfoTimestampSubmessage},
+                submessages::{InfoDestinationSubmessage, InfoTimestampSubmessage, GapSubmessageWrite},
                 types::{FragmentNumber, ProtocolId}, RtpsSubmessageWriteKind, RtpsMessageWrite, RtpsMessageRead,
             },
             reader_locator::WriterAssociatedReaderLocator,
@@ -1929,7 +1929,7 @@ fn send_message_best_effort_reader_proxy(
                 ))
             }
         } else {
-            let gap_submessage: GapSubmessage = change
+            let gap_submessage: GapSubmessageWrite = change
                 .cache_change()
                 .as_gap_message(reader_proxy.remote_reader_guid().entity_id());
             submessages.push(RtpsSubmessageWriteKind::Gap(gap_submessage));
@@ -1995,7 +1995,7 @@ fn send_message_reliable_reader_proxy(
                     ))
                 }
             } else {
-                let gap_submessage: GapSubmessage = change.cache_change().as_gap_message(reader_id);
+                let gap_submessage: GapSubmessageWrite = change.cache_change().as_gap_message(reader_id);
 
                 submessages.push(RtpsSubmessageWriteKind::Gap(gap_submessage));
             }
@@ -2049,7 +2049,7 @@ fn send_message_reliable_reader_proxy(
                     ))
                 }
             } else {
-                let gap_submessage: GapSubmessage =
+                let gap_submessage: GapSubmessageWrite =
                     change_for_reader.cache_change().as_gap_message(reader_id);
 
                 submessages.push(RtpsSubmessageWriteKind::Gap(gap_submessage));
@@ -2073,7 +2073,7 @@ fn gap_submessage<'a>(
     writer_id: EntityId,
     gap_sequence_number: SequenceNumber,
 ) -> RtpsSubmessageWriteKind<'a> {
-    RtpsSubmessageWriteKind::Gap(GapSubmessage {
+    RtpsSubmessageWriteKind::Gap(GapSubmessageWrite {
         endianness_flag: true,
         reader_id: ENTITYID_UNKNOWN,
         writer_id,

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -37,9 +37,7 @@ use crate::{
             messages::{
                 overall_structure::RtpsMessageHeader,
                 submessage_elements::SequenceNumberSet,
-                submessages::{
-                    GapSubmessageWrite, InfoDestinationSubmessageWrite, InfoTimestampSubmessage,
-                },
+                submessages::{GapSubmessageWrite, InfoDestinationSubmessageWrite, InfoTimestampSubmessageWrite},
                 types::{FragmentNumber, ProtocolId},
                 RtpsMessageRead, RtpsMessageWrite, RtpsSubmessageWriteKind,
             },
@@ -2090,7 +2088,7 @@ fn gap_submessage<'a>(
 }
 
 fn info_timestamp_submessage<'a>(timestamp: Time) -> RtpsSubmessageWriteKind<'a> {
-    RtpsSubmessageWriteKind::InfoTimestamp(InfoTimestampSubmessage {
+    RtpsSubmessageWriteKind::InfoTimestamp(InfoTimestampSubmessageWrite {
         endianness_flag: true,
         invalidate_flag: false,
         timestamp: crate::implementation::rtps::messages::types::Time::new(

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -37,7 +37,7 @@ use crate::{
             messages::{
                 overall_structure::RtpsMessageHeader,
                 submessage_elements::SequenceNumberSet,
-                submessages::{InfoDestinationSubmessage, InfoTimestampSubmessage, GapSubmessageWrite},
+                submessages::{InfoTimestampSubmessage, GapSubmessageWrite, InfoDestinationSubmessageWrite},
                 types::{FragmentNumber, ProtocolId}, RtpsSubmessageWriteKind, RtpsMessageWrite, RtpsMessageRead,
             },
             reader_locator::WriterAssociatedReaderLocator,
@@ -2097,7 +2097,7 @@ fn info_timestamp_submessage<'a>(timestamp: Time) -> RtpsSubmessageWriteKind<'a>
 }
 
 fn info_destination_submessage<'a>(guid_prefix: GuidPrefix) -> RtpsSubmessageWriteKind<'a> {
-    RtpsSubmessageWriteKind::InfoDestination(InfoDestinationSubmessage {
+    RtpsSubmessageWriteKind::InfoDestination(InfoDestinationSubmessageWrite {
         endianness_flag: true,
         guid_prefix,
     })

--- a/dds/src/implementation/dds/dds_data_reader.rs
+++ b/dds/src/implementation/dds/dds_data_reader.rs
@@ -11,8 +11,8 @@ use crate::{
             messages::{
                 overall_structure::RtpsMessageHeader,
                 submessages::{
-                    DataFragSubmessageRead, DataSubmessageRead,
-                    HeartbeatFragSubmessage, HeartbeatSubmessageRead, GapSubmessageRead,
+                    DataFragSubmessageRead, DataSubmessageRead, GapSubmessageRead,
+                    HeartbeatFragSubmessageRead, HeartbeatSubmessageRead,
                 },
             },
             reader::{RtpsReaderCacheChange, RtpsReaderResult},
@@ -380,7 +380,7 @@ impl DdsDataReader<RtpsStatefulReader> {
 
     pub fn on_heartbeat_frag_submessage_received(
         &mut self,
-        heartbeat_frag_submessage: &HeartbeatFragSubmessage,
+        heartbeat_frag_submessage: &HeartbeatFragSubmessageRead,
         source_guid_prefix: GuidPrefix,
     ) {
         self.rtps_reader

--- a/dds/src/implementation/dds/dds_data_reader.rs
+++ b/dds/src/implementation/dds/dds_data_reader.rs
@@ -11,8 +11,8 @@ use crate::{
             messages::{
                 overall_structure::RtpsMessageHeader,
                 submessages::{
-                    DataFragSubmessageRead, DataSubmessageRead, GapSubmessage,
-                    HeartbeatFragSubmessage, HeartbeatSubmessageRead,
+                    DataFragSubmessageRead, DataSubmessageRead,
+                    HeartbeatFragSubmessage, HeartbeatSubmessageRead, GapSubmessageRead,
                 },
             },
             reader::{RtpsReaderCacheChange, RtpsReaderResult},
@@ -780,7 +780,7 @@ impl DdsDataReader<RtpsStatefulReader> {
 
     pub fn on_gap_submessage_received(
         &mut self,
-        gap_submessage: &GapSubmessage,
+        gap_submessage: &GapSubmessageRead,
         source_guid_prefix: GuidPrefix,
     ) {
         self.rtps_reader

--- a/dds/src/implementation/dds/dds_data_reader.rs
+++ b/dds/src/implementation/dds/dds_data_reader.rs
@@ -12,7 +12,7 @@ use crate::{
                 overall_structure::RtpsMessageHeader,
                 submessages::{
                     DataFragSubmessageRead, DataSubmessageRead, GapSubmessage,
-                    HeartbeatFragSubmessage, HeartbeatSubmessage,
+                    HeartbeatFragSubmessage, HeartbeatSubmessageRead,
                 },
             },
             reader::{RtpsReaderCacheChange, RtpsReaderResult},
@@ -371,7 +371,7 @@ impl DdsDataReader<RtpsStatefulReader> {
 
     pub fn on_heartbeat_submessage_received(
         &mut self,
-        heartbeat_submessage: &HeartbeatSubmessage,
+        heartbeat_submessage: &HeartbeatSubmessageRead,
         source_guid_prefix: GuidPrefix,
     ) {
         self.rtps_reader

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -10,7 +10,7 @@ use crate::{
             history_cache::RtpsWriterCacheChange,
             messages::{
                 submessage_elements::ParameterList,
-                submessages::{AckNackSubmessage, NackFragSubmessage},
+                submessages::{NackFragSubmessage, AckNackSubmessageRead},
             },
             reader_locator::{RtpsReaderLocator, WriterAssociatedReaderLocator},
             reader_proxy::{RtpsReaderProxy, WriterAssociatedReaderProxy},
@@ -347,7 +347,7 @@ impl DdsDataWriter<RtpsStatefulWriter> {
 
     pub fn on_acknack_submessage_received(
         &mut self,
-        acknack_submessage: &AckNackSubmessage,
+        acknack_submessage: &AckNackSubmessageRead,
         message_receiver: &MessageReceiver,
     ) {
         if self.rtps_writer.get_qos().reliability.kind == ReliabilityQosPolicyKind::Reliable {

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -8,10 +8,7 @@ use crate::{
         },
         rtps::{
             history_cache::RtpsWriterCacheChange,
-            messages::{
-                submessage_elements::ParameterList,
-                submessages::{NackFragSubmessage, AckNackSubmessageRead},
-            },
+            messages::{submessage_elements::ParameterList, submessages::{AckNackSubmessageRead, NackFragSubmessageRead}},
             reader_locator::{RtpsReaderLocator, WriterAssociatedReaderLocator},
             reader_proxy::{RtpsReaderProxy, WriterAssociatedReaderProxy},
             stateful_writer::RtpsStatefulWriter,
@@ -360,7 +357,7 @@ impl DdsDataWriter<RtpsStatefulWriter> {
 
     pub fn on_nack_frag_submessage_received(
         &mut self,
-        nackfrag_submessage: &NackFragSubmessage,
+        nackfrag_submessage: &NackFragSubmessageRead,
         message_receiver: &MessageReceiver,
     ) {
         if self.rtps_writer.get_qos().reliability.kind == ReliabilityQosPolicyKind::Reliable {

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -8,7 +8,10 @@ use crate::{
         },
         rtps::{
             history_cache::RtpsWriterCacheChange,
-            messages::{submessage_elements::ParameterList, submessages::{AckNackSubmessageRead, NackFragSubmessageRead}},
+            messages::{
+                submessage_elements::ParameterList,
+                submessages::{AckNackSubmessageRead, NackFragSubmessageRead},
+            },
             reader_locator::{RtpsReaderLocator, WriterAssociatedReaderLocator},
             reader_proxy::{RtpsReaderProxy, WriterAssociatedReaderProxy},
             stateful_writer::RtpsStatefulWriter,

--- a/dds/src/implementation/dds/dds_subscriber.rs
+++ b/dds/src/implementation/dds/dds_subscriber.rs
@@ -2,8 +2,7 @@ use crate::{
     implementation::rtps::{
         group::RtpsGroup,
         messages::submessages::{
-            DataFragSubmessageRead, DataSubmessageRead, GapSubmessage, HeartbeatFragSubmessage,
-            HeartbeatSubmessage,
+            DataFragSubmessageRead, DataSubmessageRead, GapSubmessage, HeartbeatFragSubmessage, HeartbeatSubmessageRead,
         },
         stateful_reader::RtpsStatefulReader,
         stateless_reader::RtpsStatelessReader,
@@ -211,7 +210,7 @@ impl DdsSubscriber {
 
     pub fn on_heartbeat_submessage_received(
         &mut self,
-        heartbeat_submessage: &HeartbeatSubmessage,
+        heartbeat_submessage: &HeartbeatSubmessageRead,
         source_guid_prefix: GuidPrefix,
     ) {
         for data_reader in self.stateful_data_reader_list.iter_mut() {

--- a/dds/src/implementation/dds/dds_subscriber.rs
+++ b/dds/src/implementation/dds/dds_subscriber.rs
@@ -2,7 +2,7 @@ use crate::{
     implementation::rtps::{
         group::RtpsGroup,
         messages::submessages::{
-            DataFragSubmessageRead, DataSubmessageRead, GapSubmessage, HeartbeatFragSubmessage, HeartbeatSubmessageRead,
+            DataFragSubmessageRead, DataSubmessageRead,HeartbeatFragSubmessage, HeartbeatSubmessageRead, GapSubmessageRead,
         },
         stateful_reader::RtpsStatefulReader,
         stateless_reader::RtpsStatelessReader,
@@ -275,7 +275,7 @@ impl DdsSubscriber {
 
     pub fn on_gap_submessage_received(
         &mut self,
-        gap_submessage: &GapSubmessage,
+        gap_submessage: &GapSubmessageRead,
         message_receiver: &MessageReceiver,
     ) {
         for data_reader in self.stateful_data_reader_list.iter_mut() {

--- a/dds/src/implementation/dds/dds_subscriber.rs
+++ b/dds/src/implementation/dds/dds_subscriber.rs
@@ -2,7 +2,8 @@ use crate::{
     implementation::rtps::{
         group::RtpsGroup,
         messages::submessages::{
-            DataFragSubmessageRead, DataSubmessageRead,HeartbeatFragSubmessage, HeartbeatSubmessageRead, GapSubmessageRead,
+            DataFragSubmessageRead, DataSubmessageRead, GapSubmessageRead,
+            HeartbeatFragSubmessageRead, HeartbeatSubmessageRead,
         },
         stateful_reader::RtpsStatefulReader,
         stateless_reader::RtpsStatelessReader,
@@ -220,7 +221,7 @@ impl DdsSubscriber {
 
     pub fn on_heartbeat_frag_submessage_received(
         &mut self,
-        heartbeat_frag_submessage: &HeartbeatFragSubmessage,
+        heartbeat_frag_submessage: &HeartbeatFragSubmessageRead,
         source_guid_prefix: GuidPrefix,
     ) {
         for data_reader in self.stateful_data_reader_list.iter_mut() {

--- a/dds/src/implementation/dds/message_receiver.rs
+++ b/dds/src/implementation/dds/message_receiver.rs
@@ -72,7 +72,7 @@ impl MessageReceiver {
             LOCATOR_ADDRESS_INVALID,
         ));
 
-        for submessage in message.submessages() {
+        for submessage in &message.submessages() {
             match submessage {
                 RtpsSubmessageReadKind::AckNack(acknack_submessage) => {
                     for publisher in publisher_list.iter_mut() {

--- a/dds/src/implementation/dds/message_receiver.rs
+++ b/dds/src/implementation/dds/message_receiver.rs
@@ -2,7 +2,7 @@ use crate::{
     implementation::rtps::{
         messages::{
             submessages::{
-                InfoDestinationSubmessage, InfoSourceSubmessage, InfoTimestampSubmessage,
+                InfoSourceSubmessage, InfoTimestampSubmessage, InfoDestinationSubmessageRead,
             }, RtpsMessageRead, RtpsSubmessageReadKind,
         },
         types::{
@@ -173,9 +173,9 @@ impl MessageReceiver {
 
     fn process_info_destination_submessage(
         &mut self,
-        info_destination: &InfoDestinationSubmessage,
+        info_destination: &InfoDestinationSubmessageRead,
     ) {
-        self.dest_guid_prefix = info_destination.guid_prefix;
+        self.dest_guid_prefix = info_destination.guid_prefix();
     }
 
     pub fn source_guid_prefix(&self) -> GuidPrefix {

--- a/dds/src/implementation/dds/message_receiver.rs
+++ b/dds/src/implementation/dds/message_receiver.rs
@@ -2,7 +2,7 @@ use crate::{
     implementation::rtps::{
         messages::{
             submessages::{
-                InfoDestinationSubmessageRead, InfoSourceSubmessageRead, InfoTimestampSubmessage,
+                InfoDestinationSubmessageRead, InfoSourceSubmessageRead, InfoTimestampSubmessageRead,
             },
             RtpsMessageRead, RtpsSubmessageReadKind,
         },
@@ -159,12 +159,12 @@ impl MessageReceiver {
         self.source_vendor_id = info_source.vendor_id();
     }
 
-    fn process_info_timestamp_submessage(&mut self, info_timestamp: &InfoTimestampSubmessage) {
-        if !info_timestamp.invalidate_flag {
+    fn process_info_timestamp_submessage(&mut self, info_timestamp: &InfoTimestampSubmessageRead) {
+        if !info_timestamp.invalidate_flag() {
             self.have_timestamp = true;
             self.timestamp = Time::new(
-                info_timestamp.timestamp.seconds(),
-                info_timestamp.timestamp.fraction(),
+                info_timestamp.timestamp().seconds(),
+                info_timestamp.timestamp().fraction(),
             );
         } else {
             self.have_timestamp = false;
@@ -189,41 +189,5 @@ impl MessageReceiver {
 
     pub fn reception_timestamp(&self) -> Time {
         self.reception_timestamp
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    use crate::implementation::rtps::messages::submessages::InfoTimestampSubmessage;
-
-    use super::*;
-
-    #[test]
-    fn process_info_timestamp_submessage_valid_time() {
-        let mut message_receiver = MessageReceiver::new(TIME_INVALID);
-        let info_timestamp = InfoTimestampSubmessage {
-            endianness_flag: true,
-            invalidate_flag: false,
-            timestamp: crate::implementation::rtps::messages::types::Time::new(0, 100),
-        };
-        message_receiver.process_info_timestamp_submessage(&info_timestamp);
-
-        assert!(message_receiver.have_timestamp);
-        assert_eq!(message_receiver.timestamp, Time::new(0, 100));
-    }
-
-    #[test]
-    fn process_info_timestamp_submessage_invalid_time() {
-        let mut message_receiver = MessageReceiver::new(TIME_INVALID);
-        let info_timestamp = InfoTimestampSubmessage {
-            endianness_flag: true,
-            invalidate_flag: true,
-            timestamp: crate::implementation::rtps::messages::types::Time::new(0, 100),
-        };
-        message_receiver.process_info_timestamp_submessage(&info_timestamp);
-
-        assert!(!message_receiver.have_timestamp);
-        assert_eq!(message_receiver.timestamp, TIME_INVALID);
     }
 }

--- a/dds/src/implementation/dds/message_receiver.rs
+++ b/dds/src/implementation/dds/message_receiver.rs
@@ -2,8 +2,9 @@ use crate::{
     implementation::rtps::{
         messages::{
             submessages::{
-                InfoSourceSubmessage, InfoTimestampSubmessage, InfoDestinationSubmessageRead,
-            }, RtpsMessageRead, RtpsSubmessageReadKind,
+                InfoDestinationSubmessageRead, InfoSourceSubmessageRead, InfoTimestampSubmessage,
+            },
+            RtpsMessageRead, RtpsSubmessageReadKind,
         },
         types::{
             Guid, GuidPrefix, Locator, ProtocolVersion, VendorId, GUIDPREFIX_UNKNOWN,
@@ -152,10 +153,10 @@ impl MessageReceiver {
         Ok(())
     }
 
-    fn process_info_source_submessage(&mut self, info_source: &InfoSourceSubmessage) {
-        self.source_vendor_id = info_source.vendor_id;
-        self.source_version = info_source.protocol_version;
-        self.source_vendor_id = info_source.vendor_id;
+    fn process_info_source_submessage(&mut self, info_source: &InfoSourceSubmessageRead) {
+        self.source_vendor_id = info_source.vendor_id();
+        self.source_version = info_source.protocol_version();
+        self.source_vendor_id = info_source.vendor_id();
     }
 
     fn process_info_timestamp_submessage(&mut self, info_timestamp: &InfoTimestampSubmessage) {

--- a/dds/src/implementation/rtps/history_cache.rs
+++ b/dds/src/implementation/rtps/history_cache.rs
@@ -6,7 +6,7 @@ use crate::{
 use super::{
     messages::{
         submessage_elements::{ParameterList, SequenceNumberSet},
-        submessages::{DataFragSubmessageWrite, DataSubmessageWrite, GapSubmessage},
+        submessages::{DataFragSubmessageWrite, DataSubmessageWrite, GapSubmessageWrite,},
         types::SerializedPayload,
     },
     types::{ChangeKind, EntityId, Guid, SequenceNumber},
@@ -23,8 +23,8 @@ pub struct RtpsWriterCacheChange {
 }
 
 impl RtpsWriterCacheChange {
-    pub fn as_gap_message(&self, reader_id: EntityId) -> GapSubmessage {
-        GapSubmessage {
+    pub fn as_gap_message(&self, reader_id: EntityId) -> GapSubmessageWrite {
+        GapSubmessageWrite {
             endianness_flag: true,
             reader_id,
             writer_id: self.writer_guid.entity_id(),

--- a/dds/src/implementation/rtps/messages/mod.rs
+++ b/dds/src/implementation/rtps/messages/mod.rs
@@ -1,7 +1,7 @@
 use std::io::BufRead;
 
 use crate::implementation::{
-    rtps::messages::submessages::AckNackSubmessageRead,
+    rtps::messages::submessages::{AckNackSubmessageRead, GapSubmessageRead},
     rtps_udp_psm::{
         mapping_rtps_messages::submessages::submessage_header::{
             ACKNACK, DATA, DATA_FRAG, GAP, HEARTBEAT, HEARTBEAT_FRAG, INFO_DST, INFO_REPLY,
@@ -15,10 +15,9 @@ use self::{
     overall_structure::RtpsMessageHeader,
     submessages::{
         AckNackSubmessageWrite, DataFragSubmessageRead, DataFragSubmessageWrite,
-        DataSubmessageRead, DataSubmessageWrite, GapSubmessage, HeartbeatFragSubmessage,
-        HeartbeatSubmessageRead, HeartbeatSubmessageWrite, InfoDestinationSubmessage,
-        InfoReplySubmessage, InfoSourceSubmessage, InfoTimestampSubmessage, NackFragSubmessage,
-        PadSubmessage,
+        DataSubmessageRead, DataSubmessageWrite, HeartbeatFragSubmessage, HeartbeatSubmessageRead,
+        HeartbeatSubmessageWrite, InfoDestinationSubmessage, InfoReplySubmessage,
+        InfoSourceSubmessage, InfoTimestampSubmessage, NackFragSubmessage, PadSubmessage, GapSubmessageWrite,
     },
     types::ProtocolId,
 };
@@ -86,10 +85,7 @@ impl<'a> RtpsMessageRead<'a> {
                     MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
                         .unwrap(),
                 ),
-                GAP => RtpsSubmessageReadKind::Gap(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
-                        .unwrap(),
-                ),
+                GAP => RtpsSubmessageReadKind::Gap(GapSubmessageRead::new(submessage_data)),
                 HEARTBEAT => {
                     RtpsSubmessageReadKind::Heartbeat(HeartbeatSubmessageRead::new(submessage_data))
                 }
@@ -162,7 +158,7 @@ pub enum RtpsSubmessageReadKind<'a> {
     AckNack(AckNackSubmessageRead<'a>),
     Data(DataSubmessageRead<'a>),
     DataFrag(DataFragSubmessageRead<'a>),
-    Gap(GapSubmessage),
+    Gap(GapSubmessageRead<'a>),
     Heartbeat(HeartbeatSubmessageRead<'a>),
     HeartbeatFrag(HeartbeatFragSubmessage),
     InfoDestination(InfoDestinationSubmessage),
@@ -178,7 +174,7 @@ pub enum RtpsSubmessageWriteKind<'a> {
     AckNack(AckNackSubmessageWrite),
     Data(DataSubmessageWrite<'a>),
     DataFrag(DataFragSubmessageWrite<'a>),
-    Gap(GapSubmessage),
+    Gap(GapSubmessageWrite),
     Heartbeat(HeartbeatSubmessageWrite),
     HeartbeatFrag(HeartbeatFragSubmessage),
     InfoDestination(InfoDestinationSubmessage),

--- a/dds/src/implementation/rtps/messages/mod.rs
+++ b/dds/src/implementation/rtps/messages/mod.rs
@@ -1,12 +1,25 @@
+use std::io::BufRead;
+
+use crate::implementation::rtps_udp_psm::{
+    mapping_rtps_messages::submessages::submessage_header::{
+        ACKNACK, DATA, DATA_FRAG, GAP, HEARTBEAT, HEARTBEAT_FRAG, INFO_DST, INFO_REPLY, INFO_SRC,
+        INFO_TS, NACK_FRAG, PAD,
+    },
+    mapping_traits::MappingReadByteOrderInfoInData,
+};
+
 use self::{
     overall_structure::RtpsMessageHeader,
     submessages::{
         AckNackSubmessage, DataFragSubmessageRead, DataFragSubmessageWrite, DataSubmessageRead,
-        DataSubmessageWrite, GapSubmessage, HeartbeatFragSubmessage, HeartbeatSubmessage,
+        DataSubmessageWrite, Endianness, GapSubmessage, HeartbeatFragSubmessage,
         InfoDestinationSubmessage, InfoReplySubmessage, InfoSourceSubmessage,
-        InfoTimestampSubmessage, NackFragSubmessage, PadSubmessage,
+        InfoTimestampSubmessage, NackFragSubmessage, PadSubmessage, HeartbeatSubmessageWrite, HeartbeatSubmessageRead,
     },
+    types::ProtocolId,
 };
+
+use super::types::{GuidPrefix, ProtocolVersion, VendorId};
 
 pub mod overall_structure;
 pub mod submessage_elements;
@@ -15,24 +28,105 @@ pub mod types;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct RtpsMessageRead<'a> {
-    header: RtpsMessageHeader,
-    submessages: Vec<RtpsSubmessageReadKind<'a>>,
+    data: &'a [u8],
 }
 
 impl<'a> RtpsMessageRead<'a> {
-    pub fn new(header: RtpsMessageHeader, submessages: Vec<RtpsSubmessageReadKind<'a>>) -> Self {
-        Self {
-            header,
-            submessages,
-        }
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data }
     }
 
     pub fn header(&self) -> RtpsMessageHeader {
-        self.header
+        let v = self.data;
+        let protocol = ProtocolId::PROTOCOL_RTPS; //([v[0], v[1], v[2], v[3]]);
+        let major = v[4];
+        let minor = v[5];
+        let version = ProtocolVersion::new(major, minor);
+        let vendor_id = VendorId::new([v[6], v[7]]);
+        let guid_prefix = GuidPrefix::new([
+            v[8], v[9], v[10], v[11], v[12], v[13], v[14], v[15], v[16], v[17], v[18], v[19],
+        ]);
+        RtpsMessageHeader {
+            protocol,
+            version,
+            vendor_id,
+            guid_prefix,
+        }
     }
 
-    pub fn submessages(&self) -> &[RtpsSubmessageReadKind] {
-        self.submessages.as_ref()
+    pub fn submessages(&self) -> Vec<RtpsSubmessageReadKind> {
+        let mut buf = &self.data[20..];
+        const MAX_SUBMESSAGES: usize = 2_usize.pow(16);
+        let mut submessages = vec![];
+        for _ in 0..MAX_SUBMESSAGES {
+            if buf.len() < 4 {
+                break;
+            }
+            let submessage_id = buf[0];
+            let endianness_flag = (buf[1] & 0b_0000_0001) != 0;
+            let submessage_length = if endianness_flag {
+                u16::from_le_bytes([buf[2], buf[3]])
+            } else {
+                u16::from_be_bytes([buf[2], buf[3]])
+            } as usize + 4;
+
+            let submessage_data = &buf[..submessage_length];
+
+            let submessage = match submessage_id {
+                ACKNACK => RtpsSubmessageReadKind::AckNack(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                DATA => RtpsSubmessageReadKind::Data(DataSubmessageRead::new(submessage_data)),
+                DATA_FRAG => RtpsSubmessageReadKind::DataFrag(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                GAP => RtpsSubmessageReadKind::Gap(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                HEARTBEAT => RtpsSubmessageReadKind::Heartbeat(
+                    HeartbeatSubmessageRead::new(submessage_data)
+                ),
+                HEARTBEAT_FRAG => RtpsSubmessageReadKind::HeartbeatFrag(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                INFO_DST => RtpsSubmessageReadKind::InfoDestination(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                INFO_REPLY => RtpsSubmessageReadKind::InfoReply(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                INFO_SRC => RtpsSubmessageReadKind::InfoSource(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                INFO_TS => RtpsSubmessageReadKind::InfoTimestamp(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                NACK_FRAG => RtpsSubmessageReadKind::NackFrag(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                PAD => RtpsSubmessageReadKind::Pad(
+                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
+                        .unwrap(),
+                ),
+                _ => {
+                    buf.consume(submessage_length);
+                    continue;
+                }
+            };
+
+            buf.consume(submessage_length);
+            submessages.push(submessage);
+        }
+        submessages
     }
 }
 
@@ -65,7 +159,7 @@ pub enum RtpsSubmessageReadKind<'a> {
     Data(DataSubmessageRead<'a>),
     DataFrag(DataFragSubmessageRead<'a>),
     Gap(GapSubmessage),
-    Heartbeat(HeartbeatSubmessage),
+    Heartbeat(HeartbeatSubmessageRead<'a>),
     HeartbeatFrag(HeartbeatFragSubmessage),
     InfoDestination(InfoDestinationSubmessage),
     InfoReply(InfoReplySubmessage),
@@ -81,7 +175,7 @@ pub enum RtpsSubmessageWriteKind<'a> {
     Data(DataSubmessageWrite<'a>),
     DataFrag(DataFragSubmessageWrite<'a>),
     Gap(GapSubmessage),
-    Heartbeat(HeartbeatSubmessage),
+    Heartbeat(HeartbeatSubmessageWrite),
     HeartbeatFrag(HeartbeatFragSubmessage),
     InfoDestination(InfoDestinationSubmessage),
     InfoReply(InfoReplySubmessage),

--- a/dds/src/implementation/rtps/messages/mod.rs
+++ b/dds/src/implementation/rtps/messages/mod.rs
@@ -1,7 +1,9 @@
 use std::io::BufRead;
 
 use crate::implementation::{
-    rtps::messages::submessages::{AckNackSubmessageRead, GapSubmessageRead},
+    rtps::messages::submessages::{
+        AckNackSubmessageRead, GapSubmessageRead, InfoDestinationSubmessageRead,
+    },
     rtps_udp_psm::{
         mapping_rtps_messages::submessages::submessage_header::{
             ACKNACK, DATA, DATA_FRAG, GAP, HEARTBEAT, HEARTBEAT_FRAG, INFO_DST, INFO_REPLY,
@@ -15,9 +17,10 @@ use self::{
     overall_structure::RtpsMessageHeader,
     submessages::{
         AckNackSubmessageWrite, DataFragSubmessageRead, DataFragSubmessageWrite,
-        DataSubmessageRead, DataSubmessageWrite, HeartbeatFragSubmessage, HeartbeatSubmessageRead,
-        HeartbeatSubmessageWrite, InfoDestinationSubmessage, InfoReplySubmessage,
-        InfoSourceSubmessage, InfoTimestampSubmessage, NackFragSubmessage, PadSubmessage, GapSubmessageWrite,
+        DataSubmessageRead, DataSubmessageWrite, GapSubmessageWrite, HeartbeatFragSubmessage,
+        HeartbeatSubmessageRead, HeartbeatSubmessageWrite,
+        InfoReplySubmessage, InfoSourceSubmessage, InfoTimestampSubmessage, NackFragSubmessage,
+        PadSubmessage, InfoDestinationSubmessageWrite,
     },
     types::ProtocolId,
 };
@@ -94,8 +97,7 @@ impl<'a> RtpsMessageRead<'a> {
                         .unwrap(),
                 ),
                 INFO_DST => RtpsSubmessageReadKind::InfoDestination(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
-                        .unwrap(),
+                    InfoDestinationSubmessageRead::new(submessage_data),
                 ),
                 INFO_REPLY => RtpsSubmessageReadKind::InfoReply(
                     MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
@@ -161,7 +163,7 @@ pub enum RtpsSubmessageReadKind<'a> {
     Gap(GapSubmessageRead<'a>),
     Heartbeat(HeartbeatSubmessageRead<'a>),
     HeartbeatFrag(HeartbeatFragSubmessage),
-    InfoDestination(InfoDestinationSubmessage),
+    InfoDestination(InfoDestinationSubmessageRead<'a>),
     InfoReply(InfoReplySubmessage),
     InfoSource(InfoSourceSubmessage),
     InfoTimestamp(InfoTimestampSubmessage),
@@ -177,7 +179,7 @@ pub enum RtpsSubmessageWriteKind<'a> {
     Gap(GapSubmessageWrite),
     Heartbeat(HeartbeatSubmessageWrite),
     HeartbeatFrag(HeartbeatFragSubmessage),
-    InfoDestination(InfoDestinationSubmessage),
+    InfoDestination(InfoDestinationSubmessageWrite),
     InfoReply(InfoReplySubmessage),
     InfoSource(InfoSourceSubmessage),
     InfoTimestamp(InfoTimestampSubmessage),

--- a/dds/src/implementation/rtps/messages/mod.rs
+++ b/dds/src/implementation/rtps/messages/mod.rs
@@ -18,9 +18,9 @@ use self::{
     submessages::{
         AckNackSubmessageWrite, DataFragSubmessageRead, DataFragSubmessageWrite,
         DataSubmessageRead, DataSubmessageWrite, GapSubmessageWrite, HeartbeatFragSubmessage,
-        HeartbeatSubmessageRead, HeartbeatSubmessageWrite,
-        InfoReplySubmessage, InfoSourceSubmessage, InfoTimestampSubmessage, NackFragSubmessage,
-        PadSubmessage, InfoDestinationSubmessageWrite,
+        HeartbeatSubmessageRead, HeartbeatSubmessageWrite, InfoDestinationSubmessageWrite,
+        InfoReplySubmessageRead, InfoReplySubmessageWrite,
+        InfoSourceSubmessage, InfoTimestampSubmessage, NackFragSubmessage, PadSubmessage,
     },
     types::ProtocolId,
 };
@@ -99,10 +99,9 @@ impl<'a> RtpsMessageRead<'a> {
                 INFO_DST => RtpsSubmessageReadKind::InfoDestination(
                     InfoDestinationSubmessageRead::new(submessage_data),
                 ),
-                INFO_REPLY => RtpsSubmessageReadKind::InfoReply(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
-                        .unwrap(),
-                ),
+                INFO_REPLY => {
+                    RtpsSubmessageReadKind::InfoReply(InfoReplySubmessageRead::new(submessage_data))
+                }
                 INFO_SRC => RtpsSubmessageReadKind::InfoSource(
                     MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
                         .unwrap(),
@@ -164,7 +163,7 @@ pub enum RtpsSubmessageReadKind<'a> {
     Heartbeat(HeartbeatSubmessageRead<'a>),
     HeartbeatFrag(HeartbeatFragSubmessage),
     InfoDestination(InfoDestinationSubmessageRead<'a>),
-    InfoReply(InfoReplySubmessage),
+    InfoReply(InfoReplySubmessageRead<'a>),
     InfoSource(InfoSourceSubmessage),
     InfoTimestamp(InfoTimestampSubmessage),
     NackFrag(NackFragSubmessage),
@@ -180,7 +179,7 @@ pub enum RtpsSubmessageWriteKind<'a> {
     Heartbeat(HeartbeatSubmessageWrite),
     HeartbeatFrag(HeartbeatFragSubmessage),
     InfoDestination(InfoDestinationSubmessageWrite),
-    InfoReply(InfoReplySubmessage),
+    InfoReply(InfoReplySubmessageWrite),
     InfoSource(InfoSourceSubmessage),
     InfoTimestamp(InfoTimestampSubmessage),
     NackFrag(NackFragSubmessage),

--- a/dds/src/implementation/rtps/messages/mod.rs
+++ b/dds/src/implementation/rtps/messages/mod.rs
@@ -86,10 +86,9 @@ impl<'a> RtpsMessageRead<'a> {
                     RtpsSubmessageReadKind::AckNack(AckNackSubmessageRead::new(submessage_data))
                 }
                 DATA => RtpsSubmessageReadKind::Data(DataSubmessageRead::new(submessage_data)),
-                DATA_FRAG => RtpsSubmessageReadKind::DataFrag(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
-                        .unwrap(),
-                ),
+                DATA_FRAG => {
+                    RtpsSubmessageReadKind::DataFrag(DataFragSubmessageRead::new(submessage_data))
+                }
                 GAP => RtpsSubmessageReadKind::Gap(GapSubmessageRead::new(submessage_data)),
                 HEARTBEAT => {
                     RtpsSubmessageReadKind::Heartbeat(HeartbeatSubmessageRead::new(submessage_data))

--- a/dds/src/implementation/rtps/messages/mod.rs
+++ b/dds/src/implementation/rtps/messages/mod.rs
@@ -3,6 +3,7 @@ use std::io::BufRead;
 use crate::implementation::{
     rtps::messages::submessages::{
         AckNackSubmessageRead, GapSubmessageRead, InfoDestinationSubmessageRead,
+        InfoSourceSubmessageRead,
     },
     rtps_udp_psm::{
         mapping_rtps_messages::submessages::submessage_header::{
@@ -19,8 +20,8 @@ use self::{
         AckNackSubmessageWrite, DataFragSubmessageRead, DataFragSubmessageWrite,
         DataSubmessageRead, DataSubmessageWrite, GapSubmessageWrite, HeartbeatFragSubmessage,
         HeartbeatSubmessageRead, HeartbeatSubmessageWrite, InfoDestinationSubmessageWrite,
-        InfoReplySubmessageRead, InfoReplySubmessageWrite,
-        InfoSourceSubmessage, InfoTimestampSubmessage, NackFragSubmessage, PadSubmessage,
+        InfoReplySubmessageRead, InfoReplySubmessageWrite, InfoSourceSubmessageWrite,
+        InfoTimestampSubmessage, NackFragSubmessage, PadSubmessage,
     },
     types::ProtocolId,
 };
@@ -102,10 +103,9 @@ impl<'a> RtpsMessageRead<'a> {
                 INFO_REPLY => {
                     RtpsSubmessageReadKind::InfoReply(InfoReplySubmessageRead::new(submessage_data))
                 }
-                INFO_SRC => RtpsSubmessageReadKind::InfoSource(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
-                        .unwrap(),
-                ),
+                INFO_SRC => RtpsSubmessageReadKind::InfoSource(InfoSourceSubmessageRead::new(
+                    submessage_data,
+                )),
                 INFO_TS => RtpsSubmessageReadKind::InfoTimestamp(
                     MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
                         .unwrap(),
@@ -164,7 +164,7 @@ pub enum RtpsSubmessageReadKind<'a> {
     HeartbeatFrag(HeartbeatFragSubmessage),
     InfoDestination(InfoDestinationSubmessageRead<'a>),
     InfoReply(InfoReplySubmessageRead<'a>),
-    InfoSource(InfoSourceSubmessage),
+    InfoSource(InfoSourceSubmessageRead<'a>),
     InfoTimestamp(InfoTimestampSubmessage),
     NackFrag(NackFragSubmessage),
     Pad(PadSubmessage),
@@ -180,7 +180,7 @@ pub enum RtpsSubmessageWriteKind<'a> {
     HeartbeatFrag(HeartbeatFragSubmessage),
     InfoDestination(InfoDestinationSubmessageWrite),
     InfoReply(InfoReplySubmessageWrite),
-    InfoSource(InfoSourceSubmessage),
+    InfoSource(InfoSourceSubmessageWrite),
     InfoTimestamp(InfoTimestampSubmessage),
     NackFrag(NackFragSubmessage),
     Pad(PadSubmessage),

--- a/dds/src/implementation/rtps/messages/mod.rs
+++ b/dds/src/implementation/rtps/messages/mod.rs
@@ -2,16 +2,15 @@ use std::io::BufRead;
 
 use crate::implementation::{
     rtps::messages::submessages::{
-        AckNackSubmessageRead, GapSubmessageRead, InfoDestinationSubmessageRead,
-        InfoSourceSubmessageRead, InfoTimestampSubmessageRead, NackFragSubmessageRead,
-        PadSubmessageRead,
+        AckNackSubmessageRead, GapSubmessageRead, HeartbeatFragSubmessageRead,
+        InfoDestinationSubmessageRead, InfoSourceSubmessageRead, InfoTimestampSubmessageRead,
+        NackFragSubmessageRead, PadSubmessageRead,
     },
     rtps_udp_psm::{
         mapping_rtps_messages::submessages::submessage_header::{
             ACKNACK, DATA, DATA_FRAG, GAP, HEARTBEAT, HEARTBEAT_FRAG, INFO_DST, INFO_REPLY,
             INFO_SRC, INFO_TS, NACK_FRAG, PAD,
         },
-        mapping_traits::MappingReadByteOrderInfoInData,
     },
 };
 
@@ -19,7 +18,7 @@ use self::{
     overall_structure::RtpsMessageHeader,
     submessages::{
         AckNackSubmessageWrite, DataFragSubmessageRead, DataFragSubmessageWrite,
-        DataSubmessageRead, DataSubmessageWrite, GapSubmessageWrite, HeartbeatFragSubmessage,
+        DataSubmessageRead, DataSubmessageWrite, GapSubmessageWrite, HeartbeatFragSubmessageWrite,
         HeartbeatSubmessageRead, HeartbeatSubmessageWrite, InfoDestinationSubmessageWrite,
         InfoReplySubmessageRead, InfoReplySubmessageWrite, InfoSourceSubmessageWrite,
         InfoTimestampSubmessageWrite, NackFragSubmessageWrite, PadSubmessageWrite,
@@ -94,8 +93,7 @@ impl<'a> RtpsMessageRead<'a> {
                     RtpsSubmessageReadKind::Heartbeat(HeartbeatSubmessageRead::new(submessage_data))
                 }
                 HEARTBEAT_FRAG => RtpsSubmessageReadKind::HeartbeatFrag(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
-                        .unwrap(),
+                    HeartbeatFragSubmessageRead::new(submessage_data),
                 ),
                 INFO_DST => RtpsSubmessageReadKind::InfoDestination(
                     InfoDestinationSubmessageRead::new(submessage_data),
@@ -156,7 +154,7 @@ pub enum RtpsSubmessageReadKind<'a> {
     DataFrag(DataFragSubmessageRead<'a>),
     Gap(GapSubmessageRead<'a>),
     Heartbeat(HeartbeatSubmessageRead<'a>),
-    HeartbeatFrag(HeartbeatFragSubmessage),
+    HeartbeatFrag(HeartbeatFragSubmessageRead<'a>),
     InfoDestination(InfoDestinationSubmessageRead<'a>),
     InfoReply(InfoReplySubmessageRead<'a>),
     InfoSource(InfoSourceSubmessageRead<'a>),
@@ -172,7 +170,7 @@ pub enum RtpsSubmessageWriteKind<'a> {
     DataFrag(DataFragSubmessageWrite<'a>),
     Gap(GapSubmessageWrite),
     Heartbeat(HeartbeatSubmessageWrite),
-    HeartbeatFrag(HeartbeatFragSubmessage),
+    HeartbeatFrag(HeartbeatFragSubmessageWrite),
     InfoDestination(InfoDestinationSubmessageWrite),
     InfoReply(InfoReplySubmessageWrite),
     InfoSource(InfoSourceSubmessageWrite),

--- a/dds/src/implementation/rtps/messages/mod.rs
+++ b/dds/src/implementation/rtps/messages/mod.rs
@@ -3,7 +3,7 @@ use std::io::BufRead;
 use crate::implementation::{
     rtps::messages::submessages::{
         AckNackSubmessageRead, GapSubmessageRead, InfoDestinationSubmessageRead,
-        InfoSourceSubmessageRead,
+        InfoSourceSubmessageRead, InfoTimestampSubmessageRead,
     },
     rtps_udp_psm::{
         mapping_rtps_messages::submessages::submessage_header::{
@@ -21,7 +21,7 @@ use self::{
         DataSubmessageRead, DataSubmessageWrite, GapSubmessageWrite, HeartbeatFragSubmessage,
         HeartbeatSubmessageRead, HeartbeatSubmessageWrite, InfoDestinationSubmessageWrite,
         InfoReplySubmessageRead, InfoReplySubmessageWrite, InfoSourceSubmessageWrite,
-        InfoTimestampSubmessage, NackFragSubmessage, PadSubmessage,
+        NackFragSubmessage, PadSubmessage, InfoTimestampSubmessageWrite,
     },
     types::ProtocolId,
 };
@@ -106,10 +106,9 @@ impl<'a> RtpsMessageRead<'a> {
                 INFO_SRC => RtpsSubmessageReadKind::InfoSource(InfoSourceSubmessageRead::new(
                     submessage_data,
                 )),
-                INFO_TS => RtpsSubmessageReadKind::InfoTimestamp(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
-                        .unwrap(),
-                ),
+                INFO_TS => RtpsSubmessageReadKind::InfoTimestamp(InfoTimestampSubmessageRead::new(
+                    submessage_data,
+                )),
                 NACK_FRAG => RtpsSubmessageReadKind::NackFrag(
                     MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(&mut buf)
                         .unwrap(),
@@ -165,7 +164,7 @@ pub enum RtpsSubmessageReadKind<'a> {
     InfoDestination(InfoDestinationSubmessageRead<'a>),
     InfoReply(InfoReplySubmessageRead<'a>),
     InfoSource(InfoSourceSubmessageRead<'a>),
-    InfoTimestamp(InfoTimestampSubmessage),
+    InfoTimestamp(InfoTimestampSubmessageRead<'a>),
     NackFrag(NackFragSubmessage),
     Pad(PadSubmessage),
 }
@@ -181,7 +180,7 @@ pub enum RtpsSubmessageWriteKind<'a> {
     InfoDestination(InfoDestinationSubmessageWrite),
     InfoReply(InfoReplySubmessageWrite),
     InfoSource(InfoSourceSubmessageWrite),
-    InfoTimestamp(InfoTimestampSubmessage),
+    InfoTimestamp(InfoTimestampSubmessageWrite),
     NackFrag(NackFragSubmessage),
     Pad(PadSubmessage),
 }

--- a/dds/src/implementation/rtps/messages/submessages.rs
+++ b/dds/src/implementation/rtps/messages/submessages.rs
@@ -416,7 +416,46 @@ pub struct HeartbeatSubmessageWrite {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HeartbeatFragSubmessage {
+pub struct HeartbeatFragSubmessageRead<'a> {
+    data: &'a [u8],
+}
+impl Endianness for HeartbeatFragSubmessageRead<'_> {
+    fn endianness(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+}
+impl<'a> HeartbeatFragSubmessageRead<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data }
+    }
+
+    pub fn endianness_flag(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+
+    pub fn reader_id(&self) -> EntityId {
+        self.mapping_read(&self.data[4..])
+    }
+
+    pub fn writer_id(&self) -> EntityId {
+        self.mapping_read(&self.data[8..])
+    }
+
+    pub fn writer_sn(&self) -> SequenceNumber {
+        self.mapping_read(&self.data[12..])
+    }
+
+    pub fn last_fragment_num(&self) -> FragmentNumber {
+        self.mapping_read(&self.data[20..])
+    }
+
+    pub fn count(&self) -> Count {
+        self.mapping_read(&self.data[24..])
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct HeartbeatFragSubmessageWrite {
     pub endianness_flag: SubmessageFlag,
     pub reader_id: EntityId,
     pub writer_id: EntityId,

--- a/dds/src/implementation/rtps/messages/submessages.rs
+++ b/dds/src/implementation/rtps/messages/submessages.rs
@@ -245,7 +245,43 @@ pub struct DataFragSubmessageWrite<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct GapSubmessage {
+pub struct GapSubmessageRead<'a> {
+    data: &'a [u8],
+}
+impl Endianness for GapSubmessageRead<'_> {
+    fn endianness(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+}
+
+impl<'a> GapSubmessageRead<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data }
+    }
+
+    pub fn endianness_flag(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+
+    pub fn reader_id(&self) -> EntityId {
+        self.mapping_read(&self.data[4..])
+    }
+
+    pub fn writer_id(&self) -> EntityId {
+        self.mapping_read(&self.data[8..])
+    }
+
+    pub fn gap_start(&self) -> SequenceNumber {
+        self.mapping_read(&self.data[12..])
+    }
+
+    pub fn gap_list(&self) -> SequenceNumberSet {
+        self.mapping_read(&self.data[20..])
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct GapSubmessageWrite {
     pub endianness_flag: SubmessageFlag,
     pub reader_id: EntityId,
     pub writer_id: EntityId,

--- a/dds/src/implementation/rtps/messages/submessages.rs
+++ b/dds/src/implementation/rtps/messages/submessages.rs
@@ -479,7 +479,7 @@ pub struct InfoSourceSubmessageWrite {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoTimestampSubmessageRead<'a> {
-    data: &'a[u8],
+    data: &'a [u8],
 }
 
 impl Endianness for InfoTimestampSubmessageRead<'_> {
@@ -489,7 +489,9 @@ impl Endianness for InfoTimestampSubmessageRead<'_> {
 }
 
 impl<'a> InfoTimestampSubmessageRead<'a> {
-    pub fn new(data: &'a[u8]) -> Self { Self { data } }
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data }
+    }
 
     pub fn endianness_flag(&self) -> bool {
         (self.data[1] & 0b_0000_0001) != 0
@@ -516,7 +518,48 @@ pub struct InfoTimestampSubmessageWrite {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct NackFragSubmessage {
+pub struct NackFragSubmessageRead<'a> {
+    data: &'a [u8],
+}
+
+impl Endianness for NackFragSubmessageRead<'_> {
+    fn endianness(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+}
+
+impl<'a> NackFragSubmessageRead<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data }
+    }
+
+    pub fn endianness_flag(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+
+    pub fn reader_id(&self) -> EntityId {
+        self.mapping_read(&self.data[4..])
+    }
+
+    pub fn writer_id(&self) -> EntityId {
+        self.mapping_read(&self.data[8..])
+    }
+
+    pub fn writer_sn(&self) -> SequenceNumber {
+        self.mapping_read(&self.data[12..])
+    }
+
+    pub fn fragment_number_state(&self) -> FragmentNumberSet {
+        self.mapping_read(&self.data[20..])
+    }
+
+    pub fn count(&self) -> Count {
+        self.mapping_read(&self.data[self.data.len() - 4..])
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct NackFragSubmessageWrite {
     pub endianness_flag: SubmessageFlag,
     pub reader_id: EntityId,
     pub writer_id: EntityId,
@@ -526,6 +569,25 @@ pub struct NackFragSubmessage {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct PadSubmessage {
+pub struct PadSubmessageRead<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> PadSubmessageRead<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data }
+    }
+    pub fn endianness(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+}
+
+impl Endianness for PadSubmessageRead<'_> {
+    fn endianness(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+}
+#[derive(Debug, PartialEq, Eq)]
+pub struct PadSubmessageWrite {
     pub endianness_flag: SubmessageFlag,
 }

--- a/dds/src/implementation/rtps/messages/submessages.rs
+++ b/dds/src/implementation/rtps/messages/submessages.rs
@@ -437,7 +437,40 @@ pub struct InfoReplySubmessageWrite {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct InfoSourceSubmessage {
+pub struct InfoSourceSubmessageRead<'a> {
+    data: &'a [u8],
+}
+
+impl Endianness for InfoSourceSubmessageRead<'_> {
+    fn endianness(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+}
+
+impl<'a> InfoSourceSubmessageRead<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
+        Self { data }
+    }
+
+    pub fn endianness_flag(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+
+    pub fn protocol_version(&self) -> ProtocolVersion {
+        self.mapping_read(&self.data[8..])
+    }
+
+    pub fn vendor_id(&self) -> VendorId {
+        self.mapping_read(&self.data[10..])
+    }
+
+    pub fn guid_prefix(&self) -> GuidPrefix {
+        self.mapping_read(&self.data[12..])
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct InfoSourceSubmessageWrite {
     pub endianness_flag: SubmessageFlag,
     pub protocol_version: ProtocolVersion,
     pub vendor_id: VendorId,

--- a/dds/src/implementation/rtps/messages/submessages.rs
+++ b/dds/src/implementation/rtps/messages/submessages.rs
@@ -360,7 +360,29 @@ pub struct HeartbeatFragSubmessage {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct InfoDestinationSubmessage {
+pub struct InfoDestinationSubmessageRead<'a> {
+    data: &'a [u8],
+}
+
+impl Endianness for InfoDestinationSubmessageRead<'_> {
+    fn endianness(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+}
+
+impl<'a> InfoDestinationSubmessageRead<'a> {
+    pub fn new(data: &'a [u8]) -> Self { Self { data } }
+
+    pub fn endianness_flag(&self) -> bool {
+        (self.data[1] & 0b_0000_0001) != 0
+    }
+
+    pub fn guid_prefix(&self) -> GuidPrefix {
+        self.mapping_read(&self.data[4..])
+    }
+}
+#[derive(Debug, PartialEq, Eq)]
+pub struct InfoDestinationSubmessageWrite {
     pub endianness_flag: SubmessageFlag,
     pub guid_prefix: GuidPrefix,
 }

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -66,11 +66,11 @@ pub fn convert_data_frag_to_cache_change(
     source_guid_prefix: GuidPrefix,
     reception_timestamp: Time,
 ) -> Result<RtpsReaderCacheChange, RtpsReaderError> {
-    let writer_guid = Guid::new(source_guid_prefix, data_frag_submessage.writer_id);
+    let writer_guid = Guid::new(source_guid_prefix, data_frag_submessage.writer_id());
 
     let inline_qos = data_frag_submessage.inline_qos();
 
-    let change_kind = if data_frag_submessage.key_flag {
+    let change_kind = if data_frag_submessage.key_flag() {
         if let Some(p) = inline_qos
             .parameter()
             .iter()

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -257,13 +257,13 @@ impl RtpsReader {
         source_guid_prefix: GuidPrefix,
         reception_timestamp: Time,
     ) -> RtpsReaderResult<RtpsReaderCacheChange> {
-        let writer_guid = Guid::new(source_guid_prefix, data_submessage.writer_id);
+        let writer_guid = Guid::new(source_guid_prefix, data_submessage.writer_id());
 
-        let data = <&[u8]>::from(&data_submessage.serialized_payload).to_vec();
+        let data = <&[u8]>::from(data_submessage.serialized_payload()).to_vec();
 
         let inline_qos = data_submessage.inline_qos();
 
-        let change_kind = match (data_submessage.data_flag, data_submessage.key_flag) {
+        let change_kind = match (data_submessage.data_flag(), data_submessage.key_flag()) {
             (true, false) => Ok(ChangeKind::Alive),
             (false, true) | (false, false) => {
                 if let Some(p) = inline_qos

--- a/dds/src/implementation/rtps/reader_locator.rs
+++ b/dds/src/implementation/rtps/reader_locator.rs
@@ -5,7 +5,7 @@ use super::{
     messages::{
         overall_structure::RtpsMessageHeader,
         submessage_elements::SequenceNumberSet,
-        submessages::{ InfoTimestampSubmessage, GapSubmessageWrite},
+        submessages::{ GapSubmessageWrite, InfoTimestampSubmessageWrite},
         RtpsMessageWrite, RtpsSubmessageWriteKind,
     },
     transport::TransportWrite,
@@ -20,7 +20,7 @@ pub struct RtpsReaderLocator {
 }
 
 fn info_timestamp_submessage<'a>(timestamp: Time) -> RtpsSubmessageWriteKind<'a> {
-    RtpsSubmessageWriteKind::InfoTimestamp(InfoTimestampSubmessage {
+    RtpsSubmessageWriteKind::InfoTimestamp(InfoTimestampSubmessageWrite {
         endianness_flag: true,
         invalidate_flag: false,
         timestamp: super::messages::types::Time::new(timestamp.sec(), timestamp.nanosec()),

--- a/dds/src/implementation/rtps/reader_locator.rs
+++ b/dds/src/implementation/rtps/reader_locator.rs
@@ -5,7 +5,7 @@ use super::{
     messages::{
         overall_structure::RtpsMessageHeader,
         submessage_elements::SequenceNumberSet,
-        submessages::{GapSubmessage, InfoTimestampSubmessage},
+        submessages::{ InfoTimestampSubmessage, GapSubmessageWrite},
         RtpsMessageWrite, RtpsSubmessageWriteKind,
     },
     transport::TransportWrite,
@@ -31,7 +31,7 @@ fn gap_submessage<'a>(
     writer_id: EntityId,
     gap_sequence_number: SequenceNumber,
 ) -> RtpsSubmessageWriteKind<'a> {
-    RtpsSubmessageWriteKind::Gap(GapSubmessage {
+    RtpsSubmessageWriteKind::Gap(GapSubmessageWrite {
         endianness_flag: true,
         reader_id: ENTITYID_UNKNOWN,
         writer_id,

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -4,8 +4,8 @@ use super::{
     history_cache::{RtpsWriterCacheChange, WriterHistoryCache},
     messages::{
         submessages::{
-            HeartbeatFragSubmessage, HeartbeatSubmessageWrite,
-            NackFragSubmessage, AckNackSubmessageRead,
+            AckNackSubmessageRead, HeartbeatFragSubmessage, HeartbeatSubmessageWrite,
+            NackFragSubmessageRead,
         },
         types::FragmentNumber,
         RtpsSubmessageWriteKind,
@@ -183,13 +183,13 @@ impl RtpsReaderProxy {
         }
     }
 
-    pub fn receive_nack_frag(&mut self, nack_frag_submessage: &NackFragSubmessage) {
+    pub fn receive_nack_frag(&mut self, nack_frag_submessage: &NackFragSubmessageRead) {
         match self.reliability {
             ReliabilityKind::BestEffort => (),
             ReliabilityKind::Reliable => {
-                if nack_frag_submessage.count > self.last_received_nack_frag_count {
-                    self.requested_changes_set(&[nack_frag_submessage.writer_sn]);
-                    self.last_received_nack_frag_count = nack_frag_submessage.count;
+                if nack_frag_submessage.count() > self.last_received_nack_frag_count {
+                    self.requested_changes_set(&[nack_frag_submessage.writer_sn()]);
+                    self.last_received_nack_frag_count = nack_frag_submessage.count();
                 }
             }
         }

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -4,9 +4,11 @@ use super::{
     history_cache::{RtpsWriterCacheChange, WriterHistoryCache},
     messages::{
         submessages::{
-            AckNackSubmessage, HeartbeatFragSubmessage, HeartbeatSubmessage, NackFragSubmessage,
+            AckNackSubmessage, HeartbeatFragSubmessage, HeartbeatSubmessageWrite,
+            NackFragSubmessage,
         },
-        types::FragmentNumber, RtpsSubmessageWriteKind,
+        types::FragmentNumber,
+        RtpsSubmessageWriteKind,
     },
     types::{
         Count, DurabilityKind, EntityId, ExpectsInlineQos, Guid, Locator, ReliabilityKind,
@@ -43,7 +45,7 @@ impl HeartbeatMachine {
     ) -> RtpsSubmessageWriteKind<'a> {
         self.count = self.count.wrapping_add(1);
         self.timer.reset();
-        RtpsSubmessageWriteKind::Heartbeat(HeartbeatSubmessage {
+        RtpsSubmessageWriteKind::Heartbeat(HeartbeatSubmessageWrite {
             endianness_flag: true,
             final_flag: false,
             liveliness_flag: false,

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -4,8 +4,8 @@ use super::{
     history_cache::{RtpsWriterCacheChange, WriterHistoryCache},
     messages::{
         submessages::{
-            AckNackSubmessage, HeartbeatFragSubmessage, HeartbeatSubmessageWrite,
-            NackFragSubmessage,
+            HeartbeatFragSubmessage, HeartbeatSubmessageWrite,
+            NackFragSubmessage, AckNackSubmessageRead,
         },
         types::FragmentNumber,
         RtpsSubmessageWriteKind,
@@ -169,15 +169,15 @@ impl RtpsReaderProxy {
         self.durability
     }
 
-    pub fn receive_acknack(&mut self, acknack_submessage: &AckNackSubmessage) {
+    pub fn receive_acknack(&mut self, acknack_submessage: &AckNackSubmessageRead) {
         match self.reliability {
             ReliabilityKind::BestEffort => (),
             ReliabilityKind::Reliable => {
-                if acknack_submessage.count > self.last_received_acknack_count {
-                    self.acked_changes_set(acknack_submessage.reader_sn_state.base - 1);
-                    self.requested_changes_set(acknack_submessage.reader_sn_state.set.as_ref());
+                if acknack_submessage.count() > self.last_received_acknack_count {
+                    self.acked_changes_set(acknack_submessage.reader_sn_state().base - 1);
+                    self.requested_changes_set(acknack_submessage.reader_sn_state().set.as_ref());
 
-                    self.last_received_acknack_count = acknack_submessage.count;
+                    self.last_received_acknack_count = acknack_submessage.count();
                 }
             }
         }

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -4,7 +4,7 @@ use super::{
     history_cache::{RtpsWriterCacheChange, WriterHistoryCache},
     messages::{
         submessages::{
-            AckNackSubmessageRead, HeartbeatFragSubmessage, HeartbeatSubmessageWrite,
+            AckNackSubmessageRead, HeartbeatFragSubmessageWrite, HeartbeatSubmessageWrite,
             NackFragSubmessageRead,
         },
         types::FragmentNumber,
@@ -78,7 +78,7 @@ impl HeartbeatFragMachine {
         last_fragment_num: FragmentNumber,
     ) -> RtpsSubmessageWriteKind<'a> {
         self.count = self.count.wrapping_add(1);
-        RtpsSubmessageWriteKind::HeartbeatFrag(HeartbeatFragSubmessage {
+        RtpsSubmessageWriteKind::HeartbeatFrag(HeartbeatFragSubmessageWrite {
             endianness_flag: true,
             reader_id: self.reader_id,
             writer_id,

--- a/dds/src/implementation/rtps/stateful_reader.rs
+++ b/dds/src/implementation/rtps/stateful_reader.rs
@@ -302,10 +302,10 @@ impl RtpsStatefulReader {
         data_frag_submessage: &DataFragSubmessageRead<'_>,
         message_receiver: &MessageReceiver,
     ) -> StatefulReaderDataReceivedResult {
-        let sequence_number = data_frag_submessage.writer_sn;
+        let sequence_number = data_frag_submessage.writer_sn();
         let writer_guid = Guid::new(
             message_receiver.source_guid_prefix(),
-            data_frag_submessage.writer_id,
+            data_frag_submessage.writer_id(),
         );
 
         if let Some(writer_proxy) = self

--- a/dds/src/implementation/rtps/stateful_reader.rs
+++ b/dds/src/implementation/rtps/stateful_reader.rs
@@ -19,7 +19,7 @@ use super::{
     messages::{
         overall_structure::RtpsMessageHeader,
         submessages::{
-            DataFragSubmessageRead, DataSubmessageRead, GapSubmessage, HeartbeatFragSubmessage, HeartbeatSubmessageRead,
+            DataFragSubmessageRead, DataSubmessageRead,  HeartbeatFragSubmessage, HeartbeatSubmessageRead, GapSubmessageRead,
         },
     },
     reader::{
@@ -454,22 +454,22 @@ impl RtpsStatefulReader {
 
     pub fn on_gap_submessage_received(
         &mut self,
-        gap_submessage: &GapSubmessage,
+        gap_submessage: &GapSubmessageRead,
         source_guid_prefix: GuidPrefix,
     ) {
-        let writer_guid = Guid::new(source_guid_prefix, gap_submessage.writer_id);
+        let writer_guid = Guid::new(source_guid_prefix, gap_submessage.writer_id());
         if let Some(writer_proxy) = self
             .matched_writers
             .iter_mut()
             .find(|x| x.remote_writer_guid() == writer_guid)
         {
             for seq_num in
-                i64::from(gap_submessage.gap_start)..i64::from(gap_submessage.gap_list.base)
+                i64::from(gap_submessage.gap_start())..i64::from(gap_submessage.gap_list().base)
             {
                 writer_proxy.irrelevant_change_set(SequenceNumber::new(seq_num))
             }
 
-            for seq_num in &gap_submessage.gap_list.set {
+            for seq_num in &gap_submessage.gap_list().set {
                 writer_proxy.irrelevant_change_set(*seq_num)
             }
         }

--- a/dds/src/implementation/rtps/stateful_reader.rs
+++ b/dds/src/implementation/rtps/stateful_reader.rs
@@ -19,7 +19,8 @@ use super::{
     messages::{
         overall_structure::RtpsMessageHeader,
         submessages::{
-            DataFragSubmessageRead, DataSubmessageRead,  HeartbeatFragSubmessage, HeartbeatSubmessageRead, GapSubmessageRead,
+            DataFragSubmessageRead, DataSubmessageRead, GapSubmessageRead,
+            HeartbeatFragSubmessageRead, HeartbeatSubmessageRead,
         },
     },
     reader::{
@@ -275,7 +276,8 @@ impl RtpsStatefulReader {
 
                                 match add_change_result {
                                     Ok(instance_handle) => {
-                                        writer_proxy.received_change_set(data_submessage.writer_sn());
+                                        writer_proxy
+                                            .received_change_set(data_submessage.writer_sn());
                                         StatefulReaderDataReceivedResult::NewSampleAdded(
                                             instance_handle,
                                         )
@@ -431,20 +433,21 @@ impl RtpsStatefulReader {
 
     pub fn on_heartbeat_frag_submessage_received(
         &mut self,
-        heartbeat_frag_submessage: &HeartbeatFragSubmessage,
+        heartbeat_frag_submessage: &HeartbeatFragSubmessageRead,
         source_guid_prefix: GuidPrefix,
     ) {
         if self.reader.get_qos().reliability.kind == ReliabilityQosPolicyKind::Reliable {
-            let writer_guid = Guid::new(source_guid_prefix, heartbeat_frag_submessage.writer_id);
+            let writer_guid = Guid::new(source_guid_prefix, heartbeat_frag_submessage.writer_id());
 
             if let Some(writer_proxy) = self
                 .matched_writers
                 .iter_mut()
                 .find(|x| x.remote_writer_guid() == writer_guid)
             {
-                if writer_proxy.last_received_heartbeat_count() < heartbeat_frag_submessage.count {
+                if writer_proxy.last_received_heartbeat_count() < heartbeat_frag_submessage.count()
+                {
                     writer_proxy
-                        .set_last_received_heartbeat_frag_count(heartbeat_frag_submessage.count);
+                        .set_last_received_heartbeat_frag_count(heartbeat_frag_submessage.count());
                 }
 
                 // todo!()

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -21,7 +21,7 @@ use super::{
     history_cache::RtpsWriterCacheChange,
     messages::{
         submessage_elements::{Parameter, ParameterList},
-        submessages::{AckNackSubmessage, NackFragSubmessage},
+        submessages::{NackFragSubmessage, AckNackSubmessageRead},
         types::ParameterId,
     },
     reader_proxy::{
@@ -302,11 +302,11 @@ impl RtpsStatefulWriter {
 
     pub fn on_acknack_submessage_received(
         &mut self,
-        acknack_submessage: &AckNackSubmessage,
+        acknack_submessage: &AckNackSubmessageRead,
         src_guid_prefix: GuidPrefix,
     ) {
         if self.writer.get_qos().reliability.kind == ReliabilityQosPolicyKind::Reliable {
-            let reader_guid = Guid::new(src_guid_prefix, acknack_submessage.reader_id);
+            let reader_guid = Guid::new(src_guid_prefix, acknack_submessage.reader_id());
 
             if let Some(reader_proxy) = self
                 .matched_readers

--- a/dds/src/implementation/rtps/stateful_writer.rs
+++ b/dds/src/implementation/rtps/stateful_writer.rs
@@ -21,7 +21,7 @@ use super::{
     history_cache::RtpsWriterCacheChange,
     messages::{
         submessage_elements::{Parameter, ParameterList},
-        submessages::{NackFragSubmessage, AckNackSubmessageRead},
+        submessages::{AckNackSubmessageRead, NackFragSubmessageRead},
         types::ParameterId,
     },
     reader_proxy::{
@@ -320,11 +320,11 @@ impl RtpsStatefulWriter {
 
     pub fn on_nack_frag_submessage_received(
         &mut self,
-        nackfrag_submessage: &NackFragSubmessage,
+        nackfrag_submessage: &NackFragSubmessageRead,
         src_guid_prefix: GuidPrefix,
     ) {
         if self.writer.get_qos().reliability.kind == ReliabilityQosPolicyKind::Reliable {
-            let reader_guid = Guid::new(src_guid_prefix, nackfrag_submessage.reader_id);
+            let reader_guid = Guid::new(src_guid_prefix, nackfrag_submessage.reader_id());
 
             if let Some(reader_proxy) = self
                 .matched_readers

--- a/dds/src/implementation/rtps/stateless_reader.rs
+++ b/dds/src/implementation/rtps/stateless_reader.rs
@@ -154,8 +154,8 @@ impl RtpsStatelessReader {
         data_submessage: &DataSubmessageRead<'_>,
         message_receiver: &MessageReceiver,
     ) -> StatelessReaderDataReceivedResult {
-        if data_submessage.reader_id == ENTITYID_UNKNOWN
-            || data_submessage.reader_id == self.0.guid().entity_id()
+        if data_submessage.reader_id() == ENTITYID_UNKNOWN
+            || data_submessage.reader_id() == self.0.guid().entity_id()
         {
             let change_result = self.0.convert_data_to_cache_change(
                 data_submessage,

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -8,8 +8,7 @@ use super::{
         overall_structure::RtpsMessageHeader,
         submessage_elements::{FragmentNumberSet, SequenceNumberSet},
         submessages::{
-            AckNackSubmessageWrite, DataFragSubmessageRead, InfoDestinationSubmessageWrite,
-            NackFragSubmessage,
+            AckNackSubmessageWrite, DataFragSubmessageRead, InfoDestinationSubmessageWrite, NackFragSubmessageWrite,
         },
         types::{FragmentNumber, ULong, UShort},
         RtpsMessageWrite, RtpsSubmessageWriteKind,
@@ -308,7 +307,7 @@ impl RtpsWriterProxy {
                 if !missing_fragment_number.is_empty() {
                     self.nack_frag_count = self.nack_frag_count.wrapping_add(1);
                     let nack_frag_submessage =
-                        RtpsSubmessageWriteKind::NackFrag(NackFragSubmessage {
+                        RtpsSubmessageWriteKind::NackFrag(NackFragSubmessageWrite {
                             endianness_flag: true,
                             reader_id: reader_guid.entity_id(),
                             writer_id: self.remote_writer_guid().entity_id(),

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -8,7 +8,7 @@ use super::{
         overall_structure::RtpsMessageHeader,
         submessage_elements::{FragmentNumberSet, SequenceNumberSet},
         submessages::{
-            AckNackSubmessage, DataFragSubmessageRead, InfoDestinationSubmessage,
+            AckNackSubmessageWrite, DataFragSubmessageRead, InfoDestinationSubmessage,
             NackFragSubmessage,
         },
         types::{FragmentNumber, ULong, UShort},
@@ -274,7 +274,7 @@ impl RtpsWriterProxy {
                 guid_prefix: self.remote_writer_guid().prefix(),
             };
 
-            let acknack_submessage = AckNackSubmessage {
+            let acknack_submessage = AckNackSubmessageWrite {
                 endianness_flag: true,
                 final_flag: true,
                 reader_id: reader_guid.entity_id(),

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -29,11 +29,11 @@ pub struct OwningDataFragSubmessage {
 impl From<&DataFragSubmessageRead<'_>> for OwningDataFragSubmessage {
     fn from(x: &DataFragSubmessageRead<'_>) -> Self {
         Self {
-            fragment_starting_num: x.fragment_starting_num,
-            data_size: x.data_size,
-            fragment_size: x.fragment_size,
-            fragments_in_submessage: x.fragments_in_submessage,
-            serialized_payload: <&[u8]>::from(&x.serialized_payload).to_vec(),
+            fragment_starting_num: x.fragment_starting_num(),
+            data_size: x.data_size(),
+            fragment_size: x.fragment_size(),
+            fragments_in_submessage: x.fragments_in_submessage(),
+            serialized_payload: <&[u8]>::from(&x.serialized_payload()).to_vec(),
         }
     }
 }
@@ -93,7 +93,7 @@ impl RtpsWriterProxy {
 
     pub fn push_data_frag(&mut self, submessage: &DataFragSubmessageRead) {
         let owning_data_frag = submessage.into();
-        let frag_bug_seq_num = self.frag_buffer.entry(submessage.writer_sn).or_default();
+        let frag_bug_seq_num = self.frag_buffer.entry(submessage.writer_sn()).or_default();
         if !frag_bug_seq_num.contains(&owning_data_frag) {
             frag_bug_seq_num.push(owning_data_frag);
         }

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -8,7 +8,8 @@ use super::{
         overall_structure::RtpsMessageHeader,
         submessage_elements::{FragmentNumberSet, SequenceNumberSet},
         submessages::{
-            AckNackSubmessageWrite, DataFragSubmessageRead, InfoDestinationSubmessageWrite, NackFragSubmessageWrite,
+            AckNackSubmessageWrite, DataFragSubmessageRead, InfoDestinationSubmessageWrite,
+            NackFragSubmessageWrite,
         },
         types::{FragmentNumber, ULong, UShort},
         RtpsMessageWrite, RtpsSubmessageWriteKind,

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -8,7 +8,7 @@ use super::{
         overall_structure::RtpsMessageHeader,
         submessage_elements::{FragmentNumberSet, SequenceNumberSet},
         submessages::{
-            AckNackSubmessageWrite, DataFragSubmessageRead, InfoDestinationSubmessage,
+            AckNackSubmessageWrite, DataFragSubmessageRead, InfoDestinationSubmessageWrite,
             NackFragSubmessage,
         },
         types::{FragmentNumber, ULong, UShort},
@@ -269,7 +269,7 @@ impl RtpsWriterProxy {
             self.set_must_send_acknacks(false);
             self.increment_acknack_count();
 
-            let info_dst_submessage = InfoDestinationSubmessage {
+            let info_dst_submessage = InfoDestinationSubmessageWrite {
                 endianness_flag: true,
                 guid_prefix: self.remote_writer_guid().prefix(),
             };

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/overall_structure.rs
@@ -1,21 +1,12 @@
-use std::io::{BufRead, Error, Write};
+use std::io::{Error, Write};
 
 use byteorder::LittleEndian;
 
 use crate::implementation::{
-    rtps::messages::{
-        overall_structure::RtpsSubmessageHeader, RtpsMessageRead, RtpsMessageWrite,
-        RtpsSubmessageReadKind, RtpsSubmessageWriteKind,
-    },
+    rtps::messages::{RtpsMessageRead, RtpsMessageWrite, RtpsSubmessageWriteKind},
     rtps_udp_psm::mapping_traits::{
-        MappingReadByteOrderInfoInData, MappingReadByteOrdered, MappingWriteByteOrderInfoInData,
-        MappingWriteByteOrdered,
+        MappingReadByteOrderInfoInData, MappingWriteByteOrderInfoInData, MappingWriteByteOrdered,
     },
-};
-
-use super::submessages::submessage_header::{
-    ACKNACK, DATA, DATA_FRAG, GAP, HEARTBEAT, HEARTBEAT_FRAG, INFO_DST, INFO_REPLY, INFO_SRC,
-    INFO_TS, NACK_FRAG, PAD,
 };
 
 impl MappingWriteByteOrderInfoInData for RtpsSubmessageWriteKind<'_> {
@@ -79,62 +70,62 @@ impl<'a, 'de: 'a> MappingReadByteOrderInfoInData<'de> for RtpsMessageRead<'a> {
     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
         // The byteorder is determined by each submessage individually. Hence
         // decide here for a byteorder for the header
-        let header = MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
-        const MAX_SUBMESSAGES: usize = 2_usize.pow(16);
-        let mut submessages = vec![];
-        for _ in 0..MAX_SUBMESSAGES {
-            if buf.len() < 4 {
-                break;
-            }
-            // Preview byte only (to allow full deserialization of submessage header)
-            let submessage_id = buf[0];
-            let submessage = match submessage_id {
-                ACKNACK => RtpsSubmessageReadKind::AckNack(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                DATA => RtpsSubmessageReadKind::Data(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                DATA_FRAG => RtpsSubmessageReadKind::DataFrag(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                GAP => RtpsSubmessageReadKind::Gap(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                HEARTBEAT => RtpsSubmessageReadKind::Heartbeat(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                HEARTBEAT_FRAG => RtpsSubmessageReadKind::HeartbeatFrag(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                INFO_DST => RtpsSubmessageReadKind::InfoDestination(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                INFO_REPLY => RtpsSubmessageReadKind::InfoReply(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                INFO_SRC => RtpsSubmessageReadKind::InfoSource(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                INFO_TS => RtpsSubmessageReadKind::InfoTimestamp(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                NACK_FRAG => RtpsSubmessageReadKind::NackFrag(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                PAD => RtpsSubmessageReadKind::Pad(
-                    MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
-                ),
-                _ => {
-                    let submessage_header: RtpsSubmessageHeader =
-                        MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
-                    buf.consume(submessage_header.submessage_length as usize);
-                    continue;
-                }
-            };
-            submessages.push(submessage);
-        }
-        Ok(RtpsMessageRead::new(header, submessages))
+        // let header = MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
+        // const MAX_SUBMESSAGES: usize = 2_usize.pow(16);
+        // let mut submessages = vec![];
+        // for _ in 0..MAX_SUBMESSAGES {
+        //     if buf.len() < 4 {
+        //         break;
+        //     }
+        //     // Preview byte only (to allow full deserialization of submessage header)
+        //     let submessage_id = buf[0];
+        //     let submessage = match submessage_id {
+        //         ACKNACK => RtpsSubmessageReadKind::AckNack(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         DATA => RtpsSubmessageReadKind::Data(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         DATA_FRAG => RtpsSubmessageReadKind::DataFrag(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         GAP => RtpsSubmessageReadKind::Gap(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         HEARTBEAT => RtpsSubmessageReadKind::Heartbeat(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         HEARTBEAT_FRAG => RtpsSubmessageReadKind::HeartbeatFrag(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         INFO_DST => RtpsSubmessageReadKind::InfoDestination(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         INFO_REPLY => RtpsSubmessageReadKind::InfoReply(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         INFO_SRC => RtpsSubmessageReadKind::InfoSource(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         INFO_TS => RtpsSubmessageReadKind::InfoTimestamp(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         NACK_FRAG => RtpsSubmessageReadKind::NackFrag(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         PAD => RtpsSubmessageReadKind::Pad(
+        //             MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?,
+        //         ),
+        //         _ => {
+        //             let submessage_header: RtpsSubmessageHeader =
+        //                 MappingReadByteOrderInfoInData::mapping_read_byte_order_info_in_data(buf)?;
+        //             buf.consume(submessage_header.submessage_length as usize);
+        //             continue;
+        //         }
+        //     };
+        //     submessages.push(submessage);
+        // }
+        Ok(RtpsMessageRead::new(buf))
     }
 }
 
@@ -146,15 +137,16 @@ mod tests {
             messages::{
                 overall_structure::RtpsMessageHeader,
                 submessage_elements::{Parameter, ParameterList},
-                submessages::{DataSubmessageRead, DataSubmessageWrite, HeartbeatSubmessage},
+                submessages::{DataSubmessageRead, DataSubmessageWrite, HeartbeatSubmessageRead},
                 types::{ParameterId, ProtocolId, SerializedPayload},
+                RtpsSubmessageReadKind,
             },
             types::{
-                Count, EntityId, EntityKey, GuidPrefix, ProtocolVersion, SequenceNumber, VendorId,
+                EntityId, EntityKey, GuidPrefix, ProtocolVersion, SequenceNumber, VendorId,
                 USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY,
             },
         },
-        rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
+        rtps_udp_psm::mapping_traits::to_bytes,
     };
 
     use super::*;
@@ -242,76 +234,56 @@ mod tests {
             guid_prefix: GuidPrefix::new([3; 12]),
         };
 
-        let expected = RtpsMessageRead::new(header, Vec::new());
         #[rustfmt::skip]
-        let result: RtpsMessageRead = from_bytes(&[
+        let rtps_message = RtpsMessageRead::new(&[
             b'R', b'T', b'P', b'S', // Protocol
             2, 3, 9, 8, // ProtocolVersion | VendorId
             3, 3, 3, 3, // GuidPrefix
             3, 3, 3, 3, // GuidPrefix
             3, 3, 3, 3, // GuidPrefix
-        ]).unwrap();
-        assert_eq!(result, expected);
+        ]);
+        assert_eq!(header, rtps_message.header());
     }
 
     #[test]
     fn deserialize_rtps_message() {
-        let header = RtpsMessageHeader {
+        let expected_header = RtpsMessageHeader {
             protocol: ProtocolId::PROTOCOL_RTPS,
             version: ProtocolVersion::new(2, 3),
             vendor_id: VendorId::new([9, 8]),
             guid_prefix: GuidPrefix::new([3; 12]),
         };
-        let endianness_flag = true;
-        let inline_qos_flag = true;
-        let data_flag = false;
-        let key_flag = false;
-        let non_standard_payload_flag = false;
-        let reader_id = EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
-        let writer_id = EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
-        let writer_sn = SequenceNumber::new(5);
-        let inline_qos = &[
+
+        #[rustfmt::skip]
+        let data_submessage = RtpsSubmessageReadKind::Data(DataSubmessageRead::new(
+            &[0x15, 0b_0000_0011, 40, 0, // Submessage header
+            0, 0, 16, 0, // extraFlags, octetsToInlineQos
+            1, 2, 3, 4, // readerId: value[4]
+            6, 7, 8, 9, // writerId: value[4]
+            0, 0, 0, 0, // writerSN: high
+            5, 0, 0, 0, // writerSN: low
             6, 0, 4, 0, // inlineQos: parameterId_1, length_1
             10, 11, 12, 13, // inlineQos: value_1[length_1]
             7, 0, 4, 0, // inlineQos: parameterId_2, length_2
             20, 21, 22, 23, // inlineQos: value_2[length_2]
             1, 0, 1, 0, // inlineQos: Sentinel
-        ];
-        let serialized_payload = SerializedPayload::new(&[]);
-
-        let data_submessage = RtpsSubmessageReadKind::Data(DataSubmessageRead {
-            endianness_flag,
-            inline_qos_flag,
-            data_flag,
-            key_flag,
-            non_standard_payload_flag,
-            reader_id,
-            writer_id,
-            writer_sn,
-            inline_qos,
-            serialized_payload,
-        });
-        let endianness_flag = true;
-        let final_flag = false;
-        let liveliness_flag = true;
-        let reader_id = EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
-        let writer_id = EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
-        let first_sn = SequenceNumber::new(5);
-        let last_sn = SequenceNumber::new(7);
-        let count = Count::new(2);
-        let heartbeat_submessage = RtpsSubmessageReadKind::Heartbeat(HeartbeatSubmessage {
-            endianness_flag,
-            final_flag,
-            liveliness_flag,
-            reader_id,
-            writer_id,
-            first_sn,
-            last_sn,
-            count,
-        });
-        let expected = RtpsMessageRead::new(header, vec![data_submessage, heartbeat_submessage]);
+        ]));
         #[rustfmt::skip]
-        let result: RtpsMessageRead = from_bytes(&[
+        let heartbeat_submessage = RtpsSubmessageReadKind::Heartbeat(HeartbeatSubmessageRead::new(&[
+            0x07, 0b_0000_0101, 28, 0, // Submessage header
+            1, 2, 3, 4, // readerId: value[4]
+            6, 7, 8, 9, // writerId: value[4]
+            0, 0, 0, 0, // firstSN: SequenceNumber: high
+            5, 0, 0, 0, // firstSN: SequenceNumber: low
+            0, 0, 0, 0, // lastSN: SequenceNumberSet: high
+            7, 0, 0, 0, // lastSN: SequenceNumberSet: low
+            2, 0, 0, 0, // count: Count: value (long)
+        ]));
+
+        let expected_submessages = vec![data_submessage, heartbeat_submessage];
+
+        #[rustfmt::skip]
+        let rtps_message: RtpsMessageRead = RtpsMessageRead::new(&[
             b'R', b'T', b'P', b'S', // Protocol
             2, 3, 9, 8, // ProtocolVersion | VendorId
             3, 3, 3, 3, // GuidPrefix
@@ -336,50 +308,31 @@ mod tests {
             0, 0, 0, 0, // lastSN: SequenceNumberSet: high
             7, 0, 0, 0, // lastSN: SequenceNumberSet: low
             2, 0, 0, 0, // count: Count: value (long)
-        ]).unwrap();
-        assert_eq!(result, expected);
+        ]);
+        assert_eq!(expected_header, rtps_message.header());
+        assert_eq!(expected_submessages, rtps_message.submessages());
     }
 
     #[test]
     fn deserialize_rtps_message_unknown_submessage() {
-        let header = RtpsMessageHeader {
-            protocol: ProtocolId::PROTOCOL_RTPS,
-            version: ProtocolVersion::new(2, 3),
-            vendor_id: VendorId::new([9, 8]),
-            guid_prefix: GuidPrefix::new([3; 12]),
-        };
-        let endianness_flag = true;
-        let inline_qos_flag = true;
-        let data_flag = false;
-        let key_flag = false;
-        let non_standard_payload_flag = false;
-        let reader_id = EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
-        let writer_id = EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
-        let writer_sn = SequenceNumber::new(5);
-        let inline_qos = &[
+        #[rustfmt::skip]
+        let submessage = RtpsSubmessageReadKind::Data(DataSubmessageRead::new(&[
+            0x15, 0b_0000_0011, 40, 0, // Submessage header
+            0, 0, 16, 0, // extraFlags, octetsToInlineQos
+            1, 2, 3, 4, // readerId: value[4]
+            6, 7, 8, 9, // writerId: value[4]
+            0, 0, 0, 0, // writerSN: high
+            5, 0, 0, 0, // writerSN: low
             6, 0, 4, 0, // inlineQos: parameterId_1, length_1
             10, 11, 12, 13, // inlineQos: value_1[length_1]
             7, 0, 4, 0, // inlineQos: parameterId_2, length_2
             20, 21, 22, 23, // inlineQos: value_2[length_2]
             1, 0, 0, 0, // inlineQos: Sentinel
-        ];
-        let serialized_payload = SerializedPayload::new(&[]);
+        ]));
+        let expected_submessages = vec![submessage];
 
-        let submessage = RtpsSubmessageReadKind::Data(DataSubmessageRead {
-            endianness_flag,
-            inline_qos_flag,
-            data_flag,
-            key_flag,
-            non_standard_payload_flag,
-            reader_id,
-            writer_id,
-            writer_sn,
-            inline_qos,
-            serialized_payload,
-        });
-        let expected = RtpsMessageRead::new(header, vec![submessage]);
         #[rustfmt::skip]
-        let result: RtpsMessageRead = from_bytes(&[
+        let rtps_message = RtpsMessageRead::new(&[
             b'R', b'T', b'P', b'S', // Protocol
             2, 3, 9, 8, // ProtocolVersion | VendorId
             3, 3, 3, 3, // GuidPrefix
@@ -398,7 +351,7 @@ mod tests {
             7, 0, 4, 0, // inlineQos: parameterId_2, length_2
             20, 21, 22, 23, // inlineQos: value_2[length_2]
             1, 0, 0, 0, // inlineQos: Sentinel
-        ]).unwrap();
-        assert_eq!(result, expected);
+        ]);
+        assert_eq!(expected_submessages, rtps_message.submessages());
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/serialized_payload.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/serialized_payload.rs
@@ -9,7 +9,7 @@ use crate::implementation::{
 
 impl<'de> MappingReadByteOrdered<'de> for SerializedPayload<'de> {
     fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
-        Ok(SerializedPayload::new(*buf))
+        Ok(SerializedPayload::new(buf))
     }
 }
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/serialized_payload.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessage_elements/serialized_payload.rs
@@ -4,8 +4,14 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::types::SerializedPayload,
-    rtps_udp_psm::mapping_traits::{MappingWriteByteOrdered, NumberOfBytes},
+    rtps_udp_psm::mapping_traits::{MappingWriteByteOrdered, NumberOfBytes, MappingReadByteOrdered},
 };
+
+impl<'de> MappingReadByteOrdered<'de> for SerializedPayload<'de> {
+    fn mapping_read_byte_ordered<B: ByteOrder>(buf: &mut &'de [u8]) -> Result<Self, Error> {
+        Ok(SerializedPayload::new(*buf))
+    }
+}
 
 impl MappingWriteByteOrdered for SerializedPayload<'_> {
     fn mapping_write_byte_ordered<W: Write, B: ByteOrder>(

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
@@ -1,20 +1,16 @@
 use std::io::{Error, Write};
 
-use byteorder::{ByteOrder, ReadBytesExt};
+use byteorder::ByteOrder;
 
 use crate::implementation::{
-    data_representation_builtin_endpoints::parameter_id_values::PID_SENTINEL,
     rtps::messages::{
-        overall_structure::RtpsSubmessageHeader,
-        submessages::{DataFragSubmessageRead, DataFragSubmessageWrite},
-        types::{SerializedPayload, SubmessageKind},
+        overall_structure::RtpsSubmessageHeader, submessages::DataFragSubmessageWrite,
+        types::SubmessageKind,
     },
-    rtps_udp_psm::mapping_traits::{
-        MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
-    },
+    rtps_udp_psm::mapping_traits::{MappingWriteByteOrdered, NumberOfBytes},
 };
 
-use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
+use super::submessage::MappingWriteSubmessage;
 
 impl MappingWriteSubmessage for DataFragSubmessageWrite<'_> {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
@@ -83,73 +79,6 @@ impl MappingWriteSubmessage for DataFragSubmessageWrite<'_> {
     }
 }
 
-impl<'de: 'a, 'a> MappingReadSubmessage<'de> for DataFragSubmessageRead<'a> {
-    fn mapping_read_submessage<B: ByteOrder>(
-        buf: &mut &'de [u8],
-        header: RtpsSubmessageHeader,
-    ) -> Result<Self, Error> {
-        let endianness_flag = header.flags[0];
-        let inline_qos_flag = header.flags[1];
-        let key_flag = header.flags[3];
-        let non_standard_payload_flag = header.flags[4];
-        let _extra_flags: u16 = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let octets_to_inline_qos: u16 =
-            MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let reader_id = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let writer_id = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let writer_sn = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let fragment_starting_num = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let fragments_in_submessage = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let fragment_size = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let data_size = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-
-        let mut parameter_list_buf = *buf;
-        let parameter_list_buf_length = parameter_list_buf.len();
-        let inline_qos_len = if inline_qos_flag {
-            loop {
-                let pid = parameter_list_buf.read_u16::<B>().expect("pid read failed");
-                let length = parameter_list_buf
-                    .read_i16::<B>()
-                    .expect("length read failed");
-                if pid == PID_SENTINEL {
-                    break;
-                } else {
-                    (_, parameter_list_buf) = parameter_list_buf.split_at(length as usize);
-                }
-            }
-            parameter_list_buf_length - parameter_list_buf.len()
-        } else {
-            0
-        };
-
-        let (inline_qos, following) = buf.split_at(inline_qos_len);
-        *buf = following;
-
-        let serialized_payload_length =
-            header.submessage_length as usize - octets_to_inline_qos as usize - 4 - inline_qos_len;
-        let (data, following) = buf.split_at(serialized_payload_length);
-        *buf = following;
-        let serialized_payload = SerializedPayload::new(data);
-
-        Ok(Self {
-            endianness_flag,
-            inline_qos_flag,
-            key_flag,
-            non_standard_payload_flag,
-            reader_id,
-            writer_id,
-            writer_sn,
-            fragment_starting_num,
-            fragments_in_submessage,
-            data_size,
-            fragment_size,
-            inline_qos,
-            serialized_payload,
-        })
-        // todo!()
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
@@ -157,14 +86,14 @@ mod tests {
         rtps::{
             messages::{
                 submessage_elements::{Parameter, ParameterList},
-                types::{FragmentNumber, ParameterId, SerializedPayload, ULong, UShort},
+                types::{FragmentNumber, ParameterId, SerializedPayload, ULong, UShort}, submessages::DataFragSubmessageRead,
             },
             types::{
                 EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
                 USER_DEFINED_READER_NO_KEY,
             },
         },
-        rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
+        rtps_udp_psm::mapping_traits::to_bytes,
     };
 
     use super::*;
@@ -242,23 +171,8 @@ mod tests {
 
     #[test]
     fn deserialize_no_inline_qos_no_serialized_payload() {
-        let expected = DataFragSubmessageRead {
-            endianness_flag: true,
-            inline_qos_flag: false,
-            non_standard_payload_flag: false,
-            key_flag: false,
-            reader_id: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
-            writer_id: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
-            writer_sn: SequenceNumber::new(5),
-            fragment_starting_num: FragmentNumber::new(2),
-            fragments_in_submessage: UShort::new(3),
-            data_size: ULong::new(4),
-            fragment_size: UShort::new(5),
-            inline_qos: &[],
-            serialized_payload: SerializedPayload::new(&[]),
-        };
         #[rustfmt::skip]
-        let result = from_bytes(&[
+        let submessage = DataFragSubmessageRead::new(&[
             0x16_u8, 0b_0000_0001, 32, 0, // Submessage header
             0, 0, 28, 0, // extraFlags, octetsToInlineQos
             1, 2, 3, 4, // readerId: value[4]
@@ -268,33 +182,52 @@ mod tests {
             2, 0, 0, 0, // fragmentStartingNum
             3, 0, 5, 0, // fragmentsInSubmessage | fragmentSize
             4, 0, 0, 0, // sampleSize
-        ]).unwrap();
-        assert_eq!(expected, result);
+        ]);
+
+        let expected_endianness_flag = true;
+        let expected_inline_qos_flag = false;
+        let expected_non_standard_payload_flag = false;
+        let expected_key_flag = false;
+        let expected_reader_id =
+            EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
+        let expected_writer_id =
+            EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
+        let expected_writer_sn = SequenceNumber::new(5);
+        let expected_fragment_starting_num = FragmentNumber::new(2);
+        let expected_fragments_in_submessage = UShort::new(3);
+        let expected_data_size = ULong::new(4);
+        let expected_fragment_size = UShort::new(5);
+        let expected_inline_qos = ParameterList::empty();
+        let expected_serialized_payload = SerializedPayload::new(&[]);
+
+        assert_eq!(expected_endianness_flag, submessage.endianness_flag());
+        assert_eq!(expected_inline_qos_flag, submessage.inline_qos_flag());
+        assert_eq!(
+            expected_non_standard_payload_flag,
+            submessage.non_standard_payload_flag()
+        );
+        assert_eq!(expected_key_flag, submessage.key_flag());
+        assert_eq!(expected_reader_id, submessage.reader_id());
+        assert_eq!(expected_writer_id, submessage.writer_id());
+        assert_eq!(expected_writer_sn, submessage.writer_sn());
+        assert_eq!(
+            expected_fragment_starting_num,
+            submessage.fragment_starting_num()
+        );
+        assert_eq!(
+            expected_fragments_in_submessage,
+            submessage.fragments_in_submessage()
+        );
+        assert_eq!(expected_data_size, submessage.data_size());
+        assert_eq!(expected_fragment_size, submessage.fragment_size());
+        assert_eq!(expected_inline_qos, submessage.inline_qos());
+        assert_eq!(expected_serialized_payload, submessage.serialized_payload());
     }
 
     #[test]
     fn deserialize_with_inline_qos_with_serialized_payload() {
-        let expected = DataFragSubmessageRead {
-            endianness_flag: true,
-            inline_qos_flag: true,
-            non_standard_payload_flag: false,
-            key_flag: false,
-            reader_id: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
-            writer_id: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
-            writer_sn: SequenceNumber::new(6),
-            fragment_starting_num: FragmentNumber::new(2),
-            fragments_in_submessage: UShort::new(3),
-            data_size: ULong::new(8),
-            fragment_size: UShort::new(5),
-            inline_qos: &[
-                8, 0, 4, 0, // inlineQos: parameterId, length
-                71, 72, 73, 74, // inlineQos: value[length]
-                1, 0, 0, 0, // inlineQos: Sentinel
-            ],
-            serialized_payload: SerializedPayload::new(&[1, 2, 3, 0]),
-        };
         #[rustfmt::skip]
-        let result = from_bytes(&[
+        let submessage = DataFragSubmessageRead::new(&[
             0x16_u8, 0b_0000_0011, 48, 0, // Submessage header
             0, 0, 28, 0, // extraFlags | octetsToInlineQos
             1, 2, 3, 4, // readerId
@@ -308,7 +241,46 @@ mod tests {
             71, 72, 73, 74, // inlineQos: value[length]
             1, 0, 0, 0, // inlineQos: Sentinel
             1, 2, 3, 0, // serializedPayload
-        ]).unwrap();
-        assert_eq!(expected, result);
+        ]);
+
+        let expected_endianness_flag = true;
+        let expected_inline_qos_flag = true;
+        let expected_non_standard_payload_flag = false;
+        let expected_key_flag = false;
+        let expected_reader_id =
+            EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
+        let expected_writer_id =
+            EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
+        let expected_writer_sn = SequenceNumber::new(6);
+        let expected_fragment_starting_num = FragmentNumber::new(2);
+        let expected_fragments_in_submessage = UShort::new(3);
+        let expected_data_size = ULong::new(8);
+        let expected_fragment_size = UShort::new(5);
+        let expected_inline_qos =
+            ParameterList::new(vec![Parameter::new(ParameterId(8), vec![71, 72, 73, 74])]);
+        let expected_serialized_payload = SerializedPayload::new(&[1, 2, 3, 0]);
+
+        assert_eq!(expected_endianness_flag, submessage.endianness_flag());
+        assert_eq!(expected_inline_qos_flag, submessage.inline_qos_flag());
+        assert_eq!(
+            expected_non_standard_payload_flag,
+            submessage.non_standard_payload_flag()
+        );
+        assert_eq!(expected_key_flag, submessage.key_flag());
+        assert_eq!(expected_reader_id, submessage.reader_id());
+        assert_eq!(expected_writer_id, submessage.writer_id());
+        assert_eq!(expected_writer_sn, submessage.writer_sn());
+        assert_eq!(
+            expected_fragment_starting_num,
+            submessage.fragment_starting_num()
+        );
+        assert_eq!(
+            expected_fragments_in_submessage,
+            submessage.fragments_in_submessage()
+        );
+        assert_eq!(expected_data_size, submessage.data_size());
+        assert_eq!(expected_fragment_size, submessage.fragment_size());
+        assert_eq!(expected_inline_qos, submessage.inline_qos());
+        assert_eq!(expected_serialized_payload, submessage.serialized_payload());
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/data_frag.rs
@@ -86,7 +86,8 @@ mod tests {
         rtps::{
             messages::{
                 submessage_elements::{Parameter, ParameterList},
-                types::{FragmentNumber, ParameterId, SerializedPayload, ULong, UShort}, submessages::DataFragSubmessageRead,
+                submessages::DataFragSubmessageRead,
+                types::{FragmentNumber, ParameterId, SerializedPayload, ULong, UShort},
             },
             types::{
                 EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat.rs
@@ -2,15 +2,16 @@ use std::io::{Error, Write};
 
 use crate::implementation::{
     rtps::messages::{
-        overall_structure::RtpsSubmessageHeader, submessages::HeartbeatSubmessage,
+        overall_structure::RtpsSubmessageHeader,
+        submessages::{HeartbeatSubmessageRead, HeartbeatSubmessageWrite},
         types::SubmessageKind,
     },
-    rtps_udp_psm::mapping_traits::{MappingReadByteOrdered, MappingWriteByteOrdered},
+    rtps_udp_psm::mapping_traits::MappingWriteByteOrdered,
 };
 
 use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
 
-impl MappingWriteSubmessage for HeartbeatSubmessage {
+impl MappingWriteSubmessage for HeartbeatSubmessageWrite {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
         RtpsSubmessageHeader {
             submessage_id: SubmessageKind::HEARTBEAT,
@@ -44,29 +45,30 @@ impl MappingWriteSubmessage for HeartbeatSubmessage {
     }
 }
 
-impl<'de> MappingReadSubmessage<'de> for HeartbeatSubmessage {
+impl<'de> MappingReadSubmessage<'de> for HeartbeatSubmessageRead<'de> {
     fn mapping_read_submessage<B: byteorder::ByteOrder>(
-        buf: &mut &'de [u8],
-        header: RtpsSubmessageHeader,
+        _buf: &mut &'de [u8],
+        _header: RtpsSubmessageHeader,
     ) -> Result<Self, Error> {
-        let endianness_flag = header.flags[0];
-        let final_flag = header.flags[1];
-        let liveliness_flag = header.flags[2];
-        let reader_id = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let writer_id = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let first_sn = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let last_sn = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let count = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        Ok(Self {
-            endianness_flag,
-            final_flag,
-            liveliness_flag,
-            reader_id,
-            writer_id,
-            first_sn,
-            last_sn,
-            count,
-        })
+        // let endianness_flag = header.flags[0];
+        // let final_flag = header.flags[1];
+        // let liveliness_flag = header.flags[2];
+        // let reader_id = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
+        // let writer_id = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
+        // let first_sn = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
+        // let last_sn = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
+        // let count = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
+        // Ok(Self {
+        //     endianness_flag,
+        //     final_flag,
+        //     liveliness_flag,
+        //     reader_id,
+        //     writer_id,
+        //     first_sn,
+        //     last_sn,
+        //     count,
+        // })
+        todo!()
     }
 }
 
@@ -78,7 +80,7 @@ mod tests {
             Count, EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
             USER_DEFINED_READER_NO_KEY,
         },
-        rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
+        rtps_udp_psm::mapping_traits::to_bytes,
     };
 
     use super::*;
@@ -93,7 +95,7 @@ mod tests {
         let first_sn = SequenceNumber::new(5);
         let last_sn = SequenceNumber::new(7);
         let count = Count::new(2);
-        let submessage = HeartbeatSubmessage {
+        let submessage = HeartbeatSubmessageWrite {
             endianness_flag,
             final_flag,
             liveliness_flag,
@@ -119,26 +121,18 @@ mod tests {
 
     #[test]
     fn deserialize_heart_beat() {
-        let endianness_flag = true;
-        let final_flag = false;
-        let liveliness_flag = true;
-        let reader_id = EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
-        let writer_id = EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
-        let first_sn = SequenceNumber::new(5);
-        let last_sn = SequenceNumber::new(7);
-        let count = Count::new(2);
-        let expected = HeartbeatSubmessage {
-            endianness_flag,
-            final_flag,
-            liveliness_flag,
-            reader_id,
-            writer_id,
-            first_sn,
-            last_sn,
-            count,
-        };
+        let expected_endianness_flag = true;
+        let expected_final_flag = false;
+        let expected_liveliness_flag = true;
+        let expected_reader_id =
+            EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
+        let expected_writer_id =
+            EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
+        let expected_first_sn = SequenceNumber::new(5);
+        let expected_last_sn = SequenceNumber::new(7);
+        let expected_count = Count::new(2);
         #[rustfmt::skip]
-        let result = from_bytes(&[
+        let submessage = HeartbeatSubmessageRead::new(&[
             0x07, 0b_0000_0101, 28, 0, // Submessage header
             1, 2, 3, 4, // readerId: value[4]
             6, 7, 8, 9, // writerId: value[4]
@@ -147,7 +141,14 @@ mod tests {
             0, 0, 0, 0, // lastSN: SequenceNumberSet: high
             7, 0, 0, 0, // lastSN: SequenceNumberSet: low
             2, 0, 0, 0, // count: Count: value (long)
-        ]).unwrap();
-        assert_eq!(expected, result);
+        ]);
+        assert_eq!(expected_endianness_flag, submessage.endianness_flag());
+        assert_eq!(expected_final_flag, submessage.final_flag());
+        assert_eq!(expected_liveliness_flag, submessage.liveliness_flag());
+        assert_eq!(expected_reader_id, submessage.reader_id());
+        assert_eq!(expected_writer_id, submessage.writer_id());
+        assert_eq!(expected_first_sn, submessage.first_sn());
+        assert_eq!(expected_last_sn, submessage.last_sn());
+        assert_eq!(expected_count, submessage.count());
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/heart_beat_frag.rs
@@ -4,15 +4,15 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::{
-        overall_structure::RtpsSubmessageHeader, submessages::HeartbeatFragSubmessage,
+        overall_structure::RtpsSubmessageHeader, submessages::HeartbeatFragSubmessageWrite,
         types::SubmessageKind,
     },
-    rtps_udp_psm::mapping_traits::{MappingReadByteOrdered, MappingWriteByteOrdered},
+    rtps_udp_psm::mapping_traits::MappingWriteByteOrdered,
 };
 
-use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
+use super::submessage::MappingWriteSubmessage;
 
-impl MappingWriteSubmessage for HeartbeatFragSubmessage {
+impl MappingWriteSubmessage for HeartbeatFragSubmessageWrite {
     fn submessage_header(
         &self,
     ) -> crate::implementation::rtps::messages::overall_structure::RtpsSubmessageHeader {
@@ -48,41 +48,25 @@ impl MappingWriteSubmessage for HeartbeatFragSubmessage {
     }
 }
 
-impl<'de> MappingReadSubmessage<'de> for HeartbeatFragSubmessage {
-    fn mapping_read_submessage<B: ByteOrder>(
-        buf: &mut &'de [u8],
-        header: RtpsSubmessageHeader,
-    ) -> Result<Self, Error> {
-        Ok(Self {
-            endianness_flag: header.flags[0],
-            reader_id: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-            writer_id: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-            writer_sn: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-            last_fragment_num: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-            count: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
 
     use crate::implementation::{
         rtps::{
-            messages::types::FragmentNumber,
+            messages::{submessages::HeartbeatFragSubmessageRead, types::FragmentNumber},
             types::{
                 Count, EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
                 USER_DEFINED_READER_NO_KEY,
             },
         },
-        rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
+        rtps_udp_psm::mapping_traits::to_bytes,
     };
 
     use super::*;
 
     #[test]
     fn serialize_heart_beat() {
-        let submessage = HeartbeatFragSubmessage {
+        let submessage = HeartbeatFragSubmessageWrite {
             endianness_flag: true,
             reader_id: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
             writer_id: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
@@ -105,16 +89,8 @@ mod tests {
 
     #[test]
     fn deserialize_heart_beat_frag() {
-        let expected = HeartbeatFragSubmessage {
-            endianness_flag: true,
-            reader_id: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
-            writer_id: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
-            writer_sn: SequenceNumber::new(5),
-            last_fragment_num: FragmentNumber::new(7),
-            count: Count::new(2),
-        };
         #[rustfmt::skip]
-        let result = from_bytes(&[
+        let submessage = HeartbeatFragSubmessageRead::new(&[
             0x13_u8, 0b_0000_0001, 24, 0, // Submessage header
             1, 2, 3, 4, // readerId: value[4]
             6, 7, 8, 9, // writerId: value[4]
@@ -122,7 +98,22 @@ mod tests {
             5, 0, 0, 0, // writerSN: SequenceNumber: low
             7, 0, 0, 0, // lastFragmentNum
             2, 0, 0, 0, // count: Count
-        ]).unwrap();
-        assert_eq!(expected, result);
+        ]);
+
+        let expected_endianness_flag = true;
+        let expected_reader_id =
+            EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
+        let expected_writer_id =
+            EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
+        let expected_writer_sn = SequenceNumber::new(5);
+        let expected_last_fragment_num = FragmentNumber::new(7);
+        let expected_count = Count::new(2);
+
+        assert_eq!(expected_endianness_flag, submessage.endianness_flag());
+        assert_eq!(expected_reader_id, submessage.reader_id());
+        assert_eq!(expected_writer_id, submessage.writer_id());
+        assert_eq!(expected_writer_sn, submessage.writer_sn());
+        assert_eq!(expected_last_fragment_num, submessage.last_fragment_num());
+        assert_eq!(expected_count, submessage.count());
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_destination.rs
@@ -4,17 +4,15 @@ use byteorder::ByteOrder;
 
 use crate::implementation::{
     rtps::messages::{
-        overall_structure::RtpsSubmessageHeader, submessages::InfoDestinationSubmessage,
+        overall_structure::RtpsSubmessageHeader, submessages::InfoDestinationSubmessageWrite,
         types::SubmessageKind,
     },
-    rtps_udp_psm::mapping_traits::{
-        MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
-    },
+    rtps_udp_psm::mapping_traits::{MappingWriteByteOrdered, NumberOfBytes},
 };
 
-use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
+use super::submessage::MappingWriteSubmessage;
 
-impl MappingWriteSubmessage for InfoDestinationSubmessage {
+impl MappingWriteSubmessage for InfoDestinationSubmessageWrite {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
         let octets_to_next_header = self.guid_prefix.number_of_bytes();
         RtpsSubmessageHeader {
@@ -39,19 +37,5 @@ impl MappingWriteSubmessage for InfoDestinationSubmessage {
     ) -> Result<(), Error> {
         self.guid_prefix
             .mapping_write_byte_ordered::<_, B>(&mut writer)
-    }
-}
-
-impl<'de> MappingReadSubmessage<'de> for InfoDestinationSubmessage {
-    fn mapping_read_submessage<B: ByteOrder>(
-        buf: &mut &'de [u8],
-        header: RtpsSubmessageHeader,
-    ) -> Result<Self, Error> {
-        let endianness_flag = header.flags[0];
-        let guid_prefix = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        Ok(Self {
-            endianness_flag,
-            guid_prefix,
-        })
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_reply.rs
@@ -2,19 +2,18 @@ use std::io::{Error, Write};
 
 use byteorder::ByteOrder;
 
+use crate::implementation::rtps_udp_psm::mapping_traits::NumberOfBytes;
 use crate::implementation::{
     rtps::messages::{
-        overall_structure::RtpsSubmessageHeader, submessage_elements::LocatorList,
-        submessages::InfoReplySubmessage, types::SubmessageKind,
+        overall_structure::RtpsSubmessageHeader, submessages::InfoReplySubmessageWrite,
+        types::SubmessageKind,
     },
-    rtps_udp_psm::mapping_traits::{
-        MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
-    },
+    rtps_udp_psm::mapping_traits::MappingWriteByteOrdered,
 };
 
-use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
+use super::submessage::MappingWriteSubmessage;
 
-impl MappingWriteSubmessage for InfoReplySubmessage {
+impl MappingWriteSubmessage for InfoReplySubmessageWrite {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
         let unicast_locator_list_number_of_bytes = self.unicast_locator_list.number_of_bytes();
         let submessage_length = match self.multicast_flag {
@@ -53,36 +52,14 @@ impl MappingWriteSubmessage for InfoReplySubmessage {
     }
 }
 
-impl<'de> MappingReadSubmessage<'de> for InfoReplySubmessage {
-    fn mapping_read_submessage<B: ByteOrder>(
-        buf: &mut &'de [u8],
-        header: RtpsSubmessageHeader,
-    ) -> Result<Self, Error> {
-        let endianness_flag = header.flags[0];
-        let multicast_flag = header.flags[1];
-        let unicast_locator_list = MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?;
-        let multicast_locator_list = if multicast_flag {
-            MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?
-        } else {
-            LocatorList::new(vec![])
-        };
-        Ok(InfoReplySubmessage {
-            endianness_flag,
-            multicast_flag,
-            unicast_locator_list,
-            multicast_locator_list,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::implementation::{
         rtps::{
-            messages::submessage_elements::LocatorList,
+            messages::{submessage_elements::LocatorList, submessages::InfoReplySubmessageRead},
             types::{Locator, LocatorAddress, LocatorKind, LocatorPort},
         },
-        rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
+        rtps_udp_psm::mapping_traits::to_bytes,
     };
 
     use super::*;
@@ -94,7 +71,7 @@ mod tests {
             LocatorPort::new(12),
             LocatorAddress::new([1; 16]),
         );
-        let submessage = InfoReplySubmessage {
+        let submessage = InfoReplySubmessageWrite {
             endianness_flag: true,
             multicast_flag: false,
             unicast_locator_list: LocatorList::new(vec![locator]),
@@ -121,7 +98,7 @@ mod tests {
             LocatorPort::new(12),
             LocatorAddress::new([1; 16]),
         );
-        let submessage = InfoReplySubmessage {
+        let submessage = InfoReplySubmessageWrite {
             endianness_flag: true,
             multicast_flag: true,
             unicast_locator_list: LocatorList::new(vec![]),
@@ -151,7 +128,7 @@ mod tests {
     #[test]
     fn deserialize_info_reply() {
         #[rustfmt::skip]
-        let buf = [
+        let submessage = InfoReplySubmessageRead::new(&[
             0x0f, 0b_0000_0001, 28, 0, // Submessage header
             1, 0, 0, 0, //numLocators
             11, 0, 0, 0, //kind
@@ -160,28 +137,33 @@ mod tests {
             1, 1, 1, 1, //address
             1, 1, 1, 1, //address
             1, 1, 1, 1, //address
-        ];
-
+        ]);
         let locator = Locator::new(
             LocatorKind::new(11),
             LocatorPort::new(12),
             LocatorAddress::new([1; 16]),
         );
+        let expected_endianness_flag = true;
+        let expected_multicast_flag = false;
+        let expected_unicast_locator_list = LocatorList::new(vec![locator]);
+        let expected_multicast_locator_list = LocatorList::new(vec![]);
+
+        assert_eq!(expected_endianness_flag, submessage.endianness_flag());
+        assert_eq!(expected_multicast_flag, submessage.multicast_flag());
         assert_eq!(
-            InfoReplySubmessage {
-                endianness_flag: true,
-                multicast_flag: false,
-                unicast_locator_list: LocatorList::new(vec![locator]),
-                multicast_locator_list: LocatorList::new(vec![]),
-            },
-            from_bytes(&buf).unwrap()
+            expected_unicast_locator_list,
+            submessage.unicast_locator_list()
+        );
+        assert_eq!(
+            expected_multicast_locator_list,
+            submessage.multicast_locator_list()
         );
     }
 
     #[test]
     fn deserialize_info_reply_with_multicast() {
         #[rustfmt::skip]
-        let buf = [
+        let submessage = InfoReplySubmessageRead::new(&[
             0x0f, 0b_0000_0011, 56, 0, // Submessage header
             0, 0, 0, 0, //numLocators
             2, 0, 0, 0, //numLocators
@@ -197,21 +179,26 @@ mod tests {
             1, 1, 1, 1, //address
             1, 1, 1, 1, //address
             1, 1, 1, 1, //address
-        ];
-
+        ]);
         let locator = Locator::new(
             LocatorKind::new(11),
             LocatorPort::new(12),
             LocatorAddress::new([1; 16]),
         );
+        let expected_endianness_flag = true;
+        let expected_multicast_flag = true;
+        let expected_unicast_locator_list = LocatorList::new(vec![]);
+        let expected_multicast_locator_list = LocatorList::new(vec![locator, locator]);
+
+        assert_eq!(expected_endianness_flag, submessage.endianness_flag());
+        assert_eq!(expected_multicast_flag, submessage.multicast_flag());
         assert_eq!(
-            InfoReplySubmessage {
-                endianness_flag: true,
-                multicast_flag: true,
-                unicast_locator_list: LocatorList::new(vec![]),
-                multicast_locator_list: LocatorList::new(vec![locator, locator]),
-            },
-            from_bytes(&buf).unwrap()
+            expected_unicast_locator_list,
+            submessage.unicast_locator_list()
+        );
+        assert_eq!(
+            expected_multicast_locator_list,
+            submessage.multicast_locator_list()
         );
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_timestamp.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_timestamp.rs
@@ -1,9 +1,12 @@
 use std::io::{Error, Write};
 
-use crate::implementation::{rtps::messages::{
-    overall_structure::RtpsSubmessageHeader, submessages::InfoTimestampSubmessageWrite,
-    types::SubmessageKind,
-}, rtps_udp_psm::mapping_traits::MappingWriteByteOrdered};
+use crate::implementation::{
+    rtps::messages::{
+        overall_structure::RtpsSubmessageHeader, submessages::InfoTimestampSubmessageWrite,
+        types::SubmessageKind,
+    },
+    rtps_udp_psm::mapping_traits::MappingWriteByteOrdered,
+};
 
 use super::submessage::MappingWriteSubmessage;
 
@@ -45,7 +48,10 @@ impl MappingWriteSubmessage for InfoTimestampSubmessageWrite {
 mod tests {
 
     use crate::implementation::{
-        rtps::messages::{submessages::InfoTimestampSubmessageRead, types::{Time, TIME_INVALID}},
+        rtps::messages::{
+            submessages::InfoTimestampSubmessageRead,
+            types::{Time, TIME_INVALID},
+        },
         rtps_udp_psm::mapping_traits::to_bytes,
     };
 

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_timestamp.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/info_timestamp.rs
@@ -1,17 +1,13 @@
 use std::io::{Error, Write};
 
-use crate::implementation::{
-    rtps::messages::{
-        overall_structure::RtpsSubmessageHeader,
-        submessages::InfoTimestampSubmessage,
-        types::{SubmessageKind, TIME_INVALID},
-    },
-    rtps_udp_psm::mapping_traits::{MappingReadByteOrdered, MappingWriteByteOrdered},
-};
+use crate::implementation::{rtps::messages::{
+    overall_structure::RtpsSubmessageHeader, submessages::InfoTimestampSubmessageWrite,
+    types::SubmessageKind,
+}, rtps_udp_psm::mapping_traits::MappingWriteByteOrdered};
 
-use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
+use super::submessage::MappingWriteSubmessage;
 
-impl MappingWriteSubmessage for InfoTimestampSubmessage {
+impl MappingWriteSubmessage for InfoTimestampSubmessageWrite {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
         let submessage_length = match self.invalidate_flag {
             true => 0,
@@ -44,39 +40,20 @@ impl MappingWriteSubmessage for InfoTimestampSubmessage {
         Ok(())
     }
 }
-impl<'de> MappingReadSubmessage<'de> for InfoTimestampSubmessage {
-    fn mapping_read_submessage<B: byteorder::ByteOrder>(
-        buf: &mut &'de [u8],
-        header: RtpsSubmessageHeader,
-    ) -> Result<Self, Error> {
-        let endianness_flag = header.flags[0];
-        let invalidate_flag = header.flags[1];
-        let timestamp = if invalidate_flag {
-            TIME_INVALID
-        } else {
-            MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?
-        };
-        Ok(InfoTimestampSubmessage {
-            endianness_flag,
-            invalidate_flag,
-            timestamp,
-        })
-    }
-}
 
 #[cfg(test)]
 mod tests {
 
     use crate::implementation::{
-        rtps::messages::types::Time,
-        rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
+        rtps::messages::{submessages::InfoTimestampSubmessageRead, types::{Time, TIME_INVALID}},
+        rtps_udp_psm::mapping_traits::to_bytes,
     };
 
     use super::*;
 
     #[test]
     fn serialize_info_timestamp_valid_time() {
-        let submessage = InfoTimestampSubmessage {
+        let submessage = InfoTimestampSubmessageWrite {
             endianness_flag: true,
             invalidate_flag: false,
             timestamp: Time::new(4, 0),
@@ -92,7 +69,7 @@ mod tests {
 
     #[test]
     fn serialize_info_timestamp_invalid_time() {
-        let submessage = InfoTimestampSubmessage {
+        let submessage = InfoTimestampSubmessageWrite {
             endianness_flag: true,
             invalidate_flag: true,
             timestamp: TIME_INVALID,
@@ -107,36 +84,34 @@ mod tests {
     #[test]
     fn deserialize_info_timestamp_valid_time() {
         #[rustfmt::skip]
-        let buf = [
+        let submessage = InfoTimestampSubmessageRead::new(&[
             0x09_u8, 0b_0000_0001, 8, 0, // Submessage header
             4, 0, 0, 0, // Time
             0, 0, 0, 0, // Time
-        ];
+        ]);
 
-        assert_eq!(
-            InfoTimestampSubmessage {
-                endianness_flag: true,
-                invalidate_flag: false,
-                timestamp: Time::new(4, 0),
-            },
-            from_bytes(&buf).unwrap()
-        )
+        let expected_endianness_flag = true;
+        let expected_invalidate_flag = false;
+        let expected_timestamp = Time::new(4, 0);
+
+        assert_eq!(expected_endianness_flag, submessage.endianness_flag());
+        assert_eq!(expected_invalidate_flag, submessage.invalidate_flag());
+        assert_eq!(expected_timestamp, submessage.timestamp());
     }
 
     #[test]
     fn deserialize_info_timestamp_invalid_time() {
         #[rustfmt::skip]
-        let buf = [
+        let submessage = InfoTimestampSubmessageRead::new(&[
             0x09_u8, 0b_0000_0011, 0, 0, // Submessage header
-        ];
+        ]);
 
-        assert_eq!(
-            InfoTimestampSubmessage {
-                endianness_flag: true,
-                invalidate_flag: true,
-                timestamp: TIME_INVALID,
-            },
-            from_bytes(&buf).unwrap()
-        )
+        let expected_endianness_flag = true;
+        let expected_invalidate_flag = true;
+        let expected_timestamp = TIME_INVALID;
+
+        assert_eq!(expected_endianness_flag, submessage.endianness_flag());
+        assert_eq!(expected_invalidate_flag, submessage.invalidate_flag());
+        assert_eq!(expected_timestamp, submessage.timestamp());
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/nack_frag.rs
@@ -2,18 +2,16 @@ use std::io::{Error, Write};
 
 use byteorder::ByteOrder;
 
+use crate::implementation::rtps::messages::submessages::NackFragSubmessageWrite;
 use crate::implementation::rtps::messages::{
     overall_structure::RtpsSubmessageHeader, types::SubmessageKind,
 };
 
-use crate::implementation::rtps::messages::submessages::NackFragSubmessage;
-use crate::implementation::rtps_udp_psm::mapping_traits::{
-    MappingReadByteOrdered, MappingWriteByteOrdered, NumberOfBytes,
-};
+use crate::implementation::rtps_udp_psm::mapping_traits::{MappingWriteByteOrdered, NumberOfBytes};
 
-use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
+use super::submessage::MappingWriteSubmessage;
 
-impl MappingWriteSubmessage for NackFragSubmessage {
+impl MappingWriteSubmessage for NackFragSubmessageWrite {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
         let octets_to_next_header = self.reader_id.number_of_bytes()
             + self.writer_id.number_of_bytes()
@@ -53,40 +51,27 @@ impl MappingWriteSubmessage for NackFragSubmessage {
     }
 }
 
-impl<'de> MappingReadSubmessage<'de> for NackFragSubmessage {
-    fn mapping_read_submessage<B: ByteOrder>(
-        buf: &mut &'de [u8],
-        header: RtpsSubmessageHeader,
-    ) -> Result<Self, Error> {
-        Ok(Self {
-            endianness_flag: header.flags[0],
-            reader_id: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-            writer_id: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-            writer_sn: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-            fragment_number_state: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-            count: MappingReadByteOrdered::mapping_read_byte_ordered::<B>(buf)?,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::implementation::{
         rtps::{
-            messages::{submessage_elements::FragmentNumberSet, types::FragmentNumber},
+            messages::{
+                submessage_elements::FragmentNumberSet, submessages::NackFragSubmessageRead,
+                types::FragmentNumber,
+            },
             types::{
                 Count, EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
                 USER_DEFINED_READER_NO_KEY,
             },
         },
-        rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
+        rtps_udp_psm::mapping_traits::to_bytes,
     };
 
     use super::*;
 
     #[test]
     fn serialize_nack_frag() {
-        let submessage = NackFragSubmessage {
+        let submessage = NackFragSubmessageWrite {
             endianness_flag: true,
             reader_id: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
             writer_id: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
@@ -112,9 +97,9 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_acknack() {
+    fn deserialize_nack_frag() {
         #[rustfmt::skip]
-        let buf = [
+        let submessage = NackFragSubmessageRead::new(&[
             0x12_u8, 0b_0000_0001, 28, 0, // Submessage header
             1, 2, 3, 4, // readerId: value[4]
             6, 7, 8, 9, // writerId: value[4]
@@ -123,21 +108,28 @@ mod tests {
            10, 0, 0, 0, // fragmentNumberState.base
             0, 0, 0, 0, // fragmentNumberState.numBits
             6, 0, 0, 0, // count
-        ];
+        ]);
 
+        let expected_endianness_flag = true;
+        let expected_reader_id =
+            EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
+        let expected_writer_id =
+            EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
+        let expected_writer_sn = SequenceNumber::new(4);
+        let expected_fragment_number_state = FragmentNumberSet {
+            base: FragmentNumber::new(10),
+            set: vec![],
+        };
+        let expected_count = Count::new(6);
+
+        assert_eq!(expected_endianness_flag, submessage.endianness_flag());
+        assert_eq!(expected_reader_id, submessage.reader_id());
+        assert_eq!(expected_writer_id, submessage.writer_id());
+        assert_eq!(expected_writer_sn, submessage.writer_sn());
         assert_eq!(
-            NackFragSubmessage {
-                endianness_flag: true,
-                reader_id: EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY),
-                writer_id: EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP),
-                writer_sn: SequenceNumber::new(4),
-                fragment_number_state: FragmentNumberSet {
-                    base: FragmentNumber::new(10),
-                    set: vec![],
-                },
-                count: Count::new(6),
-            },
-            from_bytes(&buf).unwrap()
+            expected_fragment_number_state,
+            submessage.fragment_number_state()
         );
+        assert_eq!(expected_count, submessage.count());
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
@@ -6,7 +6,7 @@ use crate::implementation::rtps::messages::{
     overall_structure::RtpsSubmessageHeader, submessages::PadSubmessageWrite, types::SubmessageKind,
 };
 
-use super::submessage::{MappingWriteSubmessage};
+use super::submessage::MappingWriteSubmessage;
 
 impl MappingWriteSubmessage for PadSubmessageWrite {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
@@ -37,8 +37,7 @@ impl MappingWriteSubmessage for PadSubmessageWrite {
 #[cfg(test)]
 mod tests {
     use crate::implementation::{
-        rtps::messages::submessages::PadSubmessageRead,
-        rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
+        rtps::messages::submessages::PadSubmessageRead, rtps_udp_psm::mapping_traits::to_bytes,
     };
 
     use super::*;

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/pad.rs
@@ -3,12 +3,12 @@ use std::io::{Error, Write};
 use byteorder::ByteOrder;
 
 use crate::implementation::rtps::messages::{
-    overall_structure::RtpsSubmessageHeader, submessages::PadSubmessage, types::SubmessageKind,
+    overall_structure::RtpsSubmessageHeader, submessages::PadSubmessageWrite, types::SubmessageKind,
 };
 
-use super::submessage::{MappingReadSubmessage, MappingWriteSubmessage};
+use super::submessage::{MappingWriteSubmessage};
 
-impl MappingWriteSubmessage for PadSubmessage {
+impl MappingWriteSubmessage for PadSubmessageWrite {
     fn submessage_header(&self) -> RtpsSubmessageHeader {
         RtpsSubmessageHeader {
             submessage_id: SubmessageKind::PAD,
@@ -34,26 +34,18 @@ impl MappingWriteSubmessage for PadSubmessage {
     }
 }
 
-impl<'de> MappingReadSubmessage<'de> for PadSubmessage {
-    fn mapping_read_submessage<B: ByteOrder>(
-        _buf: &mut &'de [u8],
-        header: RtpsSubmessageHeader,
-    ) -> Result<Self, Error> {
-        Ok(PadSubmessage {
-            endianness_flag: header.flags[0],
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::implementation::rtps_udp_psm::mapping_traits::{from_bytes, to_bytes};
+    use crate::implementation::{
+        rtps::messages::submessages::PadSubmessageRead,
+        rtps_udp_psm::mapping_traits::{from_bytes, to_bytes},
+    };
 
     use super::*;
 
     #[test]
     fn serialize_pad() {
-        let submessage = PadSubmessage {
+        let submessage = PadSubmessageWrite {
             endianness_flag: true,
         };
         #[rustfmt::skip]
@@ -66,14 +58,10 @@ mod tests {
     #[test]
     fn deserialize_pad() {
         #[rustfmt::skip]
-        let buf = [
+        let submessage = PadSubmessageRead::new(&[
             0x01, 0b_0000_0001, 0, 0, // Submessage header
-        ];
-        assert_eq!(
-            PadSubmessage {
-                endianness_flag: true
-            },
-            from_bytes(&buf).unwrap()
-        );
+        ]);
+        let expected_endianness_flag = true;
+        assert_eq!(expected_endianness_flag, submessage.endianness());
     }
 }

--- a/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage_header.rs
+++ b/dds/src/implementation/rtps_udp_psm/mapping_rtps_messages/submessages/submessage_header.rs
@@ -141,8 +141,7 @@ impl<'de> MappingReadByteOrderInfoInData<'de> for RtpsSubmessageHeader {
     fn mapping_read_byte_order_info_in_data(buf: &mut &'de [u8]) -> Result<Self, Error> {
         // The byteorder is determined by the one after next element. Since the submessage_id
         // is not byteorder dependent, just use a specific one (to avoid look ahead)
-        let submessage_id: u8 =
-            MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
+        let submessage_id: u8 = MappingReadByteOrdered::mapping_read_byte_ordered::<LittleEndian>(buf)?;
         let submessage_id = match submessage_id {
             DATA => SubmessageKind::DATA,
             GAP => SubmessageKind::GAP,


### PR DESCRIPTION
Make fields of Read Submessages private. This should stabilize the usage of the messages throughout the code. 