### PR TITLE
186 remove sync bound

### DIFF
--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -78,7 +78,7 @@ impl DomainParticipant {
     pub fn create_publisher(
         &self,
         qos: QosKind<PublisherQos>,
-        a_listener: Option<Box<dyn PublisherListener + Send + Sync>>,
+        a_listener: Option<Box<dyn PublisherListener + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<Publisher> {
         let publisher_address =
@@ -166,7 +166,7 @@ impl DomainParticipant {
     pub fn create_subscriber(
         &self,
         qos: QosKind<SubscriberQos>,
-        a_listener: Option<Box<dyn SubscriberListener + Send + Sync>>,
+        a_listener: Option<Box<dyn SubscriberListener + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<Subscriber> {
         let subscriber_address =
@@ -260,7 +260,7 @@ impl DomainParticipant {
         topic_name: &str,
         type_name: &str,
         qos: QosKind<TopicQos>,
-        a_listener: Option<Box<dyn TopicListener + Send + Sync>>,
+        a_listener: Option<Box<dyn TopicListener + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<Topic> {
         let topic_address = self
@@ -929,7 +929,7 @@ impl DomainParticipant {
     #[tracing::instrument(skip(self, _a_listener), fields(with_listener = _a_listener.is_some()))]
     pub fn set_listener(
         &self,
-        _a_listener: Option<Box<dyn DomainParticipantListener + Send + Sync>>,
+        _a_listener: Option<Box<dyn DomainParticipantListener + Send>>,
         _mask: &[StatusKind],
     ) -> DdsResult<()> {
         todo!()

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -69,7 +69,7 @@ impl DomainParticipantFactory {
         &self,
         domain_id: DomainId,
         qos: QosKind<DomainParticipantQos>,
-        a_listener: Option<Box<dyn DomainParticipantListener + Send + Sync>>,
+        a_listener: Option<Box<dyn DomainParticipantListener + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<DomainParticipant> {
         let domain_participant_qos = match qos {

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -566,7 +566,7 @@ where
     #[tracing::instrument(skip(self, _a_listener), fields(with_listener = _a_listener.is_some()))]
     pub fn set_listener(
         &self,
-        _a_listener: Option<Box<dyn DataWriterListener<Foo> + Send + Sync>>,
+        _a_listener: Option<Box<dyn DataWriterListener<Foo> + Send>>,
         _mask: &[StatusKind],
     ) -> DdsResult<()> {
         todo!()

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -77,7 +77,7 @@ impl Publisher {
         &self,
         a_topic: &Topic,
         qos: QosKind<DataWriterQos>,
-        a_listener: Option<Box<dyn DataWriterListener<Foo> + Send + Sync>>,
+        a_listener: Option<Box<dyn DataWriterListener<Foo> + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<DataWriter<Foo>>
     where
@@ -411,7 +411,7 @@ impl Publisher {
     #[tracing::instrument(skip(self, _a_listener), fields(with_listener=_a_listener.is_some()))]
     pub fn set_listener(
         &self,
-        _a_listener: Option<Box<dyn PublisherListener + Send + Sync>>,
+        _a_listener: Option<Box<dyn PublisherListener + Send>>,
         _mask: &[StatusKind],
     ) -> DdsResult<()> {
         todo!()

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -711,7 +711,7 @@ impl<Foo> DataReader<Foo> {
 
 impl<Foo> DataReader<Foo>
 where
-    Foo: DdsHasKey + for<'de> serde::Deserialize<'de> + 'static + Send + Sync,
+    Foo: DdsHasKey + for<'de> serde::Deserialize<'de> + 'static + Send,
 {
     /// This operation installs a Listener on the Entity. The listener will only be invoked on the changes of communication status
     /// indicated by the specified mask. It is permitted to use [`None`] as the value of the listener. The [`None`] listener behaves
@@ -722,7 +722,7 @@ where
     #[tracing::instrument(skip(self, _a_listener), fields(with_listener = _a_listener.is_some()))]
     pub fn set_listener(
         &self,
-        _a_listener: Option<Box<dyn DataReaderListener<Foo> + Send + Sync>>,
+        _a_listener: Option<Box<dyn DataReaderListener<Foo> + Send>>,
         _mask: &[StatusKind],
     ) -> DdsResult<()> {
         todo!()

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -93,7 +93,7 @@ impl Subscriber {
         &self,
         a_topic: &Topic,
         qos: QosKind<DataReaderQos>,
-        a_listener: Option<Box<dyn DataReaderListener<Foo> + Send + Sync>>,
+        a_listener: Option<Box<dyn DataReaderListener<Foo> + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<DataReader<Foo>>
     where
@@ -411,7 +411,7 @@ impl Subscriber {
     #[tracing::instrument(skip(self, _a_listener), fields(with_listener = _a_listener.is_some()))]
     pub fn set_listener(
         &self,
-        _a_listener: Option<Box<dyn SubscriberListener + Send + Sync>>,
+        _a_listener: Option<Box<dyn SubscriberListener + Send>>,
         _mask: &[StatusKind],
     ) -> DdsResult<()> {
         todo!()

--- a/dds/src/dds/topic_definition/topic.rs
+++ b/dds/src/dds/topic_definition/topic.rs
@@ -230,7 +230,7 @@ impl Topic {
     #[tracing::instrument(skip(self, _a_listener), fields(with_listener = _a_listener.is_some()))]
     pub fn set_listener(
         &self,
-        _a_listener: Option<Box<dyn TopicListener + Send + Sync>>,
+        _a_listener: Option<Box<dyn TopicListener + Send>>,
         _mask: &[StatusKind],
     ) -> DdsResult<()> {
         todo!()

--- a/dds/src/implementation/dds/any_data_reader_listener.rs
+++ b/dds/src/implementation/dds/any_data_reader_listener.rs
@@ -34,7 +34,7 @@ pub trait AnyDataReaderListener {
     fn trigger_on_sample_lost(&mut self, reader: DataReaderNode, status: SampleLostStatus);
 }
 
-impl<Foo> AnyDataReaderListener for Box<dyn DataReaderListener<Foo> + Send + Sync> {
+impl<Foo> AnyDataReaderListener for Box<dyn DataReaderListener<Foo> + Send> {
     fn trigger_on_data_available(&mut self, reader: DataReaderNode) {
         self.on_data_available(&DataReader::new(reader))
     }

--- a/dds/src/implementation/dds/any_data_writer_listener.rs
+++ b/dds/src/implementation/dds/any_data_writer_listener.rs
@@ -31,7 +31,7 @@ pub trait AnyDataWriterListener {
     );
 }
 
-impl<Foo> AnyDataWriterListener for Box<dyn DataWriterListener<Foo> + Send + Sync> {
+impl<Foo> AnyDataWriterListener for Box<dyn DataWriterListener<Foo> + Send> {
     fn trigger_on_liveliness_lost(
         &mut self,
         the_writer: DataWriterNode,

--- a/dds/src/implementation/dds/dds_domain_participant.rs
+++ b/dds/src/implementation/dds/dds_domain_participant.rs
@@ -479,7 +479,7 @@ impl DdsDomainParticipant {
     async fn create_publisher(
         &mut self,
         qos: QosKind<PublisherQos>,
-        a_listener: Option<Box<dyn PublisherListener + Send + Sync>>,
+        a_listener: Option<Box<dyn PublisherListener + Send>>,
         mask: Vec<StatusKind>,
     ) -> ActorAddress<DdsPublisher> {
         let publisher_qos = match qos {
@@ -505,7 +505,7 @@ impl DdsDomainParticipant {
     async fn create_subscriber(
         &mut self,
         qos: QosKind<SubscriberQos>,
-        a_listener: Option<Box<dyn SubscriberListener + Send + Sync>>,
+        a_listener: Option<Box<dyn SubscriberListener + Send>>,
         mask: Vec<StatusKind>,
     ) -> ActorAddress<DdsSubscriber> {
         let subscriber_qos = match qos {
@@ -535,7 +535,7 @@ impl DdsDomainParticipant {
         topic_name: String,
         type_name: String,
         qos: QosKind<TopicQos>,
-        _a_listener: Option<Box<dyn TopicListener + Send + Sync>>,
+        _a_listener: Option<Box<dyn TopicListener + Send>>,
         _mask: Vec<StatusKind>,
     ) -> ActorAddress<DdsTopic> {
         let qos = match qos {

--- a/dds/tests/listeners.rs
+++ b/dds/tests/listeners.rs
@@ -28,7 +28,7 @@ use dust_dds::{
         subscriber::Subscriber,
         subscriber_listener::SubscriberListener,
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::{topic_listener::TopicListener, type_support::DdsType},
 };
 
 mod utils;
@@ -1903,4 +1903,72 @@ fn data_writer_offered_incompatible_qos_listener() {
         .unwrap();
     assert_eq!(status.total_count, 1);
     assert_eq!(status.total_count_change, 1);
+}
+
+#[test]
+fn non_sync_listener_should_be_accepted() {
+    struct NonSyncListener(std::cell::Cell<()>);
+
+    impl NonSyncListener {
+        fn new() -> Self {
+            Self(std::cell::Cell::new(()))
+        }
+    }
+
+    impl DomainParticipantListener for NonSyncListener {}
+    impl PublisherListener for NonSyncListener {}
+    impl SubscriberListener for NonSyncListener {}
+    impl TopicListener for NonSyncListener {}
+    impl<Foo> DataWriterListener<Foo> for NonSyncListener {}
+    impl<Foo> DataReaderListener<Foo> for NonSyncListener {}
+
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let participant_factory = DomainParticipantFactory::get_instance();
+    let participant = participant_factory
+        .create_participant(
+            domain_id,
+            QosKind::Default,
+            Some(Box::new(NonSyncListener::new())),
+            NO_STATUS,
+        )
+        .unwrap();
+    let topic = participant
+        .create_topic(
+            "NonSync",
+            "MyData",
+            QosKind::Default,
+            Some(Box::new(NonSyncListener::new())),
+            NO_STATUS,
+        )
+        .unwrap();
+    let subscriber = participant
+        .create_subscriber(
+            QosKind::Default,
+            Some(Box::new(NonSyncListener::new())),
+            NO_STATUS,
+        )
+        .unwrap();
+    let _data_reader = subscriber
+        .create_datareader::<MyData>(
+            &topic,
+            QosKind::Default,
+            Some(Box::new(NonSyncListener::new())),
+            NO_STATUS,
+        )
+        .unwrap();
+    let publisher = participant
+        .create_publisher(
+            QosKind::Default,
+            Some(Box::new(NonSyncListener::new())),
+            NO_STATUS,
+        )
+        .unwrap();
+    let _data_writer = publisher
+        .create_datawriter::<MyData>(
+            &topic,
+            QosKind::Default,
+            Some(Box::new(NonSyncListener::new())),
+            NO_STATUS,
+        )
+        .unwrap();
 }

--- a/dds/tests/listeners.rs
+++ b/dds/tests/listeners.rs
@@ -1907,6 +1907,7 @@ fn data_writer_offered_incompatible_qos_listener() {
 
 #[test]
 fn non_sync_listener_should_be_accepted() {
+    // Use Cell to create a type which is Send but not Sync
     struct NonSyncListener(std::cell::Cell<()>);
 
     impl NonSyncListener {
@@ -1971,4 +1972,6 @@ fn non_sync_listener_should_be_accepted() {
             NO_STATUS,
         )
         .unwrap();
+
+    // This test doesn't assert. If trait bounds are not correct compilation will fail.
 }


### PR DESCRIPTION
This PR removes the Sync trait bound which is a leftover from a previous DustDDS architecture implementation is not anymore necessary.