### PR TITLE
DDS-328 Avoid lifetime in FromBytes trait

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -38,6 +38,8 @@ fnmatch-regex = "=0.2.0"
 
 tokio = { version = "1", features = ["full"] }
 
+itertools = "0.10.5"
+
 [dev-dependencies]
 mockall = { version = "0.11" }
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -38,8 +38,6 @@ fnmatch-regex = "=0.2.0"
 
 tokio = { version = "1", features = ["full"] }
 
-itertools = "0.10.5"
-
 [dev-dependencies]
 mockall = { version = "0.11" }
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -34,7 +34,7 @@ use crate::{
         rtps::{
             discovery_types::BuiltinEndpointSet,
             history_cache::{
-                DataFragSubmessages, RtpsWriterCacheChange, RtpsWriterCacheChangeFrag,
+               RtpsWriterCacheChange, DataFragSubmessages,
             },
             messages::{
                 overall_structure::{
@@ -1911,8 +1911,8 @@ fn send_message_best_effort_reader_proxy(
             let timestamp = cache_change.timestamp();
 
             if cache_change.data_value().len() > data_max_size_serialized {
-                let mut s = DataFragSubmessages::new(cache_change, reader_id);
-                while let Some(data_frag_submessage) = s.next() {
+                let cache_change_frag = DataFragSubmessages::new(cache_change, reader_id);
+                for data_frag_submessage in cache_change_frag.into_iter() {
                     let info_dst =
                         info_destination_submessage(reader_proxy.remote_reader_guid().prefix());
 
@@ -2117,7 +2117,7 @@ fn directly_send_data_frag(
     let reader_id = reader_proxy.remote_reader_guid().entity_id();
     let timestamp = cache_change.timestamp();
 
-    let cache_change_frag = RtpsWriterCacheChangeFrag::new(cache_change, data_max_size_serialized, reader_id);
+    let cache_change_frag = DataFragSubmessages::new(cache_change, reader_id);
     let mut data_frag_submessage_list = cache_change_frag.into_iter().peekable();
     while let Some(data_frag_submessage) = data_frag_submessage_list.next() {
         let writer_sn = data_frag_submessage.writer_sn();

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -33,7 +33,7 @@ use crate::{
         },
         rtps::{
             discovery_types::BuiltinEndpointSet,
-            history_cache::RtpsWriterCacheChange,
+            history_cache::{DataFragSubmessages, RtpsWriterCacheChange},
             messages::{
                 overall_structure::{
                     RtpsMessageHeader, RtpsMessageRead, RtpsMessageWrite, RtpsSubmessageWriteKind,
@@ -1909,9 +1909,8 @@ fn send_message_best_effort_reader_proxy(
             let timestamp = cache_change.timestamp();
 
             if cache_change.data_value().len() > data_max_size_serialized {
-                let data_frag_submessage_list =
-                    cache_change.as_data_frag_submessages(data_max_size_serialized, reader_id);
-                for data_frag_submessage in data_frag_submessage_list {
+                let mut s = DataFragSubmessages::new(cache_change, reader_id);
+                while let Some(data_frag_submessage) = s.next() {
                     let info_dst =
                         info_destination_submessage(reader_proxy.remote_reader_guid().prefix());
 

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -1910,7 +1910,7 @@ fn send_message_best_effort_reader_proxy(
             let cache_change = change.cache_change();
             let timestamp = cache_change.timestamp();
 
-            if cache_change.data_value().len() > data_max_size_serialized {
+            if cache_change.data_value().len() > 1 {
                 let cache_change_frag = DataFragSubmessages::new(cache_change, reader_id);
                 for data_frag_submessage in cache_change_frag.into_iter() {
                     let info_dst =
@@ -1980,7 +1980,7 @@ fn send_message_reliable_reader_proxy(
             // should be full-filled by next_unsent_change()
             if change.is_relevant() {
                 let cache_change = change.cache_change();
-                if cache_change.data_value().len() > data_max_size_serialized {
+                if cache_change.data_value().len() > 1 {
                     directly_send_data_frag(
                         reader_proxy,
                         cache_change,
@@ -2034,7 +2034,7 @@ fn send_message_reliable_reader_proxy(
             // should be full-filled by next_requested_change()
             if change_for_reader.is_relevant() {
                 let cache_change = change_for_reader.cache_change();
-                if cache_change.data_value().len() > data_max_size_serialized {
+                if cache_change.data_value().len() > 1 {
                     directly_send_data_frag(
                         reader_proxy,
                         cache_change,

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -33,7 +33,9 @@ use crate::{
         },
         rtps::{
             discovery_types::BuiltinEndpointSet,
-            history_cache::{DataFragSubmessages, RtpsWriterCacheChange},
+            history_cache::{
+                DataFragSubmessages, RtpsWriterCacheChange, RtpsWriterCacheChangeFrag,
+            },
             messages::{
                 overall_structure::{
                     RtpsMessageHeader, RtpsMessageRead, RtpsMessageWrite, RtpsSubmessageWriteKind,
@@ -2115,11 +2117,8 @@ fn directly_send_data_frag(
     let reader_id = reader_proxy.remote_reader_guid().entity_id();
     let timestamp = cache_change.timestamp();
 
-    let mut data_frag_submessage_list = cache_change
-        .as_data_frag_submessages(data_max_size_serialized, reader_id)
-        .into_iter()
-        .peekable();
-
+    let cache_change_frag = RtpsWriterCacheChangeFrag::new(cache_change, data_max_size_serialized, reader_id);
+    let mut data_frag_submessage_list = cache_change_frag.into_iter().peekable();
     while let Some(data_frag_submessage) = data_frag_submessage_list.next() {
         let writer_sn = data_frag_submessage.writer_sn();
         let last_fragment_num = FragmentNumber::new(

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -1985,7 +1985,6 @@ fn send_message_reliable_reader_proxy(
                         reader_proxy,
                         cache_change,
                         writer_id,
-                        data_max_size_serialized,
                         header,
                         first_sn,
                         last_sn,
@@ -2040,7 +2039,6 @@ fn send_message_reliable_reader_proxy(
                         reader_proxy,
                         cache_change,
                         writer_id,
-                        data_max_size_serialized,
                         header,
                         first_sn,
                         last_sn,
@@ -2103,12 +2101,10 @@ fn info_destination_submessage<'a>(guid_prefix: GuidPrefix) -> RtpsSubmessageWri
     RtpsSubmessageWriteKind::InfoDestination(InfoDestinationSubmessageWrite::new(guid_prefix))
 }
 
-#[allow(clippy::too_many_arguments)]
 fn directly_send_data_frag(
     reader_proxy: &mut WriterAssociatedReaderProxy,
     cache_change: &RtpsWriterCacheChange,
     writer_id: EntityId,
-    data_max_size_serialized: usize,
     header: RtpsMessageHeader,
     first_sn: SequenceNumber,
     last_sn: SequenceNumber,

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -602,7 +602,7 @@ mod test {
         Transport{}
 
         impl TransportWrite for Transport {
-            fn write<'a>(&'a mut self, message: &RtpsMessageWrite<'a>, destination_locator_list: &[Locator]);
+            fn write(&self, message: &RtpsMessageWrite, destination_locator_list: &[Locator]);
         }
     }
 

--- a/dds/src/implementation/rtps/history_cache.rs
+++ b/dds/src/implementation/rtps/history_cache.rs
@@ -179,8 +179,8 @@ impl RtpsWriterCacheChange {
         self.timestamp
     }
 
-    pub fn data_value(&self) -> &Data {
-        &self.data_value[0]
+    pub fn data_value(&self) -> &[Data] {
+        &self.data_value
     }
 
     pub fn inline_qos(&self) -> &ParameterList {

--- a/dds/src/implementation/rtps/history_cache.rs
+++ b/dds/src/implementation/rtps/history_cache.rs
@@ -1,5 +1,7 @@
 use std::marker::PhantomData;
 
+use itertools::Itertools;
+
 use crate::{
     implementation::rtps::messages::types::FragmentNumber,
     infrastructure::{instance::InstanceHandle, time::Time},
@@ -25,6 +27,10 @@ impl Data {
     }
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    pub fn chunks(&self, size: usize) -> Vec<Data> {
+        self.0.chunks(size).map(|c| Data(c.into())).collect()
     }
 }
 
@@ -59,6 +65,84 @@ pub struct RtpsWriterCacheChange {
     inline_qos: ParameterList,
 }
 
+pub struct RtpsWriterCacheChangeFrag<'a> {
+    cache_change: &'a RtpsWriterCacheChange,
+    reader_id: EntityId,
+    data: Vec<Data>,
+}
+
+impl<'a> RtpsWriterCacheChangeFrag<'a> {
+    pub fn new(cache_change: &'a RtpsWriterCacheChange, data_max_size_serialized: usize, reader_id: EntityId) -> Self {
+        let data = cache_change.data_value.chunks(data_max_size_serialized);
+        Self {
+            cache_change,
+            reader_id,
+            data,
+        }
+    }
+}
+
+pub struct DataFragSubmessagesIter<'a> {
+    cache_change: &'a RtpsWriterCacheChangeFrag<'a>,
+    data: Vec<&'a Data>,
+}
+
+impl<'a> IntoIterator for &'a RtpsWriterCacheChangeFrag<'a> {
+    type Item = DataFragSubmessageWrite<'a>;
+    type IntoIter = DataFragSubmessagesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let data = self.data.iter().collect();
+        Self::IntoIter {
+            cache_change: self,
+            data,
+        }
+    }
+}
+
+impl<'a> DataFragSubmessagesIter<'a> {
+    pub fn new(cache_change: &'a RtpsWriterCacheChangeFrag<'a>) -> Self {
+        let data = cache_change.data.iter().collect();
+        Self { cache_change, data }
+    }
+}
+impl<'a> Iterator for DataFragSubmessagesIter<'a> {
+    type Item = DataFragSubmessageWrite<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let inline_qos_flag = true;
+        let key_flag = match self.cache_change.cache_change.kind() {
+            ChangeKind::Alive => false,
+            ChangeKind::NotAliveDisposed | ChangeKind::NotAliveUnregistered => true,
+            _ => todo!(),
+        };
+        let non_standard_payload_flag = false;
+        let reader_id = self.cache_change.reader_id;
+        let writer_id = self.cache_change.cache_change.writer_guid().entity_id();
+        let writer_sn = self.cache_change.cache_change.sequence_number();
+        let fragment_starting_num = FragmentNumber::new(1);
+        let fragments_in_submessage = 1;
+        let data_size = 1;
+        let fragment_size = 1;
+        let inline_qos = &self.cache_change.cache_change.inline_qos;
+        let serialized_payload = self.data[0];
+        Some(DataFragSubmessageWrite::new(
+            inline_qos_flag,
+            non_standard_payload_flag,
+            key_flag,
+            reader_id,
+            writer_id,
+            writer_sn,
+            fragment_starting_num,
+            fragments_in_submessage,
+            data_size,
+            fragment_size,
+            inline_qos,
+            serialized_payload,
+        ))
+    }
+}
+
 pub struct DataFragSubmessages<'a> {
     cache_change: &'a RtpsWriterCacheChange,
     reader_id: EntityId,
@@ -75,7 +159,7 @@ impl<'a> DataFragSubmessages<'a> {
         }
     }
 
-    pub fn next<'b>(&'b mut self) -> Option<DataFragSubmessageWrite<'b>>{
+    pub fn next<'b>(&'b mut self) -> Option<DataFragSubmessageWrite<'b>> {
         let inline_qos_flag = true;
         let key_flag = match self.cache_change.kind() {
             ChangeKind::Alive => false,
@@ -108,7 +192,6 @@ impl<'a> DataFragSubmessages<'a> {
         ))
     }
 }
-
 
 impl RtpsWriterCacheChange {
     pub fn as_gap_message(&self, reader_id: EntityId) -> GapSubmessageWrite {

--- a/dds/src/implementation/rtps/history_cache.rs
+++ b/dds/src/implementation/rtps/history_cache.rs
@@ -1,7 +1,6 @@
 use super::{
     messages::{
-        overall_structure::{FromBytes, WriteBytes},
-        submessage_elements::{ParameterList, SequenceNumberSet},
+        submessage_elements::{Data, ParameterList, SequenceNumberSet},
         submessages::{
             data::DataSubmessageWrite, data_frag::DataFragSubmessageWrite, gap::GapSubmessageWrite,
         },
@@ -12,39 +11,6 @@ use crate::{
     implementation::rtps::messages::types::FragmentNumber,
     infrastructure::{instance::InstanceHandle, time::Time},
 };
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Data(Vec<u8>);
-
-impl Data {
-    pub fn new(data: Vec<u8>) -> Self {
-        Self(data)
-    }
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-}
-
-impl AsRef<[u8]> for Data {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl WriteBytes for &Data {
-    fn write_bytes(&self, buf: &mut [u8]) -> usize {
-        buf[..self.0.len()].copy_from_slice(&self.0);
-        let length_inclusive_padding = (self.0.len() + 3) & !3;
-        buf[self.0.len()..length_inclusive_padding].fill(0);
-        length_inclusive_padding
-    }
-}
-
-impl FromBytes for Data {
-    fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
-        Self::new(v.to_vec())
-    }
-}
 
 pub struct RtpsWriterCacheChange {
     kind: ChangeKind,

--- a/dds/src/implementation/rtps/history_cache.rs
+++ b/dds/src/implementation/rtps/history_cache.rs
@@ -40,7 +40,7 @@ impl WriteBytes for &Data {
     }
 }
 
-impl FromBytes<'_> for Data {
+impl FromBytes for Data {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         Self::new(v.to_vec())
     }

--- a/dds/src/implementation/rtps/history_cache.rs
+++ b/dds/src/implementation/rtps/history_cache.rs
@@ -61,23 +61,23 @@ pub struct RtpsWriterCacheChange {
     sequence_number: SequenceNumber,
     _instance_handle: InstanceHandle,
     timestamp: Time,
-    data_value: Data,
+    data_value: Vec<Data>,
     inline_qos: ParameterList,
 }
 
 pub struct RtpsWriterCacheChangeFrag<'a> {
     cache_change: &'a RtpsWriterCacheChange,
     reader_id: EntityId,
-    data: Vec<Data>,
+    // data: Vec<Data>,
 }
 
 impl<'a> RtpsWriterCacheChangeFrag<'a> {
     pub fn new(cache_change: &'a RtpsWriterCacheChange, data_max_size_serialized: usize, reader_id: EntityId) -> Self {
-        let data = cache_change.data_value.chunks(data_max_size_serialized);
+        // let data = cache_change.data_value;//.chunks(data_max_size_serialized);
         Self {
             cache_change,
             reader_id,
-            data,
+            // data,
         }
     }
 }
@@ -92,7 +92,7 @@ impl<'a> IntoIterator for &'a RtpsWriterCacheChangeFrag<'a> {
     type IntoIter = DataFragSubmessagesIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let data = self.data.iter().collect();
+        let data = self.cache_change.data_value.iter().collect();
         Self::IntoIter {
             cache_change: self,
             data,
@@ -102,7 +102,7 @@ impl<'a> IntoIterator for &'a RtpsWriterCacheChangeFrag<'a> {
 
 impl<'a> DataFragSubmessagesIter<'a> {
     pub fn new(cache_change: &'a RtpsWriterCacheChangeFrag<'a>) -> Self {
-        let data = cache_change.data.iter().collect();
+        let data = cache_change.cache_change.data_value.iter().collect();
         Self { cache_change, data }
     }
 }
@@ -222,7 +222,7 @@ impl RtpsWriterCacheChange {
             self.writer_guid().entity_id(),
             self.sequence_number(),
             &self.inline_qos,
-            &self.data_value,
+            &self.data_value[0],
         )
     }
 
@@ -291,7 +291,7 @@ impl RtpsWriterCacheChange {
         instance_handle: InstanceHandle,
         sequence_number: SequenceNumber,
         timestamp: Time,
-        data_value: Data,
+        data_value: Vec<Data>,
         inline_qos: ParameterList,
     ) -> Self {
         Self {
@@ -328,7 +328,7 @@ impl RtpsWriterCacheChange {
     }
 
     pub fn data_value(&self) -> &Data {
-        &self.data_value
+        &self.data_value[0]
     }
 
     pub fn inline_qos(&self) -> &ParameterList {
@@ -390,7 +390,7 @@ mod tests {
             HANDLE_NIL,
             SequenceNumber::new(1),
             TIME_INVALID,
-            Data::new(vec![]),
+            vec![Data::new(vec![])],
             ParameterList::empty(),
         );
         hc.add_change(change);
@@ -407,7 +407,7 @@ mod tests {
             HANDLE_NIL,
             SequenceNumber::new(1),
             TIME_INVALID,
-            Data::new(vec![]),
+            vec![Data::new(vec![])],
             ParameterList::empty(),
         );
         let change2 = RtpsWriterCacheChange::new(
@@ -416,7 +416,7 @@ mod tests {
             HANDLE_NIL,
             SequenceNumber::new(2),
             TIME_INVALID,
-            Data::new(vec![]),
+            vec![Data::new(vec![])],
             ParameterList::empty(),
         );
         hc.add_change(change1);
@@ -433,7 +433,7 @@ mod tests {
             HANDLE_NIL,
             SequenceNumber::new(1),
             TIME_INVALID,
-            Data::new(vec![]),
+            vec![Data::new(vec![])],
             ParameterList::empty(),
         );
         let change2 = RtpsWriterCacheChange::new(
@@ -442,7 +442,7 @@ mod tests {
             HANDLE_NIL,
             SequenceNumber::new(2),
             TIME_INVALID,
-            Data::new(vec![]),
+            vec![Data::new(vec![])],
             ParameterList::empty(),
         );
         hc.add_change(change1);

--- a/dds/src/implementation/rtps/history_cache.rs
+++ b/dds/src/implementation/rtps/history_cache.rs
@@ -1,12 +1,3 @@
-use std::marker::PhantomData;
-
-use itertools::Itertools;
-
-use crate::{
-    implementation::rtps::messages::types::FragmentNumber,
-    infrastructure::{instance::InstanceHandle, time::Time},
-};
-
 use super::{
     messages::{
         overall_structure::{FromBytes, WriteBytes},
@@ -15,7 +6,11 @@ use super::{
             data::DataSubmessageWrite, data_frag::DataFragSubmessageWrite, gap::GapSubmessageWrite,
         },
     },
-    types::{ChangeKind, EntityId, Guid, SequenceNumber, ENTITYID_UNKNOWN},
+    types::{ChangeKind, EntityId, Guid, SequenceNumber},
+};
+use crate::{
+    implementation::rtps::messages::types::FragmentNumber,
+    infrastructure::{instance::InstanceHandle, time::Time},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -27,10 +22,6 @@ impl Data {
     }
     pub fn len(&self) -> usize {
         self.0.len()
-    }
-
-    pub fn chunks(&self, size: usize) -> Vec<Data> {
-        self.0.chunks(size).map(|c| Data(c.into())).collect()
     }
 }
 

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -416,14 +416,14 @@ mod tests {
     use super::*;
     use crate::implementation::rtps::{
         messages::{
-            submessage_elements::{Parameter, ParameterList, SerializedPayload},
+            submessage_elements::{Parameter, ParameterList},
             submessages::{data::DataSubmessageRead, heartbeat::HeartbeatSubmessageRead},
             types::ParameterId,
         },
         types::{
             EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
             USER_DEFINED_READER_NO_KEY,
-        },
+        }, history_cache::Data,
     };
 
     #[test]
@@ -463,7 +463,7 @@ mod tests {
         let parameter_1 = Parameter::new(ParameterId(6), vec![10, 11, 12, 13]);
         let parameter_2 = Parameter::new(ParameterId(7), vec![20, 21, 22, 23]);
         let inline_qos = &ParameterList::new(vec![parameter_1, parameter_2]);
-        let serialized_payload = SerializedPayload::new(&[]);
+        let serialized_payload = &Data::new(vec![]);
 
         let submessage = RtpsSubmessageWriteKind::Data(DataSubmessageWrite::new(
             inline_qos_flag,

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -220,19 +220,16 @@ pub struct RtpsMessageWrite {
 
 impl RtpsMessageWrite {
     pub fn new(header: RtpsMessageHeader, submessages: Vec<RtpsSubmessageWriteKind<'_>>) -> Self {
-        let mut this = Self {
-            buffer: [0; BUFFER_SIZE],
-            len: 0,
-        };
-        let mut len = header.endian_write_bytes::<byteorder::LittleEndian>(&mut this.buffer[0..]);
+        let mut buffer = [0; BUFFER_SIZE];
+        let mut len = header.endian_write_bytes::<byteorder::LittleEndian>(&mut buffer[0..]);
         for submessage in &submessages {
-            len += submessage.write_bytes(&mut this.buffer[len..]);
+            len += submessage.write_bytes(&mut buffer[len..]);
         }
-        this
+        Self { buffer, len }
     }
 
     pub fn buffer(&self) -> &[u8] {
-        self.buffer.as_slice()
+        &self.buffer[0..self.len]
     }
 }
 
@@ -427,7 +424,7 @@ mod tests {
         };
         let message = RtpsMessageWrite::new(header, Vec::new());
         #[rustfmt::skip]
-        assert_eq!(into_bytes_le_vec(message), vec![
+        assert_eq!(message.buffer(), &[
             b'R', b'T', b'P', b'S', // Protocol
             2, 3, 9, 8, // ProtocolVersion | VendorId
             3, 3, 3, 3, // GuidPrefix
@@ -469,7 +466,7 @@ mod tests {
         ));
         let value = RtpsMessageWrite::new(header, vec![submessage]);
         #[rustfmt::skip]
-        assert_eq!(into_bytes_le_vec(value), vec![
+        assert_eq!(value.buffer(), &[
             b'R', b'T', b'P', b'S', // Protocol
             2, 3, 9, 8, // ProtocolVersion | VendorId
             3, 3, 3, 3, // GuidPrefix

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -63,16 +63,16 @@ where
     }
 }
 
-pub trait FromBytes<'a> {
-    fn from_bytes<E: byteorder::ByteOrder>(v: &'a [u8]) -> Self;
+pub trait FromBytes {
+    fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self;
 }
 
 pub trait SubmessageHeader {
     fn submessage_header(&self) -> SubmessageHeaderRead;
 }
 
-pub trait RtpsMap<'a>: SubmessageHeader {
-    fn map<T: FromBytes<'a>>(&self, data: &'a [u8]) -> T {
+pub trait RtpsMap: SubmessageHeader {
+    fn map<T: FromBytes>(&self, data: &[u8]) -> T {
         if self.submessage_header().endianness_flag() {
             T::from_bytes::<byteorder::LittleEndian>(data)
         } else {
@@ -81,7 +81,7 @@ pub trait RtpsMap<'a>: SubmessageHeader {
     }
 }
 
-impl<'a, T: SubmessageHeader> RtpsMap<'a> for T {}
+impl<T: SubmessageHeader> RtpsMap for T {}
 
 pub trait EndiannessFlag {
     fn endianness_flag(&self) -> bool;

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -404,14 +404,14 @@ mod tests {
     use super::*;
     use crate::implementation::rtps::{
         messages::{
-            submessage_elements::{Parameter, ParameterList},
+            submessage_elements::{Data, Parameter, ParameterList},
             submessages::{data::DataSubmessageRead, heartbeat::HeartbeatSubmessageRead},
             types::ParameterId,
         },
         types::{
             EntityId, EntityKey, SequenceNumber, USER_DEFINED_READER_GROUP,
             USER_DEFINED_READER_NO_KEY,
-        }, history_cache::Data,
+        },
     };
 
     #[test]

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -1,5 +1,5 @@
 use super::{
-    overall_structure::{EndianWriteBytes, FromBytes},
+    overall_structure::{EndianWriteBytes, FromBytes, WriteBytes},
     types::{ParameterId, Time},
 };
 use crate::implementation::{
@@ -9,7 +9,7 @@ use crate::implementation::{
         types::{
             EntityId, EntityKey, EntityKind, GuidPrefix, Locator, LocatorAddress,
             LocatorKind, LocatorPort, ProtocolVersion, SequenceNumber, VendorId,
-        },
+        }, history_cache::Data,
     },
 };
 use std::io::BufRead;
@@ -33,7 +33,7 @@ pub enum SubmessageElement<'a> {
     ProtocolVersion(ProtocolVersion),
     SequenceNumber(SequenceNumber),
     SequenceNumberSet(SequenceNumberSet),
-    SerializedPayload(SerializedPayload<'a>),
+    SerializedData(&'a Data),
     Timestamp(Time),
     ULong(u32),
     UShort(u16),
@@ -54,7 +54,7 @@ impl EndianWriteBytes for SubmessageElement<'_> {
             SubmessageElement::ProtocolVersion(e) => e.endian_write_bytes::<E>(buf),
             SubmessageElement::SequenceNumber(e) => e.endian_write_bytes::<E>(buf),
             SubmessageElement::SequenceNumberSet(e) => e.endian_write_bytes::<E>(buf),
-            SubmessageElement::SerializedPayload(e) => e.endian_write_bytes::<E>(buf),
+            SubmessageElement::SerializedData(e) => e.write_bytes(buf),
             SubmessageElement::Timestamp(e) => e.endian_write_bytes::<E>(buf),
             SubmessageElement::ULong(e) => e.endian_write_bytes::<E>(buf),
             SubmessageElement::UShort(e) => e.endian_write_bytes::<E>(buf),
@@ -301,11 +301,11 @@ impl EndianWriteBytes for &ParameterList {
     }
 }
 
-impl<'a> FromBytes<'a> for SerializedPayload<'a> {
-    fn from_bytes<E: byteorder::ByteOrder>(v: &'a [u8]) -> Self {
-        Self::new(v)
-    }
-}
+// impl<'a> FromBytes<'a> for SerializedPayload<'a> {
+//     fn from_bytes<E: byteorder::ByteOrder>(v: &'a [u8]) -> Self {
+//         Self::new(v)
+//     }
+// }
 
 impl FromBytes<'_> for EntityId {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
@@ -452,29 +452,29 @@ impl FromBytes<'_> for FragmentNumberSet {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, derive_more::Into, derive_more::From)]
-pub struct SerializedPayload<'a>(&'a [u8]);
+// #[derive(Debug, PartialEq, Eq, derive_more::Into, derive_more::From)]
+// pub struct SerializedPayload<'a>(&'a [u8]);
 
-impl<'a> SerializedPayload<'a> {
-    pub fn new(value: &'a [u8]) -> Self {
-        Self(value)
-    }
-}
+// impl<'a> SerializedPayload<'a> {
+//     pub fn new(value: &'a [u8]) -> Self {
+//         Self(value)
+//     }
+// }
 
-impl EndianWriteBytes for SerializedPayload<'_> {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        buf[..self.0.len()].copy_from_slice(self.0);
-        let length_inclusive_padding = (self.0.len() + 3) & !3;
-        buf[self.0.len()..length_inclusive_padding].fill(0);
-        length_inclusive_padding
-    }
-}
+// impl EndianWriteBytes for SerializedPayload<'_> {
+//     fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
+//         buf[..self.0.len()].copy_from_slice(self.0);
+//         let length_inclusive_padding = (self.0.len() + 3) & !3;
+//         buf[self.0.len()..length_inclusive_padding].fill(0);
+//         length_inclusive_padding
+//     }
+// }
 
-impl<'a> From<&'_ SerializedPayload<'a>> for &'a [u8] {
-    fn from(value: &'_ SerializedPayload<'a>) -> Self {
-        value.0
-    }
-}
+// impl<'a> From<&'_ SerializedPayload<'a>> for &'a [u8] {
+//     fn from(value: &'_ SerializedPayload<'a>) -> Self {
+//         value.0
+//     }
+// }
 
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -239,7 +239,7 @@ impl ParameterList {
     }
 }
 
-impl<'a> FromBytes<'a> for Parameter {
+impl FromBytes for Parameter {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         let parameter_id = E::read_u16(&v[0..]);
         let length = E::read_i16(&v[2..]);
@@ -253,7 +253,7 @@ impl<'a> FromBytes<'a> for Parameter {
     }
 }
 
-impl<'a> FromBytes<'a> for ParameterList {
+impl FromBytes for ParameterList {
     fn from_bytes<E: byteorder::ByteOrder>(mut v: &[u8]) -> Self {
         const MAX_PARAMETERS: usize = 2_usize.pow(16);
 
@@ -301,19 +301,13 @@ impl EndianWriteBytes for &ParameterList {
     }
 }
 
-// impl<'a> FromBytes<'a> for SerializedPayload<'a> {
-//     fn from_bytes<E: byteorder::ByteOrder>(v: &'a [u8]) -> Self {
-//         Self::new(v)
-//     }
-// }
-
-impl FromBytes<'_> for EntityId {
+impl FromBytes for EntityId {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         Self::new(EntityKey::new([v[0], v[1], v[2]]), EntityKind::new(v[3]))
     }
 }
 
-impl FromBytes<'_> for GuidPrefix {
+impl FromBytes for GuidPrefix {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         Self::new([
             v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[8], v[9], v[10], v[11],
@@ -321,7 +315,7 @@ impl FromBytes<'_> for GuidPrefix {
     }
 }
 
-impl FromBytes<'_> for SequenceNumber {
+impl FromBytes for SequenceNumber {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         let high = E::read_i32(&v[0..]);
         let low = E::read_i32(&v[4..]);
@@ -330,13 +324,13 @@ impl FromBytes<'_> for SequenceNumber {
     }
 }
 
-impl FromBytes<'_> for Count {
+impl FromBytes for Count {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         Self::new(E::read_i32(v))
     }
 }
 
-impl FromBytes<'_> for SequenceNumberSet {
+impl FromBytes for SequenceNumberSet {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         let high = E::read_i32(&v[0..]);
         let low = E::read_i32(&v[4..]);
@@ -361,31 +355,31 @@ impl FromBytes<'_> for SequenceNumberSet {
     }
 }
 
-impl FromBytes<'_> for u16 {
+impl FromBytes for u16 {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         E::read_u16(v)
     }
 }
 
-impl FromBytes<'_> for i16 {
+impl FromBytes for i16 {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         E::read_i16(v)
     }
 }
 
-impl FromBytes<'_> for u32 {
+impl FromBytes for u32 {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         E::read_u32(v)
     }
 }
 
-impl FromBytes<'_> for FragmentNumber {
+impl FromBytes for FragmentNumber {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         Self::new(E::read_u32(v))
     }
 }
 
-impl FromBytes<'_> for Locator {
+impl FromBytes for Locator {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         let kind = LocatorKind::new(E::read_i32(&v[0..]));
         let port = LocatorPort::new(E::read_u32(&v[4..]));
@@ -397,7 +391,7 @@ impl FromBytes<'_> for Locator {
     }
 }
 
-impl FromBytes<'_> for LocatorList {
+impl FromBytes for LocatorList {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         let num_locators = E::read_u32(v);
         let mut buf = &v[4..];
@@ -410,19 +404,19 @@ impl FromBytes<'_> for LocatorList {
     }
 }
 
-impl FromBytes<'_> for ProtocolVersion {
+impl FromBytes for ProtocolVersion {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         Self::new(v[0], v[1])
     }
 }
 
-impl FromBytes<'_> for VendorId {
+impl FromBytes for VendorId {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         Self::new([v[0], v[1]])
     }
 }
 
-impl FromBytes<'_> for Time {
+impl FromBytes for Time {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         let seconds = E::read_i32(&v[0..]);
         let fractions = E::read_u32(&v[4..]);
@@ -430,7 +424,7 @@ impl FromBytes<'_> for Time {
     }
 }
 
-impl FromBytes<'_> for FragmentNumberSet {
+impl FromBytes for FragmentNumberSet {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
         let base = E::read_u32(&v[0..]);
         let num_bits = E::read_u32(&v[4..]);

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -9,7 +9,7 @@ use crate::implementation::{
         types::{
             EntityId, EntityKey, EntityKind, GuidPrefix, Locator, LocatorAddress,
             LocatorKind, LocatorPort, ProtocolVersion, SequenceNumber, VendorId,
-        }, history_cache::Data,
+        },
     },
 };
 use std::io::BufRead;
@@ -300,6 +300,41 @@ impl EndianWriteBytes for &ParameterList {
         length + 4
     }
 }
+
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Data(Vec<u8>);
+
+impl Data {
+    pub fn new(data: Vec<u8>) -> Self {
+        Self(data)
+    }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl AsRef<[u8]> for Data {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl WriteBytes for &Data {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        buf[..self.0.len()].copy_from_slice(&self.0);
+        let length_inclusive_padding = (self.0.len() + 3) & !3;
+        buf[self.0.len()..length_inclusive_padding].fill(0);
+        length_inclusive_padding
+    }
+}
+
+impl FromBytes for Data {
+    fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {
+        Self::new(v.to_vec())
+    }
+}
+
 
 impl FromBytes for EntityId {
     fn from_bytes<E: byteorder::ByteOrder>(v: &[u8]) -> Self {

--- a/dds/src/implementation/rtps/messages/submessages/data.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data.rs
@@ -5,13 +5,12 @@ use crate::implementation::{
     rtps::{
         messages::{
             overall_structure::{
-                RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead,
-                SubmessageHeaderWrite,
+                RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead, SubmessageHeaderWrite,
             },
-            submessage_elements::{ParameterList, SubmessageElement},
+            submessage_elements::{Data, ParameterList, SubmessageElement},
             types::{SubmessageFlag, SubmessageKind},
         },
-        types::{EntityId, SequenceNumber}, history_cache::Data,
+        types::{EntityId, SequenceNumber},
     },
 };
 

--- a/dds/src/implementation/rtps/messages/submessages/data.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data.rs
@@ -8,10 +8,10 @@ use crate::implementation::{
                 RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead,
                 SubmessageHeaderWrite,
             },
-            submessage_elements::{SerializedPayload, ParameterList, SubmessageElement},
+            submessage_elements::{ParameterList, SubmessageElement},
             types::{SubmessageFlag, SubmessageKind},
         },
-        types::{EntityId, SequenceNumber},
+        types::{EntityId, SequenceNumber}, history_cache::Data,
     },
 };
 
@@ -97,7 +97,7 @@ impl<'a> DataSubmessageRead<'a> {
         }
     }
 
-    pub fn serialized_payload(&self) -> SerializedPayload<'a> {
+    pub fn serialized_payload(&self) -> Data {
         self.map(&self.data[8 + self.octets_to_inline_qos() + self.inline_qos_len()..])
     }
 }
@@ -123,7 +123,7 @@ impl<'a> DataSubmessageWrite<'a> {
         writer_id: EntityId,
         writer_sn: SequenceNumber,
         inline_qos: &'a ParameterList,
-        serialized_payload: SerializedPayload<'a>,
+        serialized_payload: &'a Data,
     ) -> Self {
         const EXTRA_FLAGS: u16 = 0;
         const OCTETS_TO_INLINE_QOS: u16 = 16;
@@ -138,7 +138,7 @@ impl<'a> DataSubmessageWrite<'a> {
             submessage_elements.push(SubmessageElement::ParameterList(inline_qos));
         }
         if data_flag || key_flag {
-            submessage_elements.push(SubmessageElement::SerializedPayload(serialized_payload));
+            submessage_elements.push(SubmessageElement::SerializedData(serialized_payload));
         }
         Self {
             endianness_flag: true,
@@ -195,7 +195,7 @@ mod tests {
         let writer_id = EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
         let writer_sn = SequenceNumber::new(5);
         let inline_qos = &ParameterList::empty();
-        let serialized_payload = SerializedPayload::new(&[]);
+        let serialized_payload = &Data::new(vec![]);
         let submessage = DataSubmessageWrite::new(
             inline_qos_flag,
             data_flag,
@@ -231,7 +231,7 @@ mod tests {
         let parameter_1 = Parameter::new(ParameterId(6), vec![10, 11, 12, 13]);
         let parameter_2 = Parameter::new(ParameterId(7), vec![20, 21, 22, 23]);
         let inline_qos = &ParameterList::new(vec![parameter_1, parameter_2]);
-        let serialized_payload = SerializedPayload::new(&[]);
+        let serialized_payload = &Data::new(vec![]);
 
         let submessage = DataSubmessageWrite::new(
             inline_qos_flag,
@@ -271,7 +271,7 @@ mod tests {
         let writer_id = EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
         let writer_sn = SequenceNumber::new(5);
         let inline_qos = &ParameterList::empty();
-        let serialized_payload = SerializedPayload::new(&[1, 2, 3, 4]);
+        let serialized_payload = &Data::new(vec![1, 2, 3, 4]);
         let submessage = DataSubmessageWrite::new(
             inline_qos_flag,
             data_flag,
@@ -306,7 +306,7 @@ mod tests {
         let writer_id = EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
         let writer_sn = SequenceNumber::new(5);
         let inline_qos = &ParameterList::empty();
-        let serialized_payload = SerializedPayload::new(&[1, 2, 3]);
+        let serialized_payload = &Data::new(vec![1, 2, 3]);
         let submessage = DataSubmessageWrite::new(
             inline_qos_flag,
             data_flag,
@@ -341,7 +341,7 @@ mod tests {
         let writer_id = EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
         let writer_sn = SequenceNumber::new(5);
         let inline_qos = ParameterList::empty();
-        let serialized_payload = SerializedPayload::new(&[]);
+        let serialized_payload = Data::new(vec![]);
 
         #[rustfmt::skip]
         let data_submessage = DataSubmessageRead::new(&[
@@ -370,7 +370,7 @@ mod tests {
     #[test]
     fn deserialize_no_inline_qos_with_serialized_payload() {
         let inline_qos = ParameterList::empty();
-        let serialized_payload = SerializedPayload::new(&[1, 2, 3, 4]);
+        let serialized_payload = Data::new(vec![1, 2, 3, 4]);
 
         #[rustfmt::skip]
         let data_submessage = DataSubmessageRead::new(&[
@@ -392,7 +392,7 @@ mod tests {
             Parameter::new(ParameterId(6), vec![10, 11, 12, 13]),
             Parameter::new(ParameterId(7), vec![20, 21, 22, 23]),
         ]);
-        let serialized_payload = SerializedPayload::new(&[]);
+        let serialized_payload = Data::new(vec![]);
 
         #[rustfmt::skip]
         let data_submessage = DataSubmessageRead::new(&[
@@ -418,7 +418,7 @@ mod tests {
             Parameter::new(ParameterId(6), vec![10, 11, 12, 13]),
             Parameter::new(ParameterId(7), vec![20, 21, 22, 23]),
         ]);
-        let serialized_payload = SerializedPayload::new(&[1, 2, 3, 4]);
+        let serialized_payload = Data::new(vec![1, 2, 3, 4]);
 
         #[rustfmt::skip]
         let data_submessage = DataSubmessageRead::new(&[

--- a/dds/src/implementation/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data_frag.rs
@@ -7,12 +7,12 @@ use crate::implementation::{
             overall_structure::{
                 RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead, SubmessageHeaderWrite,
             },
-            submessage_elements::{SerializedPayload, ParameterList, SubmessageElement},
+            submessage_elements::{ParameterList, SubmessageElement},
             types::{
                 FragmentNumber, SubmessageFlag, SubmessageKind,
             },
         },
-        types::{EntityId, SequenceNumber},
+        types::{EntityId, SequenceNumber}, history_cache::Data,
     },
 };
 
@@ -109,7 +109,7 @@ impl<'a> DataFragSubmessageRead<'a> {
         }
     }
 
-    pub fn serialized_payload(&self) -> SerializedPayload<'a> {
+    pub fn serialized_payload(&self) -> Data {
         self.map(&self.data[8 + self.octets_to_inline_qos() as usize + self.inline_qos_len()..])
     }
 }
@@ -137,7 +137,7 @@ impl<'a> DataFragSubmessageWrite<'a> {
         data_size: u32,
         fragment_size: u16,
         inline_qos: &'a ParameterList,
-        serialized_payload: SerializedPayload<'a>,
+        serialized_payload: &'a Data,
     ) -> Self {
         const EXTRA_FLAGS: u16 = 0;
         const OCTETS_TO_INLINE_QOS: u16 = 28;
@@ -155,7 +155,7 @@ impl<'a> DataFragSubmessageWrite<'a> {
         if inline_qos_flag {
             submessage_elements.push(SubmessageElement::ParameterList(inline_qos));
         }
-        submessage_elements.push(SubmessageElement::SerializedPayload(serialized_payload));
+        submessage_elements.push(SubmessageElement::SerializedData(serialized_payload));
 
         Self {
             endianness_flag: true,
@@ -224,6 +224,7 @@ mod tests {
     #[test]
     fn serialize_no_inline_qos_no_serialized_payload() {
         let inline_qos = &ParameterList::empty();
+        let serialized_payload = &Data::new(vec![]);
         let submessage = DataFragSubmessageWrite::new(
             false,
             false,
@@ -236,7 +237,7 @@ mod tests {
             4,
             5,
             inline_qos,
-            SerializedPayload::new(&[]),
+            serialized_payload,
         );
         #[rustfmt::skip]
         assert_eq!(into_bytes_vec(submessage), vec![
@@ -257,6 +258,7 @@ mod tests {
     fn serialize_with_inline_qos_with_serialized_payload() {
         let inline_qos =
             ParameterList::new(vec![Parameter::new(ParameterId(8), vec![71, 72, 73, 74])]);
+        let serialized_payload = Data::new(vec![1, 2, 3]);
         let submessage = DataFragSubmessageWrite::new(
             true,
             false,
@@ -269,7 +271,7 @@ mod tests {
             8,
             5,
             &inline_qos,
-            SerializedPayload::new(&[1, 2, 3]),
+            &serialized_payload,
         );
         #[rustfmt::skip]
         assert_eq!(into_bytes_vec(submessage), vec![
@@ -318,7 +320,7 @@ mod tests {
         let expected_data_size = 4;
         let expected_fragment_size = 5;
         let expected_inline_qos = ParameterList::empty();
-        let expected_serialized_payload = SerializedPayload::new(&[]);
+        let expected_serialized_payload = Data::new(vec![]);
 
         assert_eq!(expected_inline_qos_flag, submessage.inline_qos_flag());
         assert_eq!(
@@ -376,7 +378,7 @@ mod tests {
         let expected_fragment_size = 5;
         let expected_inline_qos =
             ParameterList::new(vec![Parameter::new(ParameterId(8), vec![71, 72, 73, 74])]);
-        let expected_serialized_payload = SerializedPayload::new(&[1, 2, 3, 0]);
+        let expected_serialized_payload = Data::new(vec![1, 2, 3, 0]);
 
         assert_eq!(expected_inline_qos_flag, submessage.inline_qos_flag());
         assert_eq!(

--- a/dds/src/implementation/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data_frag.rs
@@ -7,12 +7,10 @@ use crate::implementation::{
             overall_structure::{
                 RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead, SubmessageHeaderWrite,
             },
-            submessage_elements::{ParameterList, SubmessageElement},
-            types::{
-                FragmentNumber, SubmessageFlag, SubmessageKind,
-            },
+            submessage_elements::{Data, ParameterList, SubmessageElement},
+            types::{FragmentNumber, SubmessageFlag, SubmessageKind},
         },
-        types::{EntityId, SequenceNumber}, history_cache::Data,
+        types::{EntityId, SequenceNumber},
     },
 };
 

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -32,11 +32,11 @@ use crate::{
 use super::{
     endpoint::RtpsEndpoint,
     messages::{
-        submessage_elements::{Parameter, ParameterList},
+        submessage_elements::{Data, Parameter, ParameterList},
         submessages::{data::DataSubmessageRead, data_frag::DataFragSubmessageRead},
         types::ParameterId,
     },
-    types::{ChangeKind, Guid, GuidPrefix}, history_cache::Data,
+    types::{ChangeKind, Guid, GuidPrefix},
 };
 
 pub type RtpsReaderResult<T> = Result<T, RtpsReaderError>;
@@ -423,7 +423,11 @@ impl RtpsReader {
                     .iter()
                     .filter(|cc| {
                         self.instance_handle_builder
-                            .build_instance_handle(cc.kind, cc.data.as_ref(), cc.inline_qos.parameter())
+                            .build_instance_handle(
+                                cc.kind,
+                                cc.data.as_ref(),
+                                cc.inline_qos.parameter(),
+                            )
                             .unwrap()
                             == change_instance_handle
                             && cc.kind == ChangeKind::Alive

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -36,7 +36,7 @@ use super::{
         submessages::{data::DataSubmessageRead, data_frag::DataFragSubmessageRead},
         types::ParameterId,
     },
-    types::{ChangeKind, Guid, GuidPrefix},
+    types::{ChangeKind, Guid, GuidPrefix}, history_cache::Data,
 };
 
 pub type RtpsReaderResult<T> = Result<T, RtpsReaderError>;
@@ -50,7 +50,7 @@ pub enum RtpsReaderError {
 pub struct RtpsReaderCacheChange {
     kind: ChangeKind,
     writer_guid: Guid,
-    data: Vec<u8>,
+    data: Data,
     inline_qos: ParameterList,
     source_timestamp: Option<Time>,
     sample_state: SampleStateKind,
@@ -98,7 +98,7 @@ pub fn convert_data_frag_to_cache_change(
     Ok(RtpsReaderCacheChange {
         kind: change_kind,
         writer_guid,
-        data,
+        data: Data::new(data),
         inline_qos,
         source_timestamp,
         sample_state: SampleStateKind::NotRead,
@@ -259,7 +259,7 @@ impl RtpsReader {
     ) -> RtpsReaderResult<RtpsReaderCacheChange> {
         let writer_guid = Guid::new(source_guid_prefix, data_submessage.writer_id());
 
-        let data = <&[u8]>::from(data_submessage.serialized_payload()).to_vec();
+        let data = data_submessage.serialized_payload();
 
         let inline_qos = data_submessage.inline_qos();
 
@@ -314,7 +314,7 @@ impl RtpsReader {
             .filter(|cc| {
                 &self
                     .instance_handle_builder
-                    .build_instance_handle(cc.kind, &cc.data, cc.inline_qos.parameter())
+                    .build_instance_handle(cc.kind, cc.data.as_ref(), cc.inline_qos.parameter())
                     .expect("Change in cache must have valid instance handle")
                     == change_instance_handle
             })
@@ -329,7 +329,7 @@ impl RtpsReader {
             .iter()
             .map(|cc| {
                 self.instance_handle_builder
-                    .build_instance_handle(cc.kind, &cc.data, cc.inline_qos.parameter())
+                    .build_instance_handle(cc.kind, cc.data.as_ref(), cc.inline_qos.parameter())
                     .expect("Change in cache must have valid instance handle")
             })
             .collect();
@@ -351,7 +351,7 @@ impl RtpsReader {
             .filter(|cc| {
                 &self
                     .instance_handle_builder
-                    .build_instance_handle(cc.kind, &cc.data, cc.inline_qos.parameter())
+                    .build_instance_handle(cc.kind, cc.data.as_ref(), cc.inline_qos.parameter())
                     .expect("Change in cache must have valid instance handle")
                     == change_instance_handle
             })
@@ -371,7 +371,7 @@ impl RtpsReader {
             .filter(|cc| {
                 &self
                     .instance_handle_builder
-                    .build_instance_handle(cc.kind, &cc.data, cc.inline_qos.parameter())
+                    .build_instance_handle(cc.kind, cc.data.as_ref(), cc.inline_qos.parameter())
                     .expect("Change in cache must have valid instance handle")
                     == change_instance_handle
             })
@@ -398,7 +398,7 @@ impl RtpsReader {
     ) -> RtpsReaderResult<InstanceHandle> {
         let change_instance_handle = self.instance_handle_builder.build_instance_handle(
             change.kind,
-            &change.data,
+            change.data.as_ref(),
             change.inline_qos.parameter(),
         )?;
         if self.is_sample_of_interest_based_on_time(&change, &change_instance_handle) {
@@ -423,7 +423,7 @@ impl RtpsReader {
                     .iter()
                     .filter(|cc| {
                         self.instance_handle_builder
-                            .build_instance_handle(cc.kind, &cc.data, cc.inline_qos.parameter())
+                            .build_instance_handle(cc.kind, cc.data.as_ref(), cc.inline_qos.parameter())
                             .unwrap()
                             == change_instance_handle
                             && cc.kind == ChangeKind::Alive
@@ -439,7 +439,7 @@ impl RtpsReader {
                                 self.instance_handle_builder
                                     .build_instance_handle(
                                         cc.kind,
-                                        &cc.data,
+                                        cc.data.as_ref(),
                                         cc.inline_qos.parameter(),
                                     )
                                     .unwrap()
@@ -527,7 +527,7 @@ impl RtpsReader {
             .enumerate()
             .filter(|(_, cc)| {
                 let sample_instance_handle = instance_handle_build
-                    .build_instance_handle(cc.kind, &cc.data, cc.inline_qos.parameter())
+                    .build_instance_handle(cc.kind, cc.data.as_ref(), cc.inline_qos.parameter())
                     .unwrap();
 
                 sample_states.contains(&cc.sample_state)
@@ -545,7 +545,7 @@ impl RtpsReader {
                 .instance_handle_builder
                 .build_instance_handle(
                     cache_change.kind,
-                    &cache_change.data,
+                    cache_change.data.as_ref(),
                     cache_change.inline_qos.parameter(),
                 )
                 .unwrap();
@@ -572,7 +572,7 @@ impl RtpsReader {
             let (data, valid_data) = match cache_change.kind {
                 ChangeKind::Alive | ChangeKind::AliveFiltered => (
                     Some(
-                        dds_deserialize(cache_change.data.as_slice())
+                        dds_deserialize(cache_change.data.as_ref())
                             .map_err(|_err| DdsError::Error)?,
                     ),
                     true,

--- a/dds/src/implementation/rtps/reader_locator.rs
+++ b/dds/src/implementation/rtps/reader_locator.rs
@@ -195,7 +195,7 @@ mod tests {
             HANDLE_NIL,
             SequenceNumber::new(1),
             TIME_INVALID,
-            Data::new(vec![]),
+            vec![Data::new(vec![])],
             ParameterList::empty(),
         ));
         hc.add_change(RtpsWriterCacheChange::new(
@@ -204,7 +204,7 @@ mod tests {
             HANDLE_NIL,
             SequenceNumber::new(2),
             TIME_INVALID,
-            Data::new(vec![]),
+            vec![Data::new(vec![])],
             ParameterList::empty(),
         ));
         let mut reader_locator_attributes = RtpsReaderLocator::new(LOCATOR_INVALID, false);

--- a/dds/src/implementation/rtps/reader_locator.rs
+++ b/dds/src/implementation/rtps/reader_locator.rs
@@ -177,8 +177,8 @@ impl<'a> RtpsReaderLocatorCacheChange<'a> {
 mod tests {
     use crate::{
         implementation::rtps::{
-            history_cache::{RtpsWriterCacheChange, Data},
-            messages::submessage_elements::ParameterList,
+            history_cache::RtpsWriterCacheChange,
+            messages::submessage_elements::{Data, ParameterList},
             types::{ChangeKind, GUID_UNKNOWN, LOCATOR_INVALID},
         },
         infrastructure::{instance::HANDLE_NIL, time::TIME_INVALID},

--- a/dds/src/implementation/rtps/reader_locator.rs
+++ b/dds/src/implementation/rtps/reader_locator.rs
@@ -177,7 +177,7 @@ impl<'a> RtpsReaderLocatorCacheChange<'a> {
 mod tests {
     use crate::{
         implementation::rtps::{
-            history_cache::RtpsWriterCacheChange,
+            history_cache::{RtpsWriterCacheChange, Data},
             messages::submessage_elements::ParameterList,
             types::{ChangeKind, GUID_UNKNOWN, LOCATOR_INVALID},
         },
@@ -195,7 +195,7 @@ mod tests {
             HANDLE_NIL,
             SequenceNumber::new(1),
             TIME_INVALID,
-            vec![],
+            Data::new(vec![]),
             ParameterList::empty(),
         ));
         hc.add_change(RtpsWriterCacheChange::new(
@@ -204,7 +204,7 @@ mod tests {
             HANDLE_NIL,
             SequenceNumber::new(2),
             TIME_INVALID,
-            vec![],
+            Data::new(vec![]),
             ParameterList::empty(),
         ));
         let mut reader_locator_attributes = RtpsReaderLocator::new(LOCATOR_INVALID, false);

--- a/dds/src/implementation/rtps/transport.rs
+++ b/dds/src/implementation/rtps/transport.rs
@@ -1,5 +1,5 @@
 use super::{messages::overall_structure::RtpsMessageWrite, types::Locator};
 
 pub trait TransportWrite {
-    fn write(&mut self, message: &RtpsMessageWrite<'_>, destination_locator_list: &[Locator]);
+    fn write(&self, message: &RtpsMessageWrite, destination_locator_list: &[Locator]);
 }

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{
     endpoint::RtpsEndpoint,
-    history_cache::{RtpsWriterCacheChange, WriterHistoryCache},
+    history_cache::{RtpsWriterCacheChange, WriterHistoryCache, Data},
     messages::submessage_elements::ParameterList,
     types::{ChangeKind, Guid, Locator, SequenceNumber},
 };
@@ -97,7 +97,7 @@ impl RtpsWriter {
             handle,
             self.last_change_sequence_number,
             timestamp,
-            data,
+            Data::new(data),
             inline_qos,
         )
     }

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -97,7 +97,7 @@ impl RtpsWriter {
             handle,
             self.last_change_sequence_number,
             timestamp,
-            Data::new(data).chunks(self.data_max_size_serialized),
+            data.chunks(self.data_max_size_serialized).map(|c| Data::new(c.to_vec())).collect(),
             inline_qos,
         )
     }

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -97,7 +97,7 @@ impl RtpsWriter {
             handle,
             self.last_change_sequence_number,
             timestamp,
-            Data::new(data),
+            Data::new(data).chunks(self.data_max_size_serialized),
             inline_qos,
         )
     }

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -12,8 +12,8 @@ use crate::{
 
 use super::{
     endpoint::RtpsEndpoint,
-    history_cache::{RtpsWriterCacheChange, WriterHistoryCache, Data},
-    messages::submessage_elements::ParameterList,
+    history_cache::{RtpsWriterCacheChange, WriterHistoryCache},
+    messages::submessage_elements::{Data, ParameterList},
     types::{ChangeKind, Guid, Locator, SequenceNumber},
 };
 
@@ -97,7 +97,9 @@ impl RtpsWriter {
             handle,
             self.last_change_sequence_number,
             timestamp,
-            data.chunks(self.data_max_size_serialized).map(|c| Data::new(c.to_vec())).collect(),
+            data.chunks(self.data_max_size_serialized)
+                .map(|c| Data::new(c.to_vec()))
+                .collect(),
             inline_qos,
         )
     }

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -28,13 +28,14 @@ pub struct OwningDataFragSubmessage {
 
 impl From<&DataFragSubmessageRead<'_>> for OwningDataFragSubmessage {
     fn from(x: &DataFragSubmessageRead<'_>) -> Self {
-        Self {
-            fragment_starting_num: x.fragment_starting_num(),
-            data_size: x.data_size(),
-            fragment_size: x.fragment_size(),
-            fragments_in_submessage: x.fragments_in_submessage(),
-            serialized_payload: <&[u8]>::from(&x.serialized_payload()).to_vec(),
-        }
+        // Self {
+        //     fragment_starting_num: x.fragment_starting_num(),
+        //     data_size: x.data_size(),
+        //     fragment_size: x.fragment_size(),
+        //     fragments_in_submessage: x.fragments_in_submessage(),
+        //     serialized_payload: <&[u8]>::from(&x.serialized_payload()).to_vec(),
+        // }
+        todo!()
     }
 }
 

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -6,7 +6,7 @@ use std::{
 use super::{
     messages::{
         overall_structure::{RtpsMessageHeader, RtpsMessageWrite, RtpsSubmessageWriteKind},
-        submessage_elements::{FragmentNumberSet, SequenceNumberSet},
+        submessage_elements::{Data, FragmentNumberSet, SequenceNumberSet},
         submessages::{
             ack_nack::AckNackSubmessageWrite, data_frag::DataFragSubmessageRead,
             info_destination::InfoDestinationSubmessageWrite, nack_frag::NackFragSubmessageWrite,
@@ -14,7 +14,7 @@ use super::{
         types::{Count, FragmentNumber},
     },
     transport::TransportWrite,
-    types::{EntityId, Guid, Locator, SequenceNumber}, history_cache::Data,
+    types::{EntityId, Guid, Locator, SequenceNumber},
 };
 
 #[derive(Debug, PartialEq, Eq)]

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -14,7 +14,7 @@ use super::{
         types::{Count, FragmentNumber},
     },
     transport::TransportWrite,
-    types::{EntityId, Guid, Locator, SequenceNumber},
+    types::{EntityId, Guid, Locator, SequenceNumber}, history_cache::Data,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -23,19 +23,18 @@ pub struct OwningDataFragSubmessage {
     data_size: u32,
     fragment_size: u16,
     fragments_in_submessage: u16,
-    serialized_payload: Vec<u8>,
+    serialized_payload: Data,
 }
 
 impl From<&DataFragSubmessageRead<'_>> for OwningDataFragSubmessage {
     fn from(x: &DataFragSubmessageRead<'_>) -> Self {
-        // Self {
-        //     fragment_starting_num: x.fragment_starting_num(),
-        //     data_size: x.data_size(),
-        //     fragment_size: x.fragment_size(),
-        //     fragments_in_submessage: x.fragments_in_submessage(),
-        //     serialized_payload: <&[u8]>::from(&x.serialized_payload()).to_vec(),
-        // }
-        todo!()
+        Self {
+            fragment_starting_num: x.fragment_starting_num(),
+            data_size: x.data_size(),
+            fragment_size: x.fragment_size(),
+            fragments_in_submessage: x.fragments_in_submessage(),
+            serialized_payload: x.serialized_payload(),
+        }
     }
 }
 
@@ -114,8 +113,8 @@ impl RtpsWriterProxy {
                 frag_seq_num_list.sort_by_key(|k| k.fragment_starting_num);
 
                 let mut data = Vec::new();
-                for mut frag in frag_seq_num_list {
-                    data.append(&mut frag.serialized_payload);
+                for frag in frag_seq_num_list {
+                    data.append(&mut frag.serialized_payload.as_ref().to_vec());
                 }
                 return Some(data);
             }

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -1,5 +1,5 @@
 use crate::implementation::rtps::{
-    messages::overall_structure::{EndianWriteBytes, RtpsMessageRead, RtpsMessageWrite},
+    messages::overall_structure::{RtpsMessageRead, RtpsMessageWrite},
     transport::TransportWrite,
     types::{Locator, LocatorAddress, LocatorPort, LOCATOR_KIND_UDP_V4, LOCATOR_KIND_UDP_V6},
 };

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -1,5 +1,5 @@
 use crate::implementation::rtps::{
-    messages::overall_structure::{RtpsMessageRead, RtpsMessageWrite, EndianWriteBytes},
+    messages::overall_structure::{EndianWriteBytes, RtpsMessageRead, RtpsMessageWrite},
     transport::TransportWrite,
     types::{Locator, LocatorAddress, LocatorPort, LOCATOR_KIND_UDP_V4, LOCATOR_KIND_UDP_V6},
 };
@@ -41,9 +41,8 @@ impl UdpTransportWrite {
 }
 
 impl TransportWrite for UdpTransportWrite {
-    fn write(&mut self, message: &RtpsMessageWrite<'_>, destination_locator_list: &[Locator]) {
-        let mut buf = [0u8; 35000];
-        message.endian_write_bytes::<byteorder::LittleEndian>(&mut buf);
+    fn write(&self, message: &RtpsMessageWrite, destination_locator_list: &[Locator]) {
+        let buf = message.buffer();
 
         for &destination_locator in destination_locator_list {
             if UdpLocator(destination_locator).is_multicast() {
@@ -61,13 +60,13 @@ impl TransportWrite for UdpTransportWrite {
                 for address in interface_addresses {
                     if socket2.set_multicast_if_v4(&address).is_ok() {
                         self.socket
-                            .send_to(buf.as_slice(), UdpLocator(destination_locator))
+                            .send_to(buf, UdpLocator(destination_locator))
                             .ok();
                     }
                 }
             } else {
                 self.socket
-                    .send_to(buf.as_slice(), UdpLocator(destination_locator))
+                    .send_to(buf, UdpLocator(destination_locator))
                     .ok();
             }
         }


### PR DESCRIPTION
Removes unnecessary lifetime in the  FromBytes trait. This is possible since the Data submessage element is used as the data_value returned from the history cache. As such the FromBytes can directly "de-serialize" and hence clone into the history cache. This makes the HC more consistent, i.e. like the ParameterList. 
The lifetime of the RtpsMessageWrite is removed. This is possible since the data gets directly serialized into it's containing buffer.