### PR TITLE
DDS-341 Remove endianess from serialization

### DIFF
--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -1,4 +1,4 @@
-use std::{io::BufRead, sync::Arc};
+use std::{io::{BufRead, Write}, sync::Arc};
 
 use crate::implementation::rtps::{
     messages::{
@@ -44,22 +44,13 @@ where
     T: Submessage,
 {
     fn write_bytes(&self, buf: &mut [u8]) -> usize {
-        let mut len = 4;
+        let (header, body) = buf.split_at_mut(4);
+        let mut len = 0;
         for submessage_element in self.submessage_elements() {
-            len += if self.endianness_flag() {
-                submessage_element.endian_write_bytes::<byteorder::LittleEndian>(&mut buf[len..])
-            } else {
-                submessage_element.endian_write_bytes::<byteorder::BigEndian>(&mut buf[len..])
-            };
+            len += submessage_element.write_bytes(&mut body[len..]);
         }
-        let octets_to_next_header = len - 4;
-        let submessage_header = self.submessage_header(octets_to_next_header as u16);
-        if self.endianness_flag() {
-            submessage_header.endian_write_bytes::<byteorder::LittleEndian>(&mut buf[0..]);
-        } else {
-            submessage_header.endian_write_bytes::<byteorder::BigEndian>(&mut buf[0..]);
-        }
-        len
+        let submessage_header = self.submessage_header(len as u16);
+        submessage_header.write_bytes(header) + len
     }
 }
 
@@ -186,14 +177,11 @@ pub trait WriteBytes {
     fn write_bytes(&self, buf: &mut [u8]) -> usize;
 }
 
-pub trait EndianWriteBytes {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize;
-}
 
 #[allow(dead_code)]
-pub fn into_bytes_le_vec<T: EndianWriteBytes>(value: T) -> Vec<u8> {
+pub fn into_bytes_le_vec<T: WriteBytes>(value: T) -> Vec<u8> {
     let mut buf = [0u8; BUFFER_SIZE];
-    let len = value.endian_write_bytes::<byteorder::LittleEndian>(buf.as_mut_slice());
+    let len = value.write_bytes(buf.as_mut_slice());
     Vec::from(&buf[0..len])
 }
 
@@ -213,7 +201,7 @@ pub struct RtpsMessageWrite {
 impl RtpsMessageWrite {
     pub fn new(header: RtpsMessageHeader, submessages: Vec<RtpsSubmessageWriteKind<'_>>) -> Self {
         let mut buffer = [0; BUFFER_SIZE];
-        let mut len = header.endian_write_bytes::<byteorder::LittleEndian>(&mut buffer[0..]);
+        let mut len = header.write_bytes(&mut buffer[0..]);
         for submessage in &submessages {
             len += submessage.write_bytes(&mut buffer[len..]);
         }
@@ -311,12 +299,12 @@ impl RtpsMessageHeader {
     }
 }
 
-impl EndianWriteBytes for RtpsMessageHeader {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        self.protocol.endian_write_bytes::<E>(&mut buf[0..]);
-        self.version.endian_write_bytes::<E>(&mut buf[4..]);
-        self.vendor_id.endian_write_bytes::<E>(&mut buf[6..]);
-        self.guid_prefix.endian_write_bytes::<E>(&mut buf[8..]);
+impl WriteBytes for RtpsMessageHeader {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        self.protocol.write_bytes(&mut buf[0..]);
+        self.version.write_bytes(&mut buf[4..]);
+        self.vendor_id.write_bytes(&mut buf[6..]);
+        self.guid_prefix.write_bytes(&mut buf[8..]);
         20
     }
 }
@@ -345,12 +333,12 @@ impl SubmessageHeaderWrite {
     }
 }
 
-impl EndianWriteBytes for SubmessageHeaderWrite {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
+impl WriteBytes for SubmessageHeaderWrite {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
         self.submessage_id.write_bytes(&mut buf[0..]);
         self.flags.write_bytes(&mut buf[1..]);
         self.submessage_length
-            .endian_write_bytes::<E>(&mut buf[2..]);
+            .write_bytes(&mut buf[2..]);
         4
     }
 }

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -36,7 +36,6 @@ const BUFFER_SIZE: usize = 65000;
 pub trait Submessage {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite;
     fn submessage_elements(&self) -> &[SubmessageElement];
-    fn endianness_flag(&self) -> bool;
 }
 
 impl<T> WriteBytes for T

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -63,7 +63,7 @@ pub trait SubmessageHeader {
 
 pub trait RtpsMap: SubmessageHeader {
     fn map<T: FromBytes>(&self, data: &[u8]) -> T {
-        if self.submessage_header().endianness_flag() {
+        if self.submessage_header().flags()[0] {
             T::from_bytes::<byteorder::LittleEndian>(data)
         } else {
             T::from_bytes::<byteorder::BigEndian>(data)
@@ -391,7 +391,7 @@ impl<'a> SubmessageHeaderRead<'a> {
     pub fn flags(&self) -> [SubmessageFlag; 8] {
         let flags_byte = self.data[1];
         [
-            self.endianness_flag(),
+            flags_byte & 0b_0000_0001 != 0,
             flags_byte & 0b_0000_0010 != 0,
             flags_byte & 0b_0000_0100 != 0,
             flags_byte & 0b_0000_1000 != 0,
@@ -400,10 +400,6 @@ impl<'a> SubmessageHeaderRead<'a> {
             flags_byte & 0b_0100_0000 != 0,
             flags_byte & 0b_1000_0000 != 0,
         ]
-    }
-
-    pub fn endianness_flag(&self) -> bool {
-        self.data[1] & 0b_0000_0001 != 0
     }
 }
 

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -500,7 +500,7 @@ impl FromBytes for FragmentNumberSet {
 mod tests {
     use super::*;
     use crate::implementation::rtps::{
-        messages::overall_structure::into_bytes_le_vec,
+        messages::overall_structure::into_bytes_vec,
         types::{Locator, LocatorAddress, LocatorKind, LocatorPort},
     };
 
@@ -511,7 +511,7 @@ mod tests {
             set: vec![FragmentNumber::new(2), FragmentNumber::new(257)],
         };
         #[rustfmt::skip]
-        assert_eq!(into_bytes_le_vec(fragment_number_set), vec![
+        assert_eq!(into_bytes_vec(fragment_number_set), vec![
             2, 0, 0, 0, // bitmapBase: (unsigned long)
             0, 1, 0, 0, // numBits (unsigned long)
             0b000_0000, 0b_0000_0000, 0b_0000_0000, 0b_1000_0000, // bitmap[0] (long)
@@ -539,7 +539,7 @@ mod tests {
         );
         let locator_list = LocatorList::new(vec![locator_1, locator_2]);
         assert_eq!(
-            into_bytes_le_vec(locator_list),
+            into_bytes_vec(locator_list),
             vec![
                 2, 0, 0, 0, // numLocators (unsigned long)
                 1, 0, 0, 0, // kind (long)
@@ -684,7 +684,7 @@ mod tests {
             set: vec![SequenceNumber::new(2), SequenceNumber::new(257)],
         };
         #[rustfmt::skip]
-        assert_eq!(into_bytes_le_vec(sequence_number_set), vec![
+        assert_eq!(into_bytes_vec(sequence_number_set), vec![
             0, 0, 0, 0, // bitmapBase: high (long)
             2, 0, 0, 0, // bitmapBase: low (unsigned long)
             0, 1, 0, 0, // numBits (unsigned long)
@@ -726,7 +726,7 @@ mod tests {
     fn serialize_parameter() {
         let parameter = Parameter::new(ParameterId(2), vec![5, 6, 7, 8]);
         #[rustfmt::skip]
-        assert_eq!(into_bytes_le_vec(parameter), vec![
+        assert_eq!(into_bytes_vec(parameter), vec![
             0x02, 0x00, 4, 0, // Parameter | length
             5, 6, 7, 8,       // value
         ]);
@@ -736,7 +736,7 @@ mod tests {
     fn serialize_parameter_non_multiple_4() {
         let parameter = Parameter::new(ParameterId(2), vec![5, 6, 7]);
         #[rustfmt::skip]
-        assert_eq!(into_bytes_le_vec(parameter), vec![
+        assert_eq!(into_bytes_vec(parameter), vec![
             0x02, 0x00, 4, 0, // Parameter | length
             5, 6, 7, 0,       // value
         ]);
@@ -746,7 +746,7 @@ mod tests {
     fn serialize_parameter_zero_size() {
         let parameter = Parameter::new(ParameterId(2), vec![]);
         assert_eq!(
-            into_bytes_le_vec(parameter),
+            into_bytes_vec(parameter),
             vec![
             0x02, 0x00, 0, 0, // Parameter | length
         ]
@@ -759,7 +759,7 @@ mod tests {
         let parameter_2 = Parameter::new(ParameterId(3), vec![52, 62, 0, 0]);
         let parameter_list_submessage_element = &ParameterList::new(vec![parameter_1, parameter_2]);
         #[rustfmt::skip]
-        assert_eq!(into_bytes_le_vec(parameter_list_submessage_element), vec![
+        assert_eq!(into_bytes_vec(parameter_list_submessage_element), vec![
             0x02, 0x00, 4, 0, // Parameter ID | length
             51, 61, 71, 81,   // value
             0x03, 0x00, 4, 0, // Parameter ID | length
@@ -772,7 +772,7 @@ mod tests {
     fn serialize_parameter_list_empty() {
         let parameter = &ParameterList::empty();
         #[rustfmt::skip]
-        assert_eq!(into_bytes_le_vec(parameter), vec![
+        assert_eq!(into_bytes_vec(parameter), vec![
             0x01, 0x00, 0, 0, // Sentinel: PID_SENTINEL | PID_PAD
         ]);
     }

--- a/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
+++ b/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
@@ -86,10 +86,6 @@ impl Submessage for AckNackSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
+++ b/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
@@ -48,7 +48,6 @@ impl<'a> AckNackSubmessageRead<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct AckNackSubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     final_flag: SubmessageFlag,
     submessage_elements: [SubmessageElement<'a>; 4],
 }
@@ -62,7 +61,6 @@ impl AckNackSubmessageWrite<'_> {
         count: Count,
     ) -> Self {
         Self {
-            endianness_flag: true,
             final_flag,
             submessage_elements: [
                 SubmessageElement::EntityId(reader_id),
@@ -78,7 +76,7 @@ impl Submessage for AckNackSubmessageWrite<'_> {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite {
         SubmessageHeaderWrite::new(
             SubmessageKind::ACKNACK,
-            &[self.endianness_flag, self.final_flag],
+            &[self.final_flag],
             octets_to_next_header,
         )
     }

--- a/dds/src/implementation/rtps/messages/submessages/data.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data.rs
@@ -168,10 +168,6 @@ impl Submessage for DataSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/data.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data.rs
@@ -103,7 +103,6 @@ impl<'a> DataSubmessageRead<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct DataSubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     inline_qos_flag: SubmessageFlag,
     data_flag: SubmessageFlag,
     key_flag: SubmessageFlag,
@@ -140,7 +139,6 @@ impl<'a> DataSubmessageWrite<'a> {
             submessage_elements.push(SubmessageElement::SerializedData(serialized_payload));
         }
         Self {
-            endianness_flag: true,
             inline_qos_flag,
             data_flag,
             key_flag,
@@ -155,7 +153,6 @@ impl Submessage for DataSubmessageWrite<'_> {
         SubmessageHeaderWrite::new(
             SubmessageKind::DATA,
             &[
-                self.endianness_flag,
                 self.inline_qos_flag,
                 self.data_flag,
                 self.key_flag,

--- a/dds/src/implementation/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data_frag.rs
@@ -114,7 +114,6 @@ impl<'a> DataFragSubmessageRead<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct DataFragSubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     inline_qos_flag: SubmessageFlag,
     non_standard_payload_flag: SubmessageFlag,
     key_flag: SubmessageFlag,
@@ -156,7 +155,6 @@ impl<'a> DataFragSubmessageWrite<'a> {
         submessage_elements.push(SubmessageElement::SerializedData(serialized_payload));
 
         Self {
-            endianness_flag: true,
             inline_qos_flag,
             non_standard_payload_flag,
             key_flag,
@@ -191,7 +189,6 @@ impl Submessage for DataFragSubmessageWrite<'_> {
         SubmessageHeaderWrite::new(
             SubmessageKind::DATA_FRAG,
             &[
-                self.endianness_flag,
                 self.inline_qos_flag,
                 self.key_flag,
                 self.non_standard_payload_flag,

--- a/dds/src/implementation/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data_frag.rs
@@ -203,10 +203,6 @@ impl Submessage for DataFragSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/gap.rs
+++ b/dds/src/implementation/rtps/messages/submessages/gap.rs
@@ -79,10 +79,6 @@ impl Submessage for GapSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/gap.rs
+++ b/dds/src/implementation/rtps/messages/submessages/gap.rs
@@ -4,7 +4,7 @@ use crate::implementation::rtps::{
             RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead, SubmessageHeaderWrite,
         },
         submessage_elements::{SequenceNumberSet, SubmessageElement},
-        types::{SubmessageFlag, SubmessageKind},
+        types::SubmessageKind,
     },
     types::{EntityId, SequenceNumber},
 };
@@ -44,7 +44,6 @@ impl<'a> GapSubmessageRead<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct GapSubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     submessage_elements: [SubmessageElement<'a>; 4],
 }
 
@@ -56,7 +55,6 @@ impl GapSubmessageWrite<'_> {
         gap_list: SequenceNumberSet,
     ) -> Self {
         Self {
-            endianness_flag: true,
             submessage_elements: [
                 SubmessageElement::EntityId(reader_id),
                 SubmessageElement::EntityId(writer_id),
@@ -69,11 +67,7 @@ impl GapSubmessageWrite<'_> {
 
 impl Submessage for GapSubmessageWrite<'_> {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite {
-        SubmessageHeaderWrite::new(
-            SubmessageKind::GAP,
-            &[self.endianness_flag],
-            octets_to_next_header,
-        )
+        SubmessageHeaderWrite::new(SubmessageKind::GAP, &[], octets_to_next_header)
     }
 
     fn submessage_elements(&self) -> &[SubmessageElement] {
@@ -93,12 +87,8 @@ mod tests {
         let reader_id = EntityId::new(EntityKey::new([1, 2, 3]), USER_DEFINED_READER_NO_KEY);
         let writer_id = EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
         let gap_start = SequenceNumber::new(5);
-        let gap_list = SequenceNumberSet::new(
-            SequenceNumber::new(10),
-            vec![],
-        );
-        let submessage =
-            GapSubmessageWrite::new(reader_id, writer_id, gap_start, gap_list);
+        let gap_list = SequenceNumberSet::new(SequenceNumber::new(10), vec![]);
+        let submessage = GapSubmessageWrite::new(reader_id, writer_id, gap_start, gap_list);
         #[rustfmt::skip]
         assert_eq!(into_bytes_vec(submessage), vec![
                 0x08_u8, 0b_0000_0001, 28, 0, // Submessage header
@@ -121,10 +111,7 @@ mod tests {
         let expected_writer_id =
             EntityId::new(EntityKey::new([6, 7, 8]), USER_DEFINED_READER_GROUP);
         let expected_gap_start = SequenceNumber::new(5);
-        let expected_gap_list = SequenceNumberSet::new(
-             SequenceNumber::new(10),
-             vec![],
-        );
+        let expected_gap_list = SequenceNumberSet::new(SequenceNumber::new(10), vec![]);
         #[rustfmt::skip]
         let submessage = GapSubmessageRead::new(&[
             0x08, 0b_0000_0001, 28, 0, // Submessage header

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
@@ -55,7 +55,6 @@ impl<'a> HeartbeatSubmessageRead<'a> {
 }
 #[derive(Debug, PartialEq, Eq)]
 pub struct HeartbeatSubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     final_flag: SubmessageFlag,
     liveliness_flag: SubmessageFlag,
     submessage_elements: [SubmessageElement<'a>; 5],
@@ -72,7 +71,6 @@ impl HeartbeatSubmessageWrite<'_> {
         count: Count,
     ) -> Self {
         Self {
-            endianness_flag: true,
             final_flag,
             liveliness_flag,
             submessage_elements: [
@@ -90,7 +88,7 @@ impl Submessage for HeartbeatSubmessageWrite<'_> {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite {
         SubmessageHeaderWrite::new(
             SubmessageKind::HEARTBEAT,
-            &[self.endianness_flag, self.final_flag, self.liveliness_flag],
+            &[self.final_flag, self.liveliness_flag],
             octets_to_next_header,
         )
     }

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
@@ -98,10 +98,6 @@ impl Submessage for HeartbeatSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
@@ -87,10 +87,6 @@ impl Submessage for HeartbeatFragSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
@@ -4,7 +4,7 @@ use crate::implementation::rtps::{
             RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead, SubmessageHeaderWrite,
         },
         submessage_elements::SubmessageElement,
-        types::{Count, FragmentNumber, SubmessageFlag, SubmessageKind},
+        types::{Count, FragmentNumber, SubmessageKind},
     },
     types::{EntityId, SequenceNumber},
 };
@@ -48,7 +48,6 @@ impl<'a> HeartbeatFragSubmessageRead<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HeartbeatFragSubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     submessage_elements: [SubmessageElement<'a>; 5],
 }
 impl HeartbeatFragSubmessageWrite<'_> {
@@ -60,7 +59,6 @@ impl HeartbeatFragSubmessageWrite<'_> {
         count: Count,
     ) -> Self {
         Self {
-            endianness_flag: true,
             submessage_elements: [
                 SubmessageElement::EntityId(reader_id),
                 SubmessageElement::EntityId(writer_id),
@@ -77,11 +75,7 @@ impl Submessage for HeartbeatFragSubmessageWrite<'_> {
         &self,
         octets_to_next_header: u16,
     ) -> crate::implementation::rtps::messages::overall_structure::SubmessageHeaderWrite {
-        SubmessageHeaderWrite::new(
-            SubmessageKind::HEARTBEAT_FRAG,
-            &[self.endianness_flag],
-            octets_to_next_header,
-        )
+        SubmessageHeaderWrite::new(SubmessageKind::HEARTBEAT_FRAG, &[], octets_to_next_header)
     }
 
     fn submessage_elements(&self) -> &[SubmessageElement] {

--- a/dds/src/implementation/rtps/messages/submessages/info_destination.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_destination.rs
@@ -56,10 +56,6 @@ impl Submessage for InfoDestinationSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/info_destination.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_destination.rs
@@ -4,7 +4,7 @@ use crate::implementation::rtps::{
             RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead, SubmessageHeaderWrite,
         },
         submessage_elements::SubmessageElement,
-        types::{SubmessageFlag, SubmessageKind},
+        types::SubmessageKind,
     },
     types::GuidPrefix,
 };
@@ -31,14 +31,12 @@ impl<'a> InfoDestinationSubmessageRead<'a> {
 }
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoDestinationSubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     submessage_elements: [SubmessageElement<'a>; 1],
 }
 
 impl InfoDestinationSubmessageWrite<'_> {
     pub fn new(guid_prefix: GuidPrefix) -> Self {
         Self {
-            endianness_flag: true,
             submessage_elements: [SubmessageElement::GuidPrefix(guid_prefix)],
         }
     }
@@ -46,11 +44,7 @@ impl InfoDestinationSubmessageWrite<'_> {
 
 impl Submessage for InfoDestinationSubmessageWrite<'_> {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite {
-        SubmessageHeaderWrite::new(
-            SubmessageKind::INFO_DST,
-            &[self.endianness_flag],
-            octets_to_next_header,
-        )
+        SubmessageHeaderWrite::new(SubmessageKind::INFO_DST, &[], octets_to_next_header)
     }
 
     fn submessage_elements(&self) -> &[SubmessageElement] {

--- a/dds/src/implementation/rtps/messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_reply.rs
@@ -78,10 +78,6 @@ impl Submessage for InfoReplySubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_reply.rs
@@ -43,7 +43,6 @@ impl<'a> InfoReplySubmessageRead<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoReplySubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     multicast_flag: SubmessageFlag,
     submessage_elements: Vec<SubmessageElement<'a>>,
 }
@@ -59,7 +58,6 @@ impl<'a> InfoReplySubmessageWrite<'a> {
             submessage_elements.push(SubmessageElement::LocatorList(multicast_locator_list));
         }
         Self {
-            endianness_flag: true,
             multicast_flag,
             submessage_elements,
         }
@@ -68,11 +66,7 @@ impl<'a> InfoReplySubmessageWrite<'a> {
 
 impl Submessage for InfoReplySubmessageWrite<'_> {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite {
-        SubmessageHeaderWrite::new(
-            SubmessageKind::INFO_REPLY,
-            &[self.endianness_flag],
-            octets_to_next_header,
-        )
+        SubmessageHeaderWrite::new(SubmessageKind::INFO_REPLY, &[], octets_to_next_header)
     }
 
     fn submessage_elements(&self) -> &[SubmessageElement] {

--- a/dds/src/implementation/rtps/messages/submessages/info_source.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_source.rs
@@ -4,7 +4,7 @@ use crate::implementation::rtps::{
             RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead, SubmessageHeaderWrite,
         },
         submessage_elements::SubmessageElement,
-        types::{SubmessageFlag, SubmessageKind},
+        types::SubmessageKind,
     },
     types::{GuidPrefix, ProtocolVersion, VendorId},
 };
@@ -40,7 +40,6 @@ impl<'a> InfoSourceSubmessageRead<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoSourceSubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     submessage_elements: [SubmessageElement<'a>; 4],
 }
 
@@ -51,7 +50,6 @@ impl InfoSourceSubmessageWrite<'_> {
         guid_prefix: GuidPrefix,
     ) -> Self {
         Self {
-            endianness_flag: true,
             submessage_elements: [
                 SubmessageElement::Long(0),
                 SubmessageElement::ProtocolVersion(protocol_version),
@@ -64,11 +62,7 @@ impl InfoSourceSubmessageWrite<'_> {
 
 impl Submessage for InfoSourceSubmessageWrite<'_> {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite {
-        SubmessageHeaderWrite::new(
-            SubmessageKind::INFO_SRC,
-            &[self.endianness_flag],
-            octets_to_next_header,
-        )
+        SubmessageHeaderWrite::new(SubmessageKind::INFO_SRC, &[], octets_to_next_header)
     }
 
     fn submessage_elements(&self) -> &[SubmessageElement] {

--- a/dds/src/implementation/rtps/messages/submessages/info_source.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_source.rs
@@ -74,10 +74,6 @@ impl Submessage for InfoSourceSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/info_timestamp.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_timestamp.rs
@@ -70,10 +70,6 @@ impl Submessage for InfoTimestampSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/info_timestamp.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_timestamp.rs
@@ -36,22 +36,17 @@ impl<'a> InfoTimestampSubmessageRead<'a> {
 }
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoTimestampSubmessageWrite<'a> {
-    pub endianness_flag: SubmessageFlag,
     pub invalidate_flag: SubmessageFlag,
     submessage_elements: Vec<SubmessageElement<'a>>,
 }
 
 impl InfoTimestampSubmessageWrite<'_> {
-    pub fn new(
-        invalidate_flag: SubmessageFlag,
-        timestamp: Time,
-    ) -> Self {
+    pub fn new(invalidate_flag: SubmessageFlag, timestamp: Time) -> Self {
         let mut submessage_elements = vec![];
         if !invalidate_flag {
             submessage_elements.push(SubmessageElement::Timestamp(timestamp))
         }
         Self {
-            endianness_flag: true,
             invalidate_flag,
             submessage_elements,
         }
@@ -62,7 +57,7 @@ impl Submessage for InfoTimestampSubmessageWrite<'_> {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite {
         SubmessageHeaderWrite::new(
             SubmessageKind::INFO_TS,
-            &[self.endianness_flag, self.invalidate_flag],
+            &[self.invalidate_flag],
             octets_to_next_header,
         )
     }

--- a/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
@@ -4,7 +4,7 @@ use crate::implementation::rtps::{
             RtpsMap, Submessage, SubmessageHeader, SubmessageHeaderRead, SubmessageHeaderWrite,
         },
         submessage_elements::{FragmentNumberSet, SubmessageElement},
-        types::{Count, SubmessageFlag, SubmessageKind},
+        types::{Count, SubmessageKind},
     },
     types::{EntityId, SequenceNumber},
 };
@@ -48,7 +48,6 @@ impl<'a> NackFragSubmessageRead<'a> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct NackFragSubmessageWrite<'a> {
-    endianness_flag: SubmessageFlag,
     submessage_elements: [SubmessageElement<'a>; 5],
 }
 
@@ -61,7 +60,6 @@ impl NackFragSubmessageWrite<'_> {
         count: Count,
     ) -> Self {
         Self {
-            endianness_flag: true,
             submessage_elements: [
                 SubmessageElement::EntityId(reader_id),
                 SubmessageElement::EntityId(writer_id),
@@ -75,11 +73,7 @@ impl NackFragSubmessageWrite<'_> {
 
 impl Submessage for NackFragSubmessageWrite<'_> {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite {
-        SubmessageHeaderWrite::new(
-            SubmessageKind::NACK_FRAG,
-            &[self.endianness_flag],
-            octets_to_next_header,
-        )
+        SubmessageHeaderWrite::new(SubmessageKind::NACK_FRAG, &[], octets_to_next_header)
     }
 
     fn submessage_elements(&self) -> &[SubmessageElement] {

--- a/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
@@ -85,10 +85,6 @@ impl Submessage for NackFragSubmessageWrite<'_> {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &self.submessage_elements
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps/messages/submessages/pad.rs
@@ -71,7 +71,7 @@ mod tests {
         let expected_endianness_flag = true;
         assert_eq!(
             expected_endianness_flag,
-            submessage.submessage_header().endianness_flag()
+            submessage.submessage_header().flags()[0]
         );
     }
 }

--- a/dds/src/implementation/rtps/messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps/messages/submessages/pad.rs
@@ -3,7 +3,7 @@ use crate::implementation::rtps::messages::{
         Submessage, SubmessageHeader, SubmessageHeaderRead, SubmessageHeaderWrite,
     },
     submessage_elements::SubmessageElement,
-    types::{SubmessageFlag, SubmessageKind},
+    types::SubmessageKind,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -24,13 +24,11 @@ impl<'a> PadSubmessageRead<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct PadSubmessageWrite {
-    endianness_flag: SubmessageFlag,
-}
+pub struct PadSubmessageWrite {}
 
 impl PadSubmessageWrite {
     pub fn new() -> Self {
-        Self { endianness_flag: true }
+        Self {}
     }
 }
 
@@ -41,11 +39,7 @@ impl Default for PadSubmessageWrite {
 }
 impl Submessage for PadSubmessageWrite {
     fn submessage_header(&self, octets_to_next_header: u16) -> SubmessageHeaderWrite {
-        SubmessageHeaderWrite::new(
-            SubmessageKind::PAD,
-            &[self.endianness_flag],
-            octets_to_next_header,
-        )
+        SubmessageHeaderWrite::new(SubmessageKind::PAD, &[], octets_to_next_header)
     }
 
     fn submessage_elements(&self) -> &[SubmessageElement] {

--- a/dds/src/implementation/rtps/messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps/messages/submessages/pad.rs
@@ -51,10 +51,6 @@ impl Submessage for PadSubmessageWrite {
     fn submessage_elements(&self) -> &[SubmessageElement] {
         &[]
     }
-
-    fn endianness_flag(&self) -> bool {
-        self.endianness_flag
-    }
 }
 
 #[cfg(test)]

--- a/dds/src/implementation/rtps/messages/types.rs
+++ b/dds/src/implementation/rtps/messages/types.rs
@@ -1,5 +1,7 @@
+use byteorder::ByteOrder;
+
+use super::overall_structure::WriteBytes;
 use std::io::Read;
-use super::overall_structure::{EndianWriteBytes, WriteBytes};
 
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.3
 /// Table 8.13 - Types used to define RTPS messages
@@ -14,8 +16,8 @@ pub enum ProtocolId {
     PROTOCOL_RTPS,
 }
 
-impl EndianWriteBytes for ProtocolId {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
+impl WriteBytes for ProtocolId {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
         b"RTPS".as_slice().read(buf).unwrap()
     }
 }
@@ -119,11 +121,9 @@ impl Time {
     }
 }
 
-impl EndianWriteBytes for Time {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        self.seconds.endian_write_bytes::<E>(&mut buf[0..]);
-        self.fraction.endian_write_bytes::<E>(&mut buf[4..]);
-        8
+impl WriteBytes for Time {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        self.seconds.write_bytes(&mut buf[0..]) + self.fraction.write_bytes(&mut buf[4..])
     }
 }
 
@@ -165,20 +165,18 @@ impl PartialOrd<Count> for Count {
     }
 }
 
-impl EndianWriteBytes for Count {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        E::write_i32(buf, self.0);
+impl WriteBytes for Count {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        byteorder::LittleEndian::write_i32(buf, self.0);
         4
     }
 }
-
 
 /// ParameterId_t
 /// Type used to uniquely identify a parameter in a parameter list.
 /// Used extensively by the Discovery Module mainly to define QoS Parameters. A range of values is reserved for protocol-defined parameters, while another range can be used for vendor-defined parameters, see 8.3.5.9.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, derive_more::Into)]
 pub struct ParameterId(pub u16);
-
 
 /// FragmentNumber_t
 /// Type used to hold fragment numbers.
@@ -206,9 +204,9 @@ impl FragmentNumber {
     }
 }
 
-impl EndianWriteBytes for FragmentNumber {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        E::write_u32(buf, self.0);
+impl WriteBytes for FragmentNumber {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        byteorder::LittleEndian::write_u32(buf, self.0);
         4
     }
 }
@@ -223,4 +221,3 @@ impl GroupDigest {
         Self(value)
     }
 }
-

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -531,12 +531,12 @@ impl Default for ExpectsInlineQos {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::implementation::rtps::messages::overall_structure::into_bytes_le_vec;
+    use crate::implementation::rtps::messages::overall_structure::into_bytes_vec;
 
     #[test]
     fn serialize_sequence_number() {
         let data = SequenceNumber::new(7);
-        let result = into_bytes_le_vec(data);
+        let result = into_bytes_vec(data);
         assert_eq!(
             result,
             vec![
@@ -550,7 +550,7 @@ mod tests {
     fn serialize_entity_id() {
         let data = EntityId::new(EntityKey::new([1, 2, 3]), EntityKind::new(0x04));
         assert_eq!(
-            into_bytes_le_vec(data),
+            into_bytes_vec(data),
             vec![
             1, 2, 3, 0x04, //value (long)
         ]

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -1,9 +1,10 @@
-use super::messages::overall_structure::EndianWriteBytes;
 use crate::implementation::data_representation_builtin_endpoints::parameter_id_values::DEFAULT_EXPECTS_INLINE_QOS;
 use std::{
     io::Read,
     ops::{Add, AddAssign, Sub, SubAssign},
 };
+
+use super::messages::overall_structure::WriteBytes;
 
 ///
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.3
@@ -102,8 +103,8 @@ impl GuidPrefix {
     }
 }
 
-impl EndianWriteBytes for GuidPrefix {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
+impl WriteBytes for GuidPrefix {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
         self.0.as_slice().read(buf).unwrap()
     }
 }
@@ -151,10 +152,10 @@ pub const ENTITYID_PARTICIPANT: EntityId = EntityId {
     entity_kind: BUILT_IN_PARTICIPANT,
 };
 
-impl EndianWriteBytes for EntityId {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        self.entity_key().endian_write_bytes::<E>(&mut buf[0..]);
-        self.entity_kind().endian_write_bytes::<E>(&mut buf[3..]);
+impl WriteBytes for EntityId {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        self.entity_key().write_bytes(&mut buf[0..]);
+        self.entity_kind().write_bytes(&mut buf[3..]);
         4
     }
 }
@@ -168,8 +169,8 @@ impl EntityKind {
     }
 }
 
-impl EndianWriteBytes for EntityKind {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
+impl WriteBytes for EntityKind {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
         buf[0] = self.0;
         1
     }
@@ -219,8 +220,8 @@ impl EntityKey {
     }
 }
 
-impl EndianWriteBytes for EntityKey {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
+impl WriteBytes for EntityKey {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
         self.0.as_slice().read(buf).unwrap()
     }
 }
@@ -252,13 +253,11 @@ impl SequenceNumber {
     }
 }
 
-impl EndianWriteBytes for SequenceNumber {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        let high = (<i64>::from(*self) >> 32) as i32;
-        let low = <i64>::from(*self) as i32;
-        E::write_i32(&mut buf[0..], high);
-        E::write_i32(&mut buf[4..], low);
-        8
+impl WriteBytes for SequenceNumber {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        let high = (self.0 >> 32) as i32;
+        let low = self.0 as i32;
+        high.write_bytes(&mut buf[0..]) + low.write_bytes(&mut buf[4..])
     }
 }
 
@@ -301,11 +300,11 @@ pub struct Locator {
     address: LocatorAddress,
 }
 
-impl EndianWriteBytes for Locator {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        self.kind.endian_write_bytes::<E>(&mut buf[0..]);
-        self.port.endian_write_bytes::<E>(&mut buf[4..]);
-        self.address.endian_write_bytes::<E>(&mut buf[8..]);
+impl WriteBytes for Locator {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        self.kind.write_bytes(&mut buf[0..]);
+        self.port.write_bytes(&mut buf[4..]);
+        self.address.write_bytes(&mut buf[8..]);
         24
     }
 }
@@ -321,9 +320,9 @@ impl LocatorKind {
     }
 }
 
-impl EndianWriteBytes for LocatorKind {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        self.0.endian_write_bytes::<E>(buf)
+impl WriteBytes for LocatorKind {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        self.0.write_bytes(buf)
     }
 }
 
@@ -338,9 +337,9 @@ impl LocatorPort {
     }
 }
 
-impl EndianWriteBytes for LocatorPort {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
-        self.0.endian_write_bytes::<E>(buf)
+impl WriteBytes for LocatorPort {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
+        self.0.write_bytes(buf)
     }
 }
 
@@ -355,8 +354,8 @@ impl LocatorAddress {
     }
 }
 
-impl EndianWriteBytes for LocatorAddress {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
+impl WriteBytes for LocatorAddress {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
         buf[..self.0.len()].copy_from_slice(&self.0);
         16
     }
@@ -445,8 +444,8 @@ pub struct ProtocolVersion {
     minor: u8,
 }
 
-impl EndianWriteBytes for ProtocolVersion {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
+impl WriteBytes for ProtocolVersion {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
         buf[0] = self.major;
         buf[1] = self.minor;
         2
@@ -494,8 +493,8 @@ impl VendorId {
     }
 }
 
-impl EndianWriteBytes for VendorId {
-    fn endian_write_bytes<E: byteorder::ByteOrder>(&self, buf: &mut [u8]) -> usize {
+impl WriteBytes for VendorId {
+    fn write_bytes(&self, buf: &mut [u8]) -> usize {
         self.0.as_slice().read(buf).unwrap()
     }
 }


### PR DESCRIPTION
The big Endianness of the RTPS message serialization was not tested and is likely to be not used in the future, This PR removes the endianness switch from the message serialization (WriteBytes trait)