### PR TITLE
Return actor address reference and clone where necessary

### DIFF
--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -108,7 +108,7 @@ impl DomainParticipant {
         let publisher = DdsPublisher::new(publisher_qos, rtps_group, listener, status_kind);
 
         let publisher_actor = spawn_actor(publisher);
-        let publisher_address = publisher_actor.address();
+        let publisher_address = publisher_actor.address().clone();
         self.0.add_user_defined_publisher(publisher_actor)?;
 
         let publisher = Publisher::new(PublisherNode::new(publisher_address, self.0.clone()));
@@ -180,7 +180,7 @@ impl DomainParticipant {
 
         let subscriber_actor = spawn_actor(subscriber);
         let subscriber = Subscriber::new(SubscriberNodeKind::UserDefined(SubscriberNode::new(
-            subscriber_actor.address(),
+            subscriber_actor.address().clone(),
             self.0.clone(),
         )));
         self.0.add_user_defined_subscriber(subscriber_actor)?;
@@ -250,7 +250,7 @@ impl DomainParticipant {
         let topic = DdsTopic::new(guid, qos, Foo::type_name(), topic_name);
 
         let topic_actor: crate::implementation::utils::actor::Actor<DdsTopic> = spawn_actor(topic);
-        let topic_address = topic_actor.address();
+        let topic_address = topic_actor.address().clone();
         self.0.add_user_defined_topic(topic_actor)?;
 
         let topic = Topic::new(TopicNodeKind::UserDefined(TopicNode::new(

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -207,7 +207,7 @@ impl DomainParticipantFactory {
         );
 
         let participant_actor = spawn_actor(domain_participant);
-        let participant_address = participant_actor.address();
+        let participant_address = participant_actor.address().clone();
         self.0.address().add_participant(participant_actor)?;
         let domain_participant = DomainParticipant::new(participant_address.clone());
 
@@ -255,7 +255,8 @@ impl DomainParticipantFactory {
         let participant_address_clone = participant_address;
         THE_RUNTIME.spawn(async move {
             let mut default_unicast_transport = UdpTransportRead::new(
-                tokio::net::UdpSocket::from_std(default_unicast_socket).expect("Should not fail to open default unicast socket"),
+                tokio::net::UdpSocket::from_std(default_unicast_socket)
+                    .expect("Should not fail to open default unicast socket"),
             );
 
             while let Some((_locator, message)) = default_unicast_transport.read().await {

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -83,10 +83,11 @@ where
     /// The explicit use of this operation is optional as the application may call directly [`DataWriter::write`]
     /// and specify no [`InstanceHandle`] to indicate that the *key* should be examined to identify the instance.
     pub fn register_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
-        let timestamp = self
-            .get_publisher()?
-            .get_participant()?
-            .get_current_time()?;
+        let timestamp = match &self.0 {
+            DataWriterNodeKind::UserDefined(dw) | DataWriterNodeKind::Listener(dw) => {
+                dw.parent_participant().get_current_time()?
+            }
+        };
         self.register_instance_w_timestamp(instance, timestamp)
     }
 
@@ -138,10 +139,11 @@ where
         instance: &Foo,
         handle: Option<InstanceHandle>,
     ) -> DdsResult<()> {
-        let timestamp = self
-            .get_publisher()?
-            .get_participant()?
-            .get_current_time()?;
+        let timestamp = match &self.0 {
+            DataWriterNodeKind::UserDefined(dw) | DataWriterNodeKind::Listener(dw) => {
+                dw.parent_participant().get_current_time()?
+            }
+        };
         self.unregister_instance_w_timestamp(instance, handle, timestamp)
     }
 
@@ -256,10 +258,11 @@ where
     /// is exceeded and the service determines that even waiting the [`ReliabilityQosPolicy::max_waiting_time`](crate::infrastructure::qos_policy::ReliabilityQosPolicy) has no
     /// chance of freeing the necessary resources. For example, if the only way to gain the necessary resources would be for the user to unregister an instance.
     pub fn write(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
-        let timestamp = self
-            .get_publisher()?
-            .get_participant()?
-            .get_current_time()?;
+        let timestamp = match &self.0 {
+            DataWriterNodeKind::UserDefined(dw) | DataWriterNodeKind::Listener(dw) => {
+                dw.parent_participant().get_current_time()?
+            }
+        };
         self.write_w_timestamp(data, handle, timestamp)
     }
 
@@ -313,10 +316,11 @@ where
     /// This operation may block and return [`DdsError::Timeout`](crate::infrastructure::error::DdsError) or
     /// [`DdsError::OutOfResources`](crate::infrastructure::error::DdsError) under the same circumstances described for [`DataWriter::write`].
     pub fn dispose(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
-        let timestamp = self
-            .get_publisher()?
-            .get_participant()?
-            .get_current_time()?;
+        let timestamp = match &self.0 {
+            DataWriterNodeKind::UserDefined(dw) | DataWriterNodeKind::Listener(dw) => {
+                dw.parent_participant().get_current_time()?
+            }
+        };
         self.dispose_w_timestamp(data, handle, timestamp)
     }
 

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -154,7 +154,7 @@ impl Publisher {
             status_kind,
         );
         let data_writer_actor = spawn_actor(data_writer);
-        let data_writer_address = data_writer_actor.address();
+        let data_writer_address = data_writer_actor.address().clone();
         self.0
             .address()
             .stateful_datawriter_add(data_writer_actor)?;

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -164,7 +164,7 @@ impl Subscriber {
                 );
 
                 let reader_actor = spawn_actor(data_reader);
-                let reader_address = reader_actor.address();
+                let reader_address = reader_actor.address().clone();
                 s.address().stateful_data_reader_add(reader_actor)?;
 
                 let data_reader =
@@ -451,10 +451,9 @@ impl Subscriber {
         match &self.0 {
             SubscriberNodeKind::Builtin(s)
             | SubscriberNodeKind::UserDefined(s)
-            | SubscriberNodeKind::Listener(s) => s
-                .address()
-                .get_statuscondition()
-                .map(StatusCondition::new),
+            | SubscriberNodeKind::Listener(s) => {
+                s.address().get_statuscondition().map(StatusCondition::new)
+            }
         }
     }
 

--- a/dds/src/implementation/dds/dds_data_reader.rs
+++ b/dds/src/implementation/dds/dds_data_reader.rs
@@ -1011,7 +1011,7 @@ impl DdsDataReader<RtpsStatefulReader> {
             .write_lock()
             .add_communication_state(StatusKind::SubscriptionMatched);
         if self.listener.is_some() && self.status_kind.contains(&StatusKind::SubscriptionMatched) {
-            let listener_address = self.listener.as_ref().unwrap().address();
+            let listener_address = self.listener.as_ref().unwrap().address().clone();
             let reader =
                 DataReaderNode::new(data_reader_address, subscriber_address, participant_address);
             let status = self.get_subscription_matched_status();
@@ -1062,7 +1062,7 @@ impl DdsDataReader<RtpsStatefulReader> {
             .add_communication_state(StatusKind::SampleRejected);
         if self.listener.is_some() && self.status_kind.contains(&StatusKind::SampleRejected) {
             let status = self.get_sample_rejected_status();
-            let listener_address = self.listener.as_ref().unwrap().address();
+            let listener_address = self.listener.as_ref().unwrap().address().clone();
             let reader = DataReaderNode::new(
                 data_reader_address.clone(),
                 subscriber_address.clone(),

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -1058,7 +1058,7 @@ impl DdsDataWriter<RtpsStatefulWriter> {
             .write_lock()
             .add_communication_state(StatusKind::PublicationMatched);
         if self.listener.is_some() && self.status_kind.contains(&StatusKind::PublicationMatched) {
-            let listener_address = self.listener.as_ref().unwrap().address();
+            let listener_address = self.listener.as_ref().unwrap().address().clone();
             let writer =
                 DataWriterNode::new(data_writer_address, publisher_address, participant_address);
             let status = self.get_publication_matched_status();

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -415,11 +415,11 @@ impl DdsDomainParticipant {
     }
 
     pub fn get_builtin_subscriber(&self) -> ActorAddress<DdsSubscriber> {
-        self.builtin_subscriber.address()
+        self.builtin_subscriber.address().clone()
     }
 
     pub fn get_builtin_publisher(&self) -> ActorAddress<DdsPublisher> {
-        self.builtin_publisher.address()
+        self.builtin_publisher.address().clone()
     }
 
     pub fn get_instance_handle(&self) -> InstanceHandle {
@@ -510,7 +510,7 @@ impl DdsDomainParticipant {
     }
 
     pub fn get_user_defined_publisher_list(&self) -> Vec<ActorAddress<DdsPublisher>> {
-        self.user_defined_publisher_list.iter().map(|a| a.address()).collect()
+        self.user_defined_publisher_list.iter().map(|a| a.address().clone()).collect()
     }
 
     pub fn delete_user_defined_publisher(&mut self, handle: InstanceHandle) {
@@ -535,7 +535,7 @@ impl DdsDomainParticipant {
     }
 
     pub fn get_user_defined_subscriber_list(&self) -> Vec<ActorAddress<DdsSubscriber>> {
-        self.user_defined_subscriber_list.iter().map(|a| a.address()).collect()
+        self.user_defined_subscriber_list.iter().map(|a| a.address().clone()).collect()
     }
 
     pub fn delete_user_defined_subscriber(&mut self, handle: InstanceHandle) {
@@ -560,7 +560,7 @@ impl DdsDomainParticipant {
     }
 
     pub fn get_user_defined_topic_list(&self) -> Vec<ActorAddress<DdsTopic>> {
-        self.topic_list.iter().map(|a| a.address()).collect()
+        self.topic_list.iter().map(|a| a.address().clone()).collect()
     }
 
     pub fn delete_user_defined_topic(&mut self, handle: InstanceHandle) {
@@ -699,7 +699,7 @@ impl DdsDomainParticipant {
     }
 
     pub fn get_udp_transport_write(&self) -> ActorAddress<UdpTransportWrite> {
-        self.udp_transport_write.address()
+        self.udp_transport_write.address().clone()
     }
 
     pub fn discovered_topic_add(&mut self, handle: InstanceHandle, topic_data: TopicBuiltinTopicData) {
@@ -709,7 +709,7 @@ impl DdsDomainParticipant {
     }
 
     pub fn get_listener(&self) -> Option<ActorAddress<DdsDomainParticipantListener>> {
-        self.listener.as_ref().map(|l| l.address())
+        self.listener.as_ref().map(|l| l.address().clone())
     }
 
     pub fn status_kind(&self) -> Vec<StatusKind> {

--- a/dds/src/implementation/dds/dds_domain_participant_factory.rs
+++ b/dds/src/implementation/dds/dds_domain_participant_factory.rs
@@ -38,7 +38,7 @@ impl DdsDomainParticipantFactory {
     }
 
     pub fn get_participant_list(&self) -> Vec<ActorAddress<DdsDomainParticipant>> {
-        self.domain_participant_list.iter().map(|dp| dp.address()).collect()
+        self.domain_participant_list.iter().map(|dp| dp.address().clone()).collect()
     }
 
     pub fn get_unique_participant_id(&mut self) -> u32 {

--- a/dds/src/implementation/dds/dds_publisher.rs
+++ b/dds/src/implementation/dds/dds_publisher.rs
@@ -95,7 +95,7 @@ impl DdsPublisher {
     ) -> Vec<ActorAddress<DdsDataWriter<RtpsStatefulWriter>>> {
         self.stateful_data_writer_list
             .iter()
-            .map(|x| x.address())
+            .map(|x| x.address().clone())
             .collect()
     }
 
@@ -109,7 +109,7 @@ impl DdsPublisher {
     pub fn stateless_datawriter_list(&self) -> Vec<ActorAddress<DdsDataWriter<RtpsStatelessWriter>>> {
         self.stateless_data_writer_list
             .iter()
-            .map(|x| x.address())
+            .map(|x| x.address().clone())
             .collect()
     }
 
@@ -149,7 +149,7 @@ impl DdsPublisher {
     }
 
     pub fn get_listener(&self) -> Option<ActorAddress<DdsPublisherListener>> {
-        self.listener.as_ref().map(|l| l.address())
+        self.listener.as_ref().map(|l| l.address().clone())
     }
 
     pub fn status_kind(&self) -> Vec<StatusKind> {

--- a/dds/src/implementation/dds/dds_subscriber.rs
+++ b/dds/src/implementation/dds/dds_subscriber.rs
@@ -92,7 +92,7 @@ impl DdsSubscriber {
     }
 
     pub fn stateless_data_reader_list(&self) -> Vec<ActorAddress<DdsDataReader<RtpsStatelessReader>>> {
-        self.stateless_data_reader_list.iter().map(|dr| dr.address()).collect()
+        self.stateless_data_reader_list.iter().map(|dr| dr.address().clone()).collect()
     }
 
     pub fn stateful_data_reader_add(
@@ -114,7 +114,7 @@ impl DdsSubscriber {
     }
 
     pub fn stateful_data_reader_list(&self) -> Vec<ActorAddress<DdsDataReader<RtpsStatefulReader>>> {
-        self.stateful_data_reader_list.iter().map(|dr| dr.address()).collect()
+        self.stateful_data_reader_list.iter().map(|dr| dr.address().clone()).collect()
     }
 
     pub fn set_default_datareader_qos(&mut self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
@@ -160,7 +160,7 @@ impl DdsSubscriber {
     }
 
     pub fn get_listener(&self) -> Option<ActorAddress<DdsSubscriberListener>> {
-        self.listener.as_ref().map(|l| l.address())
+        self.listener.as_ref().map(|l| l.address().clone())
     }
 
     pub fn status_kind(&self) -> Vec<StatusKind> {

--- a/dds/src/implementation/utils/actor.rs
+++ b/dds/src/implementation/utils/actor.rs
@@ -140,8 +140,8 @@ pub struct Actor<A> {
 }
 
 impl<A> Actor<A> {
-    pub fn address(&self) -> ActorAddress<A> {
-        self.address.clone()
+    pub fn address(&self) -> &ActorAddress<A> {
+        &self.address
     }
 }
 
@@ -329,7 +329,7 @@ mod tests {
     fn actor_increment() {
         let my_data = MyData { data: 0 };
         let actor = spawn_actor(my_data);
-        let data_interface = DataInterface(actor.address());
+        let data_interface = DataInterface(actor.address().clone());
         assert_eq!(data_interface.increment(10).unwrap(), 10)
     }
 
@@ -337,7 +337,7 @@ mod tests {
     fn actor_already_deleted() {
         let my_data = MyData { data: 0 };
         let actor = spawn_actor(my_data);
-        let data_interface = DataInterface(actor.address());
+        let data_interface = DataInterface(actor.address().clone());
         std::mem::drop(actor);
         std::thread::sleep(std::time::Duration::from_millis(100));
         assert_eq!(data_interface.increment(10), Err(DdsError::AlreadyDeleted));


### PR DESCRIPTION
Tokio channels notify the receiver every time a sender is dropped. For the actor framework this means that cloning senders for a short duration can have an impact on performance since the receiver side will get unblocked and the runtime has to process potentially many requests. To minimize the impact on performance actor addresses are only cloned where needed and otherwise a reference is used.