### PR TITLE
Replace Ifcfg crate to enable cross compilation

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -27,7 +27,7 @@ byteorder = "=1.4.3"
 lazy_static = "=1.4"
 
 socket2 = "=0.4"
-ifcfg = "=0.1"
+network-interface = "1.0.1"
 mac_address = "=1.1"
 
 jsonschema = {version = "=0.12.0", default-features = false}

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -114,12 +114,18 @@ impl DomainParticipantFactory {
             .filter_map(|i| i.mac_addr)
             .find(|m| m != "00:00:00:00:00:00")
             .expect("Could not find any mac address");
+        let mut mac_address_octets = [0u8; 6];
+        for (index, octet_str) in mac_address.split(|c| c == ':' || c == '-').enumerate() {
+            mac_address_octets[index] =
+                u8::from_str_radix(octet_str, 16).expect("All octet strings should be valid");
+        }
+
         let app_id = std::process::id().to_ne_bytes();
         let instance_id = self.0.address().get_unique_participant_id()?.to_ne_bytes();
 
         #[rustfmt::skip]
         let guid_prefix = GuidPrefix::new([
-            mac_address.as_bytes()[2],  mac_address.as_bytes()[3], mac_address.as_bytes()[4], mac_address.as_bytes()[5], // Host ID
+            mac_address_octets[2],  mac_address_octets[3], mac_address_octets[4], mac_address_octets[5], // Host ID
             app_id[0], app_id[1], app_id[2], app_id[3], // App ID
             instance_id[0], instance_id[1], instance_id[2], instance_id[3], // Instance ID
         ]);

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -112,8 +112,7 @@ impl DomainParticipantFactory {
             .expect("Could not scan interfaces")
             .into_iter()
             .filter_map(|i| i.mac_addr)
-            .filter(|m| m != "00:00:00:00:00:00")
-            .next()
+            .find(|m| m != "00:00:00:00:00:00")
             .expect("Could not find any mac address");
         let app_id = std::process::id().to_ne_bytes();
         let instance_id = self.0.address().get_unique_participant_id()?.to_ne_bytes();

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -112,9 +112,9 @@ impl DomainParticipantFactory {
             .expect("Could not scan interfaces")
             .into_iter()
             .filter_map(|i| i.mac_addr)
+            .filter(|m| m != "00:00:00:00:00:00")
             .next()
             .expect("Could not find any mac address");
-        println!("Mac address: {:?}", mac_address);
         let app_id = std::process::id().to_ne_bytes();
         let instance_id = self.0.address().get_unique_participant_id()?.to_ne_bytes();
 
@@ -124,7 +124,6 @@ impl DomainParticipantFactory {
             app_id[0], app_id[1], app_id[2], app_id[3], // App ID
             instance_id[0], instance_id[1], instance_id[2], instance_id[3], // Instance ID
         ]);
-        println!("guid_prefix: {:?}", guid_prefix);
 
         let interface_address_list =
             get_interface_address_list(THE_DDS_CONFIGURATION.interface_name.as_ref());

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -114,7 +114,7 @@ impl DomainParticipantFactory {
             .filter_map(|i| i.mac_addr)
             .next()
             .expect("Could not find any mac address");
-
+        println!("Mac address: {:?}", mac_address);
         let app_id = std::process::id().to_ne_bytes();
         let instance_id = self.0.address().get_unique_participant_id()?.to_ne_bytes();
 
@@ -124,6 +124,7 @@ impl DomainParticipantFactory {
             app_id[0], app_id[1], app_id[2], app_id[3], // App ID
             instance_id[0], instance_id[1], instance_id[2], instance_id[3], // Instance ID
         ]);
+        println!("guid_prefix: {:?}", guid_prefix);
 
         let interface_address_list =
             get_interface_address_list(THE_DDS_CONFIGURATION.interface_name.as_ref());

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -5,6 +5,7 @@ use crate::implementation::{
     },
     utils::actor::actor_interface,
 };
+use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, ToSocketAddrs};
 
 pub struct UdpTransportRead {
@@ -52,12 +53,12 @@ impl UdpTransportWrite {
         for destination_locator in destination_locator_list {
             if UdpLocator(destination_locator).is_multicast() {
                 let socket2: socket2::Socket = self.socket.try_clone().unwrap().into();
-                let interface_addresses: Vec<_> = ifcfg::IfCfg::get()
+                let interface_addresses: Vec<_> = NetworkInterface::show()
                     .expect("Could not scan interfaces")
                     .into_iter()
                     .flat_map(|i| {
-                        i.addresses.into_iter().filter_map(|a| match a.address? {
-                            SocketAddr::V4(v4) => Some(*v4.ip()),
+                        i.addr.into_iter().filter_map(|a| match a {
+                            Addr::V4(v4) => Some(v4.ip),
                             _ => None,
                         })
                     })

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -53,7 +53,9 @@ impl UdpTransportWrite {
         for destination_locator in destination_locator_list {
             if UdpLocator(destination_locator).is_multicast() {
                 let socket2: socket2::Socket = self.socket.try_clone().unwrap().into();
-                let interface_addresses: Vec<_> = NetworkInterface::show()
+                let interface_addresses = NetworkInterface::show();
+                println!("multicast {:?}", interface_addresses);
+                let interface_addresses: Vec<_> = interface_addresses
                     .expect("Could not scan interfaces")
                     .into_iter()
                     .flat_map(|i| {

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -54,7 +54,6 @@ impl UdpTransportWrite {
             if UdpLocator(destination_locator).is_multicast() {
                 let socket2: socket2::Socket = self.socket.try_clone().unwrap().into();
                 let interface_addresses = NetworkInterface::show();
-                println!("multicast {:?}", interface_addresses);
                 let interface_addresses: Vec<_> = interface_addresses
                     .expect("Could not scan interfaces")
                     .into_iter()

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1892,13 +1892,14 @@ fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
         )
         .unwrap();
 
-    let cond = writer.get_statuscondition().unwrap();
-    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+    let writer_cond = writer.get_statuscondition().unwrap();
+    writer_cond
+        .set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
 
     let mut wait_set = WaitSet::new();
     wait_set
-        .attach_condition(Condition::StatusCondition(cond))
+        .attach_condition(Condition::StatusCondition(writer_cond))
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
     writer.get_publication_matched_status().unwrap(); // To reset wait_set for subsequent calls
@@ -1913,7 +1914,19 @@ fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
     let reader_new = subscriber
         .create_datareader(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
         .unwrap();
+
+    // Wait for writer to match reader
     wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let reader_new_statuscond = reader_new.get_statuscondition().unwrap();
+    reader_new_statuscond
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut wait_set_reader = WaitSet::new();
+    wait_set_reader
+        .attach_condition(Condition::StatusCondition(reader_new_statuscond))
+        .unwrap();
+    wait_set_reader.wait(Duration::new(5, 0)).unwrap();
 
     let data2 = KeyedData { id: 2, value: 10 };
     writer.write(&data2, None).unwrap();

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1918,6 +1918,8 @@ fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
     // Wait for writer to match reader
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
     let data2 = KeyedData { id: 2, value: 10 };
     writer.write(&data2, None).unwrap();
 

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1893,8 +1893,7 @@ fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
         .unwrap();
 
     let cond = writer.get_statuscondition().unwrap();
-    cond
-        .set_enabled_statuses(&[StatusKind::PublicationMatched])
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
 
     let mut wait_set = WaitSet::new();

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1892,14 +1892,14 @@ fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
         )
         .unwrap();
 
-    let writer_cond = writer.get_statuscondition().unwrap();
-    writer_cond
+    let cond = writer.get_statuscondition().unwrap();
+    cond
         .set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
 
     let mut wait_set = WaitSet::new();
     wait_set
-        .attach_condition(Condition::StatusCondition(writer_cond))
+        .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
     writer.get_publication_matched_status().unwrap(); // To reset wait_set for subsequent calls
@@ -1916,23 +1916,13 @@ fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
         .unwrap();
 
     // Wait for writer to match reader
-    wait_set.wait(Duration::new(5, 0)).unwrap();
-
-    let reader_new_statuscond = reader_new.get_statuscondition().unwrap();
-    reader_new_statuscond
-        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
-        .unwrap();
-    let mut wait_set_reader = WaitSet::new();
-    wait_set_reader
-        .attach_condition(Condition::StatusCondition(reader_new_statuscond))
-        .unwrap();
-    wait_set_reader.wait(Duration::new(5, 0)).unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 
     let data2 = KeyedData { id: 2, value: 10 };
     writer.write(&data2, None).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(5, 0))
+        .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
     let samples = reader_new


### PR DESCRIPTION
The Ifcfg doesn't allow cross-compilation from windows to raspberry pi because of the way its build.rs script is used. To enable cross compilation this crate is replaced by network_interfaces