### PR TITLE
Replace vec by seq number to improve performance

### DIFF
--- a/dds/benches/benchmark.rs
+++ b/dds/benches/benchmark.rs
@@ -113,6 +113,7 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
             the_reader
                 .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
                 .ok();
+            println!("Received data");
             self.sender.send(()).unwrap();
         }
     }

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -190,11 +190,7 @@ impl RtpsWriterProxy {
         // In between those two numbers, every change that is not RECEIVED or IRRELEVANT is MISSING
         let mut seq_num = self.first_available_seq_num;
         while seq_num <= highest_number {
-            let received = if seq_num <= self.highest_received_change_sn {
-                true
-            } else {
-                false
-            };
+            let received = seq_num <= self.highest_received_change_sn;
 
             let irrelevant = self.irrelevant_changes.contains(&seq_num);
             if !(irrelevant || received) {


### PR DESCRIPTION
Replace the Vec<> of received samples on reader proxy by a sequence number to improve performance