### PR TITLE
176 Discovery steps refactor

### DIFF
--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -9,7 +9,6 @@ use crate::{
             dds_publisher, dds_subscriber, dds_topic,
             nodes::{DomainParticipantNode, PublisherNode, SubscriberNode, TopicNode},
         },
-        rtps::messages::overall_structure::RtpsMessageHeader,
         utils::actor::THE_RUNTIME,
     },
     infrastructure::{
@@ -1064,34 +1063,8 @@ impl DomainParticipant {
                                     )
                                     .await??;
 
-                                data_writer
-                                    .send_mail(dds_data_writer::send_message::new(
-                                        RtpsMessageHeader::new(
-                                            domain_participant_address
-                                                .send_mail_and_await_reply(
-                                                    dds_domain_participant::get_protocol_version::new(),
-                                                )
-                                                .await?,
-                                            domain_participant_address
-                                                .send_mail_and_await_reply(
-                                                    dds_domain_participant::get_vendor_id::new(),
-                                                )
-                                                .await?,
-                                            domain_participant_address
-                                                .send_mail_and_await_reply(
-                                                    dds_domain_participant::get_guid::new(),
-                                                )
-                                                .await?
-                                                .prefix(),
-                                        ),
-                                        domain_participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_upd_transport_write::new(),
-                                            )
-                                            .await?,
-                                        timestamp,
-                                    ))
-                                    .await?;
+
+                                domain_participant_address.send_mail(dds_domain_participant::send_message::new()).await?;
                             }
                         }
 
@@ -1114,14 +1087,20 @@ impl DomainParticipant {
                 loop {
                     let r: DdsResult<()> = async {
                         let now = domain_participant_address
-                            .send_mail_and_await_reply(dds_domain_participant::get_current_time::new())
+                            .send_mail_and_await_reply(
+                                dds_domain_participant::get_current_time::new(),
+                            )
                             .await?;
                         let participant_mask_listener = (
                             domain_participant_address
-                                .send_mail_and_await_reply(dds_domain_participant::get_listener::new())
+                                .send_mail_and_await_reply(
+                                    dds_domain_participant::get_listener::new(),
+                                )
                                 .await?,
                             domain_participant_address
-                                .send_mail_and_await_reply(dds_domain_participant::get_status_kind::new())
+                                .send_mail_and_await_reply(
+                                    dds_domain_participant::get_status_kind::new(),
+                                )
                                 .await?,
                         );
                         for subscriber in domain_participant_address
@@ -1157,50 +1136,9 @@ impl DomainParticipant {
                             }
                         }
 
-                        for user_defined_publisher in domain_participant_address
-                            .send_mail_and_await_reply(
-                                dds_domain_participant::get_user_defined_publisher_list::new(),
-                            )
-                            .await?
-                        {
-                            for data_writer in user_defined_publisher
-                                .send_mail_and_await_reply(dds_publisher::data_writer_list::new())
-                                .await?
-                            {
-                                data_writer
-                                    .send_mail(dds_data_writer::send_message::new(
-                                        RtpsMessageHeader::new(
-                                            domain_participant_address
-                                                .send_mail_and_await_reply(
-                                                    dds_domain_participant::get_protocol_version::new(),
-                                                )
-                                                .await?,
-                                            domain_participant_address
-                                                .send_mail_and_await_reply(
-                                                    dds_domain_participant::get_vendor_id::new(),
-                                                )
-                                                .await?,
-                                            domain_participant_address
-                                                .send_mail_and_await_reply(
-                                                    dds_domain_participant::get_guid::new(),
-                                                )
-                                                .await?
-                                                .prefix(),
-                                        ),
-                                        domain_participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_upd_transport_write::new(),
-                                            )
-                                            .await?,
-                                        domain_participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_current_time::new(),
-                                            )
-                                            .await?,
-                                    ))
-                                    .await?;
-                            }
-                        }
+                        domain_participant_address
+                            .send_mail(dds_domain_participant::send_message::new())
+                            .await?;
 
                         Ok(())
                     }

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -26,7 +26,7 @@ use crate::{
         },
         rtps::{
             discovery_types::BuiltinEndpointSet,
-            messages::overall_structure::{RtpsMessageHeader, RtpsMessageRead},
+            messages::overall_structure::RtpsMessageRead,
             participant::RtpsParticipant,
             reader_proxy::RtpsReaderProxy,
             types::{
@@ -808,38 +808,8 @@ async fn process_spdp_metatraffic(
                             )
                             .await;
 
-                            sedp_publications_announcer
-                                .send_mail(dds_data_writer::send_message::new(
-                                    RtpsMessageHeader::new(
-                                        participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_protocol_version::new(),
-                                            )
-                                            .await?,
-                                        participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_vendor_id::new(),
-                                            )
-                                            .await?,
-                                        participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_guid::new(),
-                                            )
-                                            .await?
-                                            .prefix(),
-                                    ),
-                                    participant_address
-                                        .send_mail_and_await_reply(
-                                            dds_domain_participant::get_upd_transport_write::new(),
-                                        )
-                                        .await?,
-                                    participant_address
-                                        .send_mail_and_await_reply(
-                                            dds_domain_participant::get_current_time::new(),
-                                        )
-                                        .await?,
-                                ))
-                                .await?;
+                            participant_address
+                                .send_mail_blocking(dds_domain_participant::send_message::new())?;
                         }
 
                         if let Some(sedp_publications_detector) = lookup_data_reader_by_topic_name(
@@ -867,38 +837,9 @@ async fn process_spdp_metatraffic(
                                 &discovered_participant_data,
                             )
                             .await;
-                            sedp_subscriptions_announcer
-                                .send_mail(dds_data_writer::send_message::new(
-                                    RtpsMessageHeader::new(
-                                        participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_protocol_version::new(),
-                                            )
-                                            .await?,
-                                        participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_vendor_id::new(),
-                                            )
-                                            .await?,
-                                        participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_guid::new(),
-                                            )
-                                            .await?
-                                            .prefix(),
-                                    ),
-                                    participant_address
-                                        .send_mail_and_await_reply(
-                                            dds_domain_participant::get_upd_transport_write::new(),
-                                        )
-                                        .await?,
-                                    participant_address
-                                        .send_mail_and_await_reply(
-                                            dds_domain_participant::get_current_time::new(),
-                                        )
-                                        .await?,
-                                ))
-                                .await?;
+
+                            participant_address
+                                .send_mail_blocking(dds_domain_participant::send_message::new())?;
                         }
 
                         if let Some(sedp_subscriptions_detector) = lookup_data_reader_by_topic_name(
@@ -924,38 +865,8 @@ async fn process_spdp_metatraffic(
                             )
                             .await;
 
-                            sedp_topics_announcer
-                                .send_mail(dds_data_writer::send_message::new(
-                                    RtpsMessageHeader::new(
-                                        participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_protocol_version::new(),
-                                            )
-                                            .await?,
-                                        participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_vendor_id::new(),
-                                            )
-                                            .await?,
-                                        participant_address
-                                            .send_mail_and_await_reply(
-                                                dds_domain_participant::get_guid::new(),
-                                            )
-                                            .await?
-                                            .prefix(),
-                                    ),
-                                    participant_address
-                                        .send_mail_and_await_reply(
-                                            dds_domain_participant::get_upd_transport_write::new(),
-                                        )
-                                        .await?,
-                                    participant_address
-                                        .send_mail_and_await_reply(
-                                            dds_domain_participant::get_current_time::new(),
-                                        )
-                                        .await?,
-                                ))
-                                .await?;
+                            participant_address
+                                .send_mail_blocking(dds_domain_participant::send_message::new())?;
                         }
 
                         if let Some(sedp_topics_detector) =
@@ -1012,32 +923,8 @@ async fn process_sedp_metatraffic(
         stateful_builtin_writer
             .send_mail_and_await_reply(dds_data_writer::process_rtps_message::new(message.clone()))
             .await?;
-        stateful_builtin_writer
-            .send_mail_and_await_reply(dds_data_writer::send_message::new(
-                RtpsMessageHeader::new(
-                    participant_address
-                        .send_mail_and_await_reply(
-                            dds_domain_participant::get_protocol_version::new(),
-                        )
-                        .await?,
-                    participant_address
-                        .send_mail_and_await_reply(dds_domain_participant::get_vendor_id::new())
-                        .await?,
-                    participant_address
-                        .send_mail_and_await_reply(dds_domain_participant::get_guid::new())
-                        .await?
-                        .prefix(),
-                ),
-                participant_address
-                    .send_mail_and_await_reply(
-                        dds_domain_participant::get_upd_transport_write::new(),
-                    )
-                    .await?,
-                participant_address
-                    .send_mail_and_await_reply(dds_domain_participant::get_current_time::new())
-                    .await?,
-            ))
-            .await?;
+
+        participant_address.send_mail_blocking(dds_domain_participant::send_message::new())?;
     }
 
     builtin_subscriber
@@ -1052,26 +939,7 @@ async fn process_sedp_metatraffic(
         ))
         .await??;
 
-    builtin_subscriber
-        .send_mail_and_await_reply(dds_subscriber::send_message::new(
-            RtpsMessageHeader::new(
-                participant_address
-                    .send_mail_and_await_reply(dds_domain_participant::get_protocol_version::new())
-                    .await?,
-                participant_address
-                    .send_mail_and_await_reply(dds_domain_participant::get_vendor_id::new())
-                    .await?,
-                participant_address
-                    .send_mail_and_await_reply(dds_domain_participant::get_guid::new())
-                    .await?
-                    .prefix(),
-            ),
-            participant_address
-                .send_mail_and_await_reply(dds_domain_participant::get_upd_transport_write::new())
-                .await?,
-        ))
-        .await
-        .expect("Should not fail to send command");
+    participant_address.send_mail_blocking(dds_domain_participant::send_message::new())?;
 
     Ok(())
 }
@@ -1264,33 +1132,10 @@ async fn discover_matched_writers(
                                             ),
                                         )
                                         .await??;
-                                    data_reader_address
-                                        .send_mail(dds_data_reader::send_message::new(
-                                            RtpsMessageHeader::new(
-                                                participant_address
-                                                    .send_mail_and_await_reply(
-                                                        dds_domain_participant::get_protocol_version::new(),
-                                                    )
-                                                    .await?,
-                                                participant_address
-                                                    .send_mail_and_await_reply(
-                                                        dds_domain_participant::get_vendor_id::new(),
-                                                    )
-                                                    .await?,
-                                                participant_address
-                                                    .send_mail_and_await_reply(
-                                                        dds_domain_participant::get_guid::new(),
-                                                    )
-                                                    .await?
-                                                    .prefix(),
-                                            ),
-                                            participant_address
-                                                .send_mail_and_await_reply(
-                                                    dds_domain_participant::get_upd_transport_write::new(),
-                                                )
-                                                .await?,
-                                        ))
-                                        .await?;
+
+                                    participant_address.send_mail_blocking(
+                                        dds_domain_participant::send_message::new(),
+                                    )?;
                                 }
                             }
                         }
@@ -1540,38 +1385,10 @@ pub async fn discover_matched_readers(
                                             ),
                                         )
                                         .await??;
-                                    data_writer
-                                        .send_mail(dds_data_writer::send_message::new(
-                                            RtpsMessageHeader::new(
-                                                participant_address
-                                                    .send_mail_and_await_reply(
-                                                        dds_domain_participant::get_protocol_version::new(),
-                                                    )
-                                                    .await?,
-                                                participant_address
-                                                    .send_mail_and_await_reply(
-                                                        dds_domain_participant::get_vendor_id::new(),
-                                                    )
-                                                    .await?,
-                                                participant_address
-                                                    .send_mail_and_await_reply(
-                                                        dds_domain_participant::get_guid::new(),
-                                                    )
-                                                    .await?
-                                                    .prefix(),
-                                            ),
-                                            participant_address
-                                                .send_mail_and_await_reply(
-                                                    dds_domain_participant::get_upd_transport_write::new(),
-                                                )
-                                                .await?,
-                                            participant_address
-                                                .send_mail_and_await_reply(
-                                                    dds_domain_participant::get_current_time::new(),
-                                                )
-                                                .await?,
-                                        ))
-                                        .await?;
+
+                                    participant_address.send_mail_blocking(
+                                        dds_domain_participant::send_message::new(),
+                                    )?;
                                 }
                             }
                         }

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -187,7 +187,7 @@ impl DomainParticipantFactory {
         );
 
         let participant_actor = spawn_actor(domain_participant);
-        let participant_address = participant_actor.address().clone();
+        let participant_address = participant_actor.address();
         self.0.address().send_mail_and_await_reply_blocking(
             dds_domain_participant_factory::add_participant::new(
                 participant_guid.into(),

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -3,15 +3,13 @@ use std::{marker::PhantomData, time::Instant};
 use crate::{
     builtin_topics::SubscriptionBuiltinTopicData,
     implementation::{
-        data_representation_builtin_endpoints::discovered_writer_data::DiscoveredWriterData,
         dds::{
             dds_data_writer,
-            dds_domain_participant::{self, DdsDomainParticipant},
+            dds_domain_participant,
             dds_publisher,
             nodes::{DataWriterNode, PublisherNode},
         },
         rtps::messages::overall_structure::RtpsMessageHeader,
-        utils::actor::ActorAddress,
     },
     infrastructure::{
         condition::StatusCondition,
@@ -558,9 +556,8 @@ where
             .writer_address()
             .send_mail_and_await_reply_blocking(dds_data_writer::is_enabled::new())?
         {
-            announce_data_writer(
-                self.0.participant_address(),
-                &self.0.writer_address().send_mail_and_await_reply_blocking(
+            let discovered_writer_data =
+                self.0.writer_address().send_mail_and_await_reply_blocking(
                     dds_data_writer::as_discovered_writer_data::new(
                         TopicQos::default(),
                         self.0
@@ -577,7 +574,11 @@ where
                                 dds_domain_participant::get_default_multicast_locator_list::new(),
                             )?,
                     ),
-                )?,
+                )?;
+            self.0.participant_address().send_mail_blocking(
+                dds_domain_participant::announce_created_or_modified_data_writer::new(
+                    discovered_writer_data,
+                ),
             )?;
         }
 
@@ -659,10 +660,8 @@ where
             self.0
                 .writer_address()
                 .send_mail_and_await_reply_blocking(dds_data_writer::enable::new())?;
-
-            announce_data_writer(
-                self.0.participant_address(),
-                &self.0.writer_address().send_mail_and_await_reply_blocking(
+            let discovered_writer_data =
+                self.0.writer_address().send_mail_and_await_reply_blocking(
                     dds_data_writer::as_discovered_writer_data::new(
                         TopicQos::default(),
                         self.0
@@ -679,7 +678,11 @@ where
                                 dds_domain_participant::get_default_multicast_locator_list::new(),
                             )?,
                     ),
-                )?,
+                )?;
+            self.0.participant_address().send_mail_blocking(
+                dds_domain_participant::announce_created_or_modified_data_writer::new(
+                    discovered_writer_data,
+                ),
             )?;
         }
         Ok(())
@@ -695,57 +698,3 @@ where
 }
 
 pub trait AnyDataWriter {}
-
-fn announce_data_writer(
-    domain_participant: &ActorAddress<DdsDomainParticipant>,
-    discovered_writer_data: &DiscoveredWriterData,
-) -> DdsResult<()> {
-    let serialized_data = dds_serialize_to_bytes(discovered_writer_data)?;
-    let timestamp = domain_participant
-        .send_mail_and_await_reply_blocking(dds_domain_participant::get_current_time::new())?;
-
-    let builtin_publisher = domain_participant
-        .send_mail_and_await_reply_blocking(dds_domain_participant::get_builtin_publisher::new())?;
-    let data_writer_list = builtin_publisher
-        .send_mail_and_await_reply_blocking(dds_publisher::data_writer_list::new())?;
-
-    for dw in data_writer_list {
-        if dw.send_mail_and_await_reply_blocking(dds_data_writer::get_type_name::new())
-            == Ok("DiscoveredWriterData".to_string())
-        {
-            dw.send_mail_and_await_reply_blocking(dds_data_writer::write_w_timestamp::new(
-                serialized_data,
-                dds_serialize_key(discovered_writer_data)?,
-                None,
-                timestamp,
-            ))??;
-
-            dw.send_mail_blocking(
-                dds_data_writer::send_message::new(
-                    RtpsMessageHeader::new(
-                        domain_participant.send_mail_and_await_reply_blocking(
-                            dds_domain_participant::get_protocol_version::new(),
-                        )?,
-                        domain_participant.send_mail_and_await_reply_blocking(
-                            dds_domain_participant::get_vendor_id::new(),
-                        )?,
-                        domain_participant
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_guid::new(),
-                            )?
-                            .prefix(),
-                    ),
-                    domain_participant.send_mail_and_await_reply_blocking(
-                        dds_domain_participant::get_upd_transport_write::new(),
-                    )?,
-                    domain_participant.send_mail_and_await_reply_blocking(
-                        dds_domain_participant::get_current_time::new(),
-                    )?,
-                ),
-            )?;
-            break;
-        }
-    }
-
-    Ok(())
-}

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -416,7 +416,7 @@ impl<Foo> DataWriter<Foo> {
     pub fn get_publication_matched_status(&self) -> DdsResult<PublicationMatchedStatus> {
         self.0.writer_address().send_mail_and_await_reply_blocking(
             dds_data_writer::get_publication_matched_status::new(),
-        )?
+        )
     }
 
     /// This operation returns the [`Topic`] associated with the [`DataWriter`]. This is the same [`Topic`] that was used to create the [`DataWriter`].

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -2,14 +2,9 @@ use std::{marker::PhantomData, time::Instant};
 
 use crate::{
     builtin_topics::SubscriptionBuiltinTopicData,
-    implementation::{
-        dds::{
-            dds_data_writer,
-            dds_domain_participant,
-            dds_publisher,
-            nodes::{DataWriterNode, PublisherNode},
-        },
-        rtps::messages::overall_structure::RtpsMessageHeader,
+    implementation::dds::{
+        dds_data_writer, dds_domain_participant, dds_publisher,
+        nodes::{DataWriterNode, PublisherNode},
     },
     infrastructure::{
         condition::StatusCondition,
@@ -295,39 +290,8 @@ where
             ))??;
 
         self.0
-            .writer_address()
-            .send_mail_blocking(
-                dds_data_writer::send_message::new(
-                    RtpsMessageHeader::new(
-                        self.0
-                            .participant_address()
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_protocol_version::new(),
-                            )?,
-                        self.0
-                            .participant_address()
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_vendor_id::new(),
-                            )?,
-                        self.0
-                            .participant_address()
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_guid::new(),
-                            )?
-                            .prefix(),
-                    ),
-                    self.0
-                        .participant_address()
-                        .send_mail_and_await_reply_blocking(
-                            dds_domain_participant::get_upd_transport_write::new(),
-                        )?,
-                    self.0
-                        .participant_address()
-                        .send_mail_and_await_reply_blocking(
-                            dds_domain_participant::get_current_time::new(),
-                        )?,
-                ),
-            )?;
+            .participant_address()
+            .send_mail_blocking(dds_domain_participant::send_message::new())?;
 
         Ok(())
     }

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -261,22 +261,20 @@ impl Publisher {
     /// If multiple [`DataWriter`] attached to the [`Publisher`] satisfy this condition, then the operation will return one of them. It is not
     /// specified which one.
     #[tracing::instrument(skip(self))]
-    pub fn lookup_datawriter<Foo>(&self, _topic_name: &str) -> DdsResult<Option<DataWriter<Foo>>>
-    where
-        Foo: DdsHasKey,
-    {
-        todo!()
-        // self.call_participant_mut_method(|dp| {
-        //     Ok(
-        //         crate::implementation::behavior::user_defined_publisher::lookup_datawriter(
-        //             dp,
-        //             self.0.guid(),
-        //             Foo,
-        //             topic_name,
-        //         )?
-        //         .map(|x| DataWriter::new(DataWriterNodeKind::UserDefined(x))),
-        //     )
-        // })
+    pub fn lookup_datawriter<Foo>(&self, topic_name: &str) -> DdsResult<Option<DataWriter<Foo>>> {
+        Ok(self
+            .0
+            .publisher_address()
+            .send_mail_and_await_reply_blocking(dds_publisher::lookup_datawriter::new(
+                topic_name.to_string(),
+            ))?
+            .map(|dw| {
+                DataWriter::new(DataWriterNode::new(
+                    dw,
+                    self.0.publisher_address().clone(),
+                    self.0.participant_address().clone(),
+                ))
+            }))
     }
 
     /// This operation indicates to the Service that the application is about to make multiple modifications using [`DataWriter`] objects

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -7,7 +7,6 @@ use crate::{
             dds_domain_participant, dds_publisher,
             nodes::{DataWriterNode, DomainParticipantNode, PublisherNode},
         },
-        rtps::messages::overall_structure::RtpsMessageHeader,
         utils::actor::spawn_actor,
     },
     infrastructure::{
@@ -213,41 +212,9 @@ impl Publisher {
                         ),
                     )??;
 
-                    data_writer.send_mail_blocking(dds_data_writer::send_message::new(
-                        RtpsMessageHeader::new(
-                            a_datawriter
-                                .node()
-                                .participant_address()
-                                .send_mail_and_await_reply_blocking(
-                                    dds_domain_participant::get_protocol_version::new(),
-                                )?,
-                            a_datawriter
-                                .node()
-                                .participant_address()
-                                .send_mail_and_await_reply_blocking(
-                                    dds_domain_participant::get_vendor_id::new(),
-                                )?,
-                            a_datawriter
-                                .node()
-                                .participant_address()
-                                .send_mail_and_await_reply_blocking(
-                                    dds_domain_participant::get_guid::new(),
-                                )?
-                                .prefix(),
-                        ),
-                        a_datawriter
-                            .node()
-                            .participant_address()
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_upd_transport_write::new(),
-                            )?,
-                        a_datawriter
-                            .node()
-                            .participant_address()
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_current_time::new(),
-                            )?,
-                    ))?;
+                    self.0
+                        .participant_address()
+                        .send_mail_blocking(dds_domain_participant::send_message::new())?;
                     break;
                 }
             }

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -470,7 +470,7 @@ impl<Foo> DataReader<Foo> {
     pub fn get_subscription_matched_status(&self) -> DdsResult<SubscriptionMatchedStatus> {
         self.0.reader_address().send_mail_and_await_reply_blocking(
             dds_data_reader::get_subscription_matched_status::new(),
-        )?
+        )
     }
 
     /// This operation returns the [`Topic`] associated with the [`DataReader`]. This is the same [`Topic`]

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -7,7 +7,7 @@ use crate::{
             dds_publisher, dds_subscriber,
             nodes::{DataReaderNode, TopicNode},
         },
-        rtps::messages::{overall_structure::RtpsMessageHeader, submessage_elements::Data},
+        rtps::messages::submessage_elements::Data,
         utils::actor::ActorAddress,
     },
     infrastructure::{
@@ -753,29 +753,7 @@ fn announce_data_reader(
                 timestamp,
             ))??;
 
-            dw.send_mail_blocking(
-                dds_data_writer::send_message::new(
-                    RtpsMessageHeader::new(
-                        domain_participant.send_mail_and_await_reply_blocking(
-                            dds_domain_participant::get_protocol_version::new(),
-                        )?,
-                        domain_participant.send_mail_and_await_reply_blocking(
-                            dds_domain_participant::get_vendor_id::new(),
-                        )?,
-                        domain_participant
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_guid::new(),
-                            )?
-                            .prefix(),
-                    ),
-                    domain_participant.send_mail_and_await_reply_blocking(
-                        dds_domain_participant::get_upd_transport_write::new(),
-                    )?,
-                    domain_participant.send_mail_and_await_reply_blocking(
-                        dds_domain_participant::get_current_time::new(),
-                    )?,
-                ),
-            )?;
+            domain_participant.send_mail_blocking(dds_domain_participant::send_message::new())?;
             break;
         }
     }

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -287,11 +287,20 @@ impl Subscriber {
     /// specified which one.
     /// The use of this operation on the built-in [`Subscriber`] allows access to the built-in [`DataReader`] entities for the built-in topics.
     #[tracing::instrument(skip(self))]
-    pub fn lookup_datareader<Foo>(&self, _topic_name: &str) -> DdsResult<Option<DataReader<Foo>>>
-    where
-        Foo: DdsHasKey + for<'de> serde::Deserialize<'de>,
-    {
-        todo!()
+    pub fn lookup_datareader<Foo>(&self, topic_name: &str) -> DdsResult<Option<DataReader<Foo>>> {
+        Ok(self
+            .0
+            .subscriber_address()
+            .send_mail_and_await_reply_blocking(dds_subscriber::lookup_datareader::new(
+                topic_name.to_string(),
+            ))?
+            .map(|reader_address| {
+                DataReader::new(DataReaderNode::new(
+                    reader_address,
+                    self.0.subscriber_address().clone(),
+                    self.0.participant_address().clone(),
+                ))
+            }))
     }
 
     /// This operation invokes the operation [`DataReaderListener::on_data_available`] on the listener objects attached to contained [`DataReader`]

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -9,7 +9,6 @@ use crate::{
         },
         rtps::{
             endpoint::RtpsEndpoint,
-            messages::overall_structure::RtpsMessageHeader,
             reader::RtpsReader,
             types::{
                 EntityId, Guid, TopicKind, USER_DEFINED_READER_NO_KEY, USER_DEFINED_READER_WITH_KEY,
@@ -272,41 +271,9 @@ impl Subscriber {
                         ),
                     )??;
 
-                    dw.send_mail_blocking(dds_data_writer::send_message::new(
-                        RtpsMessageHeader::new(
-                            a_datareader
-                                .node()
-                                .participant_address()
-                                .send_mail_and_await_reply_blocking(
-                                    dds_domain_participant::get_protocol_version::new(),
-                                )?,
-                            a_datareader
-                                .node()
-                                .participant_address()
-                                .send_mail_and_await_reply_blocking(
-                                    dds_domain_participant::get_vendor_id::new(),
-                                )?,
-                            a_datareader
-                                .node()
-                                .participant_address()
-                                .send_mail_and_await_reply_blocking(
-                                    dds_domain_participant::get_guid::new(),
-                                )?
-                                .prefix(),
-                        ),
-                        a_datareader
-                            .node()
-                            .participant_address()
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_upd_transport_write::new(),
-                            )?,
-                        a_datareader
-                            .node()
-                            .participant_address()
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_current_time::new(),
-                            )?,
-                    ))?;
+                    self.0
+                        .participant_address()
+                        .send_mail_blocking(dds_domain_participant::send_message::new())?;
                     break;
                 }
             }

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -174,7 +174,7 @@ impl Subscriber {
         );
 
         let reader_actor = spawn_actor(data_reader);
-        let reader_address = reader_actor.address().clone();
+        let reader_address = reader_actor.address();
         self.0
             .subscriber_address()
             .send_mail_and_await_reply_blocking(dds_subscriber::data_reader_add::new(

--- a/dds/src/dds/topic_definition/topic.rs
+++ b/dds/src/dds/topic_definition/topic.rs
@@ -8,7 +8,6 @@ use crate::{
             dds_publisher, dds_topic,
             nodes::{DomainParticipantNode, TopicNode},
         },
-        rtps::messages::overall_structure::RtpsMessageHeader,
         utils::actor::ActorAddress,
     },
     infrastructure::{
@@ -262,29 +261,7 @@ fn announce_topic(
                 ),
             )??;
 
-            data_writer.send_mail_blocking(
-                dds_data_writer::send_message::new(
-                    RtpsMessageHeader::new(
-                        domain_participant.send_mail_and_await_reply_blocking(
-                            dds_domain_participant::get_protocol_version::new(),
-                        )?,
-                        domain_participant.send_mail_and_await_reply_blocking(
-                            dds_domain_participant::get_vendor_id::new(),
-                        )?,
-                        domain_participant
-                            .send_mail_and_await_reply_blocking(
-                                dds_domain_participant::get_guid::new(),
-                            )?
-                            .prefix(),
-                    ),
-                    domain_participant.send_mail_and_await_reply_blocking(
-                        dds_domain_participant::get_upd_transport_write::new(),
-                    )?,
-                    domain_participant.send_mail_and_await_reply_blocking(
-                        dds_domain_participant::get_current_time::new(),
-                    )?,
-                ),
-            )?;
+            domain_participant.send_mail_blocking(dds_domain_participant::send_message::new())?;
             break;
         }
     }

--- a/dds/src/implementation/dds/dds_data_reader.rs
+++ b/dds/src/implementation/dds/dds_data_reader.rs
@@ -1580,7 +1580,7 @@ impl DdsDataReader {
     }
 
     async fn get_statuscondition(&self) -> ActorAddress<DdsStatusCondition> {
-        self.status_condition.address().clone()
+        self.status_condition.address()
     }
 
     async fn get_matched_publications(&self) -> Vec<InstanceHandle> {

--- a/dds/src/implementation/dds/dds_data_reader.rs
+++ b/dds/src/implementation/dds/dds_data_reader.rs
@@ -169,7 +169,7 @@ impl RequestedDeadlineMissedStatus {
 }
 
 impl LivelinessChangedStatus {
-    fn read_and_reset(&mut self) -> Self {
+    fn _read_and_reset(&mut self) -> Self {
         let status = self.clone();
 
         self.alive_count_change = 0;
@@ -241,7 +241,7 @@ pub struct DdsDataReader {
     instance_handle_builder: InstanceHandleBuilder,
     type_name: String,
     topic_name: String,
-    liveliness_changed_status: LivelinessChangedStatus,
+    _liveliness_changed_status: LivelinessChangedStatus,
     requested_deadline_missed_status: RequestedDeadlineMissedStatus,
     requested_incompatible_qos_status: RequestedIncompatibleQosStatus,
     sample_lost_status: SampleLostStatus,
@@ -279,7 +279,7 @@ impl DdsDataReader {
             changes: Vec::new(),
             type_name,
             topic_name,
-            liveliness_changed_status: LivelinessChangedStatus::default(),
+            _liveliness_changed_status: LivelinessChangedStatus::default(),
             requested_deadline_missed_status: RequestedDeadlineMissedStatus::default(),
             requested_incompatible_qos_status: RequestedIncompatibleQosStatus::default(),
             sample_lost_status: SampleLostStatus::default(),
@@ -297,10 +297,6 @@ impl DdsDataReader {
             instance_handle_builder,
             instances: HashMap::new(),
         }
-    }
-
-    pub fn get_liveliness_changed_status(&mut self) -> LivelinessChangedStatus {
-        self.liveliness_changed_status.read_and_reset()
     }
 
     pub fn get_requested_deadline_missed_status(&mut self) -> RequestedDeadlineMissedStatus {
@@ -566,22 +562,6 @@ impl DdsDataReader {
         }
 
         incompatible_qos_policy_list
-    }
-
-    pub fn get_key_value<Foo>(
-        &self,
-        _key_holder: &mut Foo,
-        _handle: InstanceHandle,
-    ) -> DdsResult<()> {
-        if !self.enabled {
-            return Err(DdsError::NotEnabled);
-        }
-
-        todo!()
-    }
-
-    pub fn lookup_instance<Foo>(&self, _instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
-        todo!()
     }
 
     pub fn on_gap_submessage_received(
@@ -904,10 +884,6 @@ impl DdsDataReader {
                 },
             },
         }
-    }
-
-    pub fn guid(&self) -> Guid {
-        self.rtps_reader.guid()
     }
 
     fn convert_received_data_to_cache_change(

--- a/dds/src/implementation/dds/dds_data_reader.rs
+++ b/dds/src/implementation/dds/dds_data_reader.rs
@@ -628,7 +628,7 @@ impl DdsDataReader {
                 StatusKind::SampleLost,
             ))
             .await?;
-        match self.listener.as_ref().map(|a| a.address()).cloned() {
+        match self.listener.as_ref().map(|a| a.address()) {
             Some(l) if self.status_kind.contains(&StatusKind::SampleLost) => {
                 let reader = DataReaderNode::new(
                     data_reader_address.clone(),
@@ -699,7 +699,7 @@ impl DdsDataReader {
             ))
             .await?;
         const SUBSCRIPTION_MATCHED_STATUS_KIND: &StatusKind = &StatusKind::SubscriptionMatched;
-        match self.listener.as_ref().map(|a| a.address()).cloned() {
+        match self.listener.as_ref().map(|a| a.address()) {
             Some(l) if self.status_kind.contains(SUBSCRIPTION_MATCHED_STATUS_KIND) => {
                 let reader = DataReaderNode::new(
                     data_reader_address,
@@ -776,7 +776,7 @@ impl DdsDataReader {
                 StatusKind::SampleRejected,
             ))
             .await?;
-        match self.listener.as_ref().map(|a| a.address()).cloned() {
+        match self.listener.as_ref().map(|a| a.address()) {
             Some(l) if self.status_kind.contains(&StatusKind::SampleRejected) => {
                 let status = self.get_sample_rejected_status();
                 let reader = DataReaderNode::new(
@@ -848,7 +848,7 @@ impl DdsDataReader {
             ))
             .await?;
 
-        match self.listener.as_ref().map(|a| a.address()).cloned() {
+        match self.listener.as_ref().map(|a| a.address()) {
             Some(l)
                 if self
                     .status_kind
@@ -1948,7 +1948,7 @@ impl DdsDataReader {
                     StatusKind::RequestedDeadlineMissed,
                 ))
                 .await?;
-            match self.listener.as_ref().map(|a| a.address()).cloned() {
+            match self.listener.as_ref().map(|a| a.address()) {
                 Some(l)
                     if self
                         .status_kind

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -64,10 +64,7 @@ use crate::{
         },
         time::DurationKind,
     },
-    topic_definition::type_support::{
-        dds_serialize_key, dds_set_key_fields_from_serialized_key, DdsSerializedKey,
-        DdsSetKeyFields,
-    },
+    topic_definition::type_support::{dds_serialize_key, DdsSerializedKey},
     {
         builtin_topics::SubscriptionBuiltinTopicData,
         infrastructure::{
@@ -254,29 +251,6 @@ impl DdsDataWriter {
             qos,
             registered_instance_list: HashMap::new(),
         }
-    }
-
-    pub fn get_key_value<Foo>(&self, key_holder: &mut Foo, handle: InstanceHandle) -> DdsResult<()>
-    where
-        Foo: DdsSetKeyFields,
-    {
-        if !self.enabled {
-            return Err(DdsError::NotEnabled);
-        }
-
-        let serialized_key = self
-            .registered_instance_list
-            .get(&handle)
-            .ok_or(DdsError::BadParameter)?;
-        dds_set_key_fields_from_serialized_key(key_holder, serialized_key.as_ref())
-    }
-
-    pub fn reader_locator_list(&mut self) -> &[RtpsReaderLocator] {
-        &self.reader_locators
-    }
-
-    pub fn matched_reader_list(&mut self) -> &[RtpsReaderProxy] {
-        &self.matched_readers
     }
 
     fn add_change(&mut self, change: RtpsWriterCacheChange) {
@@ -557,14 +531,13 @@ impl DdsDataWriter {
         )
     }
 
-    async fn get_publication_matched_status(&mut self) -> DdsResult<PublicationMatchedStatus> {
+    async fn get_publication_matched_status(&mut self) -> PublicationMatchedStatus {
         self.status_condition
-            .address()
             .send_mail_and_await_reply(dds_status_condition::remove_communication_state::new(
                 StatusKind::PublicationMatched,
             ))
-            .await?;
-        Ok(self.matched_subscriptions.get_publication_matched_status())
+            .await;
+        self.matched_subscriptions.get_publication_matched_status()
     }
 
     async fn matched_reader_add(&mut self, a_reader_proxy: RtpsReaderProxy) {
@@ -627,7 +600,7 @@ impl DdsDataWriter {
         offered_incompatible_qos_participant_listener: Option<
             ActorAddress<DdsDomainParticipantListener>,
         >,
-    ) -> DdsResult<()> {
+    ) {
         let is_matched_topic_name = discovered_reader_data
             .subscription_builtin_topic_data()
             .topic_name()
@@ -739,7 +712,7 @@ impl DdsDataWriter {
                         publisher_publication_matched_listener,
                         participant_publication_matched_listener,
                     )
-                    .await?;
+                    .await;
                 }
             } else {
                 self.incompatible_subscriptions
@@ -751,10 +724,9 @@ impl DdsDataWriter {
                     offered_incompatible_qos_publisher_listener,
                     offered_incompatible_qos_participant_listener,
                 )
-                .await?;
+                .await;
             }
         }
-        Ok(())
     }
 
     async fn remove_matched_reader(
@@ -767,7 +739,7 @@ impl DdsDataWriter {
         participant_publication_matched_listener: Option<
             ActorAddress<DdsDomainParticipantListener>,
         >,
-    ) -> DdsResult<()> {
+    ) {
         if let Some(r) = self
             .get_matched_subscription_data(discovered_reader_handle)
             .await
@@ -783,9 +755,8 @@ impl DdsDataWriter {
                 publisher_publication_matched_listener,
                 participant_publication_matched_listener,
             )
-            .await?;
+            .await;
         }
-        Ok(())
     }
 
     async fn process_rtps_message(&mut self, message: RtpsMessageRead) {
@@ -1018,38 +989,39 @@ impl DdsDataWriter {
         participant_publication_matched_listener: Option<
             ActorAddress<DdsDomainParticipantListener>,
         >,
-    ) -> DdsResult<()> {
+    ) {
         self.status_condition
-            .address()
             .send_mail_and_await_reply(dds_status_condition::add_communication_state::new(
                 StatusKind::PublicationMatched,
             ))
-            .await?;
+            .await;
         if self.listener.is_some() && self.status_kind.contains(&StatusKind::PublicationMatched) {
-            let listener_address = self.listener.as_ref().unwrap().address().clone();
             let writer =
                 DataWriterNode::new(data_writer_address, publisher_address, participant_address);
-            let status = self.get_publication_matched_status().await?;
-            listener_address
+            let status = self.get_publication_matched_status().await;
+            self.listener
+                .as_ref()
+                .unwrap()
                 .send_mail(
                     dds_data_writer_listener::trigger_on_publication_matched::new(writer, status),
                 )
-                .await?
+                .await;
         } else if let Some(publisher_publication_matched_listener) =
             publisher_publication_matched_listener
         {
-            let status = self.get_publication_matched_status().await?;
+            let status = self.get_publication_matched_status().await;
             let writer =
                 DataWriterNode::new(data_writer_address, publisher_address, participant_address);
             publisher_publication_matched_listener
                 .send_mail(dds_publisher_listener::trigger_on_publication_matched::new(
                     writer, status,
                 ))
-                .await?;
+                .await
+                .expect("Listener should exist");
         } else if let Some(participant_publication_matched_listener) =
             participant_publication_matched_listener
         {
-            let status = self.get_publication_matched_status().await?;
+            let status = self.get_publication_matched_status().await;
             let writer =
                 DataWriterNode::new(data_writer_address, publisher_address, participant_address);
             participant_publication_matched_listener
@@ -1058,9 +1030,9 @@ impl DdsDataWriter {
                         writer, status,
                     ),
                 )
-                .await?;
+                .await
+                .expect("Listener should exist");
         }
-        Ok(())
     }
 
     async fn on_offered_incompatible_qos(
@@ -1072,29 +1044,30 @@ impl DdsDataWriter {
         offered_incompatible_qos_participant_listener: Option<
             ActorAddress<DdsDomainParticipantListener>,
         >,
-    ) -> DdsResult<()> {
+    ) {
         self.status_condition
-            .address()
             .send_mail_and_await_reply(dds_status_condition::add_communication_state::new(
                 StatusKind::OfferedIncompatibleQos,
             ))
-            .await?;
+            .await;
         if self.listener.is_some()
             && self
                 .status_kind
                 .contains(&StatusKind::OfferedIncompatibleQos)
         {
             let status = self.get_offered_incompatible_qos_status().await;
-            let listener_address = self.listener.as_ref().unwrap().address();
+
             let writer =
                 DataWriterNode::new(data_writer_address, publisher_address, participant_address);
-            listener_address
+            self.listener
+                .as_ref()
+                .unwrap()
                 .send_mail(
                     dds_data_writer_listener::trigger_on_offered_incompatible_qos::new(
                         writer, status,
                     ),
                 )
-                .await?;
+                .await;
         } else if let Some(offered_incompatible_qos_publisher_listener) =
             offered_incompatible_qos_publisher_listener
         {
@@ -1107,7 +1080,8 @@ impl DdsDataWriter {
                         writer, status,
                     ),
                 )
-                .await?;
+                .await
+                .expect("Listener should exist");
         } else if let Some(offered_incompatible_qos_participant_listener) =
             offered_incompatible_qos_participant_listener
         {
@@ -1120,9 +1094,9 @@ impl DdsDataWriter {
                         writer, status,
                     ),
                 )
-                .await?;
+                .await
+                .expect("Listener should exist");
         }
-        Ok(())
     }
 }
 

--- a/dds/src/implementation/dds/dds_data_writer.rs
+++ b/dds/src/implementation/dds/dds_data_writer.rs
@@ -327,7 +327,7 @@ impl DdsDataWriter {
     }
 
     async fn get_statuscondition(&self) -> ActorAddress<DdsStatusCondition> {
-        self.status_condition.address().clone()
+        self.status_condition.address()
     }
 
     async fn guid(&self) -> Guid {

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -494,7 +494,7 @@ impl DdsDomainParticipant {
         let publisher = DdsPublisher::new(publisher_qos, rtps_group, listener, status_kind);
 
         let publisher_actor = spawn_actor(publisher);
-        let publisher_address = publisher_actor.address().clone();
+        let publisher_address = publisher_actor.address();
         self.user_defined_publisher_list
             .insert(guid.into(), publisher_actor);
 
@@ -521,7 +521,7 @@ impl DdsDomainParticipant {
         let subscriber = DdsSubscriber::new(subscriber_qos, rtps_group, listener, status_kind);
 
         let subscriber_actor = spawn_actor(subscriber);
-        let subscriber_address = subscriber_actor.address().clone();
+        let subscriber_address = subscriber_actor.address();
 
         self.user_defined_subscriber_list
             .insert(guid.into(), subscriber_actor);
@@ -548,7 +548,7 @@ impl DdsDomainParticipant {
         let topic = DdsTopic::new(guid, qos, type_name, &topic_name);
 
         let topic_actor: crate::implementation::utils::actor::Actor<DdsTopic> = spawn_actor(topic);
-        let topic_address = topic_actor.address().clone();
+        let topic_address = topic_actor.address();
         self.topic_list.insert(guid.into(), topic_actor);
 
         topic_address
@@ -742,7 +742,7 @@ impl DdsDomainParticipant {
     async fn get_user_defined_topic_list(&self) -> Vec<ActorAddress<DdsTopic>> {
         self.topic_list
             .values()
-            .map(|a| a.address().clone())
+            .map(|a| a.address())
             .collect()
     }
 
@@ -774,11 +774,11 @@ impl DdsDomainParticipant {
     }
 
     async fn get_built_in_subscriber(&self) -> ActorAddress<DdsSubscriber> {
-        self.builtin_subscriber.address().clone()
+        self.builtin_subscriber.address()
     }
 
     async fn get_upd_transport_write(&self) -> ActorAddress<UdpTransportWrite> {
-        self.udp_transport_write.address().clone()
+        self.udp_transport_write.address()
     }
 
     async fn get_guid(&self) -> Guid {
@@ -788,14 +788,14 @@ impl DdsDomainParticipant {
     async fn get_user_defined_publisher_list(&self) -> Vec<ActorAddress<DdsPublisher>> {
         self.user_defined_publisher_list
             .values()
-            .map(|a| a.address().clone())
+            .map(|a| a.address())
             .collect()
     }
 
     async fn get_user_defined_subscriber_list(&self) -> Vec<ActorAddress<DdsSubscriber>> {
         self.user_defined_subscriber_list
             .values()
-            .map(|a| a.address().clone())
+            .map(|a| a.address())
             .collect()
     }
 
@@ -835,7 +835,7 @@ impl DdsDomainParticipant {
     }
 
     async fn get_listener(&self) -> Option<ActorAddress<DdsDomainParticipantListener>> {
-        self.listener.as_ref().map(|l| l.address().clone())
+        self.listener.as_ref().map(|l| l.address())
     }
 
     async fn get_status_kind(&self) -> Vec<StatusKind> {
@@ -851,7 +851,7 @@ impl DdsDomainParticipant {
     }
 
     async fn get_builtin_publisher(&self) -> ActorAddress<DdsPublisher> {
-        self.builtin_publisher.address().clone()
+        self.builtin_publisher.address()
     }
 
     async fn send_message(&self) {

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -1015,13 +1015,13 @@ impl DdsDomainParticipant {
         }
     }
 
-    async fn process_builtin_discovery(&self) {
+    async fn process_builtin_discovery(&mut self) {
         self.process_spdp_participant_discovery().await;
     }
 }
 
 impl DdsDomainParticipant {
-    async fn process_spdp_participant_discovery(&self) {
+    async fn process_spdp_participant_discovery(&mut self) {
         if let Some(spdp_participant_reader) = self
             .builtin_subscriber
             .send_mail_and_await_reply(dds_subscriber::lookup_datareader::new(
@@ -1059,7 +1059,7 @@ impl DdsDomainParticipant {
     }
 
     async fn process_discovered_participant_data(
-        &self,
+        &mut self,
         discovered_participant_data: SpdpDiscoveredParticipantData,
     ) {
         // Check that the domainId of the discovered participant equals the local one.
@@ -1077,7 +1077,7 @@ impl DdsDomainParticipant {
             .unwrap_or(self.domain_id)
             == self.domain_id;
         let is_domain_tag_matching =
-            discovered_participant_data.participant_proxy().domain_tag() == &self.domain_tag;
+            discovered_participant_data.participant_proxy().domain_tag() == self.domain_tag;
         let discovered_participant_handle = InstanceHandle::new(
             discovered_participant_data
                 .dds_participant_data()
@@ -1100,6 +1100,16 @@ impl DdsDomainParticipant {
                 .await;
             self.add_matched_topics_announcer(&discovered_participant_data)
                 .await;
+
+            self.discovered_participant_list.insert(
+                InstanceHandle::new(
+                    discovered_participant_data
+                        .dds_participant_data()
+                        .key()
+                        .value,
+                ),
+                discovered_participant_data,
+            );
         }
     }
 

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -915,6 +915,13 @@ impl DdsDomainParticipant {
                 .expect("Should not fail to send command");
         }
     }
+
+    async fn announce_creater_or_modified_data_writer(
+        &self,
+        discovered_writer_data: DiscoveredWriterData,
+    ) {
+        todo!()
+    }
 }
 
 fn create_builtin_stateful_writer(guid: Guid) -> RtpsWriter {

--- a/dds/src/implementation/dds/dds_domain_participant_factory.rs
+++ b/dds/src/implementation/dds/dds_domain_participant_factory.rs
@@ -49,7 +49,7 @@ impl DdsDomainParticipantFactory {
     async fn get_participant_list(&self) -> Vec<ActorAddress<DdsDomainParticipant>> {
         self.domain_participant_list
             .values()
-            .map(|dp| dp.address().clone())
+            .map(|dp| dp.address())
             .collect()
     }
 

--- a/dds/src/implementation/dds/dds_publisher.rs
+++ b/dds/src/implementation/dds/dds_publisher.rs
@@ -128,7 +128,7 @@ impl DdsPublisher {
             qos,
         );
         let data_writer_actor = spawn_actor(data_writer);
-        let data_writer_address = data_writer_actor.address().clone();
+        let data_writer_address = data_writer_actor.address();
         self.data_writer_list.insert(guid.into(), data_writer_actor);
 
         Ok(data_writer_address)
@@ -217,7 +217,7 @@ impl DdsPublisher {
     }
 
     async fn get_listener(&self) -> Option<ActorAddress<DdsPublisherListener>> {
-        self.listener.as_ref().map(|l| l.address().clone())
+        self.listener.as_ref().map(|l| l.address())
     }
 
     async fn get_qos(&self) -> PublisherQos {
@@ -227,7 +227,7 @@ impl DdsPublisher {
     async fn data_writer_list(&self) -> Vec<ActorAddress<DdsDataWriter>> {
         self.data_writer_list
             .values()
-            .map(|x| x.address().clone())
+            .map(|x| x.address())
             .collect()
     }
 

--- a/dds/src/implementation/dds/dds_publisher.rs
+++ b/dds/src/implementation/dds/dds_publisher.rs
@@ -257,6 +257,7 @@ impl DdsPublisher {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn add_matched_reader(
         &self,
         discovered_reader_data: DiscoveredReaderData,

--- a/dds/src/implementation/dds/dds_publisher.rs
+++ b/dds/src/implementation/dds/dds_publisher.rs
@@ -240,15 +240,14 @@ impl DdsPublisher {
         udp_transport_write: ActorAddress<UdpTransportWrite>,
         now: Time,
     ) {
-        for data_writer_address in self.data_writer_list.values().map(|a| a.address()) {
+        for data_writer_address in self.data_writer_list.values() {
             data_writer_address
                 .send_mail(dds_data_writer::send_message::new(
                     header,
                     udp_transport_write.clone(),
                     now,
                 ))
-                .await
-                .expect("Should not fail to send command");
+                .await;
         }
     }
 }

--- a/dds/src/implementation/dds/dds_publisher.rs
+++ b/dds/src/implementation/dds/dds_publisher.rs
@@ -128,6 +128,19 @@ impl DdsPublisher {
         Ok(data_writer_address)
     }
 
+    async fn lookup_datawriter(&self, topic_name: String) -> Option<ActorAddress<DdsDataWriter>> {
+        for (_, dw) in &self.data_writer_list {
+            if dw
+                .send_mail_and_await_reply(dds_data_writer::get_topic_name::new())
+                .await
+                == topic_name
+            {
+                return Some(dw.address());
+            }
+        }
+        None
+    }
+
     async fn enable(&mut self) {
         self.enabled = true;
     }

--- a/dds/src/implementation/dds/dds_publisher.rs
+++ b/dds/src/implementation/dds/dds_publisher.rs
@@ -129,7 +129,7 @@ impl DdsPublisher {
     }
 
     async fn lookup_datawriter(&self, topic_name: String) -> Option<ActorAddress<DdsDataWriter>> {
-        for (_, dw) in &self.data_writer_list {
+        for dw in self.data_writer_list.values() {
             if dw
                 .send_mail_and_await_reply(dds_data_writer::get_topic_name::new())
                 .await

--- a/dds/src/implementation/dds/dds_subscriber.rs
+++ b/dds/src/implementation/dds/dds_subscriber.rs
@@ -153,7 +153,7 @@ impl DdsSubscriber {
     }
 
     async fn get_statuscondition(&self) -> ActorAddress<DdsStatusCondition> {
-        self.status_condition.address().clone()
+        self.status_condition.address()
     }
 
     async fn get_qos(&self) -> SubscriberQos {
@@ -163,12 +163,12 @@ impl DdsSubscriber {
     async fn data_reader_list(&self) -> Vec<ActorAddress<DdsDataReader>> {
         self.data_reader_list
             .values()
-            .map(|dr| dr.address().clone())
+            .map(|dr| dr.address())
             .collect()
     }
 
     async fn get_listener(&self) -> Option<ActorAddress<DdsSubscriberListener>> {
-        self.listener.as_ref().map(|l| l.address().clone())
+        self.listener.as_ref().map(|l| l.address())
     }
 
     async fn get_status_kind(&self) -> Vec<StatusKind> {

--- a/dds/src/implementation/dds/dds_subscriber.rs
+++ b/dds/src/implementation/dds/dds_subscriber.rs
@@ -164,14 +164,13 @@ impl DdsSubscriber {
         header: RtpsMessageHeader,
         udp_transport_write: ActorAddress<UdpTransportWrite>,
     ) {
-        for data_reader_address in self.data_reader_list.values().map(|a| a.address()) {
+        for data_reader_address in self.data_reader_list.values() {
             data_reader_address
                 .send_mail(dds_data_reader::send_message::new(
                     header,
                     udp_transport_write.clone(),
                 ))
-                .await
-                .expect("Should not fail to send command");
+                .await;
         }
     }
 

--- a/dds/src/implementation/dds/dds_subscriber.rs
+++ b/dds/src/implementation/dds/dds_subscriber.rs
@@ -187,7 +187,7 @@ impl DdsSubscriber {
         ),
     ) -> DdsResult<()> {
         let subscriber_mask_listener = (
-            self.listener.as_ref().map(|a| a.address()).cloned(),
+            self.listener.as_ref().map(|a| a.address()),
             self.status_kind.clone(),
         );
 

--- a/dds/src/implementation/dds/dds_subscriber.rs
+++ b/dds/src/implementation/dds/dds_subscriber.rs
@@ -66,6 +66,18 @@ impl DdsSubscriber {
 
 #[actor_interface]
 impl DdsSubscriber {
+    async fn lookup_datareader(&self, topic_name: String) -> Option<ActorAddress<DdsDataReader>> {
+        for dr in self.data_reader_list.values() {
+            if dr
+                .send_mail_and_await_reply(dds_data_reader::get_topic_name::new())
+                .await
+                == topic_name
+            {
+                return Some(dr.address());
+            }
+        }
+        None
+    }
     async fn delete_contained_entities(&mut self) {}
 
     async fn guid(&self) -> Guid {

--- a/dds/src/implementation/dds/dds_topic.rs
+++ b/dds/src/implementation/dds/dds_topic.rs
@@ -127,10 +127,7 @@ impl DdsTopic {
         Ok(status)
     }
 
-    async fn process_discovered_topic(
-        &mut self,
-        discovered_topic_data: DiscoveredTopicData,
-    ) -> DdsResult<()> {
+    async fn process_discovered_topic(&mut self, discovered_topic_data: DiscoveredTopicData) {
         if discovered_topic_data
             .topic_builtin_topic_data()
             .get_type_name()
@@ -140,13 +137,11 @@ impl DdsTopic {
         {
             self.inconsistent_topic_status.increment();
             self.status_condition
-                .address()
                 .send_mail_and_await_reply(dds_status_condition::add_communication_state::new(
                     StatusKind::InconsistentTopic,
                 ))
-                .await?;
+                .await;
         }
-        Ok(())
     }
 }
 

--- a/dds/src/implementation/dds/dds_topic.rs
+++ b/dds/src/implementation/dds/dds_topic.rs
@@ -90,7 +90,7 @@ impl DdsTopic {
     }
 
     async fn get_statuscondition(&self) -> ActorAddress<DdsStatusCondition> {
-        self.status_condition.address().clone()
+        self.status_condition.address()
     }
 
     async fn as_discovered_topic_data(&self) -> DiscoveredTopicData {

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -214,6 +214,7 @@ pub enum RtpsSubmessageReadKind<'a> {
     Pad(PadSubmessageRead<'a>),
 }
 
+#[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq)]
 pub enum RtpsSubmessageWriteKind<'a> {
     AckNack(AckNackSubmessageWrite<'a>),
@@ -267,7 +268,7 @@ impl RtpsMessageHeader {
         }
     }
 
-    pub fn protocol(&self) -> ProtocolId {
+    pub fn _protocol(&self) -> ProtocolId {
         self.protocol
     }
 

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -19,6 +19,7 @@ use std::{
 /// 8.3.5 RTPS SubmessageElements
 ///
 
+#[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq)]
 pub enum SubmessageElement<'a> {
     Count(Count),

--- a/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
+++ b/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
@@ -25,7 +25,7 @@ impl<'a> AckNackSubmessageRead<'a> {
         Self { data }
     }
 
-    pub fn final_flag(&self) -> bool {
+    pub fn _final_flag(&self) -> bool {
         self.submessage_header().flags()[1]
     }
 
@@ -33,7 +33,7 @@ impl<'a> AckNackSubmessageRead<'a> {
         self.map(&self.data[4..])
     }
 
-    pub fn writer_id(&self) -> EntityId {
+    pub fn _writer_id(&self) -> EntityId {
         self.map(&self.data[8..])
     }
 
@@ -133,16 +133,14 @@ mod tests {
         ]);
 
         let expected_final_flag = false;
-        let expected_reader_id =
-            EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
-        let expected_writer_id =
-            EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);
+        let expected_reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
+        let expected_writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);
         let expected_reader_sn_state = SequenceNumberSet::new(SequenceNumber::from(10), vec![]);
         let expected_count = 2;
 
-        assert_eq!(expected_final_flag, submessage.final_flag());
+        assert_eq!(expected_final_flag, submessage._final_flag());
         assert_eq!(expected_reader_id, submessage.reader_id());
-        assert_eq!(expected_writer_id, submessage.writer_id());
+        assert_eq!(expected_writer_id, submessage._writer_id());
         assert_eq!(expected_reader_sn_state, submessage.reader_sn_state());
         assert_eq!(expected_count, submessage.count());
     }

--- a/dds/src/implementation/rtps/messages/submessages/data.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data.rs
@@ -64,7 +64,7 @@ impl DataSubmessageRead {
         self.submessage_header().flags()[1]
     }
 
-    pub fn data_flag(&self) -> bool {
+    pub fn _data_flag(&self) -> bool {
         self.submessage_header().flags()[2]
     }
 
@@ -72,7 +72,7 @@ impl DataSubmessageRead {
         self.submessage_header().flags()[3]
     }
 
-    pub fn non_standard_payload_flag(&self) -> bool {
+    pub fn _non_standard_payload_flag(&self) -> bool {
         self.submessage_header().flags()[4]
     }
 
@@ -347,11 +347,11 @@ mod tests {
         ].into());
 
         assert_eq!(inline_qos_flag, data_submessage.inline_qos_flag());
-        assert_eq!(data_flag, data_submessage.data_flag());
+        assert_eq!(data_flag, data_submessage._data_flag());
         assert_eq!(key_flag, data_submessage.key_flag());
         assert_eq!(
             non_standard_payload_flag,
-            data_submessage.non_standard_payload_flag()
+            data_submessage._non_standard_payload_flag()
         );
         assert_eq!(reader_id, data_submessage.reader_id());
         assert_eq!(writer_id, data_submessage.writer_id());

--- a/dds/src/implementation/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data_frag.rs
@@ -55,7 +55,7 @@ impl DataFragSubmessageRead {
         }
     }
 
-    pub fn endianness_flag(&self) -> bool {
+    pub fn _endianness_flag(&self) -> bool {
         (self.data[1] & 0b_0000_0001) != 0
     }
 
@@ -67,7 +67,7 @@ impl DataFragSubmessageRead {
         (self.data[1] & 0b_0000_0100) != 0
     }
 
-    pub fn non_standard_payload_flag(&self) -> bool {
+    pub fn _non_standard_payload_flag(&self) -> bool {
         (self.data[1] & 0b_0000_1000) != 0
     }
 
@@ -314,7 +314,7 @@ mod tests {
         assert_eq!(expected_inline_qos_flag, submessage.inline_qos_flag());
         assert_eq!(
             expected_non_standard_payload_flag,
-            submessage.non_standard_payload_flag()
+            submessage._non_standard_payload_flag()
         );
         assert_eq!(expected_key_flag, submessage.key_flag());
         assert_eq!(expected_reader_id, submessage.reader_id());
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(expected_inline_qos_flag, submessage.inline_qos_flag());
         assert_eq!(
             expected_non_standard_payload_flag,
-            submessage.non_standard_payload_flag()
+            submessage._non_standard_payload_flag()
         );
         assert_eq!(expected_key_flag, submessage.key_flag());
         assert_eq!(expected_reader_id, submessage.reader_id());

--- a/dds/src/implementation/rtps/messages/submessages/gap.rs
+++ b/dds/src/implementation/rtps/messages/submessages/gap.rs
@@ -25,7 +25,7 @@ impl<'a> GapSubmessageRead<'a> {
         Self { data }
     }
 
-    pub fn reader_id(&self) -> EntityId {
+    pub fn _reader_id(&self) -> EntityId {
         self.map(&self.data[4..])
     }
 
@@ -121,7 +121,7 @@ mod tests {
            10, 0, 0, 0, // gapList: SequenceNumberSet: bitmapBase: low
             0, 0, 0, 0, // gapList: SequenceNumberSet: numBits (ULong)
         ]);
-        assert_eq!(expected_reader_id, submessage.reader_id());
+        assert_eq!(expected_reader_id, submessage._reader_id());
         assert_eq!(expected_writer_id, submessage.writer_id());
         assert_eq!(expected_gap_start, submessage.gap_start());
         assert_eq!(expected_gap_list, submessage.gap_list());

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
@@ -33,7 +33,7 @@ impl<'a> HeartbeatSubmessageRead<'a> {
         self.submessage_header().flags()[2]
     }
 
-    pub fn reader_id(&self) -> EntityId {
+    pub fn _reader_id(&self) -> EntityId {
         self.map(&self.data[4..])
     }
 
@@ -160,7 +160,7 @@ mod tests {
         ]);
         assert_eq!(expected_final_flag, submessage.final_flag());
         assert_eq!(expected_liveliness_flag, submessage.liveliness_flag());
-        assert_eq!(expected_reader_id, submessage.reader_id());
+        assert_eq!(expected_reader_id, submessage._reader_id());
         assert_eq!(expected_writer_id, submessage.writer_id());
         assert_eq!(expected_first_sn, submessage.first_sn());
         assert_eq!(expected_last_sn, submessage.last_sn());

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
@@ -25,7 +25,7 @@ impl<'a> HeartbeatFragSubmessageRead<'a> {
         Self { data }
     }
 
-    pub fn reader_id(&self) -> EntityId {
+    pub fn _reader_id(&self) -> EntityId {
         self.map(&self.data[4..])
     }
 
@@ -33,11 +33,11 @@ impl<'a> HeartbeatFragSubmessageRead<'a> {
         self.map(&self.data[8..])
     }
 
-    pub fn writer_sn(&self) -> SequenceNumber {
+    pub fn _writer_sn(&self) -> SequenceNumber {
         self.map(&self.data[12..])
     }
 
-    pub fn last_fragment_num(&self) -> FragmentNumber {
+    pub fn _last_fragment_num(&self) -> FragmentNumber {
         self.map(&self.data[20..])
     }
 
@@ -51,7 +51,7 @@ pub struct HeartbeatFragSubmessageWrite<'a> {
     submessage_elements: [SubmessageElement<'a>; 5],
 }
 impl HeartbeatFragSubmessageWrite<'_> {
-    pub fn new(
+    pub fn _new(
         reader_id: EntityId,
         writer_id: EntityId,
         writer_sn: SequenceNumber,
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn serialize_heart_beat() {
-        let submessage = HeartbeatFragSubmessageWrite::new(
+        let submessage = HeartbeatFragSubmessageWrite::_new(
             EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
             EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
             SequenceNumber::from(5),
@@ -132,10 +132,10 @@ mod tests {
         let expected_last_fragment_num = 7;
         let expected_count = 2;
 
-        assert_eq!(expected_reader_id, submessage.reader_id());
+        assert_eq!(expected_reader_id, submessage._reader_id());
         assert_eq!(expected_writer_id, submessage.writer_id());
-        assert_eq!(expected_writer_sn, submessage.writer_sn());
-        assert_eq!(expected_last_fragment_num, submessage.last_fragment_num());
+        assert_eq!(expected_writer_sn, submessage._writer_sn());
+        assert_eq!(expected_last_fragment_num, submessage._last_fragment_num());
         assert_eq!(expected_count, submessage.count());
     }
 }

--- a/dds/src/implementation/rtps/messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_reply.rs
@@ -22,16 +22,16 @@ impl<'a> InfoReplySubmessageRead<'a> {
         Self { data }
     }
 
-    pub fn multicast_flag(&self) -> bool {
+    pub fn _multicast_flag(&self) -> bool {
         self.submessage_header().flags()[1]
     }
 
-    pub fn unicast_locator_list(&self) -> LocatorList {
+    pub fn _unicast_locator_list(&self) -> LocatorList {
         self.map(&self.data[4..])
     }
 
-    pub fn multicast_locator_list(&self) -> LocatorList {
-        if self.multicast_flag() {
+    pub fn _multicast_locator_list(&self) -> LocatorList {
+        if self._multicast_flag() {
             let num_locators: u32 = self.map(&self.data[4..]);
             let octets_to_multicat_loctor_list = num_locators as usize * 24 + 8;
             self.map(&self.data[octets_to_multicat_loctor_list..])
@@ -48,7 +48,7 @@ pub struct InfoReplySubmessageWrite<'a> {
 }
 
 impl<'a> InfoReplySubmessageWrite<'a> {
-    pub fn new(
+    pub fn _new(
         multicast_flag: SubmessageFlag,
         unicast_locator_list: LocatorList,
         multicast_locator_list: LocatorList,
@@ -84,7 +84,7 @@ mod tests {
     #[test]
     fn serialize_info_reply() {
         let locator = Locator::new(11, 12, [1; 16]);
-        let submessage = InfoReplySubmessageWrite::new(
+        let submessage = InfoReplySubmessageWrite::_new(
             false,
             LocatorList::new(vec![locator]),
             LocatorList::new(vec![]),
@@ -121,14 +121,14 @@ mod tests {
         let expected_unicast_locator_list = LocatorList::new(vec![locator]);
         let expected_multicast_locator_list = LocatorList::new(vec![]);
 
-        assert_eq!(expected_multicast_flag, submessage.multicast_flag());
+        assert_eq!(expected_multicast_flag, submessage._multicast_flag());
         assert_eq!(
             expected_unicast_locator_list,
-            submessage.unicast_locator_list()
+            submessage._unicast_locator_list()
         );
         assert_eq!(
             expected_multicast_locator_list,
-            submessage.multicast_locator_list()
+            submessage._multicast_locator_list()
         );
     }
 
@@ -157,14 +157,14 @@ mod tests {
         let expected_unicast_locator_list = LocatorList::new(vec![]);
         let expected_multicast_locator_list = LocatorList::new(vec![locator, locator]);
 
-        assert_eq!(expected_multicast_flag, submessage.multicast_flag());
+        assert_eq!(expected_multicast_flag, submessage._multicast_flag());
         assert_eq!(
             expected_unicast_locator_list,
-            submessage.unicast_locator_list()
+            submessage._unicast_locator_list()
         );
         assert_eq!(
             expected_multicast_locator_list,
-            submessage.multicast_locator_list()
+            submessage._multicast_locator_list()
         );
     }
 }

--- a/dds/src/implementation/rtps/messages/submessages/info_source.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_source.rs
@@ -44,7 +44,7 @@ pub struct InfoSourceSubmessageWrite<'a> {
 }
 
 impl InfoSourceSubmessageWrite<'_> {
-    pub fn new(
+    pub fn _new(
         protocol_version: ProtocolVersion,
         vendor_id: VendorId,
         guid_prefix: GuidPrefix,
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn serialize_info_source() {
-        let submessage = InfoSourceSubmessageWrite::new(
+        let submessage = InfoSourceSubmessageWrite::_new(
             PROTOCOLVERSION_1_0,
             VENDOR_ID_UNKNOWN,
             GUIDPREFIX_UNKNOWN,

--- a/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
@@ -29,7 +29,7 @@ impl<'a> NackFragSubmessageRead<'a> {
         self.map(&self.data[4..])
     }
 
-    pub fn writer_id(&self) -> EntityId {
+    pub fn _writer_id(&self) -> EntityId {
         self.map(&self.data[8..])
     }
 
@@ -37,7 +37,7 @@ impl<'a> NackFragSubmessageRead<'a> {
         self.map(&self.data[12..])
     }
 
-    pub fn fragment_number_state(&self) -> FragmentNumberSet {
+    pub fn _fragment_number_state(&self) -> FragmentNumberSet {
         self.map(&self.data[20..])
     }
 
@@ -133,11 +133,11 @@ mod tests {
         let expected_count = 6;
 
         assert_eq!(expected_reader_id, submessage.reader_id());
-        assert_eq!(expected_writer_id, submessage.writer_id());
+        assert_eq!(expected_writer_id, submessage._writer_id());
         assert_eq!(expected_writer_sn, submessage.writer_sn());
         assert_eq!(
             expected_fragment_number_state,
-            submessage.fragment_number_state()
+            submessage._fragment_number_state()
         );
         assert_eq!(expected_count, submessage.count());
     }

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -1,5 +1,4 @@
 use super::{
-    writer_history_cache::WriterHistoryCache,
     messages::{
         overall_structure::RtpsSubmessageWriteKind,
         submessages::{
@@ -9,6 +8,7 @@ use super::{
     },
     types::{EntityId, Guid, Locator, ReliabilityKind, SequenceNumber},
     utils::clock::{StdTimer, Timer, TimerConstructor},
+    writer_history_cache::WriterHistoryCache,
 };
 use crate::infrastructure::time::Duration;
 
@@ -64,14 +64,14 @@ impl HeartbeatFragMachine {
             reader_id,
         }
     }
-    pub fn submessage<'a>(
+    pub fn _submessage<'a>(
         &mut self,
         writer_id: EntityId,
         writer_sn: SequenceNumber,
         last_fragment_num: FragmentNumber,
     ) -> RtpsSubmessageWriteKind<'a> {
         self.count = self.count.wrapping_add(1);
-        RtpsSubmessageWriteKind::HeartbeatFrag(HeartbeatFragSubmessageWrite::new(
+        RtpsSubmessageWriteKind::HeartbeatFrag(HeartbeatFragSubmessageWrite::_new(
             self.reader_id,
             writer_id,
             writer_sn,
@@ -149,7 +149,7 @@ impl RtpsReaderProxy {
         &mut self.heartbeat_machine
     }
 
-    pub fn heartbeat_frag_machine(&mut self) -> &mut HeartbeatFragMachine {
+    pub fn _heartbeat_frag_machine(&mut self) -> &mut HeartbeatFragMachine {
         &mut self.heartbeat_frag_machine
     }
 
@@ -241,7 +241,7 @@ impl RtpsReaderProxy {
         self.first_relevant_sample_seq_num
     }
 
-    pub fn set_first_relevant_sample_seq_num(&mut self, seq_num: SequenceNumber) {
+    pub fn _set_first_relevant_sample_seq_num(&mut self, seq_num: SequenceNumber) {
         self.first_relevant_sample_seq_num = seq_num;
     }
 

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -398,10 +398,10 @@ impl ProtocolVersion {
     pub const fn new(major: Octet, minor: Octet) -> Self {
         Self { major, minor }
     }
-    pub const fn major(&self) -> Octet {
+    pub const fn _major(&self) -> Octet {
         self.major
     }
-    pub const fn minor(&self) -> Octet {
+    pub const fn _minor(&self) -> Octet {
         self.minor
     }
 }

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -12,7 +12,7 @@ use super::{
 
 pub struct RtpsWriter {
     endpoint: RtpsEndpoint,
-    push_mode: bool,
+    _push_mode: bool,
     heartbeat_period: Duration,
     _nack_response_delay: Duration,
     _nack_suppression_duration: Duration,
@@ -31,7 +31,7 @@ impl RtpsWriter {
     ) -> Self {
         Self {
             endpoint,
-            push_mode,
+            _push_mode: push_mode,
             heartbeat_period,
             _nack_response_delay: nack_response_delay,
             _nack_suppression_duration: nack_suppression_duration,
@@ -52,8 +52,8 @@ impl RtpsWriter {
         self.endpoint.multicast_locator_list()
     }
 
-    pub fn push_mode(&self) -> bool {
-        self.push_mode
+    pub fn _push_mode(&self) -> bool {
+        self._push_mode
     }
 
     pub fn heartbeat_period(&self) -> Duration {

--- a/dds/src/implementation/rtps/writer_history_cache.rs
+++ b/dds/src/implementation/rtps/writer_history_cache.rs
@@ -220,7 +220,7 @@ impl WriterHistoryCache {
         }
     }
 
-    pub fn get_seq_num_min(&self) -> Option<SequenceNumber> {
+    pub fn _get_seq_num_min(&self) -> Option<SequenceNumber> {
         self.changes
             .values()
             .flatten()
@@ -228,7 +228,7 @@ impl WriterHistoryCache {
             .min()
     }
 
-    pub fn get_seq_num_max(&self) -> Option<SequenceNumber> {
+    pub fn _get_seq_num_max(&self) -> Option<SequenceNumber> {
         self.changes
             .values()
             .flatten()
@@ -301,7 +301,7 @@ mod tests {
                 kind: HistoryQosPolicyKind::KeepAll,
             },
         );
-        assert_eq!(hc.get_seq_num_min(), Some(SequenceNumber::from(1)));
+        assert_eq!(hc._get_seq_num_min(), Some(SequenceNumber::from(1)));
     }
 
     #[test]
@@ -337,6 +337,6 @@ mod tests {
                 kind: HistoryQosPolicyKind::KeepAll,
             },
         );
-        assert_eq!(hc.get_seq_num_max(), Some(SequenceNumber::from(2)));
+        assert_eq!(hc._get_seq_num_max(), Some(SequenceNumber::from(2)));
     }
 }

--- a/dds/src/implementation/utils/actor.rs
+++ b/dds/src/implementation/utils/actor.rs
@@ -250,12 +250,26 @@ impl<A> Actor<A> {
             .await
             .map_err(|_| ())
             .expect(
-                "Received is guaranteed to exist while actor object is alive. Sending must succeed",
+                "Receiver is guaranteed to exist while actor object is alive. Sending must succeed",
             );
 
         response_receiver
             .await
             .expect("Message is always processed as long as actor object exists")
+    }
+
+    pub async fn send_mail<M>(&self, mail: M)
+    where
+        A: MailHandler<M> + Send,
+        M: Mail + Send + 'static,
+    {
+        self.sender
+            .send(Box::new(CommandMail::new(mail)))
+            .await
+            .map_err(|_| ())
+            .expect(
+                "Receiver is guaranteed to exist while actor object is alive. Sending must succeed",
+            );
     }
 }
 


### PR DESCRIPTION
As a first step to fix #176 this PR refactors the steps of the discovery by moving the different parts into the class where the different responsibilities are handled. In brief, the DomainParticipant is now responsible for checking whether discovered readers and writers are ignored or not; the publisher/subscriber checks for the partition match; and the data reader/writer checks whether the discovered entities are matches and compatible. Originally all this was done in methods in the top level participant factory.

Bringing the code into the inner modules resulted in some unused functions now being reported as warnings. I prepended an _ to the unused RTPS methods instead of deleting since they are standard defined. The enums with unused variants are marked to allow dead code.