### PR TITLE
DDS-280 Ack mechanism on many irrelevant samples

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -50,7 +50,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run: cargo bench
+      - run: cargo bench --package dust_dds
       - store_artifacts:
           path: ./target/criterion
   build:

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -36,8 +36,6 @@ schemars = "=0.8.11"
 
 fnmatch-regex = "=0.2.0"
 
-async-trait = "0.1.73"
-
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -36,6 +36,8 @@ schemars = "=0.8.11"
 
 fnmatch-regex = "=0.2.0"
 
+async-trait = "0.1.73"
+
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]

--- a/dds/benches/benchmark.rs
+++ b/dds/benches/benchmark.rs
@@ -151,11 +151,6 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
     writer_cond
         .set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
-    let mut wait_set = WaitSet::new();
-    wait_set
-        .attach_condition(Condition::StatusCondition(writer_cond))
-        .unwrap();
-    wait_set.wait(Duration::new(60, 0)).unwrap();
 
     let mut wait_set2 = WaitSet::new();
     reader_cond
@@ -164,7 +159,13 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
     wait_set2
         .attach_condition(Condition::StatusCondition(reader_cond))
         .unwrap();
-    wait_set2.wait(Duration::new(60, 0)).unwrap();
+    wait_set2.wait(Duration::new(20, 0)).unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(writer_cond))
+        .unwrap();
+    wait_set.wait(Duration::new(20, 0)).unwrap();
 
     c.bench_function("best_effort_write_and_receive", |b| {
         b.iter(|| {
@@ -178,8 +179,8 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    best_effort_write_only,
-    best_effort_read_only,
+    // best_effort_write_only,
+    // best_effort_read_only,
     best_effort_write_and_receive
 );
 criterion_main!(benches);

--- a/dds/benches/benchmark.rs
+++ b/dds/benches/benchmark.rs
@@ -152,20 +152,20 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
         .set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
 
-    let mut wait_set2 = WaitSet::new();
+    let mut wait_set = WaitSet::new();
     reader_cond
         .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
         .unwrap();
-    wait_set2
+    wait_set
         .attach_condition(Condition::StatusCondition(reader_cond))
         .unwrap();
-    wait_set2.wait(Duration::new(20, 0)).unwrap();
+    wait_set.wait(Duration::new(20, 0)).unwrap();
 
-    let mut wait_set = WaitSet::new();
-    wait_set
+    let mut wait_set2 = WaitSet::new();
+    wait_set2
         .attach_condition(Condition::StatusCondition(writer_cond))
         .unwrap();
-    wait_set.wait(Duration::new(20, 0)).unwrap();
+    wait_set2.wait(Duration::new(20, 0)).unwrap();
 
     c.bench_function("best_effort_write_and_receive", |b| {
         b.iter(|| {
@@ -179,8 +179,8 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    // best_effort_write_only,
-    // best_effort_read_only,
+    best_effort_write_only,
+    best_effort_read_only,
     best_effort_write_and_receive
 );
 criterion_main!(benches);

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -753,16 +753,23 @@ impl DomainParticipant {
                 loop {
                     let r: DdsResult<()> = tokio::task::block_in_place(|| {
                         let now = domain_participant_address.get_current_time()?;
-
+                        let participant_mask_listener = (
+                            domain_participant_address.get_listener()?,
+                            domain_participant_address.status_kind()?,
+                        );
                         for subscriber in
                             domain_participant_address.get_user_defined_subscriber_list()?
                         {
+                            let subscriber_mask_listener =
+                                (subscriber.get_listener()?, subscriber.status_kind()?);
                             for data_reader in subscriber.data_reader_list()? {
                                 data_reader.update_communication_status(
                                     now,
                                     data_reader.clone(),
                                     subscriber.clone(),
                                     domain_participant_address.clone(),
+                                    subscriber_mask_listener.clone(),
+                                    participant_mask_listener.clone(),
                                 )?;
                             }
                         }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -774,6 +774,22 @@ impl DomainParticipant {
                             }
                         }
 
+                        for user_defined_publisher in
+                            domain_participant_address.get_user_defined_publisher_list()?
+                        {
+                            for data_writer in user_defined_publisher.data_writer_list()? {
+                                data_writer.send_message(
+                                    RtpsMessageHeader::new(
+                                        domain_participant_address.get_protocol_version()?,
+                                        domain_participant_address.get_vendor_id()?,
+                                        domain_participant_address.get_guid()?.prefix(),
+                                    ),
+                                    domain_participant_address.get_udp_transport_write()?,
+                                    domain_participant_address.get_current_time()?,
+                                )?;
+                            }
+                        }
+
                         Ok(())
                     });
 

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -416,7 +416,24 @@ impl DomainParticipant {
     /// Once this operation returns successfully, the application may delete the [`DomainParticipant`] knowing that it has no
     /// contained entities.
     pub fn delete_contained_entities(&self) -> DdsResult<()> {
-        self.0.delete_contained_entities()?
+        for publisher in self.0.get_user_defined_publisher_list()? {
+            for data_writer in publisher.data_writer_list()? {
+                publisher.datawriter_delete(data_writer.get_instance_handle()?)?;
+            }
+            self.0
+                .delete_user_defined_publisher(publisher.get_instance_handle()?)?;
+        }
+        for subscriber in self.0.get_user_defined_subscriber_list()? {
+            for data_reader in subscriber.data_reader_list()? {
+                subscriber.data_reader_delete(data_reader.get_instance_handle()?)?;
+            }
+            self.0
+                .delete_user_defined_subscriber(subscriber.get_instance_handle()?)?;
+        }
+        for topic in self.0.get_user_defined_topic_list()? {
+            self.0.delete_topic(topic.get_instance_handle()?)?;
+        }
+        Ok(())
     }
 
     /// This operation manually asserts the liveliness of the [`DomainParticipant`]. This is used in combination

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -955,6 +955,29 @@ fn discover_matched_writers(
                                 for data_reader_address in
                                     user_defined_subscriber_address.data_reader_list()?
                                 {
+                                    let subscriber_subscription_matched_listener =
+                                        match user_defined_subscriber_address.get_listener()? {
+                                            Some(l)
+                                                if user_defined_subscriber_address
+                                                    .status_kind()?
+                                                    .contains(&StatusKind::SubscriptionMatched) =>
+                                            {
+                                                Some(l)
+                                            }
+                                            _ => None,
+                                        };
+                                    let participant_subscription_matched_listener =
+                                        match participant_address.get_listener()? {
+                                            Some(l)
+                                                if participant_address
+                                                    .status_kind()?
+                                                    .contains(&StatusKind::SubscriptionMatched) =>
+                                            {
+                                                Some(l)
+                                            }
+                                            _ => None,
+                                        };
+
                                     data_reader_address.add_matched_writer(
                                         discovered_writer_data.clone(),
                                         default_unicast_locator_list.clone(),
@@ -962,6 +985,9 @@ fn discover_matched_writers(
                                         data_reader_address.clone(),
                                         user_defined_subscriber_address.clone(),
                                         participant_address.clone(),
+                                        user_defined_subscriber_address.get_qos()?,
+                                        subscriber_subscription_matched_listener,
+                                        participant_subscription_matched_listener,
                                     )?;
                                     data_reader_address.send_message(
                                         RtpsMessageHeader::new(
@@ -981,11 +1007,36 @@ fn discover_matched_writers(
         InstanceStateKind::NotAliveDisposed => {
             for subscriber in participant_address.get_user_defined_subscriber_list()? {
                 for data_reader in subscriber.data_reader_list()? {
+                    let subscriber_subscription_matched_listener =
+                        match subscriber.get_listener()? {
+                            Some(l)
+                                if subscriber
+                                    .status_kind()?
+                                    .contains(&StatusKind::SubscriptionMatched) =>
+                            {
+                                Some(l)
+                            }
+                            _ => None,
+                        };
+                    let participant_subscription_matched_listener =
+                        match participant_address.get_listener()? {
+                            Some(l)
+                                if participant_address
+                                    .status_kind()?
+                                    .contains(&StatusKind::SubscriptionMatched) =>
+                            {
+                                Some(l)
+                            }
+                            _ => None,
+                        };
+
                     data_reader.remove_matched_writer(
                         discovered_writer_sample.sample_info.instance_handle,
                         data_reader.clone(),
                         subscriber.clone(),
                         participant_address.clone(),
+                        subscriber_subscription_matched_listener,
+                        participant_subscription_matched_listener,
                     )?;
                 }
             }
@@ -1070,6 +1121,28 @@ pub fn discover_matched_readers(
                                 for data_writer in
                                     user_defined_publisher_address.data_writer_list()?
                                 {
+                                    let publisher_publication_matched_listener =
+                                        match user_defined_publisher_address.get_listener()? {
+                                            Some(l)
+                                                if user_defined_publisher_address
+                                                    .status_kind()?
+                                                    .contains(&StatusKind::PublicationMatched) =>
+                                            {
+                                                Some(l)
+                                            }
+                                            _ => None,
+                                        };
+                                    let participant_publication_matched_listener =
+                                        match participant_address.get_listener()? {
+                                            Some(l)
+                                                if participant_address
+                                                    .status_kind()?
+                                                    .contains(&StatusKind::PublicationMatched) =>
+                                            {
+                                                Some(l)
+                                            }
+                                            _ => None,
+                                        };
                                     data_writer.add_matched_reader(
                                         discovered_reader_data.clone(),
                                         default_unicast_locator_list.clone(),
@@ -1077,6 +1150,9 @@ pub fn discover_matched_readers(
                                         data_writer.clone(),
                                         user_defined_publisher_address.clone(),
                                         participant_address.clone(),
+                                        publisher_qos.clone(),
+                                        publisher_publication_matched_listener,
+                                        participant_publication_matched_listener,
                                     )?;
                                     data_writer.send_message(
                                         RtpsMessageHeader::new(
@@ -1097,11 +1173,34 @@ pub fn discover_matched_readers(
         InstanceStateKind::NotAliveDisposed => {
             for publisher in participant_address.get_user_defined_publisher_list()? {
                 for data_writer in publisher.data_writer_list()? {
+                    let publisher_publication_matched_listener = match publisher.get_listener()? {
+                        Some(l)
+                            if publisher
+                                .status_kind()?
+                                .contains(&StatusKind::PublicationMatched) =>
+                        {
+                            Some(l)
+                        }
+                        _ => None,
+                    };
+                    let participant_publication_matched_listener =
+                        match participant_address.get_listener()? {
+                            Some(l)
+                                if participant_address
+                                    .status_kind()?
+                                    .contains(&StatusKind::PublicationMatched) =>
+                            {
+                                Some(l)
+                            }
+                            _ => None,
+                        };
                     data_writer.remove_matched_reader(
                         discovered_reader_sample.sample_info.instance_handle,
                         data_writer.clone(),
                         publisher.clone(),
                         participant_address.clone(),
+                        publisher_publication_matched_listener,
+                        participant_publication_matched_listener,
                     )?;
                 }
             }

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -810,7 +810,7 @@ fn process_sedp_metatraffic(
     }
 
     builtin_subscriber.process_rtps_message(
-        message.clone(),
+        message,
         participant_address.get_current_time()?,
         participant_address.clone(),
         builtin_subscriber.clone(),

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -189,6 +189,7 @@ impl DomainParticipantFactory {
             PROTOCOLVERSION,
             VENDOR_ID_S2E,
         );
+        let participant_guid = rtps_participant.guid();
 
         let listener = a_listener.map(|l| spawn_actor(DdsDomainParticipantListener::new(l)));
         let status_kind = mask.to_vec();
@@ -207,7 +208,9 @@ impl DomainParticipantFactory {
 
         let participant_actor = spawn_actor(domain_participant);
         let participant_address = participant_actor.address().clone();
-        self.0.address().add_participant(participant_actor)?;
+        self.0
+            .address()
+            .add_participant(participant_guid.into(), participant_actor)?;
         let domain_participant = DomainParticipant::new(participant_address.clone());
 
         let participant_address_clone = participant_address.clone();

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -393,6 +393,7 @@ impl<Foo> DataWriter<Foo> {
                     if dw.address().are_all_changes_acknowledge()? {
                         return Ok(());
                     }
+                    std::thread::sleep(std::time::Duration::from_millis(25));
                 }
 
                 Err(DdsError::Timeout)

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -726,10 +726,9 @@ fn announce_data_writer(
     let serialized_data = dds_serialize_to_bytes(discovered_writer_data)?;
     let timestamp = domain_participant.get_current_time()?;
 
-    let builtin_publisher = domain_participant.get_builtin_publisher()?;
-    let data_writer_list = builtin_publisher.data_writer_list()?;
-
-    if let Some(sedp_writer_announcer) = data_writer_list
+    if let Some(sedp_writer_announcer) = domain_participant
+        .get_builtin_publisher()?
+        .data_writer_list()?
         .iter()
         .find(|x| x.get_type_name().unwrap() == "DiscoveredWriterData")
     {

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -726,9 +726,10 @@ fn announce_data_writer(
     let serialized_data = dds_serialize_to_bytes(discovered_writer_data)?;
     let timestamp = domain_participant.get_current_time()?;
 
-    if let Some(sedp_writer_announcer) = domain_participant
-        .get_builtin_publisher()?
-        .data_writer_list()?
+    let builtin_publisher = domain_participant.get_builtin_publisher()?;
+    let data_writer_list = builtin_publisher.data_writer_list()?;
+
+    if let Some(sedp_writer_announcer) = data_writer_list
         .iter()
         .find(|x| x.get_type_name().unwrap() == "DiscoveredWriterData")
     {

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -2,18 +2,10 @@ use crate::{
     domain::domain_participant::DomainParticipant,
     implementation::{
         dds::{
-            dds_data_writer::DdsDataWriter,
             dds_data_writer_listener::DdsDataWriterListener,
             nodes::{DataWriterNode, DataWriterNodeKind, PublisherNode},
         },
-        rtps::{
-            endpoint::RtpsEndpoint,
-            messages::overall_structure::RtpsMessageHeader,
-            types::{
-                EntityId, Guid, TopicKind, USER_DEFINED_WRITER_NO_KEY, USER_DEFINED_WRITER_WITH_KEY,
-            },
-            writer::RtpsWriter,
-        },
+        rtps::messages::overall_structure::RtpsMessageHeader,
         utils::actor::spawn_actor,
     },
     infrastructure::{
@@ -22,7 +14,7 @@ use crate::{
         instance::InstanceHandle,
         qos::{DataWriterQos, PublisherQos, QosKind, TopicQos},
         status::StatusKind,
-        time::{Duration, DURATION_ZERO},
+        time::Duration,
     },
     publication::data_writer::DataWriter,
     topic_definition::topic::Topic,
@@ -100,59 +92,19 @@ impl Publisher {
             .get_default_multicast_locator_list()?;
         let data_max_size_serialized = self.0.parent_participant().data_max_size_serialized()?;
 
-        let qos = match qos {
-            QosKind::Default => self.0.address().get_default_datawriter_qos()?,
-            QosKind::Specific(q) => {
-                q.is_consistent()?;
-                q
-            }
-        };
-
-        let guid_prefix = self.0.address().guid()?.prefix();
-        let entity_kind = match Foo::HAS_KEY {
-            true => USER_DEFINED_WRITER_WITH_KEY,
-            false => USER_DEFINED_WRITER_NO_KEY,
-        };
-        let entity_key = [
-            self.0.address().guid()?.entity_id().entity_key()[0],
-            self.0.address().get_unique_writer_id()?,
-            0,
-        ];
-        let entity_id = EntityId::new(entity_key, entity_kind);
-        let guid = Guid::new(guid_prefix, entity_id);
-
-        let topic_kind = match Foo::HAS_KEY {
-            true => TopicKind::WithKey,
-            false => TopicKind::NoKey,
-        };
-
-        let rtps_writer_impl = RtpsWriter::new(
-            RtpsEndpoint::new(
-                guid,
-                topic_kind,
-                &default_unicast_locator_list,
-                &default_multicast_locator_list,
-            ),
-            true,
-            Duration::new(0, 200_000_000),
-            DURATION_ZERO,
-            DURATION_ZERO,
-            data_max_size_serialized,
-        );
-        let topic_name = a_topic.get_name()?;
         let listener = a_listener.map(|l| spawn_actor(DdsDataWriterListener::new(Box::new(l))));
-        let status_kind = mask.to_vec();
-        let data_writer = DdsDataWriter::new(
-            rtps_writer_impl,
+        let data_writer_address = self.0.address().create_datawriter(
             a_topic.get_type_name()?,
-            topic_name,
-            listener,
-            status_kind,
+            a_topic.get_name()?,
+            Foo::HAS_KEY,
+            data_max_size_serialized,
             qos,
-        );
-        let data_writer_actor = spawn_actor(data_writer);
-        let data_writer_address = data_writer_actor.address().clone();
-        self.0.address().datawriter_add(data_writer_actor)?;
+            listener,
+            mask.to_vec(),
+            default_unicast_locator_list,
+            default_multicast_locator_list,
+        )??;
+
         let data_writer = DataWriter::new(DataWriterNodeKind::UserDefined(DataWriterNode::new(
             data_writer_address,
             self.0.address().clone(),
@@ -167,7 +119,7 @@ impl Publisher {
                 .entity_factory
                 .autoenable_created_entities
         {
-            data_writer.enable()?
+                data_writer.enable()?
         }
 
         Ok(data_writer)

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -167,7 +167,7 @@ impl Subscriber {
 
                 let reader_actor = spawn_actor(data_reader);
                 let reader_address = reader_actor.address().clone();
-                s.address().data_reader_add(reader_actor)?;
+                s.address().data_reader_add(guid.into(), reader_actor)?;
 
                 let data_reader =
                     DataReader::new(DataReaderNodeKind::UserDefined(DataReaderNode::new(

--- a/dds/src/implementation/dds/dds_data_reader.rs
+++ b/dds/src/implementation/dds/dds_data_reader.rs
@@ -362,6 +362,7 @@ impl DdsDataReader {
             .ok_or(DdsError::BadParameter)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn process_rtps_message(
         &mut self,
         message: RtpsMessageRead,
@@ -618,6 +619,7 @@ impl DdsDataReader {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_matched_writer(
         &mut self,
         discovered_writer_data: DiscoveredWriterData,
@@ -1212,6 +1214,7 @@ impl DdsDataReader {
         };
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn on_sample_rejected(
         &mut self,
         instance_handle: InstanceHandle,
@@ -1441,6 +1444,7 @@ impl DdsDataReader {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn process_received_change(
         &mut self,
         cache_change: RtpsReaderCacheChange,
@@ -1513,6 +1517,7 @@ impl DdsDataReader {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add_change(
         &mut self,
         change: RtpsReaderCacheChange,

--- a/dds/src/implementation/dds/dds_data_reader_listener.rs
+++ b/dds/src/implementation/dds/dds_data_reader_listener.rs
@@ -1,11 +1,8 @@
 use crate::{
-    implementation::utils::actor::{ActorAddress, CommandHandler},
-    infrastructure::{
-        error::DdsResult,
-        status::{
-            RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus, SampleRejectedStatus,
-            SubscriptionMatchedStatus,
-        },
+    implementation::utils::actor::actor_command_interface,
+    infrastructure::status::{
+        RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus, SampleRejectedStatus,
+        SubscriptionMatchedStatus,
     },
 };
 
@@ -21,16 +18,21 @@ impl DdsDataReaderListener {
     }
 }
 
+actor_command_interface! {
 impl DdsDataReaderListener {
-    fn trigger_on_data_available(&mut self, reader: DataReaderNode) {
+    pub fn trigger_on_data_available(&mut self, reader: DataReaderNode) {
         self.listener.trigger_on_data_available(reader)
     }
 
-    fn trigger_on_sample_rejected(&mut self, reader: DataReaderNode, status: SampleRejectedStatus) {
+    pub fn trigger_on_sample_rejected(
+        &mut self,
+        reader: DataReaderNode,
+        status: SampleRejectedStatus,
+    ) {
         self.listener.trigger_on_sample_rejected(reader, status)
     }
 
-    fn trigger_on_requested_incompatible_qos(
+    pub fn trigger_on_requested_incompatible_qos(
         &mut self,
         reader: DataReaderNode,
         status: RequestedIncompatibleQosStatus,
@@ -39,7 +41,7 @@ impl DdsDataReaderListener {
             .trigger_on_requested_incompatible_qos(reader, status)
     }
 
-    fn trigger_on_subscription_matched(
+    pub fn trigger_on_subscription_matched(
         &mut self,
         reader: DataReaderNode,
         status: SubscriptionMatchedStatus,
@@ -47,97 +49,14 @@ impl DdsDataReaderListener {
         self.listener
             .trigger_on_subscription_matched(reader, status)
     }
-}
-
-impl ActorAddress<DdsDataReaderListener> {
-    pub fn trigger_on_data_available(&self, reader: DataReaderNode) -> DdsResult<()> {
-        struct TriggerOnDataAvailable {
-            reader: DataReaderNode,
-        }
-
-        impl CommandHandler<TriggerOnDataAvailable> for DdsDataReaderListener {
-            fn handle(&mut self, mail: TriggerOnDataAvailable) {
-                self.trigger_on_data_available(mail.reader)
-            }
-        }
-
-        self.send_command(TriggerOnDataAvailable { reader })
-    }
-
-    pub fn trigger_on_sample_rejected(
-        &self,
-        reader: DataReaderNode,
-        status: SampleRejectedStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnSampleRejected {
-            reader: DataReaderNode,
-            status: SampleRejectedStatus,
-        }
-
-        impl CommandHandler<TriggerOnSampleRejected> for DdsDataReaderListener {
-            fn handle(&mut self, mail: TriggerOnSampleRejected) {
-                self.trigger_on_sample_rejected(mail.reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnSampleRejected { reader, status })
-    }
-
-    pub fn trigger_on_requested_incompatible_qos(
-        &self,
-        reader: DataReaderNode,
-        status: RequestedIncompatibleQosStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnRequestedIncompatibleQos {
-            reader: DataReaderNode,
-            status: RequestedIncompatibleQosStatus,
-        }
-
-        impl CommandHandler<TriggerOnRequestedIncompatibleQos> for DdsDataReaderListener {
-            fn handle(&mut self, mail: TriggerOnRequestedIncompatibleQos) {
-                self.trigger_on_requested_incompatible_qos(mail.reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnRequestedIncompatibleQos { reader, status })
-    }
-
-    pub fn trigger_on_subscription_matched(
-        &self,
-        reader: DataReaderNode,
-        status: SubscriptionMatchedStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnSubscriptionMatched {
-            reader: DataReaderNode,
-            status: SubscriptionMatchedStatus,
-        }
-
-        impl CommandHandler<TriggerOnSubscriptionMatched> for DdsDataReaderListener {
-            fn handle(&mut self, mail: TriggerOnSubscriptionMatched) {
-                self.trigger_on_subscription_matched(mail.reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnSubscriptionMatched { reader, status })
-    }
 
     pub fn trigger_on_requested_deadline_missed(
-        &self,
+        &mut self,
         reader: DataReaderNode,
         status: RequestedDeadlineMissedStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnRequestedDeadlineMissed {
-            reader: DataReaderNode,
-            status: RequestedDeadlineMissedStatus,
-        }
-
-        impl CommandHandler<TriggerOnRequestedDeadlineMissed> for DdsDataReaderListener {
-            fn handle(&mut self, mail: TriggerOnRequestedDeadlineMissed) {
-                self.listener
-                    .trigger_on_requested_deadline_missed(mail.reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnRequestedDeadlineMissed { reader, status })
+    ) {
+        self.listener
+            .trigger_on_requested_deadline_missed(reader, status)
     }
+}
 }

--- a/dds/src/implementation/dds/dds_data_reader_listener.rs
+++ b/dds/src/implementation/dds/dds_data_reader_listener.rs
@@ -21,7 +21,7 @@ impl DdsDataReaderListener {
 actor_command_interface! {
 impl DdsDataReaderListener {
     pub fn trigger_on_data_available(&mut self, reader: DataReaderNode) {
-        self.listener.trigger_on_data_available(reader)
+        tokio::task::block_in_place(|| self.listener.trigger_on_data_available(reader));
     }
 
     pub fn trigger_on_sample_rejected(
@@ -29,7 +29,7 @@ impl DdsDataReaderListener {
         reader: DataReaderNode,
         status: SampleRejectedStatus,
     ) {
-        self.listener.trigger_on_sample_rejected(reader, status)
+        tokio::task::block_in_place(|| self.listener.trigger_on_sample_rejected(reader, status));
     }
 
     pub fn trigger_on_requested_incompatible_qos(
@@ -37,8 +37,8 @@ impl DdsDataReaderListener {
         reader: DataReaderNode,
         status: RequestedIncompatibleQosStatus,
     ) {
-        self.listener
-            .trigger_on_requested_incompatible_qos(reader, status)
+        tokio::task::block_in_place(|| self.listener
+            .trigger_on_requested_incompatible_qos(reader, status));
     }
 
     pub fn trigger_on_subscription_matched(
@@ -46,8 +46,8 @@ impl DdsDataReaderListener {
         reader: DataReaderNode,
         status: SubscriptionMatchedStatus,
     ) {
-        self.listener
-            .trigger_on_subscription_matched(reader, status)
+        tokio::task::block_in_place(|| self.listener
+            .trigger_on_subscription_matched(reader, status));
     }
 
     pub fn trigger_on_requested_deadline_missed(
@@ -55,8 +55,8 @@ impl DdsDataReaderListener {
         reader: DataReaderNode,
         status: RequestedDeadlineMissedStatus,
     ) {
-        self.listener
-            .trigger_on_requested_deadline_missed(reader, status)
+        tokio::task::block_in_place(|| self.listener
+            .trigger_on_requested_deadline_missed(reader, status));
     }
 }
 }

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -17,7 +17,6 @@ use crate::{
             },
         },
         rtps::{
-            writer_history_cache::{DataFragSubmessages, RtpsWriterCacheChange, WriterHistoryCache},
             messages::{
                 overall_structure::{
                     RtpsMessageHeader, RtpsMessageRead, RtpsMessageWrite, RtpsSubmessageReadKind,
@@ -38,6 +37,9 @@ use crate::{
                 ENTITYID_UNKNOWN, GUID_UNKNOWN, USER_DEFINED_UNKNOWN,
             },
             writer::RtpsWriter,
+            writer_history_cache::{
+                DataFragSubmessages, RtpsWriterCacheChange, WriterHistoryCache,
+            },
         },
         rtps_udp_psm::udp_transport::UdpTransportWrite,
         utils::{
@@ -1493,12 +1495,9 @@ fn send_change_message_reader_proxy_reliable(
                 .map(|x| x.sequence_number())
                 .max()
                 .unwrap_or_else(|| SequenceNumber::from(0));
-            let heartbeat = reader_proxy
-                .heartbeat_machine()
-                .submessage(writer_id, first_sn, last_sn);
             udp_transport_write
                 .write(
-                    RtpsMessageWrite::new(header, vec![info_dst, gap_submessage, heartbeat]),
+                    RtpsMessageWrite::new(header, vec![info_dst, gap_submessage]),
                     reader_proxy.unicast_locator_list().to_vec(),
                 )
                 .expect("Should not fail cause actor always exists");

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -1485,16 +1485,7 @@ fn send_change_message_reader_proxy_reliable(
                 change_seq_num,
                 SequenceNumberSet::new(change_seq_num + 1, vec![]),
             ));
-            let first_sn = writer_cache
-                .change_list()
-                .map(|x| x.sequence_number())
-                .min()
-                .unwrap_or_else(|| SequenceNumber::from(1));
-            let last_sn = writer_cache
-                .change_list()
-                .map(|x| x.sequence_number())
-                .max()
-                .unwrap_or_else(|| SequenceNumber::from(0));
+
             udp_transport_write
                 .write(
                     RtpsMessageWrite::new(header, vec![info_dst, gap_submessage]),

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -855,12 +855,8 @@ impl ActorAddress<DdsDataWriter> {
             type Result = ();
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<ReaderLocatorAdd> for DdsDataWriter {
-            async fn handle(
-                &mut self,
-                mail: ReaderLocatorAdd,
-            ) -> <ReaderLocatorAdd as Mail>::Result {
+            fn handle(&mut self, mail: ReaderLocatorAdd) -> <ReaderLocatorAdd as Mail>::Result {
                 self.reader_locator_add(mail.a_locator)
             }
         }

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -1458,23 +1458,10 @@ fn send_change_message_reader_proxy_reliable(
                 change_seq_num,
                 SequenceNumberSet::new(change_seq_num + 1, vec![]),
             ));
-            let first_sn = writer_cache
-                .change_list()
-                .map(|x| x.sequence_number())
-                .min()
-                .unwrap_or_else(|| SequenceNumber::from(1));
-            let last_sn = writer_cache
-                .change_list()
-                .map(|x| x.sequence_number())
-                .max()
-                .unwrap_or_else(|| SequenceNumber::from(0));
-            let heartbeat = reader_proxy
-                .heartbeat_machine()
-                .submessage(writer_id, first_sn, last_sn);
 
             udp_transport_write
                 .write(
-                    RtpsMessageWrite::new(header, vec![info_dst, gap_submessage, heartbeat]),
+                    RtpsMessageWrite::new(header, vec![info_dst, gap_submessage]),
                     reader_proxy.unicast_locator_list().to_vec(),
                 )
                 .expect("Should not fail cause actor always exists");

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -631,6 +631,10 @@ impl DdsDataWriter {
         participant_publication_matched_listener: Option<
             ActorAddress<DdsDomainParticipantListener>,
         >,
+        offered_incompatible_qos_publisher_listener: Option<ActorAddress<DdsPublisherListener>>,
+        offered_incompatible_qos_participant_listener: Option<
+            ActorAddress<DdsDomainParticipantListener>,
+        >,
     ) {
         let is_matched_topic_name = discovered_reader_data
             .subscription_builtin_topic_data()
@@ -744,6 +748,8 @@ impl DdsDataWriter {
                     data_writer_address,
                     publisher_address,
                     participant_address,
+                    offered_incompatible_qos_publisher_listener,
+                    offered_incompatible_qos_participant_listener,
                 );
             }
         }
@@ -1042,6 +1048,10 @@ impl DdsDataWriter {
         data_writer_address: ActorAddress<DdsDataWriter>,
         publisher_address: ActorAddress<DdsPublisher>,
         participant_address: ActorAddress<DdsDomainParticipant>,
+        offered_incompatible_qos_publisher_listener: Option<ActorAddress<DdsPublisherListener>>,
+        offered_incompatible_qos_participant_listener: Option<
+            ActorAddress<DdsDomainParticipantListener>,
+        >,
     ) {
         self.status_condition
             .write_lock()
@@ -1058,30 +1068,22 @@ impl DdsDataWriter {
             listener_address
                 .trigger_on_offered_incompatible_qos(writer, status)
                 .expect("Should not fail to send message");
-        } else if publisher_address.get_listener().unwrap().is_some()
-            && publisher_address
-                .status_kind()
-                .unwrap()
-                .contains(&StatusKind::OfferedIncompatibleQos)
+        } else if let Some(offered_incompatible_qos_publisher_listener) =
+            offered_incompatible_qos_publisher_listener
         {
             let status = self.get_offered_incompatible_qos_status();
-            let listener_address = publisher_address.get_listener().unwrap().unwrap();
             let writer =
                 DataWriterNode::new(data_writer_address, publisher_address, participant_address);
-            listener_address
+            offered_incompatible_qos_publisher_listener
                 .trigger_on_offered_incompatible_qos(writer, status)
                 .expect("Should not fail to send message");
-        } else if participant_address.get_listener().unwrap().is_some()
-            && participant_address
-                .status_kind()
-                .unwrap()
-                .contains(&StatusKind::OfferedIncompatibleQos)
+        } else if let Some(offered_incompatible_qos_participant_listener) =
+            offered_incompatible_qos_participant_listener
         {
             let status = self.get_offered_incompatible_qos_status();
-            let listener_address = participant_address.get_listener().unwrap().unwrap();
             let writer =
                 DataWriterNode::new(data_writer_address, publisher_address, participant_address);
-            listener_address
+            offered_incompatible_qos_participant_listener
                 .trigger_on_offered_incompatible_qos(writer, status)
                 .expect("Should not fail to send message");
         }

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -855,8 +855,12 @@ impl ActorAddress<DdsDataWriter> {
             type Result = ();
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<ReaderLocatorAdd> for DdsDataWriter {
-            fn handle(&mut self, mail: ReaderLocatorAdd) -> <ReaderLocatorAdd as Mail>::Result {
+            async fn handle(
+                &mut self,
+                mail: ReaderLocatorAdd,
+            ) -> <ReaderLocatorAdd as Mail>::Result {
                 self.reader_locator_add(mail.a_locator)
             }
         }

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -43,7 +43,7 @@ use crate::{
         },
         rtps_udp_psm::udp_transport::UdpTransportWrite,
         utils::{
-            actor::{actor_interface, Actor, ActorAddress, Mail, MailHandler},
+            actor::{actor_mailbox_interface, Actor, ActorAddress, Mail, MailHandler},
             shared_object::{DdsRwLock, DdsShared},
         },
     },
@@ -293,7 +293,7 @@ impl DdsDataWriter {
     }
 }
 
-actor_interface! {
+actor_mailbox_interface! {
 impl DdsDataWriter {
     pub fn get_instance_handle(&self) -> InstanceHandle {
         self.rtps_writer.guid().into()

--- a/dds/src/implementation/dds/dds_data_writer_listener.rs
+++ b/dds/src/implementation/dds/dds_data_writer_listener.rs
@@ -1,12 +1,6 @@
 use crate::{
-    implementation::{
-        dds::nodes::DataWriterNode,
-        utils::actor::{ActorAddress, CommandHandler},
-    },
-    infrastructure::{
-        error::DdsResult,
-        status::{OfferedIncompatibleQosStatus, PublicationMatchedStatus},
-    },
+    implementation::{dds::nodes::DataWriterNode, utils::actor::actor_command_interface},
+    infrastructure::status::{OfferedIncompatibleQosStatus, PublicationMatchedStatus},
 };
 
 use super::any_data_writer_listener::AnyDataWriterListener;
@@ -21,44 +15,24 @@ impl DdsDataWriterListener {
     }
 }
 
-impl ActorAddress<DdsDataWriterListener> {
+actor_command_interface! {
+impl DdsDataWriterListener {
     pub fn trigger_on_offered_incompatible_qos(
-        &self,
+        &mut self,
         the_writer: DataWriterNode,
         status: OfferedIncompatibleQosStatus,
-    ) -> DdsResult<()> {
-        struct OnOfferedIncompatibleQos {
-            the_writer: DataWriterNode,
-            status: OfferedIncompatibleQosStatus,
-        }
-
-        impl CommandHandler<OnOfferedIncompatibleQos> for DdsDataWriterListener {
-            fn handle(&mut self, mail: OnOfferedIncompatibleQos) {
-                self.listener
-                    .trigger_on_offered_incompatible_qos(mail.the_writer, mail.status)
-            }
-        }
-
-        self.send_command(OnOfferedIncompatibleQos { the_writer, status })
+    ) {
+        self.listener
+            .trigger_on_offered_incompatible_qos(the_writer, status)
     }
 
     pub fn trigger_on_publication_matched(
-        &self,
+        &mut self,
         the_writer: DataWriterNode,
         status: PublicationMatchedStatus,
-    ) -> DdsResult<()> {
-        struct OnPublicationMatched {
-            the_writer: DataWriterNode,
-            status: PublicationMatchedStatus,
-        }
-
-        impl CommandHandler<OnPublicationMatched> for DdsDataWriterListener {
-            fn handle(&mut self, mail: OnPublicationMatched) {
-                self.listener
-                    .trigger_on_publication_matched(mail.the_writer, mail.status)
-            }
-        }
-
-        self.send_command(OnPublicationMatched { the_writer, status })
+    ) {
+        self.listener
+            .trigger_on_publication_matched(the_writer, status)
     }
+}
 }

--- a/dds/src/implementation/dds/dds_data_writer_listener.rs
+++ b/dds/src/implementation/dds/dds_data_writer_listener.rs
@@ -22,8 +22,8 @@ impl DdsDataWriterListener {
         the_writer: DataWriterNode,
         status: OfferedIncompatibleQosStatus,
     ) {
-        self.listener
-            .trigger_on_offered_incompatible_qos(the_writer, status)
+        tokio::task::block_in_place(|| self.listener
+            .trigger_on_offered_incompatible_qos(the_writer, status));
     }
 
     pub fn trigger_on_publication_matched(
@@ -31,8 +31,8 @@ impl DdsDataWriterListener {
         the_writer: DataWriterNode,
         status: PublicationMatchedStatus,
     ) {
-        self.listener
-            .trigger_on_publication_matched(the_writer, status)
+        tokio::task::block_in_place(|| self.listener
+            .trigger_on_publication_matched(the_writer, status));
     }
 }
 }

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -828,6 +828,7 @@ impl DdsDomainParticipant {
         message: RtpsMessageRead,
         participant_address: ActorAddress<DdsDomainParticipant>,
     ) {
+        let participant_mask_listener = (self.listener.as_ref().map(|a| a.address()).cloned(), self.status_kind.clone());
         for user_defined_subscriber_address in self.user_defined_subscriber_list.values().map(|a| a.address()) {
             user_defined_subscriber_address
                 .process_rtps_message(
@@ -835,6 +836,7 @@ impl DdsDomainParticipant {
                     self.get_current_time(),
                     participant_address.clone(),
                     user_defined_subscriber_address.clone(),
+                    participant_mask_listener.clone(),
                 )
                 .expect("Should not fail to send command");
 

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -512,7 +512,7 @@ impl DdsDomainParticipant {
         let entity_id = EntityId::new([topic_counter, 0, 0], USER_DEFINED_TOPIC);
         let guid = Guid::new(self.rtps_participant.guid().prefix(), entity_id);
 
-        let topic = DdsTopic::new(guid, qos, type_name.to_string(), &topic_name);
+        let topic = DdsTopic::new(guid, qos, type_name, &topic_name);
 
         let topic_actor: crate::implementation::utils::actor::Actor<DdsTopic> = spawn_actor(topic);
         let topic_address = topic_actor.address().clone();

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -854,7 +854,7 @@ impl DdsDomainParticipant {
 
         for user_defined_publisher_address in self.user_defined_publisher_list.values().map(|a| a.address()) {
             user_defined_publisher_address.process_rtps_message(message.clone()).expect("Should not fail to send command");
-            user_defined_publisher_address .send_message(
+            user_defined_publisher_address.send_message(
                 RtpsMessageHeader::new(
                     self.get_protocol_version(),
                     self.get_vendor_id(),

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -195,12 +195,11 @@ impl DdsDomainParticipant {
             },
             ..Default::default()
         };
+        let spdp_builtin_participant_reader_guid =
+            Guid::new(guid_prefix, ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER);
         let spdp_builtin_participant_reader =
             spawn_actor(DdsDataReader::new::<SpdpDiscoveredParticipantData>(
-                create_builtin_stateless_reader(Guid::new(
-                    guid_prefix,
-                    ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER,
-                )),
+                create_builtin_stateless_reader(spdp_builtin_participant_reader_guid),
                 "SpdpDiscoveredParticipantData".to_string(),
                 String::from(DCPS_PARTICIPANT),
                 spdp_reader_qos,
@@ -222,11 +221,10 @@ impl DdsDomainParticipant {
             ..Default::default()
         };
 
+        let sedp_builtin_topics_reader_guid =
+            Guid::new(guid_prefix, ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR);
         let sedp_builtin_topics_reader = spawn_actor(DdsDataReader::new::<DiscoveredTopicData>(
-            create_builtin_stateful_reader(Guid::new(
-                guid_prefix,
-                ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR,
-            )),
+            create_builtin_stateful_reader(sedp_builtin_topics_reader_guid),
             "DiscoveredTopicData".to_string(),
             String::from(DCPS_TOPIC),
             sedp_reader_qos.clone(),
@@ -234,12 +232,11 @@ impl DdsDomainParticipant {
             vec![],
         ));
 
+        let sedp_builtin_publications_reader_guid =
+            Guid::new(guid_prefix, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR);
         let sedp_builtin_publications_reader =
             spawn_actor(DdsDataReader::new::<DiscoveredWriterData>(
-                create_builtin_stateful_reader(Guid::new(
-                    guid_prefix,
-                    ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR,
-                )),
+                create_builtin_stateful_reader(sedp_builtin_publications_reader_guid),
                 "DiscoveredWriterData".to_string(),
                 String::from(DCPS_PUBLICATION),
                 sedp_reader_qos.clone(),
@@ -247,12 +244,11 @@ impl DdsDomainParticipant {
                 vec![],
             ));
 
+        let sedp_builtin_subscriptions_reader_guid =
+            Guid::new(guid_prefix, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR);
         let sedp_builtin_subscriptions_reader =
             spawn_actor(DdsDataReader::new::<DiscoveredReaderData>(
-                create_builtin_stateful_reader(Guid::new(
-                    guid_prefix,
-                    ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR,
-                )),
+                create_builtin_stateful_reader(sedp_builtin_subscriptions_reader_guid),
                 "DiscoveredReaderData".to_string(),
                 String::from(DCPS_SUBSCRIPTION),
                 sedp_reader_qos,
@@ -272,19 +268,31 @@ impl DdsDomainParticipant {
 
         builtin_subscriber
             .address()
-            .data_reader_add(spdp_builtin_participant_reader)
+            .data_reader_add(
+                spdp_builtin_participant_reader_guid.into(),
+                spdp_builtin_participant_reader,
+            )
             .unwrap();
         builtin_subscriber
             .address()
-            .data_reader_add(sedp_builtin_topics_reader)
+            .data_reader_add(
+                sedp_builtin_topics_reader_guid.into(),
+                sedp_builtin_topics_reader,
+            )
             .unwrap();
         builtin_subscriber
             .address()
-            .data_reader_add(sedp_builtin_publications_reader)
+            .data_reader_add(
+                sedp_builtin_publications_reader_guid.into(),
+                sedp_builtin_publications_reader,
+            )
             .unwrap();
         builtin_subscriber
             .address()
-            .data_reader_add(sedp_builtin_subscriptions_reader)
+            .data_reader_add(
+                sedp_builtin_subscriptions_reader_guid.into(),
+                sedp_builtin_subscriptions_reader,
+            )
             .unwrap();
 
         // Built-in publisher creation

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -841,20 +841,29 @@ impl DdsDomainParticipant {
         participant_address: ActorAddress<DdsDomainParticipant>,
     ) {
         for user_defined_subscriber in &self.user_defined_subscriber_list {
+            user_defined_subscriber
+                .address()
+                .process_rtps_message(
+                    message.clone(),
+                    self.get_current_time(),
+                    participant_address.clone(),
+                    user_defined_subscriber.address().clone(),
+                )
+                .expect("Should not fail to send command");
             for user_defined_data_reader in user_defined_subscriber
                 .address()
                 .data_reader_list()
                 .unwrap()
             {
-                user_defined_data_reader
-                    .process_rtps_message(
-                        message.clone(),
-                        self.get_current_time(),
-                        user_defined_data_reader.clone(),
-                        user_defined_subscriber.address().clone(),
-                        participant_address.clone(),
-                    )
-                    .unwrap();
+                // user_defined_data_reader
+                //     .process_rtps_message(
+                //         message.clone(),
+                //         self.get_current_time(),
+                //         user_defined_data_reader.clone(),
+                //         user_defined_subscriber.address().clone(),
+                //         participant_address.clone(),
+                //     )
+                //     .unwrap();
                 user_defined_data_reader
                     .send_message(
                         RtpsMessageHeader::new(

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -27,7 +27,7 @@ use crate::{
             writer::RtpsWriter,
         },
         rtps_udp_psm::udp_transport::UdpTransportWrite,
-        utils::actor::{actor_interface, spawn_actor, Actor, ActorAddress},
+        utils::actor::{actor_mailbox_interface, spawn_actor, Actor, ActorAddress},
     },
     infrastructure::{
         instance::InstanceHandle,
@@ -425,7 +425,7 @@ impl DdsDomainParticipant {
     }
 }
 
-actor_interface! {
+actor_mailbox_interface! {
 // Rtps Entity methods
 impl DdsDomainParticipant {
         pub fn get_guid(&self) -> Guid {
@@ -434,7 +434,7 @@ impl DdsDomainParticipant {
 }
 }
 
-actor_interface! {
+actor_mailbox_interface! {
 // Rtps Participant methods
 impl DdsDomainParticipant {
     pub fn get_default_unicast_locator_list(&self) -> Vec<Locator> {
@@ -459,7 +459,7 @@ impl DdsDomainParticipant {
 }
 }
 
-actor_interface! {
+actor_mailbox_interface! {
 impl DdsDomainParticipant {
     pub fn get_metatraffic_unicast_locator_list(&self) -> Vec<Locator> {
         self.rtps_participant

--- a/dds/src/implementation/dds/dds_domain_participant_factory.rs
+++ b/dds/src/implementation/dds/dds_domain_participant_factory.rs
@@ -1,5 +1,5 @@
 use crate::{
-    implementation::utils::actor::{actor_interface, Actor, ActorAddress},
+    implementation::utils::actor::{actor_mailbox_interface, Actor, ActorAddress},
     infrastructure::{
         instance::InstanceHandle,
         qos::{DomainParticipantFactoryQos, DomainParticipantQos},
@@ -31,7 +31,7 @@ impl DdsDomainParticipantFactory {
     }
 }
 
-actor_interface! {
+actor_mailbox_interface! {
 impl DdsDomainParticipantFactory {
     pub fn add_participant(&mut self, participant: Actor<DdsDomainParticipant>) {
         self.domain_participant_list.push(participant)

--- a/dds/src/implementation/dds/dds_domain_participant_listener.rs
+++ b/dds/src/implementation/dds/dds_domain_participant_listener.rs
@@ -26,7 +26,7 @@ impl DdsDomainParticipantListener {
         the_reader: DataReaderNode,
         status: SampleRejectedStatus,
     ) {
-        self.listener.on_sample_rejected(&the_reader, status)
+        tokio::task::block_in_place(|| self.listener.on_sample_rejected(&the_reader, status));
     }
 
     pub fn trigger_on_requested_incompatible_qos(
@@ -34,8 +34,8 @@ impl DdsDomainParticipantListener {
         the_reader: DataReaderNode,
         status: RequestedIncompatibleQosStatus,
     ) {
-        self.listener
-            .on_requested_incompatible_qos(&the_reader, status)
+        tokio::task::block_in_place(|| self.listener
+            .on_requested_incompatible_qos(&the_reader, status));
     }
 
     pub fn trigger_on_offered_incompatible_qos(
@@ -43,8 +43,8 @@ impl DdsDomainParticipantListener {
         the_writer: DataWriterNode,
         status: OfferedIncompatibleQosStatus,
     ) {
-        self.listener
-            .on_offered_incompatible_qos(&the_writer, status)
+        tokio::task::block_in_place(|| self.listener
+            .on_offered_incompatible_qos(&the_writer, status));
     }
 
     pub fn trigger_on_requested_deadline_missed(
@@ -52,7 +52,7 @@ impl DdsDomainParticipantListener {
         reader: DataReaderNode,
         status: RequestedDeadlineMissedStatus,
     ) {
-        self.listener.on_requested_deadline_missed(&reader, status)
+        tokio::task::block_in_place(|| self.listener.on_requested_deadline_missed(&reader, status));
     }
 
     pub fn trigger_on_subscription_matched(
@@ -60,7 +60,7 @@ impl DdsDomainParticipantListener {
         reader: DataReaderNode,
         status: SubscriptionMatchedStatus,
     ) {
-        self.listener.on_subscription_matched(&reader, status)
+        tokio::task::block_in_place(|| self.listener.on_subscription_matched(&reader, status));
     }
 
     pub fn trigger_on_publication_matched(
@@ -68,7 +68,7 @@ impl DdsDomainParticipantListener {
         the_writer: DataWriterNode,
         status: PublicationMatchedStatus,
     ) {
-        self.listener.on_publication_matched(&the_writer, status)
+        tokio::task::block_in_place(|| self.listener.on_publication_matched(&the_writer, status));
     }
 }
 }

--- a/dds/src/implementation/dds/dds_domain_participant_listener.rs
+++ b/dds/src/implementation/dds/dds_domain_participant_listener.rs
@@ -1,12 +1,9 @@
 use crate::{
     domain::domain_participant_listener::DomainParticipantListener,
-    implementation::utils::actor::{ActorAddress, CommandHandler},
-    infrastructure::{
-        error::DdsResult,
-        status::{
-            OfferedIncompatibleQosStatus, PublicationMatchedStatus, RequestedDeadlineMissedStatus,
-            RequestedIncompatibleQosStatus, SampleRejectedStatus, SubscriptionMatchedStatus,
-        },
+    implementation::utils::actor::actor_command_interface,
+    infrastructure::status::{
+        OfferedIncompatibleQosStatus, PublicationMatchedStatus, RequestedDeadlineMissedStatus,
+        RequestedIncompatibleQosStatus, SampleRejectedStatus, SubscriptionMatchedStatus,
     },
 };
 
@@ -22,124 +19,56 @@ impl DdsDomainParticipantListener {
     }
 }
 
-impl ActorAddress<DdsDomainParticipantListener> {
+actor_command_interface! {
+impl DdsDomainParticipantListener {
     pub fn trigger_on_sample_rejected(
-        &self,
+        &mut self,
         the_reader: DataReaderNode,
         status: SampleRejectedStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnSampleRejected {
-            the_reader: DataReaderNode,
-            status: SampleRejectedStatus,
-        }
-
-        impl CommandHandler<TriggerOnSampleRejected> for DdsDomainParticipantListener {
-            fn handle(&mut self, mail: TriggerOnSampleRejected) {
-                self.listener
-                    .on_sample_rejected(&mail.the_reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnSampleRejected { the_reader, status })
+    ) {
+        self.listener.on_sample_rejected(&the_reader, status)
     }
 
     pub fn trigger_on_requested_incompatible_qos(
-        &self,
+        &mut self,
         the_reader: DataReaderNode,
         status: RequestedIncompatibleQosStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnRequestedIncompatibleQos {
-            the_reader: DataReaderNode,
-            status: RequestedIncompatibleQosStatus,
-        }
-
-        impl CommandHandler<TriggerOnRequestedIncompatibleQos> for DdsDomainParticipantListener {
-            fn handle(&mut self, mail: TriggerOnRequestedIncompatibleQos) {
-                self.listener
-                    .on_requested_incompatible_qos(&mail.the_reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnRequestedIncompatibleQos { the_reader, status })
+    ) {
+        self.listener
+            .on_requested_incompatible_qos(&the_reader, status)
     }
 
     pub fn trigger_on_offered_incompatible_qos(
-        &self,
+        &mut self,
         the_writer: DataWriterNode,
         status: OfferedIncompatibleQosStatus,
-    ) -> DdsResult<()> {
-        struct OnOfferedIncompatibleQos {
-            the_writer: DataWriterNode,
-            status: OfferedIncompatibleQosStatus,
-        }
-
-        impl CommandHandler<OnOfferedIncompatibleQos> for DdsDomainParticipantListener {
-            fn handle(&mut self, mail: OnOfferedIncompatibleQos) {
-                self.listener
-                    .on_offered_incompatible_qos(&mail.the_writer, mail.status)
-            }
-        }
-
-        self.send_command(OnOfferedIncompatibleQos { the_writer, status })
+    ) {
+        self.listener
+            .on_offered_incompatible_qos(&the_writer, status)
     }
 
     pub fn trigger_on_requested_deadline_missed(
-        &self,
+        &mut self,
         reader: DataReaderNode,
         status: RequestedDeadlineMissedStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnRequestedDeadlineMissed {
-            reader: DataReaderNode,
-            status: RequestedDeadlineMissedStatus,
-        }
-
-        impl CommandHandler<TriggerOnRequestedDeadlineMissed> for DdsDomainParticipantListener {
-            fn handle(&mut self, mail: TriggerOnRequestedDeadlineMissed) {
-                self.listener
-                    .on_requested_deadline_missed(&mail.reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnRequestedDeadlineMissed { reader, status })
+    ) {
+        self.listener.on_requested_deadline_missed(&reader, status)
     }
 
     pub fn trigger_on_subscription_matched(
-        &self,
+        &mut self,
         reader: DataReaderNode,
         status: SubscriptionMatchedStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnSubscriptionMatched {
-            reader: DataReaderNode,
-            status: SubscriptionMatchedStatus,
-        }
-
-        impl CommandHandler<TriggerOnSubscriptionMatched> for DdsDomainParticipantListener {
-            fn handle(&mut self, mail: TriggerOnSubscriptionMatched) {
-                self.listener
-                    .on_subscription_matched(&mail.reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnSubscriptionMatched { reader, status })
+    ) {
+        self.listener.on_subscription_matched(&reader, status)
     }
 
     pub fn trigger_on_publication_matched(
-        &self,
+        &mut self,
         the_writer: DataWriterNode,
         status: PublicationMatchedStatus,
-    ) -> DdsResult<()> {
-        struct OnPublicationMatched {
-            the_writer: DataWriterNode,
-            status: PublicationMatchedStatus,
-        }
-
-        impl CommandHandler<OnPublicationMatched> for DdsDomainParticipantListener {
-            fn handle(&mut self, mail: OnPublicationMatched) {
-                self.listener
-                    .on_publication_matched(&mail.the_writer, mail.status)
-            }
-        }
-
-        self.send_command(OnPublicationMatched { the_writer, status })
+    ) {
+        self.listener.on_publication_matched(&the_writer, status)
     }
+}
 }

--- a/dds/src/implementation/dds/dds_publisher.rs
+++ b/dds/src/implementation/dds/dds_publisher.rs
@@ -1,7 +1,7 @@
 use crate::{
     implementation::{
         rtps::{group::RtpsGroup, types::Guid},
-        utils::actor::{actor_interface, Actor, ActorAddress},
+        utils::actor::{actor_mailbox_interface, Actor, ActorAddress},
     },
     infrastructure::{
         error::DdsResult,
@@ -44,7 +44,7 @@ impl DdsPublisher {
     }
 }
 
-actor_interface! {
+actor_mailbox_interface! {
 impl DdsPublisher {
     pub fn enable(&mut self) {
         self.enabled = true;

--- a/dds/src/implementation/dds/dds_publisher_listener.rs
+++ b/dds/src/implementation/dds/dds_publisher_listener.rs
@@ -21,8 +21,8 @@ impl DdsPublisherListener {
         the_writer: DataWriterNode,
         status: OfferedIncompatibleQosStatus,
     ) {
-        self.listener
-            .on_offered_incompatible_qos(&the_writer, status)
+        tokio::task::block_in_place(|| self.listener
+            .on_offered_incompatible_qos(&the_writer, status));
     }
 
     pub fn trigger_on_publication_matched(
@@ -30,8 +30,8 @@ impl DdsPublisherListener {
         the_writer: DataWriterNode,
         status: PublicationMatchedStatus,
     ) {
-        self.listener
-        .on_publication_matched(&the_writer, status)
+        tokio::task::block_in_place(|| self.listener
+        .on_publication_matched(&the_writer, status));
     }
 }
 }

--- a/dds/src/implementation/dds/dds_publisher_listener.rs
+++ b/dds/src/implementation/dds/dds_publisher_listener.rs
@@ -1,12 +1,6 @@
 use crate::{
-    implementation::{
-        dds::nodes::DataWriterNode,
-        utils::actor::{ActorAddress, CommandHandler},
-    },
-    infrastructure::{
-        error::DdsResult,
-        status::{OfferedIncompatibleQosStatus, PublicationMatchedStatus},
-    },
+    implementation::{dds::nodes::DataWriterNode, utils::actor::actor_command_interface},
+    infrastructure::status::{OfferedIncompatibleQosStatus, PublicationMatchedStatus},
     publication::publisher_listener::PublisherListener,
 };
 
@@ -20,44 +14,24 @@ impl DdsPublisherListener {
     }
 }
 
-impl ActorAddress<DdsPublisherListener> {
+actor_command_interface! {
+impl DdsPublisherListener {
     pub fn trigger_on_offered_incompatible_qos(
-        &self,
+        &mut self,
         the_writer: DataWriterNode,
         status: OfferedIncompatibleQosStatus,
-    ) -> DdsResult<()> {
-        struct OnOfferedIncompatibleQos {
-            the_writer: DataWriterNode,
-            status: OfferedIncompatibleQosStatus,
-        }
-
-        impl CommandHandler<OnOfferedIncompatibleQos> for DdsPublisherListener {
-            fn handle(&mut self, mail: OnOfferedIncompatibleQos) {
-                self.listener
-                    .on_offered_incompatible_qos(&mail.the_writer, mail.status)
-            }
-        }
-
-        self.send_command(OnOfferedIncompatibleQos { the_writer, status })
+    ) {
+        self.listener
+            .on_offered_incompatible_qos(&the_writer, status)
     }
 
     pub fn trigger_on_publication_matched(
-        &self,
+        &mut self,
         the_writer: DataWriterNode,
         status: PublicationMatchedStatus,
-    ) -> DdsResult<()> {
-        struct OnPublicationMatched {
-            the_writer: DataWriterNode,
-            status: PublicationMatchedStatus,
-        }
-
-        impl CommandHandler<OnPublicationMatched> for DdsPublisherListener {
-            fn handle(&mut self, mail: OnPublicationMatched) {
-                self.listener
-                    .on_publication_matched(&mail.the_writer, mail.status)
-            }
-        }
-
-        self.send_command(OnPublicationMatched { the_writer, status })
+    ) {
+        self.listener
+        .on_publication_matched(&the_writer, status)
     }
+}
 }

--- a/dds/src/implementation/dds/dds_subscriber.rs
+++ b/dds/src/implementation/dds/dds_subscriber.rs
@@ -6,7 +6,7 @@ use crate::{
     implementation::{
         rtps::{group::RtpsGroup, types::Guid},
         utils::{
-            actor::{actor_interface, Actor, ActorAddress},
+            actor::{actor_mailbox_interface, Actor, ActorAddress},
             shared_object::{DdsRwLock, DdsShared},
         },
     },
@@ -51,7 +51,7 @@ impl DdsSubscriber {
     }
 }
 
-actor_interface! {
+actor_mailbox_interface! {
 impl DdsSubscriber {
     pub fn delete_contained_entities(&mut self) {
 

--- a/dds/src/implementation/dds/dds_subscriber_listener.rs
+++ b/dds/src/implementation/dds/dds_subscriber_listener.rs
@@ -1,14 +1,11 @@
 use crate::{
     implementation::{
         dds::nodes::{DataReaderNode, SubscriberNode, SubscriberNodeKind},
-        utils::actor::{ActorAddress, CommandHandler},
+        utils::actor::actor_command_interface,
     },
-    infrastructure::{
-        error::DdsResult,
-        status::{
-            RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus, SampleRejectedStatus,
-            SubscriptionMatchedStatus,
-        },
+    infrastructure::status::{
+        RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus, SampleRejectedStatus,
+        SubscriptionMatchedStatus,
     },
     subscription::{subscriber::Subscriber, subscriber_listener::SubscriberListener},
 };
@@ -23,101 +20,46 @@ impl DdsSubscriberListener {
     }
 }
 
-impl ActorAddress<DdsSubscriberListener> {
-    pub fn trigger_on_data_on_readers(&self, the_subscriber: SubscriberNode) -> DdsResult<()> {
-        struct TriggerOnDataOnReaders {
-            the_subscriber: SubscriberNode,
-        }
-
-        impl CommandHandler<TriggerOnDataOnReaders> for DdsSubscriberListener {
-            fn handle(&mut self, mail: TriggerOnDataOnReaders) {
-                self.listener
-                    .on_data_on_readers(&Subscriber::new(SubscriberNodeKind::Listener(
-                        mail.the_subscriber,
-                    )))
-            }
-        }
-
-        self.send_command(TriggerOnDataOnReaders { the_subscriber })
+actor_command_interface! {
+impl DdsSubscriberListener {
+    pub fn trigger_on_data_on_readers(&mut self, the_subscriber: SubscriberNode) {
+        self.listener
+            .on_data_on_readers(&Subscriber::new(SubscriberNodeKind::Listener(
+                the_subscriber,
+            )));
     }
 
     pub fn trigger_on_sample_rejected(
-        &self,
+        &mut self,
         the_reader: DataReaderNode,
         status: SampleRejectedStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnSampleRejected {
-            the_reader: DataReaderNode,
-            status: SampleRejectedStatus,
-        }
-
-        impl CommandHandler<TriggerOnSampleRejected> for DdsSubscriberListener {
-            fn handle(&mut self, mail: TriggerOnSampleRejected) {
-                self.listener
-                    .on_sample_rejected(&mail.the_reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnSampleRejected { the_reader, status })
+    ) {
+        self.listener.on_sample_rejected(&the_reader, status)
     }
 
     pub fn trigger_on_requested_incompatible_qos(
-        &self,
+        &mut self,
         the_reader: DataReaderNode,
         status: RequestedIncompatibleQosStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnRequestedIncompatibleQos {
-            the_reader: DataReaderNode,
-            status: RequestedIncompatibleQosStatus,
-        }
-
-        impl CommandHandler<TriggerOnRequestedIncompatibleQos> for DdsSubscriberListener {
-            fn handle(&mut self, mail: TriggerOnRequestedIncompatibleQos) {
-                self.listener
-                    .on_requested_incompatible_qos(&mail.the_reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnRequestedIncompatibleQos { the_reader, status })
+    ) {
+        self.listener
+            .on_requested_incompatible_qos(&the_reader, status)
     }
 
     pub fn trigger_on_requested_deadline_missed(
-        &self,
+        &mut self,
         reader: DataReaderNode,
         status: RequestedDeadlineMissedStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnRequestedDeadlineMissed {
-            reader: DataReaderNode,
-            status: RequestedDeadlineMissedStatus,
-        }
-
-        impl CommandHandler<TriggerOnRequestedDeadlineMissed> for DdsSubscriberListener {
-            fn handle(&mut self, mail: TriggerOnRequestedDeadlineMissed) {
-                self.listener
-                    .on_requested_deadline_missed(&mail.reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnRequestedDeadlineMissed { reader, status })
+    ) {
+        self.listener.on_requested_deadline_missed(&reader, status)
     }
 
     pub fn trigger_on_subscription_matched(
-        &self,
+        &mut self,
         reader: DataReaderNode,
         status: SubscriptionMatchedStatus,
-    ) -> DdsResult<()> {
-        struct TriggerOnSubscriptionMatched {
-            reader: DataReaderNode,
-            status: SubscriptionMatchedStatus,
-        }
-
-        impl CommandHandler<TriggerOnSubscriptionMatched> for DdsSubscriberListener {
-            fn handle(&mut self, mail: TriggerOnSubscriptionMatched) {
-                self.listener
-                    .on_subscription_matched(&mail.reader, mail.status)
-            }
-        }
-
-        self.send_command(TriggerOnSubscriptionMatched { reader, status })
+    ) {
+        self.listener.on_subscription_matched(&reader, status)
     }
+}
 }

--- a/dds/src/implementation/dds/dds_subscriber_listener.rs
+++ b/dds/src/implementation/dds/dds_subscriber_listener.rs
@@ -23,10 +23,10 @@ impl DdsSubscriberListener {
 actor_command_interface! {
 impl DdsSubscriberListener {
     pub fn trigger_on_data_on_readers(&mut self, the_subscriber: SubscriberNode) {
-        self.listener
+        tokio::task::block_in_place(|| self.listener
             .on_data_on_readers(&Subscriber::new(SubscriberNodeKind::Listener(
                 the_subscriber,
-            )));
+            ))));
     }
 
     pub fn trigger_on_sample_rejected(
@@ -34,7 +34,7 @@ impl DdsSubscriberListener {
         the_reader: DataReaderNode,
         status: SampleRejectedStatus,
     ) {
-        self.listener.on_sample_rejected(&the_reader, status)
+        tokio::task::block_in_place(|| self.listener.on_sample_rejected(&the_reader, status));
     }
 
     pub fn trigger_on_requested_incompatible_qos(
@@ -42,8 +42,8 @@ impl DdsSubscriberListener {
         the_reader: DataReaderNode,
         status: RequestedIncompatibleQosStatus,
     ) {
-        self.listener
-            .on_requested_incompatible_qos(&the_reader, status)
+        tokio::task::block_in_place(|| self.listener
+            .on_requested_incompatible_qos(&the_reader, status));
     }
 
     pub fn trigger_on_requested_deadline_missed(
@@ -51,7 +51,7 @@ impl DdsSubscriberListener {
         reader: DataReaderNode,
         status: RequestedDeadlineMissedStatus,
     ) {
-        self.listener.on_requested_deadline_missed(&reader, status)
+        tokio::task::block_in_place(|| self.listener.on_requested_deadline_missed(&reader, status));
     }
 
     pub fn trigger_on_subscription_matched(
@@ -59,7 +59,7 @@ impl DdsSubscriberListener {
         reader: DataReaderNode,
         status: SubscriptionMatchedStatus,
     ) {
-        self.listener.on_subscription_matched(&reader, status)
+        tokio::task::block_in_place(|| self.listener.on_subscription_matched(&reader, status));
     }
 }
 }

--- a/dds/src/implementation/dds/dds_topic.rs
+++ b/dds/src/implementation/dds/dds_topic.rs
@@ -4,7 +4,7 @@ use crate::{
         data_representation_builtin_endpoints::discovered_topic_data::DiscoveredTopicData,
         rtps::types::Guid,
         utils::{
-            actor::actor_interface,
+            actor::actor_mailbox_interface,
             shared_object::{DdsRwLock, DdsShared},
         },
     },
@@ -54,7 +54,7 @@ impl DdsTopic {
     }
 }
 
-actor_interface! {
+actor_mailbox_interface! {
 impl DdsTopic {
     pub fn get_inconsistent_topic_status(&mut self) -> InconsistentTopicStatus {
         let status = self.inconsistent_topic_status.read_and_reset();

--- a/dds/src/implementation/dds_actor/data_reader.rs
+++ b/dds/src/implementation/dds_actor/data_reader.rs
@@ -18,7 +18,7 @@ use crate::{
         },
         rtps_udp_psm::udp_transport::UdpTransportWrite,
         utils::{
-            actor::{ActorAddress, Mail, MailHandler},
+            actor::{ActorAddress, CommandHandler, Mail, MailHandler},
             shared_object::{DdsRwLock, DdsShared},
         },
     },
@@ -679,12 +679,8 @@ impl ActorAddress<DdsDataReader> {
             participant_address: ActorAddress<DdsDomainParticipant>,
         }
 
-        impl Mail for ProcessRtpsMessage {
-            type Result = ();
-        }
-
-        impl MailHandler<ProcessRtpsMessage> for DdsDataReader {
-            fn handle(&mut self, mail: ProcessRtpsMessage) -> <ProcessRtpsMessage as Mail>::Result {
+        impl CommandHandler<ProcessRtpsMessage> for DdsDataReader {
+            fn handle(&mut self, mail: ProcessRtpsMessage) {
                 self.process_rtps_message(
                     mail.message,
                     mail.reception_timestamp,
@@ -695,7 +691,7 @@ impl ActorAddress<DdsDataReader> {
             }
         }
 
-        self.send_blocking(ProcessRtpsMessage {
+        self.send_command(ProcessRtpsMessage {
             message,
             reception_timestamp,
             data_reader_address,

--- a/dds/src/implementation/dds_actor/data_reader.rs
+++ b/dds/src/implementation/dds_actor/data_reader.rs
@@ -183,6 +183,7 @@ impl ActorAddress<DdsDataReader> {
 }
 
 impl ActorAddress<DdsDataReader> {
+    #[allow(clippy::too_many_arguments)]
     pub fn add_matched_writer(
         &self,
         discovered_writer_data: DiscoveredWriterData,
@@ -703,6 +704,7 @@ impl ActorAddress<DdsDataReader> {
         })?
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn process_rtps_message(
         &self,
         message: RtpsMessageRead,

--- a/dds/src/implementation/dds_actor/data_reader.rs
+++ b/dds/src/implementation/dds_actor/data_reader.rs
@@ -310,17 +310,13 @@ impl ActorAddress<DdsDataReader> {
             udp_transport_write: ActorAddress<UdpTransportWrite>,
         }
 
-        impl Mail for SendMessage {
-            type Result = ();
-        }
-
-        impl MailHandler<SendMessage> for DdsDataReader {
-            fn handle(&mut self, mail: SendMessage) -> <SendMessage as Mail>::Result {
+        impl CommandHandler<SendMessage> for DdsDataReader {
+            fn handle(&mut self, mail: SendMessage) {
                 self.send_message(mail.header, mail.udp_transport_write)
             }
         }
 
-        self.send_blocking(SendMessage {
+        self.send_command(SendMessage {
             header,
             udp_transport_write,
         })

--- a/dds/src/implementation/dds_actor/data_reader.rs
+++ b/dds/src/implementation/dds_actor/data_reader.rs
@@ -44,8 +44,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<Enable> for DdsDataReader {
-            fn handle(&mut self, _mail: Enable) -> <Enable as Mail>::Result {
+            async fn handle(&mut self, _mail: Enable) -> <Enable as Mail>::Result {
                 self.enable()
             }
         }
@@ -59,8 +60,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = bool;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<IsEnabled> for DdsDataReader {
-            fn handle(&mut self, _mail: IsEnabled) -> <IsEnabled as Mail>::Result {
+            async fn handle(&mut self, _mail: IsEnabled) -> <IsEnabled as Mail>::Result {
                 self.is_enabled()
             }
         }
@@ -75,8 +77,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = String;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<GetTypeName> for DdsDataReader {
-            fn handle(&mut self, _mail: GetTypeName) -> <GetTypeName as Mail>::Result {
+            async fn handle(&mut self, _mail: GetTypeName) -> <GetTypeName as Mail>::Result {
                 self.get_type_name()
             }
         }
@@ -90,8 +93,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = String;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<GetTopicName> for DdsDataReader {
-            fn handle(&mut self, _mail: GetTopicName) -> <GetTopicName as Mail>::Result {
+            async fn handle(&mut self, _mail: GetTopicName) -> <GetTopicName as Mail>::Result {
                 self.get_topic_name()
             }
         }
@@ -106,8 +110,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsShared<DdsRwLock<StatusConditionImpl>>;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<GetStatusConditions> for DdsDataReader {
-            fn handle(
+            async fn handle(
                 &mut self,
                 _mail: GetStatusConditions,
             ) -> <GetStatusConditions as Mail>::Result {
@@ -124,8 +129,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = SubscriptionMatchedStatus;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<GetSubscriptionMatchedStatus> for DdsDataReader {
-            fn handle(
+            async fn handle(
                 &mut self,
                 _mail: GetSubscriptionMatchedStatus,
             ) -> <GetSubscriptionMatchedStatus as Mail>::Result {
@@ -143,8 +149,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = Vec<InstanceHandle>;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<GetMatchedPublications> for DdsDataReader {
-            fn handle(
+            async fn handle(
                 &mut self,
                 _mail: GetMatchedPublications,
             ) -> <GetMatchedPublications as Mail>::Result {
@@ -167,8 +174,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<PublicationBuiltinTopicData>;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<GetMatchedPublicationData> for DdsDataReader {
-            fn handle(
+            async fn handle(
                 &mut self,
                 mail: GetMatchedPublicationData,
             ) -> <GetMatchedPublicationData as Mail>::Result {
@@ -203,8 +211,12 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<AddMatchedWriter> for DdsDataReader {
-            fn handle(&mut self, mail: AddMatchedWriter) -> <AddMatchedWriter as Mail>::Result {
+            async fn handle(
+                &mut self,
+                mail: AddMatchedWriter,
+            ) -> <AddMatchedWriter as Mail>::Result {
                 self.add_matched_writer(
                     mail.discovered_writer_data,
                     mail.default_unicast_locator_list,
@@ -244,8 +256,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<RemoveMatchedWriter> for DdsDataReader {
-            fn handle(
+            async fn handle(
                 &mut self,
                 mail: RemoveMatchedWriter,
             ) -> <RemoveMatchedWriter as Mail>::Result {
@@ -275,8 +288,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<()>;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<SetQos> for DdsDataReader {
-            fn handle(&mut self, mail: SetQos) -> <SetQos as Mail>::Result {
+            async fn handle(&mut self, mail: SetQos) -> <SetQos as Mail>::Result {
                 self.set_qos(mail.qos)
             }
         }
@@ -291,8 +305,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = DataReaderQos;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<GetQos> for DdsDataReader {
-            fn handle(&mut self, _mail: GetQos) -> <GetQos as Mail>::Result {
+            async fn handle(&mut self, _mail: GetQos) -> <GetQos as Mail>::Result {
                 self.get_qos()
             }
         }
@@ -314,8 +329,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<SendMessage> for DdsDataReader {
-            fn handle(&mut self, mail: SendMessage) -> <SendMessage as Mail>::Result {
+            async fn handle(&mut self, mail: SendMessage) -> <SendMessage as Mail>::Result {
                 self.send_message(mail.header, mail.udp_transport_write)
             }
         }
@@ -335,8 +351,12 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<MatchedWriterAdd> for DdsDataReader {
-            fn handle(&mut self, mail: MatchedWriterAdd) -> <MatchedWriterAdd as Mail>::Result {
+            async fn handle(
+                &mut self,
+                mail: MatchedWriterAdd,
+            ) -> <MatchedWriterAdd as Mail>::Result {
                 self.matched_writer_add(mail.a_writer_proxy)
             }
         }
@@ -351,8 +371,12 @@ impl ActorAddress<DdsDataReader> {
             type Result = InstanceHandle;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<GetInstanceHandle> for DdsDataReader {
-            fn handle(&mut self, _mail: GetInstanceHandle) -> <GetInstanceHandle as Mail>::Result {
+            async fn handle(
+                &mut self,
+                _mail: GetInstanceHandle,
+            ) -> <GetInstanceHandle as Mail>::Result {
                 self.guid().into()
             }
         }
@@ -384,11 +408,12 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<Vec<Sample<Foo>>>;
         }
 
+        #[async_trait::async_trait]
         impl<Foo> MailHandler<ReadNextInstance<Foo>> for DdsDataReader
         where
-            Foo: DdsRepresentation + for<'de> serde::Deserialize<'de>,
+            Foo: DdsRepresentation + for<'de> serde::Deserialize<'de> + Send + 'static,
         {
-            fn handle(
+            async fn handle(
                 &mut self,
                 mail: ReadNextInstance<Foo>,
             ) -> <ReadNextInstance<Foo> as Mail>::Result {
@@ -436,11 +461,12 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<Vec<Sample<Foo>>>;
         }
 
+        #[async_trait::async_trait]
         impl<Foo> MailHandler<Take<Foo>> for DdsDataReader
         where
-            Foo: DdsRepresentation + for<'de> serde::Deserialize<'de>,
+            Foo: DdsRepresentation + for<'de> serde::Deserialize<'de> + Send + 'static,
         {
-            fn handle(&mut self, mail: Take<Foo>) -> <Take<Foo> as Mail>::Result {
+            async fn handle(&mut self, mail: Take<Foo>) -> <Take<Foo> as Mail>::Result {
                 self.take(
                     mail.max_samples,
                     &mail.sample_states,
@@ -485,11 +511,12 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<Vec<Sample<Foo>>>;
         }
 
+        #[async_trait::async_trait]
         impl<Foo> MailHandler<TakeNextInstance<Foo>> for DdsDataReader
         where
-            Foo: DdsRepresentation + for<'de> serde::Deserialize<'de>,
+            Foo: DdsRepresentation + for<'de> serde::Deserialize<'de> + Send + 'static,
         {
-            fn handle(
+            async fn handle(
                 &mut self,
                 mail: TakeNextInstance<Foo>,
             ) -> <TakeNextInstance<Foo> as Mail>::Result {
@@ -520,8 +547,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<bool>;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<IsHistoricalDataReceived> for DdsDataReader {
-            fn handle(
+            async fn handle(
                 &mut self,
                 _mail: IsHistoricalDataReceived,
             ) -> <IsHistoricalDataReceived as Mail>::Result {
@@ -550,8 +578,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = DiscoveredReaderData;
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<AsDiscoveredReaderData> for DdsDataReader {
-            fn handle(
+            async fn handle(
                 &mut self,
                 mail: AsDiscoveredReaderData,
             ) -> <AsDiscoveredReaderData as Mail>::Result {
@@ -590,8 +619,9 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
+        #[async_trait::async_trait]
         impl MailHandler<UpdateCommunicationStatus> for DdsDataReader {
-            fn handle(
+            async fn handle(
                 &mut self,
                 mail: UpdateCommunicationStatus,
             ) -> <UpdateCommunicationStatus as Mail>::Result {
@@ -638,11 +668,12 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<Vec<Sample<Foo>>>;
         }
 
+        #[async_trait::async_trait]
         impl<Foo> MailHandler<Read<Foo>> for DdsDataReader
         where
-            Foo: DdsRepresentation + for<'de> serde::Deserialize<'de>,
+            Foo: DdsRepresentation + for<'de> serde::Deserialize<'de> + Send + 'static,
         {
-            fn handle(&mut self, mail: Read<Foo>) -> <Read<Foo> as Mail>::Result {
+            async fn handle(&mut self, mail: Read<Foo>) -> <Read<Foo> as Mail>::Result {
                 self.read(
                     mail.max_samples,
                     &mail.sample_states,
@@ -679,8 +710,9 @@ impl ActorAddress<DdsDataReader> {
             participant_address: ActorAddress<DdsDomainParticipant>,
         }
 
+        #[async_trait::async_trait]
         impl CommandHandler<ProcessRtpsMessage> for DdsDataReader {
-            fn handle(&mut self, mail: ProcessRtpsMessage) {
+            async fn handle(&mut self, mail: ProcessRtpsMessage) {
                 self.process_rtps_message(
                     mail.message,
                     mail.reception_timestamp,

--- a/dds/src/implementation/dds_actor/data_reader.rs
+++ b/dds/src/implementation/dds_actor/data_reader.rs
@@ -9,7 +9,8 @@ use crate::{
         },
         dds::{
             dds_data_reader::DdsDataReader, dds_domain_participant::DdsDomainParticipant,
-            dds_subscriber::DdsSubscriber, status_condition_impl::StatusConditionImpl,
+            dds_subscriber::DdsSubscriber, dds_subscriber_listener::DdsSubscriberListener,
+            status_condition_impl::StatusConditionImpl,
         },
         rtps::{
             messages::overall_structure::{RtpsMessageHeader, RtpsMessageRead},
@@ -666,6 +667,8 @@ impl ActorAddress<DdsDataReader> {
         data_reader_address: ActorAddress<DdsDataReader>,
         subscriber_address: ActorAddress<DdsSubscriber>,
         participant_address: ActorAddress<DdsDomainParticipant>,
+        subscriber_status_condition: DdsShared<DdsRwLock<StatusConditionImpl>>,
+        subscriber_data_on_readers_listener: Option<ActorAddress<DdsSubscriberListener>>,
     ) -> DdsResult<()> {
         struct ProcessRtpsMessage {
             message: RtpsMessageRead,
@@ -673,6 +676,8 @@ impl ActorAddress<DdsDataReader> {
             data_reader_address: ActorAddress<DdsDataReader>,
             subscriber_address: ActorAddress<DdsSubscriber>,
             participant_address: ActorAddress<DdsDomainParticipant>,
+            subscriber_status_condition: DdsShared<DdsRwLock<StatusConditionImpl>>,
+            subscriber_data_on_readers_listener: Option<ActorAddress<DdsSubscriberListener>>,
         }
 
         impl CommandHandler<ProcessRtpsMessage> for DdsDataReader {
@@ -683,6 +688,8 @@ impl ActorAddress<DdsDataReader> {
                     mail.data_reader_address,
                     mail.subscriber_address,
                     mail.participant_address,
+                    mail.subscriber_status_condition,
+                    mail.subscriber_data_on_readers_listener,
                 )
             }
         }
@@ -693,6 +700,8 @@ impl ActorAddress<DdsDataReader> {
             data_reader_address,
             subscriber_address,
             participant_address,
+            subscriber_status_condition,
+            subscriber_data_on_readers_listener,
         })
     }
 }

--- a/dds/src/implementation/dds_actor/data_reader.rs
+++ b/dds/src/implementation/dds_actor/data_reader.rs
@@ -9,6 +9,7 @@ use crate::{
         },
         dds::{
             dds_data_reader::DdsDataReader, dds_domain_participant::DdsDomainParticipant,
+            dds_domain_participant_listener::DdsDomainParticipantListener,
             dds_subscriber::DdsSubscriber, dds_subscriber_listener::DdsSubscriberListener,
             status_condition_impl::StatusConditionImpl,
         },
@@ -190,6 +191,11 @@ impl ActorAddress<DdsDataReader> {
         data_reader_address: ActorAddress<DdsDataReader>,
         subscriber_address: ActorAddress<DdsSubscriber>,
         participant_address: ActorAddress<DdsDomainParticipant>,
+        subscriber_qos: SubscriberQos,
+        subscriber_subscription_matched_listener: Option<ActorAddress<DdsSubscriberListener>>,
+        participant_subscription_matched_listener: Option<
+            ActorAddress<DdsDomainParticipantListener>,
+        >,
     ) -> DdsResult<()> {
         struct AddMatchedWriter {
             discovered_writer_data: DiscoveredWriterData,
@@ -198,6 +204,10 @@ impl ActorAddress<DdsDataReader> {
             data_reader_address: ActorAddress<DdsDataReader>,
             subscriber_address: ActorAddress<DdsSubscriber>,
             participant_address: ActorAddress<DdsDomainParticipant>,
+            subscriber_qos: SubscriberQos,
+            subscriber_subscription_matched_listener: Option<ActorAddress<DdsSubscriberListener>>,
+            participant_subscription_matched_listener:
+                Option<ActorAddress<DdsDomainParticipantListener>>,
         }
 
         impl Mail for AddMatchedWriter {
@@ -213,6 +223,9 @@ impl ActorAddress<DdsDataReader> {
                     mail.data_reader_address,
                     mail.subscriber_address,
                     mail.participant_address,
+                    mail.subscriber_qos,
+                    mail.subscriber_subscription_matched_listener,
+                    mail.participant_subscription_matched_listener,
                 )
             }
         }
@@ -224,6 +237,9 @@ impl ActorAddress<DdsDataReader> {
             data_reader_address,
             subscriber_address,
             participant_address,
+            subscriber_qos,
+            subscriber_subscription_matched_listener,
+            participant_subscription_matched_listener,
         })
     }
 
@@ -233,12 +249,19 @@ impl ActorAddress<DdsDataReader> {
         data_reader_address: ActorAddress<DdsDataReader>,
         subscriber_address: ActorAddress<DdsSubscriber>,
         participant_address: ActorAddress<DdsDomainParticipant>,
+        subscriber_subscription_matched_listener: Option<ActorAddress<DdsSubscriberListener>>,
+        participant_subscription_matched_listener: Option<
+            ActorAddress<DdsDomainParticipantListener>,
+        >,
     ) -> DdsResult<()> {
         struct RemoveMatchedWriter {
             discovered_writer_handle: InstanceHandle,
             data_reader_address: ActorAddress<DdsDataReader>,
             subscriber_address: ActorAddress<DdsSubscriber>,
             participant_address: ActorAddress<DdsDomainParticipant>,
+            subscriber_subscription_matched_listener: Option<ActorAddress<DdsSubscriberListener>>,
+            participant_subscription_matched_listener:
+                Option<ActorAddress<DdsDomainParticipantListener>>,
         }
 
         impl Mail for RemoveMatchedWriter {
@@ -255,6 +278,8 @@ impl ActorAddress<DdsDataReader> {
                     mail.data_reader_address,
                     mail.subscriber_address,
                     mail.participant_address,
+                    mail.subscriber_subscription_matched_listener,
+                    mail.participant_subscription_matched_listener,
                 )
             }
         }
@@ -264,6 +289,8 @@ impl ActorAddress<DdsDataReader> {
             data_reader_address,
             subscriber_address,
             participant_address,
+            subscriber_subscription_matched_listener,
+            participant_subscription_matched_listener,
         })
     }
 

--- a/dds/src/implementation/dds_actor/data_reader.rs
+++ b/dds/src/implementation/dds_actor/data_reader.rs
@@ -44,9 +44,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<Enable> for DdsDataReader {
-            async fn handle(&mut self, _mail: Enable) -> <Enable as Mail>::Result {
+            fn handle(&mut self, _mail: Enable) -> <Enable as Mail>::Result {
                 self.enable()
             }
         }
@@ -60,9 +59,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = bool;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<IsEnabled> for DdsDataReader {
-            async fn handle(&mut self, _mail: IsEnabled) -> <IsEnabled as Mail>::Result {
+            fn handle(&mut self, _mail: IsEnabled) -> <IsEnabled as Mail>::Result {
                 self.is_enabled()
             }
         }
@@ -77,9 +75,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = String;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<GetTypeName> for DdsDataReader {
-            async fn handle(&mut self, _mail: GetTypeName) -> <GetTypeName as Mail>::Result {
+            fn handle(&mut self, _mail: GetTypeName) -> <GetTypeName as Mail>::Result {
                 self.get_type_name()
             }
         }
@@ -93,9 +90,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = String;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<GetTopicName> for DdsDataReader {
-            async fn handle(&mut self, _mail: GetTopicName) -> <GetTopicName as Mail>::Result {
+            fn handle(&mut self, _mail: GetTopicName) -> <GetTopicName as Mail>::Result {
                 self.get_topic_name()
             }
         }
@@ -110,9 +106,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsShared<DdsRwLock<StatusConditionImpl>>;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<GetStatusConditions> for DdsDataReader {
-            async fn handle(
+            fn handle(
                 &mut self,
                 _mail: GetStatusConditions,
             ) -> <GetStatusConditions as Mail>::Result {
@@ -129,9 +124,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = SubscriptionMatchedStatus;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<GetSubscriptionMatchedStatus> for DdsDataReader {
-            async fn handle(
+            fn handle(
                 &mut self,
                 _mail: GetSubscriptionMatchedStatus,
             ) -> <GetSubscriptionMatchedStatus as Mail>::Result {
@@ -149,9 +143,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = Vec<InstanceHandle>;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<GetMatchedPublications> for DdsDataReader {
-            async fn handle(
+            fn handle(
                 &mut self,
                 _mail: GetMatchedPublications,
             ) -> <GetMatchedPublications as Mail>::Result {
@@ -174,9 +167,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<PublicationBuiltinTopicData>;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<GetMatchedPublicationData> for DdsDataReader {
-            async fn handle(
+            fn handle(
                 &mut self,
                 mail: GetMatchedPublicationData,
             ) -> <GetMatchedPublicationData as Mail>::Result {
@@ -211,12 +203,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<AddMatchedWriter> for DdsDataReader {
-            async fn handle(
-                &mut self,
-                mail: AddMatchedWriter,
-            ) -> <AddMatchedWriter as Mail>::Result {
+            fn handle(&mut self, mail: AddMatchedWriter) -> <AddMatchedWriter as Mail>::Result {
                 self.add_matched_writer(
                     mail.discovered_writer_data,
                     mail.default_unicast_locator_list,
@@ -256,9 +244,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<RemoveMatchedWriter> for DdsDataReader {
-            async fn handle(
+            fn handle(
                 &mut self,
                 mail: RemoveMatchedWriter,
             ) -> <RemoveMatchedWriter as Mail>::Result {
@@ -288,9 +275,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<()>;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<SetQos> for DdsDataReader {
-            async fn handle(&mut self, mail: SetQos) -> <SetQos as Mail>::Result {
+            fn handle(&mut self, mail: SetQos) -> <SetQos as Mail>::Result {
                 self.set_qos(mail.qos)
             }
         }
@@ -305,9 +291,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = DataReaderQos;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<GetQos> for DdsDataReader {
-            async fn handle(&mut self, _mail: GetQos) -> <GetQos as Mail>::Result {
+            fn handle(&mut self, _mail: GetQos) -> <GetQos as Mail>::Result {
                 self.get_qos()
             }
         }
@@ -329,9 +314,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<SendMessage> for DdsDataReader {
-            async fn handle(&mut self, mail: SendMessage) -> <SendMessage as Mail>::Result {
+            fn handle(&mut self, mail: SendMessage) -> <SendMessage as Mail>::Result {
                 self.send_message(mail.header, mail.udp_transport_write)
             }
         }
@@ -351,12 +335,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<MatchedWriterAdd> for DdsDataReader {
-            async fn handle(
-                &mut self,
-                mail: MatchedWriterAdd,
-            ) -> <MatchedWriterAdd as Mail>::Result {
+            fn handle(&mut self, mail: MatchedWriterAdd) -> <MatchedWriterAdd as Mail>::Result {
                 self.matched_writer_add(mail.a_writer_proxy)
             }
         }
@@ -371,12 +351,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = InstanceHandle;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<GetInstanceHandle> for DdsDataReader {
-            async fn handle(
-                &mut self,
-                _mail: GetInstanceHandle,
-            ) -> <GetInstanceHandle as Mail>::Result {
+            fn handle(&mut self, _mail: GetInstanceHandle) -> <GetInstanceHandle as Mail>::Result {
                 self.guid().into()
             }
         }
@@ -408,12 +384,11 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<Vec<Sample<Foo>>>;
         }
 
-        #[async_trait::async_trait]
         impl<Foo> MailHandler<ReadNextInstance<Foo>> for DdsDataReader
         where
             Foo: DdsRepresentation + for<'de> serde::Deserialize<'de> + Send + 'static,
         {
-            async fn handle(
+            fn handle(
                 &mut self,
                 mail: ReadNextInstance<Foo>,
             ) -> <ReadNextInstance<Foo> as Mail>::Result {
@@ -461,12 +436,11 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<Vec<Sample<Foo>>>;
         }
 
-        #[async_trait::async_trait]
         impl<Foo> MailHandler<Take<Foo>> for DdsDataReader
         where
             Foo: DdsRepresentation + for<'de> serde::Deserialize<'de> + Send + 'static,
         {
-            async fn handle(&mut self, mail: Take<Foo>) -> <Take<Foo> as Mail>::Result {
+            fn handle(&mut self, mail: Take<Foo>) -> <Take<Foo> as Mail>::Result {
                 self.take(
                     mail.max_samples,
                     &mail.sample_states,
@@ -511,12 +485,11 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<Vec<Sample<Foo>>>;
         }
 
-        #[async_trait::async_trait]
         impl<Foo> MailHandler<TakeNextInstance<Foo>> for DdsDataReader
         where
             Foo: DdsRepresentation + for<'de> serde::Deserialize<'de> + Send + 'static,
         {
-            async fn handle(
+            fn handle(
                 &mut self,
                 mail: TakeNextInstance<Foo>,
             ) -> <TakeNextInstance<Foo> as Mail>::Result {
@@ -547,9 +520,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<bool>;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<IsHistoricalDataReceived> for DdsDataReader {
-            async fn handle(
+            fn handle(
                 &mut self,
                 _mail: IsHistoricalDataReceived,
             ) -> <IsHistoricalDataReceived as Mail>::Result {
@@ -578,9 +550,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = DiscoveredReaderData;
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<AsDiscoveredReaderData> for DdsDataReader {
-            async fn handle(
+            fn handle(
                 &mut self,
                 mail: AsDiscoveredReaderData,
             ) -> <AsDiscoveredReaderData as Mail>::Result {
@@ -619,9 +590,8 @@ impl ActorAddress<DdsDataReader> {
             type Result = ();
         }
 
-        #[async_trait::async_trait]
         impl MailHandler<UpdateCommunicationStatus> for DdsDataReader {
-            async fn handle(
+            fn handle(
                 &mut self,
                 mail: UpdateCommunicationStatus,
             ) -> <UpdateCommunicationStatus as Mail>::Result {
@@ -668,12 +638,11 @@ impl ActorAddress<DdsDataReader> {
             type Result = DdsResult<Vec<Sample<Foo>>>;
         }
 
-        #[async_trait::async_trait]
         impl<Foo> MailHandler<Read<Foo>> for DdsDataReader
         where
             Foo: DdsRepresentation + for<'de> serde::Deserialize<'de> + Send + 'static,
         {
-            async fn handle(&mut self, mail: Read<Foo>) -> <Read<Foo> as Mail>::Result {
+            fn handle(&mut self, mail: Read<Foo>) -> <Read<Foo> as Mail>::Result {
                 self.read(
                     mail.max_samples,
                     &mail.sample_states,
@@ -710,9 +679,8 @@ impl ActorAddress<DdsDataReader> {
             participant_address: ActorAddress<DdsDomainParticipant>,
         }
 
-        #[async_trait::async_trait]
         impl CommandHandler<ProcessRtpsMessage> for DdsDataReader {
-            async fn handle(&mut self, mail: ProcessRtpsMessage) {
+            fn handle(&mut self, mail: ProcessRtpsMessage) {
                 self.process_rtps_message(
                     mail.message,
                     mail.reception_timestamp,

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -263,17 +263,14 @@ impl RtpsWriterProxy {
             let info_dst_submessage =
                 InfoDestinationSubmessageWrite::new(self.remote_writer_guid().prefix());
 
-            if let Some(&min) = self.missing_changes().iter().min() {
-                let max = self.missing_changes().iter().max().cloned().unwrap();
-                if !(max - min < SequenceNumber::from(256) && min >= SequenceNumber::from(1)) {
-                    todo!("Use ack_frag")
-                }
-            };
+            let mut missing_changes = self.missing_changes();
+            missing_changes.truncate(256);
+
             let acknack_submessage = AckNackSubmessageWrite::new(
                 true,
                 reader_guid.entity_id(),
                 self.remote_writer_guid().entity_id(),
-                SequenceNumberSet::new(self.available_changes_max() + 1, self.missing_changes()),
+                SequenceNumberSet::new(self.available_changes_max() + 1, missing_changes),
                 self.acknack_count(),
             );
 

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -3,7 +3,7 @@ use crate::implementation::{
         messages::overall_structure::{RtpsMessageRead, RtpsMessageWrite},
         types::{Locator, LOCATOR_KIND_UDP_V4, LOCATOR_KIND_UDP_V6},
     },
-    utils::actor::actor_interface,
+    utils::actor::actor_mailbox_interface,
 };
 use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, ToSocketAddrs};
@@ -45,7 +45,7 @@ impl UdpTransportWrite {
     }
 }
 
-actor_interface! {
+actor_mailbox_interface! {
 impl UdpTransportWrite {
     pub fn write(&self, message: RtpsMessageWrite, destination_locator_list: Vec<Locator>) {
         let buf = message.buffer();

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -3,7 +3,7 @@ use crate::implementation::{
         messages::overall_structure::{RtpsMessageRead, RtpsMessageWrite},
         types::{Locator, LOCATOR_KIND_UDP_V4, LOCATOR_KIND_UDP_V6},
     },
-    utils::actor::actor_mailbox_interface,
+    utils::actor::actor_command_interface,
 };
 use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, ToSocketAddrs};
@@ -45,7 +45,7 @@ impl UdpTransportWrite {
     }
 }
 
-actor_mailbox_interface! {
+actor_command_interface! {
 impl UdpTransportWrite {
     pub fn write(&self, message: RtpsMessageWrite, destination_locator_list: Vec<Locator>) {
         let buf = message.buffer();

--- a/dds/src/implementation/utils/actor.rs
+++ b/dds/src/implementation/utils/actor.rs
@@ -214,7 +214,7 @@ where
 }
 
 // Macro to create both a function for the method and the equivalent wrapper for the actor
-macro_rules! actor_function {
+macro_rules! mailbox_function {
     // Match a function definition with return type
     ($type_name:ident, pub fn $fn_name:ident(&$($self_:ident)+ $(, $arg_name:ident:$arg_type:ty)* $(,)?) -> $ret_type:ty $body:block) => {
         impl $type_name {
@@ -284,21 +284,21 @@ macro_rules! actor_function {
         }
     };
 }
-pub(crate) use actor_function;
+pub(crate) use mailbox_function;
 
 // This macro should wrap an impl block and create the actor address wrapper methods with exactly the same interface
 // It is kept around the "impl" block because otherwise there is no way to find the type name it refers to ($type_name)
-macro_rules! actor_interface {
+macro_rules! actor_mailbox_interface {
     (impl $type_name:ident {
         $(
         pub fn $fn_name:ident(&$($self_:ident)+ $(, $arg_name:ident:$arg_type:ty)* $(,)?) $(-> $ret_type:ty)?
             $body:block
         )+
     }) => {
-        $(crate::implementation::utils::actor::actor_function!($type_name, pub fn $fn_name(&$($self_)+ $(, $arg_name:$arg_type)*) $(-> $ret_type)? $body );)+
+        $(crate::implementation::utils::actor::mailbox_function!($type_name, pub fn $fn_name(&$($self_)+ $(, $arg_name:$arg_type)*) $(-> $ret_type)? $body );)+
     };
 }
-pub(crate) use actor_interface;
+pub(crate) use actor_mailbox_interface;
 
 #[cfg(test)]
 mod tests {
@@ -307,7 +307,7 @@ mod tests {
     pub struct MyData {
         data: u8,
     }
-    actor_interface!(
+    actor_mailbox_interface!(
     impl MyData {
         pub fn increment(&mut self, value: u8) -> u8 {
             self.data += value;

--- a/dds/src/implementation/utils/actor.rs
+++ b/dds/src/implementation/utils/actor.rs
@@ -300,6 +300,51 @@ macro_rules! actor_mailbox_interface {
 }
 pub(crate) use actor_mailbox_interface;
 
+macro_rules! command_function {
+    // Commands are only valid for functions without return
+    ($type_name:ident, pub fn $fn_name:ident(&$($self_:ident)+ $(, $arg_name:ident:$arg_type:ty)* $(,)?) $body:block ) => {
+        impl $type_name {
+            pub fn $fn_name(&$($self_)+ $(, $arg_name:$arg_type)* ) {
+                $body
+            }
+        }
+
+        impl crate::implementation::utils::actor::ActorAddress<$type_name> {
+            pub fn $fn_name(&self $(, $arg_name:$arg_type)*) -> crate::infrastructure::error::DdsResult<()> {
+                #[allow(non_camel_case_types)]
+                struct $fn_name {
+                    $($arg_name:$arg_type,)*
+                }
+
+                impl crate::implementation::utils::actor::CommandHandler<$fn_name> for $type_name {
+                    #[allow(unused_variables)]
+                    fn handle(&mut self, mail: $fn_name) {
+                        self.$fn_name($(mail.$arg_name,)*)
+                    }
+                }
+
+                self.send_command($fn_name{
+                    $($arg_name, )*
+                })
+
+            }
+        }
+    };
+}
+pub(crate) use command_function;
+
+macro_rules! actor_command_interface {
+    (impl $type_name:ident {
+        $(
+        pub fn $fn_name:ident(&$($self_:ident)+ $(, $arg_name:ident:$arg_type:ty)* $(,)?)
+            $body:block
+        )+
+    }) => {
+        $(crate::implementation::utils::actor::command_function!($type_name, pub fn $fn_name(&$($self_)+ $(, $arg_name:$arg_type)*) $body );)+
+    };
+}
+pub(crate) use actor_command_interface;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dds/src/implementation/utils/actor.rs
+++ b/dds/src/implementation/utils/actor.rs
@@ -214,12 +214,14 @@ macro_rules! mailbox_function {
     // Match a function definition with return type
     ($type_name:ident, pub fn $fn_name:ident(&$($self_:ident)+ $(, $arg_name:ident:$arg_type:ty)* $(,)?) -> $ret_type:ty $body:block) => {
         impl $type_name {
+            #[allow(clippy::too_many_arguments)]
             pub fn $fn_name(&$($self_)+ $(, $arg_name:$arg_type)*) -> $ret_type{
                 $body
             }
         }
 
         impl crate::implementation::utils::actor::ActorAddress<$type_name> {
+            #[allow(clippy::too_many_arguments)]
             pub fn $fn_name(&self $(, $arg_name:$arg_type)*) -> crate::infrastructure::error::DdsResult<$ret_type> {
                 #[allow(non_camel_case_types)]
                 struct $fn_name {
@@ -249,12 +251,14 @@ macro_rules! mailbox_function {
     // Match a function definition without return type
     ($type_name:ident, pub fn $fn_name:ident(&$($self_:ident)+ $(, $arg_name:ident:$arg_type:ty)* $(,)?) $body:block ) => {
         impl $type_name {
+            #[allow(clippy::too_many_arguments)]
             pub fn $fn_name(&$($self_)+ $(, $arg_name:$arg_type)* ) {
                 $body
             }
         }
 
         impl crate::implementation::utils::actor::ActorAddress<$type_name> {
+            #[allow(clippy::too_many_arguments)]
             pub fn $fn_name(&self $(, $arg_name:$arg_type)*) -> crate::infrastructure::error::DdsResult<()> {
                 #[allow(non_camel_case_types)]
                 struct $fn_name {

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2002,7 +2002,7 @@ fn data_reader_publication_handle_sample_info() {
         ..Default::default()
     };
     let reader = subscriber
-        .create_datareader::<KeyedData>(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
+        .create_datareader::<UserData>(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
         .unwrap();
 
     let cond = writer.get_statuscondition().unwrap();
@@ -2018,7 +2018,7 @@ fn data_reader_publication_handle_sample_info() {
     writer.write(&UserData(1), None).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(10, 0))
+        .wait_for_acknowledgments(Duration::new(1000, 0))
         .unwrap();
 
     let samples = reader

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2445,7 +2445,7 @@ fn reader_joining_after_writer_writes_many_samples() {
     let new_data = KeyedData { id: 1, value: 1000 };
     writer.write(&new_data, None).unwrap();
     writer
-        .wait_for_acknowledgments(Duration::new(10, 0))
+        .wait_for_acknowledgments(Duration::new(20, 0))
         .unwrap();
 
     let samples = reader

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2399,9 +2399,6 @@ fn reader_joining_after_writer_writes_many_samples() {
             kind: ReliabilityQosPolicyKind::Reliable,
             max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
         },
-        history: HistoryQosPolicy {
-            kind: HistoryQosPolicyKind::KeepAll,
-        },
         ..Default::default()
     };
 
@@ -2422,9 +2419,6 @@ fn reader_joining_after_writer_writes_many_samples() {
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::Reliable,
             max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
-        },
-        history: HistoryQosPolicy {
-            kind: HistoryQosPolicyKind::KeepAll,
         },
         ..Default::default()
     };

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2018,7 +2018,7 @@ fn data_reader_publication_handle_sample_info() {
     writer.write(&UserData(1), None).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(1000, 0))
+        .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
     let samples = reader

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2432,8 +2432,8 @@ fn reader_joining_after_writer_writes_many_samples() {
         .create_datareader::<KeyedData>(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
         .unwrap();
 
-    let cond = reader.get_statuscondition().unwrap();
-    cond.set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+    let cond = writer.get_statuscondition().unwrap();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
 
     let mut wait_set = WaitSet::new();
@@ -2442,7 +2442,7 @@ fn reader_joining_after_writer_writes_many_samples() {
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
-    let new_data = KeyedData { id: 1, value: 255 };
+    let new_data = KeyedData { id: 1, value: 1000 };
     writer.write(&new_data, None).unwrap();
     writer
         .wait_for_acknowledgments(Duration::new(10, 0))


### PR DESCRIPTION
Send a Gap message when a reader joins after many samples have been written to the writer. This is a typical scenario for example when have two running shapes demo and was missing functionality up to this point. During the implementation we noticed some low performance issues when receiving a lot of messages on the wire so the actor tasks were modified to be non-blocking.