### PR TITLE
DDS-361 Replace Serializer/Deserializer concrete types by traits

### DIFF
--- a/dds/src/cdr/deserialize.rs
+++ b/dds/src/cdr/deserialize.rs
@@ -1,85 +1,88 @@
 pub use dust_dds_derive::CdrDeserialize;
 
-use super::{deserializer::CdrDeserializer, error::CdrResult};
+use super::{
+    deserializer::{CdrDeserializer, ClassicCdrDeserializer},
+    error::CdrResult,
+};
 
 pub trait CdrDeserialize<'de>: Sized {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self>;
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self>;
 }
 
 impl<'de> CdrDeserialize<'de> for bool {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_bool()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for i8 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_i8()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for i16 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_i16()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for i32 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_i32()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for i64 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_i64()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for u8 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_u8()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for u16 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_u16()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for u32 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_u32()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for u64 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_u64()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for f32 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_f32()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for f64 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_f64()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for char {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_char()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for String {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_string()
     }
 }
@@ -88,7 +91,7 @@ impl<'de, const N: usize, T> CdrDeserialize<'de> for [T; N]
 where
     T: CdrDeserialize<'de>,
 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_array()
     }
 }
@@ -97,25 +100,25 @@ impl<'de, T> CdrDeserialize<'de> for Vec<T>
 where
     T: CdrDeserialize<'de>,
 {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_seq()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for &'de [u8] {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_bytes()
     }
 }
 
 impl<'de, const N: usize> CdrDeserialize<'de> for &'de [u8; N] {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_byte_array()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for () {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_unit()
     }
 }

--- a/dds/src/cdr/deserialize.rs
+++ b/dds/src/cdr/deserialize.rs
@@ -1,88 +1,85 @@
 pub use dust_dds_derive::CdrDeserialize;
 
-use super::{
-    deserializer::{CdrDeserializer, ClassicCdrDeserializer},
-    error::CdrResult,
-};
+use super::{deserializer::CdrDeserializer, error::CdrResult};
 
 pub trait CdrDeserialize<'de>: Sized {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self>;
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self>;
 }
 
 impl<'de> CdrDeserialize<'de> for bool {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_bool()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for i8 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_i8()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for i16 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_i16()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for i32 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_i32()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for i64 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_i64()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for u8 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_u8()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for u16 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_u16()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for u32 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_u32()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for u64 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_u64()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for f32 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_f32()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for f64 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_f64()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for char {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_char()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for String {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_string()
     }
 }
@@ -91,7 +88,7 @@ impl<'de, const N: usize, T> CdrDeserialize<'de> for [T; N]
 where
     T: CdrDeserialize<'de>,
 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_array()
     }
 }
@@ -100,25 +97,25 @@ impl<'de, T> CdrDeserialize<'de> for Vec<T>
 where
     T: CdrDeserialize<'de>,
 {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_seq()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for &'de [u8] {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_bytes()
     }
 }
 
 impl<'de, const N: usize> CdrDeserialize<'de> for &'de [u8; N] {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_byte_array()
     }
 }
 
 impl<'de> CdrDeserialize<'de> for () {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         deserializer.deserialize_unit()
     }
 }

--- a/dds/src/cdr/deserializer.rs
+++ b/dds/src/cdr/deserializer.rs
@@ -7,13 +7,55 @@ use crate::cdr::{deserialize::CdrDeserialize, error::CdrResult};
 
 use super::endianness::CdrEndianness;
 
-pub struct CdrDeserializer<'de> {
+pub trait CdrDeserializer<'de> {
+    fn deserialize_bool(&mut self) -> CdrResult<bool>;
+
+    fn deserialize_i8(&mut self) -> CdrResult<i8>;
+
+    fn deserialize_i16(&mut self) -> CdrResult<i16>;
+
+    fn deserialize_i32(&mut self) -> CdrResult<i32>;
+
+    fn deserialize_i64(&mut self) -> CdrResult<i64>;
+
+    fn deserialize_u8(&mut self) -> CdrResult<u8>;
+
+    fn deserialize_u16(&mut self) -> CdrResult<u16>;
+
+    fn deserialize_u32(&mut self) -> CdrResult<u32>;
+
+    fn deserialize_u64(&mut self) -> CdrResult<u64>;
+
+    fn deserialize_f32(&mut self) -> CdrResult<f32>;
+
+    fn deserialize_f64(&mut self) -> CdrResult<f64>;
+
+    fn deserialize_char(&mut self) -> CdrResult<char>;
+
+    fn deserialize_string(&mut self) -> CdrResult<String>;
+
+    fn deserialize_seq<T>(&mut self) -> CdrResult<Vec<T>>
+    where
+        T: CdrDeserialize<'de>;
+
+    fn deserialize_array<const N: usize, T>(&mut self) -> CdrResult<[T; N]>
+    where
+        T: CdrDeserialize<'de>;
+
+    fn deserialize_bytes(&mut self) -> CdrResult<&'de [u8]>;
+
+    fn deserialize_byte_array<const N: usize>(&mut self) -> CdrResult<&'de [u8; N]>;
+
+    fn deserialize_unit(&mut self) -> CdrResult<()>;
+}
+
+pub struct ClassicCdrDeserializer<'de> {
     bytes: &'de [u8],
     reader: &'de [u8],
     endianness: CdrEndianness,
 }
 
-impl<'de> CdrDeserializer<'de> {
+impl<'de> ClassicCdrDeserializer<'de> {
     pub fn new(reader: &'de [u8], endianness: CdrEndianness) -> Self {
         Self {
             bytes: reader,
@@ -42,8 +84,8 @@ impl<'de> CdrDeserializer<'de> {
     }
 }
 
-impl<'de> CdrDeserializer<'de> {
-    pub fn deserialize_bool(&mut self) -> CdrResult<bool> {
+impl<'de> CdrDeserializer<'de> for ClassicCdrDeserializer<'de> {
+    fn deserialize_bool(&mut self) -> CdrResult<bool> {
         let value: u8 = CdrDeserialize::deserialize(self)?;
         match value {
             0 => Ok(false),
@@ -55,7 +97,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_i8(&mut self) -> CdrResult<i8> {
+    fn deserialize_i8(&mut self) -> CdrResult<i8> {
         self.read_padding_of::<i8>()?;
         let mut bytes = [0; 1];
         self.reader.read_exact(&mut bytes)?;
@@ -65,7 +107,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_i16(&mut self) -> CdrResult<i16> {
+    fn deserialize_i16(&mut self) -> CdrResult<i16> {
         self.read_padding_of::<i16>()?;
         let mut bytes = [0; 2];
         self.reader.read_exact(&mut bytes)?;
@@ -75,7 +117,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_i32(&mut self) -> CdrResult<i32> {
+    fn deserialize_i32(&mut self) -> CdrResult<i32> {
         self.read_padding_of::<i32>()?;
         let mut bytes = [0; 4];
         self.reader.read_exact(&mut bytes)?;
@@ -85,7 +127,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_i64(&mut self) -> CdrResult<i64> {
+    fn deserialize_i64(&mut self) -> CdrResult<i64> {
         self.read_padding_of::<i64>()?;
         let mut bytes = [0; 8];
         self.reader.read_exact(&mut bytes)?;
@@ -95,7 +137,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_u8(&mut self) -> CdrResult<u8> {
+    fn deserialize_u8(&mut self) -> CdrResult<u8> {
         self.read_padding_of::<u8>()?;
         let mut bytes = [0; 1];
         self.reader.read_exact(&mut bytes)?;
@@ -105,7 +147,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_u16(&mut self) -> CdrResult<u16> {
+    fn deserialize_u16(&mut self) -> CdrResult<u16> {
         self.read_padding_of::<u16>()?;
         let mut bytes = [0; 2];
         self.reader.read_exact(&mut bytes)?;
@@ -115,7 +157,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_u32(&mut self) -> CdrResult<u32> {
+    fn deserialize_u32(&mut self) -> CdrResult<u32> {
         self.read_padding_of::<u32>()?;
         let mut bytes = [0; 4];
         self.reader.read_exact(&mut bytes)?;
@@ -125,7 +167,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_u64(&mut self) -> CdrResult<u64> {
+    fn deserialize_u64(&mut self) -> CdrResult<u64> {
         self.read_padding_of::<u64>()?;
         let mut bytes = [0; 8];
         self.reader.read_exact(&mut bytes)?;
@@ -135,7 +177,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_f32(&mut self) -> CdrResult<f32> {
+    fn deserialize_f32(&mut self) -> CdrResult<f32> {
         self.read_padding_of::<f32>()?;
         let mut bytes = [0; 4];
         self.reader.read_exact(&mut bytes)?;
@@ -145,7 +187,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_f64(&mut self) -> CdrResult<f64> {
+    fn deserialize_f64(&mut self) -> CdrResult<f64> {
         self.read_padding_of::<f64>()?;
         let mut bytes = [0; 8];
         self.reader.read_exact(&mut bytes)?;
@@ -155,7 +197,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_char(&mut self) -> CdrResult<char> {
+    fn deserialize_char(&mut self) -> CdrResult<char> {
         let value: u8 = CdrDeserialize::deserialize(self)?;
         // CDR only accepts ascii characters.
         // The encoding length must be 1 which in UTF-8 is represented by a 0 on the MSB
@@ -169,7 +211,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_string(&mut self) -> CdrResult<String> {
+    fn deserialize_string(&mut self) -> CdrResult<String> {
         let len: u32 = CdrDeserialize::deserialize(self)?;
         let mut buf = vec![0_u8; len as usize];
         self.reader.read_exact(&mut buf)?;
@@ -182,7 +224,7 @@ impl<'de> CdrDeserializer<'de> {
         })
     }
 
-    pub fn deserialize_seq<T>(&mut self) -> CdrResult<Vec<T>>
+    fn deserialize_seq<T>(&mut self) -> CdrResult<Vec<T>>
     where
         T: CdrDeserialize<'de>,
     {
@@ -194,7 +236,7 @@ impl<'de> CdrDeserializer<'de> {
         Ok(seq)
     }
 
-    pub fn deserialize_array<const N: usize, T>(&mut self) -> CdrResult<[T; N]>
+    fn deserialize_array<const N: usize, T>(&mut self) -> CdrResult<[T; N]>
     where
         T: CdrDeserialize<'de>,
     {
@@ -208,7 +250,7 @@ impl<'de> CdrDeserializer<'de> {
             .expect("Must convert due to for loop succeeding"))
     }
 
-    pub fn deserialize_bytes(&mut self) -> CdrResult<&'de [u8]> {
+    fn deserialize_bytes(&mut self) -> CdrResult<&'de [u8]> {
         let len: u32 = CdrDeserialize::deserialize(&mut *self)?;
         let start_pos = self.bytes.len() - self.reader.len();
         let end_pos = start_pos + len as usize;
@@ -224,7 +266,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_byte_array<const N: usize>(&mut self) -> CdrResult<&'de [u8; N]> {
+    fn deserialize_byte_array<const N: usize>(&mut self) -> CdrResult<&'de [u8; N]> {
         let start_pos = self.bytes.len() - self.reader.len();
         let end_pos = start_pos + N;
         if self.bytes.len() >= end_pos {
@@ -241,7 +283,7 @@ impl<'de> CdrDeserializer<'de> {
         }
     }
 
-    pub fn deserialize_unit(&mut self) -> CdrResult<()> {
+    fn deserialize_unit(&mut self) -> CdrResult<()> {
         Ok(())
     }
 }
@@ -254,7 +296,7 @@ mod tests {
     where
         T: CdrDeserialize<'de> + ?Sized,
     {
-        let mut deserializer = CdrDeserializer::new(bytes, CdrEndianness::BigEndian);
+        let mut deserializer = ClassicCdrDeserializer::new(bytes, CdrEndianness::BigEndian);
         Ok(T::deserialize(&mut deserializer)?)
     }
 
@@ -262,7 +304,7 @@ mod tests {
     where
         T: CdrDeserialize<'de> + ?Sized,
     {
-        let mut deserializer = CdrDeserializer::new(bytes, CdrEndianness::LittleEndian);
+        let mut deserializer = ClassicCdrDeserializer::new(bytes, CdrEndianness::LittleEndian);
         Ok(T::deserialize(&mut deserializer)?)
     }
 

--- a/dds/src/cdr/parameter_list_deserialize.rs
+++ b/dds/src/cdr/parameter_list_deserialize.rs
@@ -1,9 +1,9 @@
-use super::parameter_list_deserializer::ParameterListDeserializer;
+use super::parameter_list_deserializer::ParameterListCdrDeserializer;
 
 pub use dust_dds_derive::ParameterListDeserialize;
 
 pub trait ParameterListDeserialize<'de>: Sized {
     fn deserialize(
-        pl_deserializer: &mut ParameterListDeserializer<'de>,
+        pl_deserializer: &mut ParameterListCdrDeserializer<'de>,
     ) -> Result<Self, std::io::Error>;
 }

--- a/dds/src/cdr/parameter_list_deserialize.rs
+++ b/dds/src/cdr/parameter_list_deserialize.rs
@@ -1,9 +1,9 @@
-use super::parameter_list_deserializer::ParameterListCdrDeserializer;
+use super::parameter_list_deserializer::ParameterListDeserializer;
 
 pub use dust_dds_derive::ParameterListDeserialize;
 
 pub trait ParameterListDeserialize<'de>: Sized {
     fn deserialize(
-        pl_deserializer: &mut ParameterListCdrDeserializer<'de>,
+        pl_deserializer: &mut impl ParameterListDeserializer<'de>,
     ) -> Result<Self, std::io::Error>;
 }

--- a/dds/src/cdr/parameter_list_deserializer.rs
+++ b/dds/src/cdr/parameter_list_deserializer.rs
@@ -1,7 +1,7 @@
 use std::io::{BufRead, Read};
 
 use crate::{
-    cdr::{deserialize::CdrDeserialize, deserializer::CdrDeserializer, endianness::CdrEndianness},
+    cdr::{deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, endianness::CdrEndianness},
     implementation::data_representation_builtin_endpoints::parameter_id_values::PID_SENTINEL,
 };
 
@@ -78,7 +78,7 @@ impl<'de> ParameterListDeserializer<'de> {
         let mut parameter_iterator = ParameterIterator::new(&mut bytes, self.endianness);
         while let Some(p) = parameter_iterator.next()? {
             if p.id() == id {
-                return T::deserialize(&mut CdrDeserializer::new(p.data(), self.endianness));
+                return T::deserialize(&mut ClassicCdrDeserializer::new(p.data(), self.endianness));
             }
         }
 
@@ -96,7 +96,7 @@ impl<'de> ParameterListDeserializer<'de> {
         let mut parameter_iterator = ParameterIterator::new(&mut bytes, self.endianness);
         while let Some(p) = parameter_iterator.next()? {
             if p.id() == id {
-                return T::deserialize(&mut CdrDeserializer::new(p.data(), self.endianness));
+                return T::deserialize(&mut ClassicCdrDeserializer::new(p.data(), self.endianness));
             }
         }
 
@@ -112,7 +112,7 @@ impl<'de> ParameterListDeserializer<'de> {
         let mut parameter_iterator = ParameterIterator::new(&mut bytes, self.endianness);
         while let Some(p) = parameter_iterator.next()? {
             if p.id() == id {
-                parameter_values.push(T::deserialize(&mut CdrDeserializer::new(
+                parameter_values.push(T::deserialize(&mut ClassicCdrDeserializer::new(
                     p.data(),
                     self.endianness,
                 ))?);

--- a/dds/src/cdr/parameter_list_deserializer.rs
+++ b/dds/src/cdr/parameter_list_deserializer.rs
@@ -1,9 +1,26 @@
 use std::io::{BufRead, Read};
 
 use crate::{
-    cdr::{deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, endianness::CdrEndianness},
+    cdr::{
+        deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer,
+        endianness::CdrEndianness,
+    },
     implementation::data_representation_builtin_endpoints::parameter_id_values::PID_SENTINEL,
 };
+
+pub trait ParameterListDeserializer<'de> {
+    fn read<T>(&self, id: i16) -> Result<T, std::io::Error>
+    where
+        T: CdrDeserialize<'de>;
+
+    fn read_with_default<T>(&self, id: i16, default: T) -> Result<T, std::io::Error>
+    where
+        T: CdrDeserialize<'de>;
+
+    fn read_collection<T>(&self, id: i16) -> Result<Vec<T>, std::io::Error>
+    where
+        T: CdrDeserialize<'de>;
+}
 
 struct Parameter<'de> {
     id: i16,
@@ -60,12 +77,12 @@ impl<'a, 'de> ParameterIterator<'a, 'de> {
     }
 }
 
-pub struct ParameterListDeserializer<'de> {
+pub struct ParameterListCdrDeserializer<'de> {
     bytes: &'de [u8],
     endianness: CdrEndianness,
 }
 
-impl<'de> ParameterListDeserializer<'de> {
+impl<'de> ParameterListCdrDeserializer<'de> {
     pub fn new(bytes: &'de [u8], endianness: CdrEndianness) -> Self {
         Self { bytes, endianness }
     }
@@ -103,7 +120,7 @@ impl<'de> ParameterListDeserializer<'de> {
         Ok(default)
     }
 
-    pub fn read_all<T>(&self, id: i16) -> Result<Vec<T>, std::io::Error>
+    pub fn read_collection<T>(&self, id: i16) -> Result<Vec<T>, std::io::Error>
     where
         T: CdrDeserialize<'de>,
     {
@@ -133,7 +150,7 @@ mod tests {
     where
         T: ParameterListDeserialize<'de>,
     {
-        let mut pl_deserializer = ParameterListDeserializer::new(data, CdrEndianness::BigEndian);
+        let mut pl_deserializer = ParameterListCdrDeserializer::new(data, CdrEndianness::BigEndian);
         ParameterListDeserialize::deserialize(&mut pl_deserializer)
     }
 
@@ -141,7 +158,8 @@ mod tests {
     where
         T: ParameterListDeserialize<'de>,
     {
-        let mut pl_deserializer = ParameterListDeserializer::new(data, CdrEndianness::LittleEndian);
+        let mut pl_deserializer =
+            ParameterListCdrDeserializer::new(data, CdrEndianness::LittleEndian);
         ParameterListDeserialize::deserialize(&mut pl_deserializer)
     }
 
@@ -154,7 +172,7 @@ mod tests {
 
         impl<'de> ParameterListDeserialize<'de> for OneParamData {
             fn deserialize(
-                pl_deserializer: &mut ParameterListDeserializer<'de>,
+                pl_deserializer: &mut ParameterListCdrDeserializer<'de>,
             ) -> Result<Self, std::io::Error> {
                 let value = pl_deserializer.read(71)?;
                 Ok(Self { value })

--- a/dds/src/cdr/parameter_list_deserializer.rs
+++ b/dds/src/cdr/parameter_list_deserializer.rs
@@ -86,8 +86,10 @@ impl<'de> ParameterListCdrDeserializer<'de> {
     pub fn new(bytes: &'de [u8], endianness: CdrEndianness) -> Self {
         Self { bytes, endianness }
     }
+}
 
-    pub fn read<T>(&self, id: i16) -> Result<T, std::io::Error>
+impl<'de> ParameterListDeserializer<'de> for ParameterListCdrDeserializer<'de> {
+    fn read<T>(&self, id: i16) -> Result<T, std::io::Error>
     where
         T: CdrDeserialize<'de>,
     {
@@ -105,7 +107,7 @@ impl<'de> ParameterListCdrDeserializer<'de> {
         ))
     }
 
-    pub fn read_with_default<T>(&self, id: i16, default: T) -> Result<T, std::io::Error>
+    fn read_with_default<T>(&self, id: i16, default: T) -> Result<T, std::io::Error>
     where
         T: CdrDeserialize<'de>,
     {
@@ -120,7 +122,7 @@ impl<'de> ParameterListCdrDeserializer<'de> {
         Ok(default)
     }
 
-    pub fn read_collection<T>(&self, id: i16) -> Result<Vec<T>, std::io::Error>
+    fn read_collection<T>(&self, id: i16) -> Result<Vec<T>, std::io::Error>
     where
         T: CdrDeserialize<'de>,
     {
@@ -172,7 +174,7 @@ mod tests {
 
         impl<'de> ParameterListDeserialize<'de> for OneParamData {
             fn deserialize(
-                pl_deserializer: &mut ParameterListCdrDeserializer<'de>,
+                pl_deserializer: &mut impl ParameterListDeserializer<'de>,
             ) -> Result<Self, std::io::Error> {
                 let value = pl_deserializer.read(71)?;
                 Ok(Self { value })

--- a/dds/src/cdr/parameter_list_serialize.rs
+++ b/dds/src/cdr/parameter_list_serialize.rs
@@ -1,7 +1,10 @@
-use super::parameter_list_serializer::ParameterListCdrSerializer;
+use super::parameter_list_serializer::ParameterListSerializer;
 
 pub use dust_dds_derive::ParameterListSerialize;
 
 pub trait ParameterListSerialize {
-    fn serialize(&self, serializer: &mut ParameterListCdrSerializer) -> Result<(), std::io::Error>;
+    fn serialize(
+        &self,
+        serializer: &mut impl ParameterListSerializer,
+    ) -> Result<(), std::io::Error>;
 }

--- a/dds/src/cdr/parameter_list_serialize.rs
+++ b/dds/src/cdr/parameter_list_serialize.rs
@@ -1,7 +1,7 @@
-use super::parameter_list_serializer::ParameterListSerializer;
+use super::parameter_list_serializer::ParameterListCdrSerializer;
 
 pub use dust_dds_derive::ParameterListSerialize;
 
 pub trait ParameterListSerialize {
-    fn serialize(&self, serializer: &mut ParameterListSerializer) -> Result<(), std::io::Error>;
+    fn serialize(&self, serializer: &mut ParameterListCdrSerializer) -> Result<(), std::io::Error>;
 }

--- a/dds/src/cdr/parameter_list_serializer.rs
+++ b/dds/src/cdr/parameter_list_serializer.rs
@@ -6,18 +6,18 @@ pub use dust_dds_derive::ParameterListDeserialize;
 
 use super::serializer::CdrSerializer;
 
-pub struct ParameterListSerializer<'s> {
+pub struct ParameterListCdrSerializer<'s> {
     writer: &'s mut Vec<u8>,
     endianness: CdrEndianness,
 }
 
-impl<'s> ParameterListSerializer<'s> {
+impl<'s> ParameterListCdrSerializer<'s> {
     pub fn new(writer: &'s mut Vec<u8>, endianness: CdrEndianness) -> Self {
         Self { writer, endianness }
     }
 }
 
-impl ParameterListSerializer<'_> {
+impl ParameterListCdrSerializer<'_> {
     pub fn write<T>(&mut self, id: i16, value: &T) -> Result<(), std::io::Error>
     where
         T: CdrSerialize,
@@ -90,7 +90,7 @@ mod tests {
         T: ParameterListSerialize,
     {
         let mut writer = Vec::new();
-        let mut serializer = ParameterListSerializer::new(&mut writer, CdrEndianness::LittleEndian);
+        let mut serializer = ParameterListCdrSerializer::new(&mut writer, CdrEndianness::LittleEndian);
         v.serialize(&mut serializer)?;
         Ok(writer)
     }
@@ -100,7 +100,7 @@ mod tests {
         T: ParameterListSerialize,
     {
         let mut writer = Vec::new();
-        let mut serializer = ParameterListSerializer::new(&mut writer, CdrEndianness::BigEndian);
+        let mut serializer = ParameterListCdrSerializer::new(&mut writer, CdrEndianness::BigEndian);
         v.serialize(&mut serializer)?;
         Ok(writer)
     }
@@ -116,7 +116,7 @@ mod tests {
         impl ParameterListSerialize for ParameterListWithoutDefaults {
             fn serialize(
                 &self,
-                serializer: &mut ParameterListSerializer,
+                serializer: &mut ParameterListCdrSerializer,
             ) -> Result<(), std::io::Error> {
                 serializer.write(1, &self.a)?;
                 serializer.write(2, &self.b)?;

--- a/dds/src/cdr/parameter_list_serializer.rs
+++ b/dds/src/cdr/parameter_list_serializer.rs
@@ -1,6 +1,10 @@
-use crate::cdr::{endianness::CdrEndianness, serialize::CdrSerialize, serializer::ClassicCdrSerializer};
+use crate::cdr::{
+    endianness::CdrEndianness, serialize::CdrSerialize, serializer::ClassicCdrSerializer,
+};
 
 pub use dust_dds_derive::ParameterListDeserialize;
+
+use super::serializer::CdrSerializer;
 
 pub struct ParameterListSerializer<'s> {
     writer: &'s mut Vec<u8>,

--- a/dds/src/cdr/parameter_list_serializer.rs
+++ b/dds/src/cdr/parameter_list_serializer.rs
@@ -64,7 +64,7 @@ impl ParameterListCdrSerializer<'_> {
         Ok(())
     }
 
-    pub fn write_list_elements<T>(
+    pub fn write_collection<T>(
         &mut self,
         id: i16,
         value_list: &[T],

--- a/dds/src/cdr/parameter_list_serializer.rs
+++ b/dds/src/cdr/parameter_list_serializer.rs
@@ -36,8 +36,8 @@ impl<'s> ParameterListCdrSerializer<'s> {
     }
 }
 
-impl ParameterListCdrSerializer<'_> {
-    pub fn write<T>(&mut self, id: i16, value: &T) -> Result<(), std::io::Error>
+impl ParameterListSerializer for ParameterListCdrSerializer<'_> {
+    fn write<T>(&mut self, id: i16, value: &T) -> Result<(), std::io::Error>
     where
         T: CdrSerialize,
     {
@@ -68,7 +68,7 @@ impl ParameterListCdrSerializer<'_> {
         }
     }
 
-    pub fn write_with_default<T>(
+    fn write_with_default<T>(
         &mut self,
         id: i16,
         value: &T,
@@ -83,7 +83,7 @@ impl ParameterListCdrSerializer<'_> {
         Ok(())
     }
 
-    pub fn write_collection<T>(&mut self, id: i16, value_list: &[T]) -> Result<(), std::io::Error>
+    fn write_collection<T>(&mut self, id: i16, value_list: &[T]) -> Result<(), std::io::Error>
     where
         T: CdrSerialize,
     {
@@ -132,7 +132,7 @@ mod tests {
         impl ParameterListSerialize for ParameterListWithoutDefaults {
             fn serialize(
                 &self,
-                serializer: &mut ParameterListCdrSerializer,
+                serializer: &mut impl ParameterListSerializer,
             ) -> Result<(), std::io::Error> {
                 serializer.write(1, &self.a)?;
                 serializer.write(2, &self.b)?;

--- a/dds/src/cdr/parameter_list_serializer.rs
+++ b/dds/src/cdr/parameter_list_serializer.rs
@@ -65,7 +65,7 @@ where
                 }
             }
 
-            self.writer.write_all(&mut data)?;
+            self.writer.write_all(&data)?;
 
             match padding_length {
                 1 => self.writer.write_all(&[0u8; 1])?,

--- a/dds/src/cdr/parameter_list_serializer.rs
+++ b/dds/src/cdr/parameter_list_serializer.rs
@@ -1,4 +1,4 @@
-use crate::cdr::{endianness::CdrEndianness, serialize::CdrSerialize, serializer::CdrSerializer};
+use crate::cdr::{endianness::CdrEndianness, serialize::CdrSerialize, serializer::ClassicCdrSerializer};
 
 pub use dust_dds_derive::ParameterListDeserialize;
 
@@ -19,7 +19,7 @@ impl ParameterListSerializer<'_> {
         T: CdrSerialize,
     {
         let mut data = Vec::new();
-        let mut data_serializer = CdrSerializer::new(&mut data, self.endianness);
+        let mut data_serializer = ClassicCdrSerializer::new(&mut data, self.endianness);
         value.serialize(&mut data_serializer)?;
 
         let length_without_padding = data.len();
@@ -29,7 +29,7 @@ impl ParameterListSerializer<'_> {
         if length > u16::MAX as usize {
             Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Serialized parameter ID {} with serialized size {} exceeds maximum parameter size of {}", id, length, u16::MAX)))
         } else {
-            let mut serializer = CdrSerializer::new(self.writer, self.endianness);
+            let mut serializer = ClassicCdrSerializer::new(self.writer, self.endianness);
             serializer.serialize_i16(id)?;
             serializer.serialize_u16(length as u16)?;
 

--- a/dds/src/cdr/serialize.rs
+++ b/dds/src/cdr/serialize.rs
@@ -1,6 +1,9 @@
 pub use dust_dds_derive::CdrSerialize;
 
-use super::{error::CdrResult, serializer::ClassicCdrSerializer};
+use super::{
+    error::CdrResult,
+    serializer::{CdrSerializer, ClassicCdrSerializer},
+};
 
 pub trait CdrSerialize {
     fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()>;

--- a/dds/src/cdr/serialize.rs
+++ b/dds/src/cdr/serialize.rs
@@ -1,91 +1,91 @@
 pub use dust_dds_derive::CdrSerialize;
 
-use super::{error::CdrResult, serializer::CdrSerializer};
+use super::{error::CdrResult, serializer::ClassicCdrSerializer};
 
 pub trait CdrSerialize {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()>;
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()>;
 }
 
 impl CdrSerialize for bool {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_bool(*self)
     }
 }
 
 impl CdrSerialize for i8 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_i8(*self)
     }
 }
 
 impl CdrSerialize for i16 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_i16(*self)
     }
 }
 
 impl CdrSerialize for i32 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_i32(*self)
     }
 }
 
 impl CdrSerialize for i64 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_i64(*self)
     }
 }
 
 impl CdrSerialize for u8 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_u8(*self)
     }
 }
 
 impl CdrSerialize for u16 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_u16(*self)
     }
 }
 
 impl CdrSerialize for u32 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_u32(*self)
     }
 }
 
 impl CdrSerialize for u64 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_u64(*self)
     }
 }
 
 impl CdrSerialize for f32 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_f32(*self)
     }
 }
 
 impl CdrSerialize for f64 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_f64(*self)
     }
 }
 
 impl CdrSerialize for char {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_char(*self)
     }
 }
 
 impl CdrSerialize for str {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_str(self)
     }
 }
 
 impl CdrSerialize for String {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_str(self)
     }
 }
@@ -94,7 +94,7 @@ impl<T> CdrSerialize for [T]
 where
     T: CdrSerialize,
 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_seq(self)
     }
 }
@@ -103,7 +103,7 @@ impl<const N: usize, T> CdrSerialize for [T; N]
 where
     T: CdrSerialize,
 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_array(self)
     }
 }
@@ -112,7 +112,7 @@ impl<T> CdrSerialize for Vec<T>
 where
     T: CdrSerialize,
 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_seq(self)
     }
 }
@@ -121,7 +121,7 @@ impl<T> CdrSerialize for &'_ T
 where
     T: CdrSerialize + ?Sized,
 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         T::serialize(*self, serializer)
     }
 }
@@ -130,7 +130,7 @@ impl<T> CdrSerialize for &'_ mut T
 where
     T: CdrSerialize + ?Sized,
 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         T::serialize(*self, serializer)
     }
 }
@@ -139,13 +139,13 @@ impl<T> CdrSerialize for Box<T>
 where
     T: CdrSerialize,
 {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         self.as_ref().serialize(serializer)
     }
 }
 
 impl CdrSerialize for () {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         serializer.serialize_unit()
     }
 }

--- a/dds/src/cdr/serialize.rs
+++ b/dds/src/cdr/serialize.rs
@@ -1,94 +1,91 @@
 pub use dust_dds_derive::CdrSerialize;
 
-use super::{
-    error::CdrResult,
-    serializer::{CdrSerializer, ClassicCdrSerializer},
-};
+use super::{error::CdrResult, serializer::CdrSerializer};
 
 pub trait CdrSerialize {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()>;
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()>;
 }
 
 impl CdrSerialize for bool {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_bool(*self)
     }
 }
 
 impl CdrSerialize for i8 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_i8(*self)
     }
 }
 
 impl CdrSerialize for i16 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_i16(*self)
     }
 }
 
 impl CdrSerialize for i32 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_i32(*self)
     }
 }
 
 impl CdrSerialize for i64 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_i64(*self)
     }
 }
 
 impl CdrSerialize for u8 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_u8(*self)
     }
 }
 
 impl CdrSerialize for u16 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_u16(*self)
     }
 }
 
 impl CdrSerialize for u32 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_u32(*self)
     }
 }
 
 impl CdrSerialize for u64 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_u64(*self)
     }
 }
 
 impl CdrSerialize for f32 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_f32(*self)
     }
 }
 
 impl CdrSerialize for f64 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_f64(*self)
     }
 }
 
 impl CdrSerialize for char {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_char(*self)
     }
 }
 
 impl CdrSerialize for str {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_str(self)
     }
 }
 
 impl CdrSerialize for String {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_str(self)
     }
 }
@@ -97,7 +94,7 @@ impl<T> CdrSerialize for [T]
 where
     T: CdrSerialize,
 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_seq(self)
     }
 }
@@ -106,7 +103,7 @@ impl<const N: usize, T> CdrSerialize for [T; N]
 where
     T: CdrSerialize,
 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_array(self)
     }
 }
@@ -115,7 +112,7 @@ impl<T> CdrSerialize for Vec<T>
 where
     T: CdrSerialize,
 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_seq(self)
     }
 }
@@ -124,7 +121,7 @@ impl<T> CdrSerialize for &'_ T
 where
     T: CdrSerialize + ?Sized,
 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         T::serialize(*self, serializer)
     }
 }
@@ -133,7 +130,7 @@ impl<T> CdrSerialize for &'_ mut T
 where
     T: CdrSerialize + ?Sized,
 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         T::serialize(*self, serializer)
     }
 }
@@ -142,13 +139,13 @@ impl<T> CdrSerialize for Box<T>
 where
     T: CdrSerialize,
 {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         self.as_ref().serialize(serializer)
     }
 }
 
 impl CdrSerialize for () {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         serializer.serialize_unit()
     }
 }

--- a/dds/src/cdr/serializer.rs
+++ b/dds/src/cdr/serializer.rs
@@ -4,6 +4,40 @@ use crate::cdr::{error::CdrResult, serialize::CdrSerialize};
 
 use super::endianness::CdrEndianness;
 
+pub trait CdrSerializer {
+    fn serialize_bool(&mut self, v: bool) -> CdrResult<()>;
+
+    fn serialize_i8(&mut self, v: i8) -> CdrResult<()>;
+
+    fn serialize_i16(&mut self, v: i16) -> CdrResult<()>;
+
+    fn serialize_i32(&mut self, v: i32) -> CdrResult<()>;
+
+    fn serialize_i64(&mut self, v: i64) -> CdrResult<()>;
+
+    fn serialize_u8(&mut self, v: u8) -> CdrResult<()>;
+
+    fn serialize_u16(&mut self, v: u16) -> CdrResult<()>;
+
+    fn serialize_u32(&mut self, v: u32) -> CdrResult<()>;
+
+    fn serialize_u64(&mut self, v: u64) -> CdrResult<()>;
+
+    fn serialize_f32(&mut self, v: f32) -> CdrResult<()>;
+
+    fn serialize_f64(&mut self, v: f64) -> CdrResult<()>;
+
+    fn serialize_char(&mut self, v: char) -> CdrResult<()>;
+
+    fn serialize_str(&mut self, v: &str) -> CdrResult<()>;
+
+    fn serialize_seq(&mut self, v: &[impl CdrSerialize]) -> CdrResult<()>;
+
+    fn serialize_array<const N: usize>(&mut self, v: &[impl CdrSerialize; N]) -> CdrResult<()>;
+
+    fn serialize_unit(&mut self) -> CdrResult<()>;
+}
+
 pub struct ClassicCdrSerializer<'s> {
     writer: &'s mut Vec<u8>,
     pos: usize,
@@ -47,12 +81,12 @@ impl<'s> ClassicCdrSerializer<'s> {
     }
 }
 
-impl ClassicCdrSerializer<'_> {
-    pub fn serialize_bool(&mut self, v: bool) -> CdrResult<()> {
+impl CdrSerializer for ClassicCdrSerializer<'_> {
+    fn serialize_bool(&mut self, v: bool) -> CdrResult<()> {
         self.serialize_u8(v as u8)
     }
 
-    pub fn serialize_i8(&mut self, v: i8) -> CdrResult<()> {
+    fn serialize_i8(&mut self, v: i8) -> CdrResult<()> {
         self.set_pos_of::<i8>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -60,7 +94,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_i16(&mut self, v: i16) -> CdrResult<()> {
+    fn serialize_i16(&mut self, v: i16) -> CdrResult<()> {
         self.set_pos_of::<i16>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -68,7 +102,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_i32(&mut self, v: i32) -> CdrResult<()> {
+    fn serialize_i32(&mut self, v: i32) -> CdrResult<()> {
         self.set_pos_of::<i32>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -76,7 +110,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_i64(&mut self, v: i64) -> CdrResult<()> {
+    fn serialize_i64(&mut self, v: i64) -> CdrResult<()> {
         self.set_pos_of::<i64>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -84,7 +118,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_u8(&mut self, v: u8) -> CdrResult<()> {
+    fn serialize_u8(&mut self, v: u8) -> CdrResult<()> {
         self.set_pos_of::<u8>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -92,7 +126,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_u16(&mut self, v: u16) -> CdrResult<()> {
+    fn serialize_u16(&mut self, v: u16) -> CdrResult<()> {
         self.set_pos_of::<u16>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -100,7 +134,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_u32(&mut self, v: u32) -> CdrResult<()> {
+    fn serialize_u32(&mut self, v: u32) -> CdrResult<()> {
         self.set_pos_of::<u32>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -108,7 +142,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_u64(&mut self, v: u64) -> CdrResult<()> {
+    fn serialize_u64(&mut self, v: u64) -> CdrResult<()> {
         self.set_pos_of::<u64>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -116,7 +150,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_f32(&mut self, v: f32) -> CdrResult<()> {
+    fn serialize_f32(&mut self, v: f32) -> CdrResult<()> {
         self.set_pos_of::<f32>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -124,7 +158,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_f64(&mut self, v: f64) -> CdrResult<()> {
+    fn serialize_f64(&mut self, v: f64) -> CdrResult<()> {
         self.set_pos_of::<f64>()?;
         match self.endianness {
             CdrEndianness::LittleEndian => self.writer.write_all(&v.to_le_bytes()),
@@ -132,7 +166,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_char(&mut self, v: char) -> CdrResult<()> {
+    fn serialize_char(&mut self, v: char) -> CdrResult<()> {
         if !v.is_ascii() {
             Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -147,7 +181,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_str(&mut self, v: &str) -> CdrResult<()> {
+    fn serialize_str(&mut self, v: &str) -> CdrResult<()> {
         if !v.is_ascii() {
             Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -171,7 +205,7 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_seq(&mut self, v: &[impl CdrSerialize]) -> CdrResult<()> {
+    fn serialize_seq(&mut self, v: &[impl CdrSerialize]) -> CdrResult<()> {
         let l = v.len();
         if l > u32::MAX as usize {
             Err(std::io::Error::new(
@@ -187,14 +221,14 @@ impl ClassicCdrSerializer<'_> {
         }
     }
 
-    pub fn serialize_array<const N: usize>(&mut self, v: &[impl CdrSerialize; N]) -> CdrResult<()> {
+    fn serialize_array<const N: usize>(&mut self, v: &[impl CdrSerialize; N]) -> CdrResult<()> {
         for e in v {
             e.serialize(self)?;
         }
         Ok(())
     }
 
-    pub fn serialize_unit(&mut self) -> CdrResult<()> {
+    fn serialize_unit(&mut self) -> CdrResult<()> {
         Ok(())
     }
 }

--- a/dds/src/cdr/serializer.rs
+++ b/dds/src/cdr/serializer.rs
@@ -4,13 +4,13 @@ use crate::cdr::{error::CdrResult, serialize::CdrSerialize};
 
 use super::endianness::CdrEndianness;
 
-pub struct CdrSerializer<'s> {
+pub struct ClassicCdrSerializer<'s> {
     writer: &'s mut Vec<u8>,
     pos: usize,
     endianness: CdrEndianness,
 }
 
-impl<'s> CdrSerializer<'s> {
+impl<'s> ClassicCdrSerializer<'s> {
     pub fn new(writer: &'s mut Vec<u8>, endianness: CdrEndianness) -> Self {
         Self {
             writer,
@@ -47,7 +47,7 @@ impl<'s> CdrSerializer<'s> {
     }
 }
 
-impl CdrSerializer<'_> {
+impl ClassicCdrSerializer<'_> {
     pub fn serialize_bool(&mut self, v: bool) -> CdrResult<()> {
         self.serialize_u8(v as u8)
     }
@@ -208,7 +208,7 @@ mod tests {
         T: CdrSerialize + ?Sized,
     {
         let mut writer = Vec::new();
-        let mut serializer = CdrSerializer::new(&mut writer, CdrEndianness::BigEndian);
+        let mut serializer = ClassicCdrSerializer::new(&mut writer, CdrEndianness::BigEndian);
         v.serialize(&mut serializer)?;
         Ok(writer)
     }
@@ -218,7 +218,7 @@ mod tests {
         T: CdrSerialize + ?Sized,
     {
         let mut writer = Vec::new();
-        let mut serializer = CdrSerializer::new(&mut writer, CdrEndianness::LittleEndian);
+        let mut serializer = ClassicCdrSerializer::new(&mut writer, CdrEndianness::LittleEndian);
         v.serialize(&mut serializer)?;
         Ok(writer)
     }

--- a/dds/src/cdr/serializer.rs
+++ b/dds/src/cdr/serializer.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use crate::cdr::{error::CdrResult, serialize::CdrSerialize};
 
 use super::endianness::CdrEndianness;
@@ -38,14 +36,17 @@ pub trait CdrSerializer {
     fn serialize_unit(&mut self) -> CdrResult<()>;
 }
 
-pub struct ClassicCdrSerializer<'s> {
-    writer: &'s mut Vec<u8>,
+pub struct ClassicCdrSerializer<W> {
+    writer: W,
     pos: usize,
     endianness: CdrEndianness,
 }
 
-impl<'s> ClassicCdrSerializer<'s> {
-    pub fn new(writer: &'s mut Vec<u8>, endianness: CdrEndianness) -> Self {
+impl<W> ClassicCdrSerializer<W>
+where
+    W: std::io::Write,
+{
+    pub fn new(writer: W, endianness: CdrEndianness) -> Self {
         Self {
             writer,
             pos: 0,
@@ -81,7 +82,10 @@ impl<'s> ClassicCdrSerializer<'s> {
     }
 }
 
-impl CdrSerializer for ClassicCdrSerializer<'_> {
+impl<W> CdrSerializer for ClassicCdrSerializer<W>
+where
+    W: std::io::Write,
+{
     fn serialize_bool(&mut self, v: bool) -> CdrResult<()> {
         self.serialize_u8(v as u8)
     }

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -2,8 +2,11 @@ use core::cmp::Ordering;
 
 use crate::{
     cdr::{
-        deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
-        serialize::CdrSerialize, serializer::ClassicCdrSerializer,
+        deserialize::CdrDeserialize,
+        deserializer::CdrDeserializer,
+        error::CdrResult,
+        serialize::CdrSerialize,
+        serializer::{CdrSerializer, ClassicCdrSerializer},
     },
     infrastructure::time::{Duration, DurationKind, DURATION_ZERO},
 };

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -2,7 +2,7 @@ use core::cmp::Ordering;
 
 use crate::{
     cdr::{
-        deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
+        deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, error::CdrResult,
         serialize::CdrSerialize, serializer::CdrSerializer,
     },
     infrastructure::time::{Duration, DurationKind, DURATION_ZERO},
@@ -26,7 +26,7 @@ impl CdrSerialize for Length {
 }
 
 impl<'de> CdrDeserialize<'de> for Length {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         let value: i32 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             LENGTH_UNLIMITED => Ok(Length::Unlimited),
@@ -267,7 +267,7 @@ impl CdrSerialize for DurabilityQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for DurabilityQosPolicyKind {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(DurabilityQosPolicyKind::Volatile),
@@ -344,7 +344,7 @@ impl CdrSerialize for PresentationQosPolicyAccessScopeKind {
 }
 
 impl<'de> CdrDeserialize<'de> for PresentationQosPolicyAccessScopeKind {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(PresentationQosPolicyAccessScopeKind::Instance),
@@ -507,7 +507,7 @@ impl CdrSerialize for OwnershipQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for OwnershipQosPolicyKind {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(OwnershipQosPolicyKind::Shared),
@@ -566,7 +566,7 @@ impl CdrSerialize for LivelinessQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for LivelinessQosPolicyKind {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(LivelinessQosPolicyKind::Automatic),
@@ -741,7 +741,7 @@ impl CdrSerialize for ReliabilityQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for ReliabilityQosPolicyKind {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         let value: i32 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             BEST_EFFORT => Ok(ReliabilityQosPolicyKind::BestEffort),
@@ -842,7 +842,7 @@ impl CdrSerialize for DestinationOrderQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for DestinationOrderQosPolicyKind {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(DestinationOrderQosPolicyKind::ByReceptionTimestamp),
@@ -923,7 +923,7 @@ impl CdrSerialize for HistoryQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for HistoryQosPolicyKind {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         let kind: u8 = CdrDeserialize::deserialize(deserializer)?;
         let depth: i32 = CdrDeserialize::deserialize(deserializer)?;
         match kind {

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -3,7 +3,7 @@ use core::cmp::Ordering;
 use crate::{
     cdr::{
         deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
-        serialize::CdrSerialize, serializer::CdrSerializer,
+        serialize::CdrSerialize, serializer::ClassicCdrSerializer,
     },
     infrastructure::time::{Duration, DurationKind, DURATION_ZERO},
 };
@@ -17,7 +17,7 @@ pub enum Length {
 
 const LENGTH_UNLIMITED: i32 = -1;
 impl CdrSerialize for Length {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         match self {
             Length::Unlimited => serializer.serialize_i32(LENGTH_UNLIMITED),
             Length::Limited(l) => serializer.serialize_u32(*l),
@@ -257,7 +257,7 @@ pub enum DurabilityQosPolicyKind {
 }
 
 impl CdrSerialize for DurabilityQosPolicyKind {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         match self {
             DurabilityQosPolicyKind::Volatile => 0u8,
             DurabilityQosPolicyKind::TransientLocal => 1,
@@ -334,7 +334,7 @@ pub enum PresentationQosPolicyAccessScopeKind {
 }
 
 impl CdrSerialize for PresentationQosPolicyAccessScopeKind {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         match self {
             PresentationQosPolicyAccessScopeKind::Instance => 0u8,
             PresentationQosPolicyAccessScopeKind::Topic => 1,
@@ -498,7 +498,7 @@ pub enum OwnershipQosPolicyKind {
 }
 
 impl CdrSerialize for OwnershipQosPolicyKind {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         match self {
             OwnershipQosPolicyKind::Shared => 0u8,
         }
@@ -555,7 +555,7 @@ pub enum LivelinessQosPolicyKind {
 }
 
 impl CdrSerialize for LivelinessQosPolicyKind {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         match self {
             LivelinessQosPolicyKind::Automatic => 0u8,
             LivelinessQosPolicyKind::ManualByParticipant => 1,
@@ -731,7 +731,7 @@ const BEST_EFFORT: i32 = 1;
 const RELIABLE: i32 = 2;
 
 impl CdrSerialize for ReliabilityQosPolicyKind {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         match self {
             ReliabilityQosPolicyKind::BestEffort => BEST_EFFORT,
             ReliabilityQosPolicyKind::Reliable => RELIABLE,
@@ -832,7 +832,7 @@ pub enum DestinationOrderQosPolicyKind {
 }
 
 impl CdrSerialize for DestinationOrderQosPolicyKind {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         match self {
             DestinationOrderQosPolicyKind::ByReceptionTimestamp => 0u8,
             DestinationOrderQosPolicyKind::BySourceTimestamp => 1,
@@ -908,7 +908,7 @@ pub enum HistoryQosPolicyKind {
 }
 
 impl CdrSerialize for HistoryQosPolicyKind {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         match self {
             HistoryQosPolicyKind::KeepLast(depth) => {
                 serializer.serialize_u8(0)?;

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -2,11 +2,8 @@ use core::cmp::Ordering;
 
 use crate::{
     cdr::{
-        deserialize::CdrDeserialize,
-        deserializer::CdrDeserializer,
-        error::CdrResult,
-        serialize::CdrSerialize,
-        serializer::{CdrSerializer, ClassicCdrSerializer},
+        deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
+        serialize::CdrSerialize, serializer::CdrSerializer,
     },
     infrastructure::time::{Duration, DurationKind, DURATION_ZERO},
 };
@@ -20,7 +17,7 @@ pub enum Length {
 
 const LENGTH_UNLIMITED: i32 = -1;
 impl CdrSerialize for Length {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         match self {
             Length::Unlimited => serializer.serialize_i32(LENGTH_UNLIMITED),
             Length::Limited(l) => serializer.serialize_u32(*l),
@@ -260,7 +257,7 @@ pub enum DurabilityQosPolicyKind {
 }
 
 impl CdrSerialize for DurabilityQosPolicyKind {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         match self {
             DurabilityQosPolicyKind::Volatile => 0u8,
             DurabilityQosPolicyKind::TransientLocal => 1,
@@ -337,7 +334,7 @@ pub enum PresentationQosPolicyAccessScopeKind {
 }
 
 impl CdrSerialize for PresentationQosPolicyAccessScopeKind {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         match self {
             PresentationQosPolicyAccessScopeKind::Instance => 0u8,
             PresentationQosPolicyAccessScopeKind::Topic => 1,
@@ -501,7 +498,7 @@ pub enum OwnershipQosPolicyKind {
 }
 
 impl CdrSerialize for OwnershipQosPolicyKind {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         match self {
             OwnershipQosPolicyKind::Shared => 0u8,
         }
@@ -558,7 +555,7 @@ pub enum LivelinessQosPolicyKind {
 }
 
 impl CdrSerialize for LivelinessQosPolicyKind {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         match self {
             LivelinessQosPolicyKind::Automatic => 0u8,
             LivelinessQosPolicyKind::ManualByParticipant => 1,
@@ -734,7 +731,7 @@ const BEST_EFFORT: i32 = 1;
 const RELIABLE: i32 = 2;
 
 impl CdrSerialize for ReliabilityQosPolicyKind {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         match self {
             ReliabilityQosPolicyKind::BestEffort => BEST_EFFORT,
             ReliabilityQosPolicyKind::Reliable => RELIABLE,
@@ -835,7 +832,7 @@ pub enum DestinationOrderQosPolicyKind {
 }
 
 impl CdrSerialize for DestinationOrderQosPolicyKind {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         match self {
             DestinationOrderQosPolicyKind::ByReceptionTimestamp => 0u8,
             DestinationOrderQosPolicyKind::BySourceTimestamp => 1,
@@ -911,7 +908,7 @@ pub enum HistoryQosPolicyKind {
 }
 
 impl CdrSerialize for HistoryQosPolicyKind {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         match self {
             HistoryQosPolicyKind::KeepLast(depth) => {
                 serializer.serialize_u8(0)?;

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -2,7 +2,7 @@ use core::cmp::Ordering;
 
 use crate::{
     cdr::{
-        deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, error::CdrResult,
+        deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
         serialize::CdrSerialize, serializer::CdrSerializer,
     },
     infrastructure::time::{Duration, DurationKind, DURATION_ZERO},
@@ -26,7 +26,7 @@ impl CdrSerialize for Length {
 }
 
 impl<'de> CdrDeserialize<'de> for Length {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         let value: i32 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             LENGTH_UNLIMITED => Ok(Length::Unlimited),
@@ -267,7 +267,7 @@ impl CdrSerialize for DurabilityQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for DurabilityQosPolicyKind {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(DurabilityQosPolicyKind::Volatile),
@@ -344,7 +344,7 @@ impl CdrSerialize for PresentationQosPolicyAccessScopeKind {
 }
 
 impl<'de> CdrDeserialize<'de> for PresentationQosPolicyAccessScopeKind {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(PresentationQosPolicyAccessScopeKind::Instance),
@@ -507,7 +507,7 @@ impl CdrSerialize for OwnershipQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for OwnershipQosPolicyKind {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(OwnershipQosPolicyKind::Shared),
@@ -566,7 +566,7 @@ impl CdrSerialize for LivelinessQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for LivelinessQosPolicyKind {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(LivelinessQosPolicyKind::Automatic),
@@ -741,7 +741,7 @@ impl CdrSerialize for ReliabilityQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for ReliabilityQosPolicyKind {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         let value: i32 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             BEST_EFFORT => Ok(ReliabilityQosPolicyKind::BestEffort),
@@ -842,7 +842,7 @@ impl CdrSerialize for DestinationOrderQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for DestinationOrderQosPolicyKind {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         let value: u8 = CdrDeserialize::deserialize(deserializer)?;
         match value {
             0 => Ok(DestinationOrderQosPolicyKind::ByReceptionTimestamp),
@@ -923,7 +923,7 @@ impl CdrSerialize for HistoryQosPolicyKind {
 }
 
 impl<'de> CdrDeserialize<'de> for HistoryQosPolicyKind {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         let kind: u8 = CdrDeserialize::deserialize(deserializer)?;
         let depth: i32 = CdrDeserialize::deserialize(deserializer)?;
         match kind {

--- a/dds/src/dds/infrastructure/time.rs
+++ b/dds/src/dds/infrastructure/time.rs
@@ -1,7 +1,7 @@
 use std::ops::Sub;
 
 use crate::cdr::{
-    deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, error::CdrResult,
+    deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
     serialize::CdrSerialize, serializer::CdrSerializer,
 };
 
@@ -29,7 +29,7 @@ impl CdrSerialize for DurationKind {
 }
 
 impl<'de> CdrDeserialize<'de> for DurationKind {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         let duration: Duration = CdrDeserialize::deserialize(deserializer)?;
         if duration == DURATION_INFINITE {
             Ok(DurationKind::Infinite)

--- a/dds/src/dds/infrastructure/time.rs
+++ b/dds/src/dds/infrastructure/time.rs
@@ -1,7 +1,7 @@
 use std::ops::Sub;
 
 use crate::cdr::{
-    deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
+    deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, error::CdrResult,
     serialize::CdrSerialize, serializer::CdrSerializer,
 };
 
@@ -29,7 +29,7 @@ impl CdrSerialize for DurationKind {
 }
 
 impl<'de> CdrDeserialize<'de> for DurationKind {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         let duration: Duration = CdrDeserialize::deserialize(deserializer)?;
         if duration == DURATION_INFINITE {
             Ok(DurationKind::Infinite)

--- a/dds/src/dds/infrastructure/time.rs
+++ b/dds/src/dds/infrastructure/time.rs
@@ -2,7 +2,7 @@ use std::ops::Sub;
 
 use crate::cdr::{
     deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
-    serialize::CdrSerialize, serializer::CdrSerializer,
+    serialize::CdrSerialize, serializer::ClassicCdrSerializer,
 };
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -19,7 +19,7 @@ const DURATION_INFINITE: Duration = Duration {
 };
 
 impl CdrSerialize for DurationKind {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         match self {
             DurationKind::Finite(d) => d,
             DurationKind::Infinite => &DURATION_INFINITE,

--- a/dds/src/dds/infrastructure/time.rs
+++ b/dds/src/dds/infrastructure/time.rs
@@ -2,7 +2,7 @@ use std::ops::Sub;
 
 use crate::cdr::{
     deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
-    serialize::CdrSerialize, serializer::ClassicCdrSerializer,
+    serialize::CdrSerialize, serializer::CdrSerializer,
 };
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -19,7 +19,7 @@ const DURATION_INFINITE: Duration = Duration {
 };
 
 impl CdrSerialize for DurationKind {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         match self {
             DurationKind::Finite(d) => d,
             DurationKind::Infinite => &DURATION_INFINITE,

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -2,11 +2,14 @@ use std::io::{Read, Write};
 
 use crate::{
     cdr::{
-        deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, endianness::CdrEndianness,
+        deserialize::CdrDeserialize,
+        deserializer::ClassicCdrDeserializer,
+        endianness::CdrEndianness,
         parameter_list_deserialize::ParameterListDeserialize,
         parameter_list_deserializer::ParameterListCdrDeserializer,
         parameter_list_serialize::ParameterListSerialize,
-        parameter_list_serializer::ParameterListCdrSerializer, serialize::CdrSerialize,
+        parameter_list_serializer::{ParameterListCdrSerializer, ParameterListSerializer},
+        serialize::CdrSerialize,
         serializer::ClassicCdrSerializer,
     },
     implementation::data_representation_builtin_endpoints::parameter_id_values::PID_SENTINEL,
@@ -199,7 +202,8 @@ where
 
     let value = match representation_identifier {
         CDR_BE => {
-            let mut deserializer = ClassicCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian);
+            let mut deserializer =
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian);
             Ok(CdrDeserialize::deserialize(&mut deserializer)?)
         }
         CDR_LE => {

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -4,7 +4,7 @@ use crate::{
     cdr::{
         deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, endianness::CdrEndianness,
         parameter_list_deserialize::ParameterListDeserialize,
-        parameter_list_deserializer::ParameterListDeserializer,
+        parameter_list_deserializer::ParameterListCdrDeserializer,
         parameter_list_serialize::ParameterListSerialize,
         parameter_list_serializer::ParameterListSerializer, serialize::CdrSerialize,
         serializer::ClassicCdrSerializer,
@@ -209,12 +209,12 @@ where
         }
         PL_CDR_BE => {
             let mut deserializer =
-                ParameterListDeserializer::new(serialized_data, CdrEndianness::BigEndian);
+                ParameterListCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian);
             Ok(ParameterListDeserialize::deserialize(&mut deserializer)?)
         }
         PL_CDR_LE => {
             let mut deserializer =
-                ParameterListDeserializer::new(serialized_data, CdrEndianness::LittleEndian);
+                ParameterListCdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian);
             Ok(ParameterListDeserialize::deserialize(&mut deserializer)?)
         }
         _ => Err(DdsError::Error(
@@ -274,11 +274,11 @@ where
         .map_err(|err| DdsError::Error(err.to_string()))?;
 
     let mut deserializer = match representation_identifier {
-        PL_CDR_BE => Ok(ParameterListDeserializer::new(
+        PL_CDR_BE => Ok(ParameterListCdrDeserializer::new(
             serialized_data,
             CdrEndianness::BigEndian,
         )),
-        PL_CDR_LE => Ok(ParameterListDeserializer::new(
+        PL_CDR_LE => Ok(ParameterListCdrDeserializer::new(
             serialized_data,
             CdrEndianness::LittleEndian,
         )),

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -7,7 +7,7 @@ use crate::{
         parameter_list_deserializer::ParameterListDeserializer,
         parameter_list_serialize::ParameterListSerialize,
         parameter_list_serializer::ParameterListSerializer, serialize::CdrSerialize,
-        serializer::CdrSerializer,
+        serializer::ClassicCdrSerializer,
     },
     implementation::data_representation_builtin_endpoints::parameter_id_values::PID_SENTINEL,
     infrastructure::{
@@ -158,7 +158,7 @@ pub fn serialize_rtps_classic_cdr(
         CdrEndianness::BigEndian => writer.write_all(&CDR_BE)?,
     }
     writer.write_all(&REPRESENTATION_OPTIONS)?;
-    let mut serializer = CdrSerializer::new(writer, endianness);
+    let mut serializer = ClassicCdrSerializer::new(writer, endianness);
     CdrSerialize::serialize(value, &mut serializer)?;
     Ok(())
 }

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -6,7 +6,7 @@ use crate::{
         parameter_list_deserialize::ParameterListDeserialize,
         parameter_list_deserializer::ParameterListCdrDeserializer,
         parameter_list_serialize::ParameterListSerialize,
-        parameter_list_serializer::ParameterListSerializer, serialize::CdrSerialize,
+        parameter_list_serializer::ParameterListCdrSerializer, serialize::CdrSerialize,
         serializer::ClassicCdrSerializer,
     },
     implementation::data_representation_builtin_endpoints::parameter_id_values::PID_SENTINEL,
@@ -174,7 +174,7 @@ pub fn serialize_rtps_cdr_pl(
         CdrEndianness::BigEndian => writer.write_all(&PL_CDR_BE)?,
     }
     writer.write_all(&REPRESENTATION_OPTIONS)?;
-    let mut serializer = ParameterListSerializer::new(writer, endianness);
+    let mut serializer = ParameterListCdrSerializer::new(writer, endianness);
     ParameterListSerialize::serialize(value, &mut serializer)?;
     serializer.write(PID_SENTINEL, &())?;
     Ok(())

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 
 use crate::{
     cdr::{
-        deserialize::CdrDeserialize, deserializer::CdrDeserializer, endianness::CdrEndianness,
+        deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, endianness::CdrEndianness,
         parameter_list_deserialize::ParameterListDeserialize,
         parameter_list_deserializer::ParameterListDeserializer,
         parameter_list_serialize::ParameterListSerialize,
@@ -199,12 +199,12 @@ where
 
     let value = match representation_identifier {
         CDR_BE => {
-            let mut deserializer = CdrDeserializer::new(serialized_data, CdrEndianness::BigEndian);
+            let mut deserializer = ClassicCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian);
             Ok(CdrDeserialize::deserialize(&mut deserializer)?)
         }
         CDR_LE => {
             let mut deserializer =
-                CdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian);
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian);
             Ok(CdrDeserialize::deserialize(&mut deserializer)?)
         }
         PL_CDR_BE => {
@@ -241,11 +241,11 @@ where
         .map_err(|err| DdsError::Error(err.to_string()))?;
 
     let mut deserializer = match representation_identifier {
-        CDR_BE => Ok(CdrDeserializer::new(
+        CDR_BE => Ok(ClassicCdrDeserializer::new(
             serialized_data,
             CdrEndianness::BigEndian,
         )),
-        CDR_LE => Ok(CdrDeserializer::new(
+        CDR_LE => Ok(ClassicCdrDeserializer::new(
             serialized_data,
             CdrEndianness::LittleEndian,
         )),

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Write};
+use std::io::Read;
 
 use crate::{
     cdr::{
@@ -46,7 +46,7 @@ pub trait DdsHasKey {
 /// The format to be used for serializing can be selected by applying the '#[dust_dds(format = ...)]' attribute to the container.
 /// Available format options are "CDR_LE", "CDR_BE", "PL_CDR_LE" and "PL_CDR_BE".
 pub trait DdsSerialize {
-    fn serialize_data(&self, writer: &mut Vec<u8>) -> DdsResult<()>;
+    fn serialize_data(&self, writer: impl std::io::Write) -> DdsResult<()>;
 }
 
 /// This trait describes how the bytes can be deserialize to construct the data structure.
@@ -73,7 +73,7 @@ pub trait DdsDeserialize<'de>: Sized {
 /// This trait can be automatically derived if the key fields of the struct implement `CdrSerialize`.
 /// The derive always uses the CDR_LE format for serializing the key
 pub trait DdsSerializeKey {
-    fn serialize_key(&self, writer: &mut Vec<u8>) -> DdsResult<()>;
+    fn serialize_key(&self, writer: impl std::io::Write) -> DdsResult<()>;
 }
 
 /// This trait defines how the unique instance handle can be generated from a given instance of a type.
@@ -153,7 +153,7 @@ const REPRESENTATION_OPTIONS: RepresentationOptions = [0x00, 0x00];
 /// This is a helper function to serialize a type implementing [`CdrSerialize`] using the RTPS defined classic CDR representation.
 pub fn serialize_rtps_classic_cdr(
     value: &impl CdrSerialize,
-    writer: &mut Vec<u8>,
+    mut writer: impl std::io::Write,
     endianness: CdrEndianness,
 ) -> DdsResult<()> {
     match endianness {
@@ -169,7 +169,7 @@ pub fn serialize_rtps_classic_cdr(
 /// This is a helper function to serialize a type implementing [`ParameterListSerialize`] using the RTPS defined CDR Parameter List representation.
 pub fn serialize_rtps_cdr_pl(
     value: &impl ParameterListSerialize,
-    writer: &mut Vec<u8>,
+    mut writer: impl std::io::Write,
     endianness: CdrEndianness,
 ) -> DdsResult<()> {
     match endianness {

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 
 use crate::{
     builtin_topics::{BuiltInTopicKey, PublicationBuiltinTopicData, SubscriptionBuiltinTopicData},
-    cdr::{deserialize::CdrDeserialize, deserializer::CdrDeserializer, endianness::CdrEndianness},
+    cdr::{deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, endianness::CdrEndianness},
     implementation::{
         data_representation_builtin_endpoints::{
             discovered_reader_data::{DiscoveredReaderData, ReaderProxy},
@@ -828,7 +828,7 @@ impl DataReaderActor {
                 .iter()
                 .find(|&x| x.parameter_id() == PID_STATUS_INFO)
             {
-                let mut deserializer = CdrDeserializer::new(p.value(), CdrEndianness::LittleEndian);
+                let mut deserializer = ClassicCdrDeserializer::new(p.value(), CdrEndianness::LittleEndian);
                 let status_info: StatusInfo =
                     CdrDeserialize::deserialize(&mut deserializer).unwrap();
                 match status_info {

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -1,6 +1,6 @@
 use crate::{
     builtin_topics::{BuiltInTopicKey, PublicationBuiltinTopicData},
-    cdr::{endianness::CdrEndianness, serialize::CdrSerialize, serializer::CdrSerializer},
+    cdr::{endianness::CdrEndianness, serialize::CdrSerialize, serializer::ClassicCdrSerializer},
     implementation::{
         data_representation_builtin_endpoints::{
             discovered_reader_data::DiscoveredReaderData,
@@ -388,7 +388,7 @@ impl DataWriterActor {
 
         let mut serialized_status_info = Vec::new();
         let mut serializer =
-            CdrSerializer::new(&mut serialized_status_info, CdrEndianness::LittleEndian);
+            ClassicCdrSerializer::new(&mut serialized_status_info, CdrEndianness::LittleEndian);
         if self
             .qos
             .writer_data_lifecycle
@@ -447,7 +447,7 @@ impl DataWriterActor {
 
         let mut serialized_status_info = Vec::new();
         let mut serializer =
-            CdrSerializer::new(&mut serialized_status_info, CdrEndianness::LittleEndian);
+            ClassicCdrSerializer::new(&mut serialized_status_info, CdrEndianness::LittleEndian);
         STATUS_INFO_DISPOSED.serialize(&mut serializer).unwrap();
 
         let inline_qos = ParameterList::new(vec![Parameter::new(

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -4,7 +4,7 @@ use crate::{
         deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
         parameter_list_deserialize::ParameterListDeserialize,
         parameter_list_serialize::ParameterListSerialize, serialize::CdrSerialize,
-        serializer::ClassicCdrSerializer,
+        serializer::CdrSerializer,
     },
     domain::domain_participant_factory::DomainId,
     implementation::rtps::{
@@ -40,7 +40,7 @@ impl Default for DomainTag {
 #[derive(Default, Debug, PartialEq, Eq, Clone, derive_more::From, derive_more::AsRef)]
 struct DomainIdParameter(Option<DomainId>);
 impl CdrSerialize for DomainIdParameter {
-    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut impl CdrSerializer) -> CdrResult<()> {
         self.0
             .expect("Default DomainId not supposed to be serialized")
             .serialize(serializer)

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -1,7 +1,7 @@
 use crate::{
     builtin_topics::ParticipantBuiltinTopicData,
     cdr::{
-        deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, error::CdrResult,
+        deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
         parameter_list_deserialize::ParameterListDeserialize,
         parameter_list_serialize::ParameterListSerialize, serialize::CdrSerialize,
         serializer::CdrSerializer,
@@ -48,7 +48,7 @@ impl CdrSerialize for DomainIdParameter {
 }
 
 impl<'de> CdrDeserialize<'de> for DomainIdParameter {
-    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> CdrResult<Self> {
         // None should not happen since this is only deserialized if the
         // corresponding PID is found
         Ok(Self(Some(CdrDeserialize::deserialize(deserializer)?)))

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -1,7 +1,7 @@
 use crate::{
     builtin_topics::ParticipantBuiltinTopicData,
     cdr::{
-        deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
+        deserialize::CdrDeserialize, deserializer::ClassicCdrDeserializer, error::CdrResult,
         parameter_list_deserialize::ParameterListDeserialize,
         parameter_list_serialize::ParameterListSerialize, serialize::CdrSerialize,
         serializer::CdrSerializer,
@@ -48,7 +48,7 @@ impl CdrSerialize for DomainIdParameter {
 }
 
 impl<'de> CdrDeserialize<'de> for DomainIdParameter {
-    fn deserialize(deserializer: &mut CdrDeserializer<'de>) -> CdrResult<Self> {
+    fn deserialize(deserializer: &mut ClassicCdrDeserializer<'de>) -> CdrResult<Self> {
         // None should not happen since this is only deserialized if the
         // corresponding PID is found
         Ok(Self(Some(CdrDeserialize::deserialize(deserializer)?)))

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -4,7 +4,7 @@ use crate::{
         deserialize::CdrDeserialize, deserializer::CdrDeserializer, error::CdrResult,
         parameter_list_deserialize::ParameterListDeserialize,
         parameter_list_serialize::ParameterListSerialize, serialize::CdrSerialize,
-        serializer::CdrSerializer,
+        serializer::ClassicCdrSerializer,
     },
     domain::domain_participant_factory::DomainId,
     implementation::rtps::{
@@ -40,7 +40,7 @@ impl Default for DomainTag {
 #[derive(Default, Debug, PartialEq, Eq, Clone, derive_more::From, derive_more::AsRef)]
 struct DomainIdParameter(Option<DomainId>);
 impl CdrSerialize for DomainIdParameter {
-    fn serialize(&self, serializer: &mut CdrSerializer) -> CdrResult<()> {
+    fn serialize(&self, serializer: &mut ClassicCdrSerializer) -> CdrResult<()> {
         self.0
             .expect("Default DomainId not supposed to be serialized")
             .serialize(serializer)

--- a/dds_derive/src/derive/cdr_deserialize.rs
+++ b/dds_derive/src/derive/cdr_deserialize.rs
@@ -54,7 +54,7 @@ pub fn expand_cdr_deserialize(input: &DeriveInput) -> Result<TokenStream> {
 
             Ok(quote! {
                     impl #generics dust_dds::cdr::deserialize::CdrDeserialize<'__de> for #ident #type_generics #where_clause {
-                        fn deserialize(deserializer: &mut dust_dds::cdr::deserializer::CdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
+                        fn deserialize(deserializer: &mut dust_dds::cdr::deserializer::ClassicCdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
                             Ok(#struct_deserialization)
                         }
                     }
@@ -97,7 +97,7 @@ mod tests {
         let expected = syn::parse2::<ItemImpl>(
             "
             impl<'__de> dust_dds::cdr::deserialize::CdrDeserialize<'__de> for MyData {
-                fn deserialize(deserializer: &mut dust_dds::cdr::deserializer::CdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
+                fn deserialize(deserializer: &mut dust_dds::cdr::deserializer::ClassicCdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
                     Ok(Self {
                         x: dust_dds::cdr::deserialize::CdrDeserialize::deserialize(deserializer)?,
                         y: dust_dds::cdr::deserialize::CdrDeserialize::deserialize(deserializer)?,
@@ -136,7 +136,7 @@ mod tests {
         let expected = syn::parse2::<ItemImpl>(
             "
             impl<'__de : 'a, 'a> dust_dds::cdr::deserialize::CdrDeserialize<'__de> for BorrowedData<'a> {
-                fn deserialize(deserializer: &mut dust_dds::cdr::deserializer::CdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
+                fn deserialize(deserializer: &mut dust_dds::cdr::deserializer::ClassicCdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
                     Ok(Self {
                         data: dust_dds::cdr::deserialize::CdrDeserialize::deserialize(deserializer)?,
                     })

--- a/dds_derive/src/derive/cdr_deserialize.rs
+++ b/dds_derive/src/derive/cdr_deserialize.rs
@@ -54,7 +54,7 @@ pub fn expand_cdr_deserialize(input: &DeriveInput) -> Result<TokenStream> {
 
             Ok(quote! {
                     impl #generics dust_dds::cdr::deserialize::CdrDeserialize<'__de> for #ident #type_generics #where_clause {
-                        fn deserialize(deserializer: &mut dust_dds::cdr::deserializer::ClassicCdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
+                        fn deserialize(deserializer: &mut impl dust_dds::cdr::deserializer::CdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
                             Ok(#struct_deserialization)
                         }
                     }
@@ -97,7 +97,7 @@ mod tests {
         let expected = syn::parse2::<ItemImpl>(
             "
             impl<'__de> dust_dds::cdr::deserialize::CdrDeserialize<'__de> for MyData {
-                fn deserialize(deserializer: &mut dust_dds::cdr::deserializer::ClassicCdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
+                fn deserialize(deserializer: &mut impl dust_dds::cdr::deserializer::CdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
                     Ok(Self {
                         x: dust_dds::cdr::deserialize::CdrDeserialize::deserialize(deserializer)?,
                         y: dust_dds::cdr::deserialize::CdrDeserialize::deserialize(deserializer)?,
@@ -136,7 +136,7 @@ mod tests {
         let expected = syn::parse2::<ItemImpl>(
             "
             impl<'__de : 'a, 'a> dust_dds::cdr::deserialize::CdrDeserialize<'__de> for BorrowedData<'a> {
-                fn deserialize(deserializer: &mut dust_dds::cdr::deserializer::ClassicCdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
+                fn deserialize(deserializer: &mut impl dust_dds::cdr::deserializer::CdrDeserializer<'__de>) -> dust_dds::cdr::error::CdrResult<Self> {
                     Ok(Self {
                         data: dust_dds::cdr::deserialize::CdrDeserialize::deserialize(deserializer)?,
                     })

--- a/dds_derive/src/derive/cdr_serialize.rs
+++ b/dds_derive/src/derive/cdr_serialize.rs
@@ -25,7 +25,7 @@ pub fn expand_cdr_serialize(input: &DeriveInput) -> Result<TokenStream> {
 
             Ok(quote! {
                 impl #impl_generics dust_dds::cdr::serialize::CdrSerialize for #ident #type_generics #where_clause {
-                    fn serialize(&self, serializer: &mut dust_dds::cdr::serializer::ClassicCdrSerializer) -> dust_dds::cdr::error::CdrResult<()> {
+                    fn serialize(&self, serializer: &mut impl dust_dds::cdr::serializer::CdrSerializer) -> dust_dds::cdr::error::CdrResult<()> {
                         #field_serialization
                         Ok(())
                     }

--- a/dds_derive/src/derive/cdr_serialize.rs
+++ b/dds_derive/src/derive/cdr_serialize.rs
@@ -25,7 +25,7 @@ pub fn expand_cdr_serialize(input: &DeriveInput) -> Result<TokenStream> {
 
             Ok(quote! {
                 impl #impl_generics dust_dds::cdr::serialize::CdrSerialize for #ident #type_generics #where_clause {
-                    fn serialize(&self, serializer: &mut dust_dds::cdr::serializer::CdrSerializer) -> dust_dds::cdr::error::CdrResult<()> {
+                    fn serialize(&self, serializer: &mut dust_dds::cdr::serializer::ClassicCdrSerializer) -> dust_dds::cdr::error::CdrResult<()> {
                         #field_serialization
                         Ok(())
                     }

--- a/dds_derive/src/derive/dds_key.rs
+++ b/dds_derive/src/derive/dds_key.rs
@@ -151,7 +151,7 @@ pub fn expand_dds_instance_handle(input: &DeriveInput) -> Result<TokenStream> {
                         }
 
                         let mut writer = Vec::new();
-                        let mut serializer = dust_dds::cdr::serializer::CdrSerializer::new(&mut writer, dust_dds::cdr::endianness::CdrEndianness::BigEndian);
+                        let mut serializer = dust_dds::cdr::serializer::ClassicCdrSerializer::new(&mut writer, dust_dds::cdr::endianness::CdrEndianness::BigEndian);
                         dust_dds::cdr::serialize::CdrSerialize::serialize(
                             &__borrowed_key_holder{
                                 #borrowed_key_holder_field_assignment

--- a/dds_derive/src/derive/dds_key.rs
+++ b/dds_derive/src/derive/dds_key.rs
@@ -102,7 +102,7 @@ pub fn expand_dds_serialize_key(input: &DeriveInput) -> Result<TokenStream> {
             };
             Ok(quote! {
                 impl #impl_generics dust_dds::topic_definition::type_support::DdsSerializeKey for #ident #type_generics #where_clause {
-                    fn serialize_key(&self, writer: &mut Vec<u8>) -> dust_dds::infrastructure::error::DdsResult<()> {
+                    fn serialize_key(&self, writer: impl std::io::Write) -> dust_dds::infrastructure::error::DdsResult<()> {
                         #serialize_key_body
                     }
                 }

--- a/dds_derive/src/derive/dds_serialize_data.rs
+++ b/dds_derive/src/derive/dds_serialize_data.rs
@@ -81,7 +81,7 @@ pub fn expand_dds_serialize_data(input: &DeriveInput) -> Result<TokenStream> {
 
             Ok(quote! {
                 impl #impl_generics dust_dds::topic_definition::type_support::DdsSerialize for #ident #type_generics #where_clause {
-                    fn serialize_data(&self, writer: &mut Vec<u8>) -> dust_dds::infrastructure::error::DdsResult<()> {
+                    fn serialize_data(&self, writer: impl std::io::Write) -> dust_dds::infrastructure::error::DdsResult<()> {
                         #serialize_function
                     }
                 }

--- a/dds_derive/src/derive/parameter_list.rs
+++ b/dds_derive/src/derive/parameter_list.rs
@@ -165,11 +165,11 @@ pub fn expand_parameter_list_deserialize(input: &DeriveInput) -> Result<TokenStr
                             if is_tuple {
                                 if collection {
                                     field_deserialization
-                                        .extend(quote! {pl_deserializer.read_collection(#id)?, });
+                                        .extend(quote! {dust_dds::cdr::parameter_list_deserializer::ParameterListDeserializer::read_collection(pl_deserializer, #id)?, });
                                 } else {
                                     match default_value {
-                                            Some(default) => field_deserialization.extend(quote!{pl_deserializer.read_with_default(#id, #default)?, }),
-                                            None => field_deserialization.extend(quote!{pl_deserializer.read(#id)?, }),
+                                            Some(default) => field_deserialization.extend(quote!{dust_dds::cdr::parameter_list_deserializer::ParameterListDeserializer::read_with_default(pl_deserializer, #id, #default)?, }),
+                                            None => field_deserialization.extend(quote!{dust_dds::cdr::parameter_list_deserializer::ParameterListDeserializer::read(pl_deserializer, #id)?, }),
                                         }
                                 }
                             } else {
@@ -178,14 +178,14 @@ pub fn expand_parameter_list_deserialize(input: &DeriveInput) -> Result<TokenStr
 
                                 if collection {
                                     field_deserialization.extend(
-                                        quote! {#field_name: pl_deserializer.read_collection(#id)?,},
+                                        quote! {#field_name: dust_dds::cdr::parameter_list_deserializer::ParameterListDeserializer::read_collection(pl_deserializer, #id)?,},
                                     );
                                 } else {
                                     match default_value {
                                     Some(default) => field_deserialization
-                                        .extend(quote! {#field_name: pl_deserializer.read_with_default(#id, #default)?,}),
+                                        .extend(quote! {#field_name: dust_dds::cdr::parameter_list_deserializer::ParameterListDeserializer::read_with_default(pl_deserializer, #id, #default)?,}),
                                     None => field_deserialization
-                                        .extend(quote! {#field_name: pl_deserializer.read(#id)?,}),
+                                        .extend(quote! {#field_name: dust_dds::cdr::parameter_list_deserializer::ParameterListDeserializer::read(pl_deserializer, #id)?,}),
                                     }
                                 }
                             }
@@ -211,7 +211,7 @@ pub fn expand_parameter_list_deserialize(input: &DeriveInput) -> Result<TokenStr
 
             Ok(quote! {
                     impl #generics dust_dds::cdr::parameter_list_deserialize::ParameterListDeserialize<'__de> for #ident #type_generics #where_clause {
-                        fn deserialize(pl_deserializer: &mut dust_dds::cdr::parameter_list_deserializer::ParameterListCdrDeserializer<'__de>) -> Result<Self, std::io::Error> {
+                        fn deserialize(pl_deserializer: &mut impl dust_dds::cdr::parameter_list_deserializer::ParameterListDeserializer<'__de>) -> Result<Self, std::io::Error> {
                             Ok(#struct_deserialization)
                         }
                     }

--- a/dds_derive/src/derive/parameter_list.rs
+++ b/dds_derive/src/derive/parameter_list.rs
@@ -82,12 +82,12 @@ pub fn expand_parameter_list_serialize(input: &DeriveInput) -> Result<TokenStrea
                         } else {
                             match &field.ident {
                                 Some(field_name) => field_serialization.extend(quote! {
-                                    serializer.write_list_elements(#id, &self.#field_name)?;
+                                    serializer.write_collection(#id, &self.#field_name)?;
                                 }),
                                 None => {
                                     let index = Index::from(field_index);
                                     field_serialization.extend(quote! {
-                                        serializer.write_list_elements(#id, &self.#index)?;
+                                        serializer.write_collection(#id, &self.#index)?;
                                     })
                                 }
                             }

--- a/dds_derive/src/derive/parameter_list.rs
+++ b/dds_derive/src/derive/parameter_list.rs
@@ -110,7 +110,7 @@ pub fn expand_parameter_list_serialize(input: &DeriveInput) -> Result<TokenStrea
 
             Ok(quote! {
                 impl #impl_generics dust_dds::cdr::parameter_list_serialize::ParameterListSerialize for #ident #type_generics #where_clause {
-                    fn serialize(&self, serializer: &mut dust_dds::cdr::parameter_list_serializer::ParameterListSerializer) -> Result<(), std::io::Error> {
+                    fn serialize(&self, serializer: &mut dust_dds::cdr::parameter_list_serializer::ParameterListCdrSerializer) -> Result<(), std::io::Error> {
                         #field_serialization
                         Ok(())
                     }
@@ -256,7 +256,7 @@ mod tests {
         let expected = syn::parse2::<ItemImpl>(
             "
             impl dust_dds::cdr::parameter_list_serialize::ParameterListSerialize for ParameterListStruct {
-                fn serialize(&self, serializer: &mut dust_dds::cdr::parameter_list_serializer::ParameterListSerializer) -> Result<(), std::io::Error> {
+                fn serialize(&self, serializer: &mut dust_dds::cdr::parameter_list_serializer::ParameterListCdrSerializer) -> Result<(), std::io::Error> {
                     serializer.write(1, &self.index)?;
                     serializer.write(PID_DATA, &self.data)?;
                     Ok(())
@@ -302,7 +302,7 @@ mod tests {
         let expected = syn::parse2::<ItemImpl>(
             "
             impl dust_dds::cdr::parameter_list_serialize::ParameterListSerialize for ParameterListStructDefault {
-                fn serialize(&self, serializer: &mut dust_dds::cdr::parameter_list_serializer::ParameterListSerializer) -> Result<(), std::io::Error> {
+                fn serialize(&self, serializer: &mut dust_dds::cdr::parameter_list_serializer::ParameterListCdrSerializer) -> Result<(), std::io::Error> {
                     serializer.write(1, &self.index)?;
                     serializer.write(PID_DATA, &self.data)?;
                     serializer.write_with_default(3, &self.name, &\"\")?;

--- a/dds_derive/src/derive/parameter_list.rs
+++ b/dds_derive/src/derive/parameter_list.rs
@@ -61,33 +61,33 @@ pub fn expand_parameter_list_serialize(input: &DeriveInput) -> Result<TokenStrea
                         if !collection {
                             match (&field.ident, default_value) {
                             (Some(field_name), None) => field_serialization.extend(quote! {
-                                serializer.write(#id, &self.#field_name)?;
+                                dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write(serializer, #id, &self.#field_name)?;
                             }),
                             (Some(field_name), Some(default)) => field_serialization.extend(quote! {
-                                serializer.write_with_default(#id, &self.#field_name, & #default)?;
+                                dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write_with_default(serializer, #id, &self.#field_name, & #default)?;
                             }),
                             (None, None) => {
                                 let index = Index::from(field_index);
                                 field_serialization.extend(quote! {
-                                    serializer.write(#id, &self.#index)?;
+                                    dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write(serializer, #id, &self.#index)?;
                                 })
                             }
                             (None, Some(default)) => {
                                 let index = Index::from(field_index);
                                 field_serialization.extend(quote! {
-                                    serializer.write_with_default(#id, &self.#index, & #default)?;
+                                    dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write_with_default(serializer, #id, &self.#index, & #default)?;
                                 })
                             }
                         }
                         } else {
                             match &field.ident {
                                 Some(field_name) => field_serialization.extend(quote! {
-                                    serializer.write_collection(#id, &self.#field_name)?;
+                                    dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write_collection(serializer, #id, &self.#field_name)?;
                                 }),
                                 None => {
                                     let index = Index::from(field_index);
                                     field_serialization.extend(quote! {
-                                        serializer.write_collection(#id, &self.#index)?;
+                                        dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write_collection(serializer, #id, &self.#index)?;
                                     })
                                 }
                             }
@@ -110,7 +110,7 @@ pub fn expand_parameter_list_serialize(input: &DeriveInput) -> Result<TokenStrea
 
             Ok(quote! {
                 impl #impl_generics dust_dds::cdr::parameter_list_serialize::ParameterListSerialize for #ident #type_generics #where_clause {
-                    fn serialize(&self, serializer: &mut dust_dds::cdr::parameter_list_serializer::ParameterListCdrSerializer) -> Result<(), std::io::Error> {
+                    fn serialize(&self, serializer: &mut impl dust_dds::cdr::parameter_list_serializer::ParameterListSerializer) -> Result<(), std::io::Error> {
                         #field_serialization
                         Ok(())
                     }
@@ -256,9 +256,9 @@ mod tests {
         let expected = syn::parse2::<ItemImpl>(
             "
             impl dust_dds::cdr::parameter_list_serialize::ParameterListSerialize for ParameterListStruct {
-                fn serialize(&self, serializer: &mut dust_dds::cdr::parameter_list_serializer::ParameterListCdrSerializer) -> Result<(), std::io::Error> {
-                    serializer.write(1, &self.index)?;
-                    serializer.write(PID_DATA, &self.data)?;
+                fn serialize(&self, serializer: &mut impl dust_dds::cdr::parameter_list_serializer::ParameterListSerializer) -> Result<(), std::io::Error> {
+                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write(serializer, 1, &self.index)?;
+                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write(serializer, PID_DATA, &self.data)?;
                     Ok(())
                 }
             }
@@ -302,11 +302,11 @@ mod tests {
         let expected = syn::parse2::<ItemImpl>(
             "
             impl dust_dds::cdr::parameter_list_serialize::ParameterListSerialize for ParameterListStructDefault {
-                fn serialize(&self, serializer: &mut dust_dds::cdr::parameter_list_serializer::ParameterListCdrSerializer) -> Result<(), std::io::Error> {
-                    serializer.write(1, &self.index)?;
-                    serializer.write(PID_DATA, &self.data)?;
-                    serializer.write_with_default(3, &self.name, &\"\")?;
-                    serializer.write_with_default(4, &self.x, &Default::default())?;
+                fn serialize(&self, serializer: &mut impl dust_dds::cdr::parameter_list_serializer::ParameterListSerializer) -> Result<(), std::io::Error> {
+                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write(serializer, 1, &self.index)?;
+                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write(serializer, PID_DATA, &self.data)?;
+                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write_with_default(serializer, 3, &self.name, &\"\")?;
+                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write_with_default(serializer, 4, &self.x, &Default::default())?;
                     Ok(())
                 }
             }

--- a/dds_derive/src/derive/parameter_list.rs
+++ b/dds_derive/src/derive/parameter_list.rs
@@ -257,8 +257,8 @@ mod tests {
             "
             impl dust_dds::cdr::parameter_list_serialize::ParameterListSerialize for ParameterListStruct {
                 fn serialize(&self, serializer: &mut impl dust_dds::cdr::parameter_list_serializer::ParameterListSerializer) -> Result<(), std::io::Error> {
-                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write(serializer, 1, &self.index)?;
-                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write(serializer, PID_DATA, &self.data)?;
+                    dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write(serializer, 1, &self.index)?;
+                    dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write(serializer, PID_DATA, &self.data)?;
                     Ok(())
                 }
             }
@@ -303,10 +303,10 @@ mod tests {
             "
             impl dust_dds::cdr::parameter_list_serialize::ParameterListSerialize for ParameterListStructDefault {
                 fn serialize(&self, serializer: &mut impl dust_dds::cdr::parameter_list_serializer::ParameterListSerializer) -> Result<(), std::io::Error> {
-                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write(serializer, 1, &self.index)?;
-                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write(serializer, PID_DATA, &self.data)?;
-                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write_with_default(serializer, 3, &self.name, &\"\")?;
-                    dust_dds::cdr::parameter_list_serialize::ParameterListSerialize::write_with_default(serializer, 4, &self.x, &Default::default())?;
+                    dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write(serializer, 1, &self.index)?;
+                    dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write(serializer, PID_DATA, &self.data)?;
+                    dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write_with_default(serializer, 3, &self.name, &\"\")?;
+                    dust_dds::cdr::parameter_list_serializer::ParameterListSerializer::write_with_default(serializer, 4, &self.x, &Default::default())?;
                     Ok(())
                 }
             }

--- a/dds_derive/src/derive/parameter_list.rs
+++ b/dds_derive/src/derive/parameter_list.rs
@@ -165,7 +165,7 @@ pub fn expand_parameter_list_deserialize(input: &DeriveInput) -> Result<TokenStr
                             if is_tuple {
                                 if collection {
                                     field_deserialization
-                                        .extend(quote! {pl_deserializer.read_all(#id)?, });
+                                        .extend(quote! {pl_deserializer.read_collection(#id)?, });
                                 } else {
                                     match default_value {
                                             Some(default) => field_deserialization.extend(quote!{pl_deserializer.read_with_default(#id, #default)?, }),
@@ -178,7 +178,7 @@ pub fn expand_parameter_list_deserialize(input: &DeriveInput) -> Result<TokenStr
 
                                 if collection {
                                     field_deserialization.extend(
-                                        quote! {#field_name: pl_deserializer.read_all(#id)?,},
+                                        quote! {#field_name: pl_deserializer.read_collection(#id)?,},
                                     );
                                 } else {
                                     match default_value {
@@ -211,7 +211,7 @@ pub fn expand_parameter_list_deserialize(input: &DeriveInput) -> Result<TokenStr
 
             Ok(quote! {
                     impl #generics dust_dds::cdr::parameter_list_deserialize::ParameterListDeserialize<'__de> for #ident #type_generics #where_clause {
-                        fn deserialize(pl_deserializer: &mut dust_dds::cdr::parameter_list_deserializer::ParameterListDeserializer<'__de>) -> Result<Self, std::io::Error> {
+                        fn deserialize(pl_deserializer: &mut dust_dds::cdr::parameter_list_deserializer::ParameterListCdrDeserializer<'__de>) -> Result<Self, std::io::Error> {
                             Ok(#struct_deserialization)
                         }
                     }


### PR DESCRIPTION
Replace the concrete Serializer/Deserializer types on the Serialize/Deserialize methods by generic types. This is done to hide away the concrete type implementation and reduce the likelihood of breaking the API due to these type changes