### PR TITLE
Performance: Replace UdpTransportWrite actor by an Arc to avoid allocations

### DIFF
--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -26,7 +26,7 @@ use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use socket2::Socket;
 use std::{
     net::{Ipv4Addr, SocketAddr},
-    sync::RwLock,
+    sync::{Arc, RwLock},
 };
 use tracing::warn;
 
@@ -151,7 +151,7 @@ impl DomainParticipantFactory {
         let spdp_discovery_locator_list = metatraffic_multicast_locator_list.clone();
 
         let socket = std::net::UdpSocket::bind("0.0.0.0:0000").unwrap();
-        let udp_transport_write = spawn_actor(UdpTransportWrite::new(socket));
+        let udp_transport_write = Arc::new(UdpTransportWrite::new(socket));
 
         let rtps_participant = RtpsParticipant::new(
             guid_prefix,

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
+    sync::Arc,
 };
 
 use dust_dds_derive::actor_interface;
@@ -1961,7 +1962,7 @@ impl DataReaderActor {
     async fn send_message(
         &mut self,
         header: RtpsMessageHeader,
-        udp_transport_write: ActorAddress<UdpTransportWrite>,
+        udp_transport_write: Arc<UdpTransportWrite>,
     ) {
         for writer_proxy in self.matched_writers.iter_mut() {
             writer_proxy

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -903,7 +903,7 @@ impl DataWriterActor {
                                         header,
                                         vec![info_ts_submessage, data_submessage],
                                     ),
-                                    &vec![reader_locator.locator()],
+                                    &[reader_locator.locator()],
                                 )
                                 .await;
                         } else {
@@ -917,7 +917,7 @@ impl DataWriterActor {
                             udp_transport_write
                                 .write(
                                     &RtpsMessageWrite::new(header, vec![gap_submessage]),
-                                    &vec![reader_locator.locator()],
+                                    &[reader_locator.locator()],
                                 )
                                 .await;
                         }

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -868,7 +868,7 @@ impl DataWriterActor {
     async fn send_message_to_reader_locators(
         &mut self,
         header: RtpsMessageHeader,
-        udp_transport_write: &Arc<UdpTransportWrite>,
+        udp_transport_write: &UdpTransportWrite,
     ) {
         for reader_locator in &mut self.reader_locators {
             match &self.qos.reliability.kind {
@@ -934,7 +934,7 @@ impl DataWriterActor {
     async fn send_message_to_reader_proxies(
         &mut self,
         header: RtpsMessageHeader,
-        udp_transport_write: &Arc<UdpTransportWrite>,
+        udp_transport_write: &UdpTransportWrite,
     ) {
         for reader_proxy in &mut self.matched_readers {
             match (&self.qos.reliability.kind, reader_proxy.reliability()) {
@@ -1160,7 +1160,7 @@ async fn send_message_to_reader_proxy_best_effort(
     reader_proxy: &mut RtpsReaderProxy,
     writer_id: EntityId,
     writer_cache: &WriterHistoryCache,
-    udp_transport_write: &Arc<UdpTransportWrite>,
+    udp_transport_write: &UdpTransportWrite,
     header: RtpsMessageHeader,
 ) {
     // a_change_seq_num := the_reader_proxy.next_unsent_change();
@@ -1295,7 +1295,7 @@ async fn send_message_to_reader_proxy_reliable(
     writer_id: EntityId,
     writer_cache: &WriterHistoryCache,
     heartbeat_period: Duration,
-    udp_transport_write: &Arc<UdpTransportWrite>,
+    udp_transport_write: &UdpTransportWrite,
     header: RtpsMessageHeader,
 ) {
     // Top part of the state machine - Figure 8.19 RTPS standard
@@ -1395,7 +1395,7 @@ async fn send_change_message_reader_proxy_reliable(
     writer_id: EntityId,
     writer_cache: &WriterHistoryCache,
     change_seq_num: SequenceNumber,
-    udp_transport_write: &Arc<UdpTransportWrite>,
+    udp_transport_write: &UdpTransportWrite,
     header: RtpsMessageHeader,
 ) {
     match writer_cache

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use dust_dds_derive::actor_interface;
 use fnmatch_regex::glob_to_regex;
@@ -247,7 +247,7 @@ impl PublisherActor {
     async fn send_message(
         &self,
         header: RtpsMessageHeader,
-        udp_transport_write: ActorAddress<UdpTransportWrite>,
+        udp_transport_write: Arc<UdpTransportWrite>,
         now: Time,
     ) {
         for data_writer_address in self.data_writer_list.values() {

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use dust_dds_derive::actor_interface;
 use fnmatch_regex::glob_to_regex;
@@ -180,7 +180,7 @@ impl SubscriberActor {
     async fn send_message(
         &self,
         header: RtpsMessageHeader,
-        udp_transport_write: ActorAddress<UdpTransportWrite>,
+        udp_transport_write: Arc<UdpTransportWrite>,
     ) {
         for data_reader_address in self.data_reader_list.values() {
             data_reader_address

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -1,7 +1,6 @@
 use std::{
     cmp::{max, min},
     collections::HashMap,
-    sync::Arc,
 };
 
 use crate::implementation::rtps_udp_psm::udp_transport::UdpTransportWrite;
@@ -253,7 +252,7 @@ impl RtpsWriterProxy {
         &mut self,
         reader_guid: &Guid,
         header: RtpsMessageHeader,
-        udp_transport_write: &Arc<UdpTransportWrite>,
+        udp_transport_write: &UdpTransportWrite,
     ) {
         if self.must_send_acknacks() || !self.missing_changes().is_empty() {
             self.set_must_send_acknacks(false);

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -2,7 +2,7 @@ use crate::implementation::rtps::{
     messages::overall_structure::{RtpsMessageRead, RtpsMessageWrite},
     types::{Locator, LOCATOR_KIND_UDP_V4, LOCATOR_KIND_UDP_V6},
 };
-use dust_dds_derive::actor_interface;
+
 use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use std::{
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, ToSocketAddrs},
@@ -49,12 +49,11 @@ impl UdpTransportWrite {
     }
 }
 
-#[actor_interface]
 impl UdpTransportWrite {
-    async fn write(&mut self, message: RtpsMessageWrite, destination_locator_list: Vec<Locator>) {
+    pub async fn write(&self, message: &RtpsMessageWrite, destination_locator_list: &[Locator]) {
         let buf = message.buffer();
 
-        for destination_locator in destination_locator_list {
+        for &destination_locator in destination_locator_list {
             if UdpLocator(destination_locator).is_multicast() {
                 let socket2: socket2::Socket = self.socket.try_clone().unwrap().into();
                 let interface_addresses = NetworkInterface::show();


### PR DESCRIPTION
Using Valgrind DHAT we have observed that there are many heap allocations on send_message which are immediately thrown away. This happens because the message was send to the UdpTransportWrite actor via actor mail which allocates a box which is immediately used and discarded. This particular allocation is very large because the message buffer was sent inside it. To improve this the UdpTransportWrite is passed around as Arc instead of an actor.