### PR TITLE
Performance: Remove more memory allocations

### DIFF
--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -518,7 +518,7 @@ impl DataReaderActor {
                     writer_proxy.set_must_send_acknacks(
                         !heartbeat_submessage.final_flag()
                             || (!heartbeat_submessage.liveliness_flag()
-                                && !writer_proxy.missing_changes().is_empty()),
+                                && !writer_proxy.missing_changes().count() == 0),
                     );
 
                     if !heartbeat_submessage.final_flag() {

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1965,9 +1965,7 @@ impl DataReaderActor {
         udp_transport_write: Arc<UdpTransportWrite>,
     ) {
         for writer_proxy in self.matched_writers.iter_mut() {
-            writer_proxy
-                .send_message(&self.rtps_reader.guid(), header, &udp_transport_write)
-                .await
+            writer_proxy.send_message(&self.rtps_reader.guid(), header, &udp_transport_write)
         }
     }
 

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -796,10 +796,8 @@ impl DataWriterActor {
         // Remove stale changes before sending
         self.remove_stale_changes(now);
 
-        self.send_message_to_reader_locators(header, &udp_transport_write)
-            .await;
-        self.send_message_to_reader_proxies(header, &udp_transport_write)
-            .await;
+        self.send_message_to_reader_locators(header, &udp_transport_write);
+        self.send_message_to_reader_proxies(header, &udp_transport_write);
     }
 
     async fn reader_locator_add(&mut self, a_locator: RtpsReaderLocator) {
@@ -865,7 +863,7 @@ impl DataWriterActor {
         }
     }
 
-    async fn send_message_to_reader_locators(
+    fn send_message_to_reader_locators(
         &mut self,
         header: RtpsMessageHeader,
         udp_transport_write: &UdpTransportWrite,
@@ -927,7 +925,7 @@ impl DataWriterActor {
         }
     }
 
-    async fn send_message_to_reader_proxies(
+    fn send_message_to_reader_proxies(
         &mut self,
         header: RtpsMessageHeader,
         udp_transport_write: &UdpTransportWrite,
@@ -943,7 +941,6 @@ impl DataWriterActor {
                         udp_transport_write,
                         header,
                     )
-                    .await
                 }
                 (ReliabilityQosPolicyKind::Reliable, ReliabilityKind::Reliable) => {
                     send_message_to_reader_proxy_reliable(
@@ -954,7 +951,6 @@ impl DataWriterActor {
                         udp_transport_write,
                         header,
                     )
-                    .await
                 }
                 (ReliabilityQosPolicyKind::BestEffort, ReliabilityKind::Reliable) => {
                     panic!("Impossible combination. Should not be matched")
@@ -1152,7 +1148,7 @@ fn get_discovered_reader_incompatible_qos_policy_list(
     incompatible_qos_policy_list
 }
 
-async fn send_message_to_reader_proxy_best_effort(
+fn send_message_to_reader_proxy_best_effort(
     reader_proxy: &mut RtpsReaderProxy,
     writer_id: EntityId,
     writer_cache: &WriterHistoryCache,
@@ -1272,7 +1268,7 @@ async fn send_message_to_reader_proxy_best_effort(
     }
 }
 
-async fn send_message_to_reader_proxy_reliable(
+fn send_message_to_reader_proxy_reliable(
     reader_proxy: &mut RtpsReaderProxy,
     writer_id: EntityId,
     writer_cache: &WriterHistoryCache,
@@ -1317,8 +1313,7 @@ async fn send_message_to_reader_proxy_reliable(
                     next_unsent_change_seq_num,
                     udp_transport_write,
                     header,
-                )
-                .await;
+                );
             }
             reader_proxy.set_highest_sent_seq_num(next_unsent_change_seq_num);
         }
@@ -1362,13 +1357,12 @@ async fn send_message_to_reader_proxy_reliable(
                 next_requested_change_seq_num,
                 udp_transport_write,
                 header,
-            )
-            .await;
+            );
         }
     }
 }
 
-async fn send_change_message_reader_proxy_reliable(
+fn send_change_message_reader_proxy_reliable(
     reader_proxy: &mut RtpsReaderProxy,
     writer_id: EntityId,
     writer_cache: &WriterHistoryCache,

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -897,15 +897,13 @@ impl DataWriterActor {
                             let data_submessage = RtpsSubmessageWriteKind::Data(
                                 cache_change.as_data_submessage(ENTITYID_UNKNOWN),
                             );
-                            udp_transport_write
-                                .write(
-                                    &RtpsMessageWrite::new(
-                                        header,
-                                        vec![info_ts_submessage, data_submessage],
-                                    ),
-                                    &[reader_locator.locator()],
-                                )
-                                .await;
+                            udp_transport_write.write(
+                                &RtpsMessageWrite::new(
+                                    header,
+                                    vec![info_ts_submessage, data_submessage],
+                                ),
+                                &[reader_locator.locator()],
+                            );
                         } else {
                             let gap_submessage =
                                 RtpsSubmessageWriteKind::Gap(GapSubmessageWrite::new(
@@ -914,12 +912,10 @@ impl DataWriterActor {
                                     unsent_change_seq_num,
                                     SequenceNumberSet::new(unsent_change_seq_num + 1, vec![]),
                                 ));
-                            udp_transport_write
-                                .write(
-                                    &RtpsMessageWrite::new(header, vec![gap_submessage]),
-                                    &[reader_locator.locator()],
-                                )
-                                .await;
+                            udp_transport_write.write(
+                                &RtpsMessageWrite::new(header, vec![gap_submessage]),
+                                &[reader_locator.locator()],
+                            );
                         }
                         reader_locator.set_highest_sent_change_sn(unsent_change_seq_num);
                     }
@@ -1197,12 +1193,10 @@ async fn send_message_to_reader_proxy_best_effort(
                 gap_start_sequence_number,
                 SequenceNumberSet::new(gap_end_sequence_number + 1, vec![]),
             ));
-            udp_transport_write
-                .write(
-                    &RtpsMessageWrite::new(header, vec![gap_submessage]),
-                    reader_proxy.unicast_locator_list(),
-                )
-                .await;
+            udp_transport_write.write(
+                &RtpsMessageWrite::new(header, vec![gap_submessage]),
+                reader_proxy.unicast_locator_list(),
+            );
             reader_proxy.set_highest_sent_seq_num(next_unsent_change_seq_num);
         } else if let Some(cache_change) = writer_cache
             .change_list()
@@ -1232,15 +1226,10 @@ async fn send_message_to_reader_proxy_best_effort(
 
                     let data_frag = RtpsSubmessageWriteKind::DataFrag(data_frag_submessage);
 
-                    udp_transport_write
-                        .write(
-                            &RtpsMessageWrite::new(
-                                header,
-                                vec![info_dst, info_timestamp, data_frag],
-                            ),
-                            reader_proxy.unicast_locator_list(),
-                        )
-                        .await;
+                    udp_transport_write.write(
+                        &RtpsMessageWrite::new(header, vec![info_dst, info_timestamp, data_frag]),
+                        reader_proxy.unicast_locator_list(),
+                    );
                 }
             } else {
                 let info_dst = RtpsSubmessageWriteKind::InfoDestination(
@@ -1259,31 +1248,24 @@ async fn send_message_to_reader_proxy_best_effort(
                 let data_submessage = RtpsSubmessageWriteKind::Data(
                     cache_change.as_data_submessage(reader_proxy.remote_reader_guid().entity_id()),
                 );
-                udp_transport_write
-                    .write(
-                        &RtpsMessageWrite::new(
-                            header,
-                            vec![info_dst, info_timestamp, data_submessage],
-                        ),
-                        reader_proxy.unicast_locator_list(),
-                    )
-                    .await;
+                udp_transport_write.write(
+                    &RtpsMessageWrite::new(header, vec![info_dst, info_timestamp, data_submessage]),
+                    reader_proxy.unicast_locator_list(),
+                );
             }
         } else {
-            udp_transport_write
-                .write(
-                    &RtpsMessageWrite::new(
-                        header,
-                        vec![RtpsSubmessageWriteKind::Gap(GapSubmessageWrite::new(
-                            ENTITYID_UNKNOWN,
-                            writer_id,
-                            next_unsent_change_seq_num,
-                            SequenceNumberSet::new(next_unsent_change_seq_num + 1, vec![]),
-                        ))],
-                    ),
-                    reader_proxy.unicast_locator_list(),
-                )
-                .await;
+            udp_transport_write.write(
+                &RtpsMessageWrite::new(
+                    header,
+                    vec![RtpsSubmessageWriteKind::Gap(GapSubmessageWrite::new(
+                        ENTITYID_UNKNOWN,
+                        writer_id,
+                        next_unsent_change_seq_num,
+                        SequenceNumberSet::new(next_unsent_change_seq_num + 1, vec![]),
+                    ))],
+                ),
+                reader_proxy.unicast_locator_list(),
+            );
         }
 
         reader_proxy.set_highest_sent_seq_num(next_unsent_change_seq_num);
@@ -1323,12 +1305,10 @@ async fn send_message_to_reader_proxy_reliable(
                 let heartbeat_submessage = reader_proxy
                     .heartbeat_machine()
                     .submessage(writer_id, first_sn, last_sn);
-                udp_transport_write
-                    .write(
-                        &RtpsMessageWrite::new(header, vec![gap_submessage, heartbeat_submessage]),
-                        reader_proxy.unicast_locator_list(),
-                    )
-                    .await;
+                udp_transport_write.write(
+                    &RtpsMessageWrite::new(header, vec![gap_submessage, heartbeat_submessage]),
+                    reader_proxy.unicast_locator_list(),
+                );
             } else {
                 send_change_message_reader_proxy_reliable(
                     reader_proxy,
@@ -1361,12 +1341,10 @@ async fn send_message_to_reader_proxy_reliable(
         let heartbeat_submessage = reader_proxy
             .heartbeat_machine()
             .submessage(writer_id, first_sn, last_sn);
-        udp_transport_write
-            .write(
-                &RtpsMessageWrite::new(header, vec![heartbeat_submessage]),
-                reader_proxy.unicast_locator_list(),
-            )
-            .await;
+        udp_transport_write.write(
+            &RtpsMessageWrite::new(header, vec![heartbeat_submessage]),
+            reader_proxy.unicast_locator_list(),
+        );
     }
 
     // Middle-part of the state-machine - Figure 8.19 RTPS standard
@@ -1427,15 +1405,10 @@ async fn send_change_message_reader_proxy_reliable(
 
                     let data_frag = RtpsSubmessageWriteKind::DataFrag(data_frag_submessage);
 
-                    udp_transport_write
-                        .write(
-                            &RtpsMessageWrite::new(
-                                header,
-                                vec![info_dst, info_timestamp, data_frag],
-                            ),
-                            reader_proxy.unicast_locator_list(),
-                        )
-                        .await;
+                    udp_transport_write.write(
+                        &RtpsMessageWrite::new(header, vec![info_dst, info_timestamp, data_frag]),
+                        reader_proxy.unicast_locator_list(),
+                    );
                 }
             } else {
                 let info_dst = RtpsSubmessageWriteKind::InfoDestination(
@@ -1469,15 +1442,13 @@ async fn send_change_message_reader_proxy_reliable(
                     .heartbeat_machine()
                     .submessage(writer_id, first_sn, last_sn);
 
-                udp_transport_write
-                    .write(
-                        &RtpsMessageWrite::new(
-                            header,
-                            vec![info_dst, info_timestamp, data_submessage, heartbeat],
-                        ),
-                        reader_proxy.unicast_locator_list(),
-                    )
-                    .await;
+                udp_transport_write.write(
+                    &RtpsMessageWrite::new(
+                        header,
+                        vec![info_dst, info_timestamp, data_submessage, heartbeat],
+                    ),
+                    reader_proxy.unicast_locator_list(),
+                );
             }
         }
         _ => {
@@ -1492,12 +1463,10 @@ async fn send_change_message_reader_proxy_reliable(
                 SequenceNumberSet::new(change_seq_num + 1, vec![]),
             ));
 
-            udp_transport_write
-                .write(
-                    &RtpsMessageWrite::new(header, vec![info_dst, gap_submessage]),
-                    reader_proxy.unicast_locator_list(),
-                )
-                .await;
+            udp_transport_write.write(
+                &RtpsMessageWrite::new(header, vec![info_dst, gap_submessage]),
+                reader_proxy.unicast_locator_list(),
+            );
         }
     }
 }

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -899,8 +899,8 @@ impl DataWriterActor {
                             );
                             udp_transport_write.write(
                                 &RtpsMessageWrite::new(
-                                    header,
-                                    vec![info_ts_submessage, data_submessage],
+                                    &header,
+                                    &[info_ts_submessage, data_submessage],
                                 ),
                                 &[reader_locator.locator()],
                             );
@@ -913,7 +913,7 @@ impl DataWriterActor {
                                     SequenceNumberSet::new(unsent_change_seq_num + 1, vec![]),
                                 ));
                             udp_transport_write.write(
-                                &RtpsMessageWrite::new(header, vec![gap_submessage]),
+                                &RtpsMessageWrite::new(&header, &[gap_submessage]),
                                 &[reader_locator.locator()],
                             );
                         }
@@ -1194,7 +1194,7 @@ async fn send_message_to_reader_proxy_best_effort(
                 SequenceNumberSet::new(gap_end_sequence_number + 1, vec![]),
             ));
             udp_transport_write.write(
-                &RtpsMessageWrite::new(header, vec![gap_submessage]),
+                &RtpsMessageWrite::new(&header, &[gap_submessage]),
                 reader_proxy.unicast_locator_list(),
             );
             reader_proxy.set_highest_sent_seq_num(next_unsent_change_seq_num);
@@ -1227,7 +1227,7 @@ async fn send_message_to_reader_proxy_best_effort(
                     let data_frag = RtpsSubmessageWriteKind::DataFrag(data_frag_submessage);
 
                     udp_transport_write.write(
-                        &RtpsMessageWrite::new(header, vec![info_dst, info_timestamp, data_frag]),
+                        &RtpsMessageWrite::new(&header, &[info_dst, info_timestamp, data_frag]),
                         reader_proxy.unicast_locator_list(),
                     );
                 }
@@ -1249,15 +1249,15 @@ async fn send_message_to_reader_proxy_best_effort(
                     cache_change.as_data_submessage(reader_proxy.remote_reader_guid().entity_id()),
                 );
                 udp_transport_write.write(
-                    &RtpsMessageWrite::new(header, vec![info_dst, info_timestamp, data_submessage]),
+                    &RtpsMessageWrite::new(&header, &[info_dst, info_timestamp, data_submessage]),
                     reader_proxy.unicast_locator_list(),
                 );
             }
         } else {
             udp_transport_write.write(
                 &RtpsMessageWrite::new(
-                    header,
-                    vec![RtpsSubmessageWriteKind::Gap(GapSubmessageWrite::new(
+                    &header,
+                    &[RtpsSubmessageWriteKind::Gap(GapSubmessageWrite::new(
                         ENTITYID_UNKNOWN,
                         writer_id,
                         next_unsent_change_seq_num,
@@ -1306,7 +1306,7 @@ async fn send_message_to_reader_proxy_reliable(
                     .heartbeat_machine()
                     .submessage(writer_id, first_sn, last_sn);
                 udp_transport_write.write(
-                    &RtpsMessageWrite::new(header, vec![gap_submessage, heartbeat_submessage]),
+                    &RtpsMessageWrite::new(&header, &[gap_submessage, heartbeat_submessage]),
                     reader_proxy.unicast_locator_list(),
                 );
             } else {
@@ -1342,7 +1342,7 @@ async fn send_message_to_reader_proxy_reliable(
             .heartbeat_machine()
             .submessage(writer_id, first_sn, last_sn);
         udp_transport_write.write(
-            &RtpsMessageWrite::new(header, vec![heartbeat_submessage]),
+            &RtpsMessageWrite::new(&header, &[heartbeat_submessage]),
             reader_proxy.unicast_locator_list(),
         );
     }
@@ -1406,7 +1406,7 @@ async fn send_change_message_reader_proxy_reliable(
                     let data_frag = RtpsSubmessageWriteKind::DataFrag(data_frag_submessage);
 
                     udp_transport_write.write(
-                        &RtpsMessageWrite::new(header, vec![info_dst, info_timestamp, data_frag]),
+                        &RtpsMessageWrite::new(&header, &[info_dst, info_timestamp, data_frag]),
                         reader_proxy.unicast_locator_list(),
                     );
                 }
@@ -1444,8 +1444,8 @@ async fn send_change_message_reader_proxy_reliable(
 
                 udp_transport_write.write(
                     &RtpsMessageWrite::new(
-                        header,
-                        vec![info_dst, info_timestamp, data_submessage, heartbeat],
+                        &header,
+                        &[info_dst, info_timestamp, data_submessage, heartbeat],
                     ),
                     reader_proxy.unicast_locator_list(),
                 );
@@ -1464,7 +1464,7 @@ async fn send_change_message_reader_proxy_reliable(
             ));
 
             udp_transport_write.write(
-                &RtpsMessageWrite::new(header, vec![info_dst, gap_submessage]),
+                &RtpsMessageWrite::new(&header, &[info_dst, gap_submessage]),
                 reader_proxy.unicast_locator_list(),
             );
         }

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -184,10 +184,10 @@ pub struct RtpsMessageWrite {
 }
 
 impl RtpsMessageWrite {
-    pub fn new(header: RtpsMessageHeader, submessages: Vec<RtpsSubmessageWriteKind<'_>>) -> Self {
+    pub fn new(header: &RtpsMessageHeader, submessages: &[RtpsSubmessageWriteKind<'_>]) -> Self {
         let mut buffer = [0; BUFFER_SIZE];
         let mut len = header.write_bytes(&mut buffer[0..]);
-        for submessage in &submessages {
+        for submessage in submessages {
             len += submessage.write_bytes(&mut buffer[len..]);
         }
         Self { buffer, len }
@@ -393,7 +393,7 @@ mod tests {
             vendor_id: [9, 8],
             guid_prefix: [3; 12],
         };
-        let message = RtpsMessageWrite::new(header, Vec::new());
+        let message = RtpsMessageWrite::new(&header, &[]);
         #[rustfmt::skip]
         assert_eq!(message.buffer(), vec![
             b'R', b'T', b'P', b'S', // Protocol
@@ -435,7 +435,7 @@ mod tests {
             inline_qos,
             serialized_payload,
         ));
-        let value = RtpsMessageWrite::new(header, vec![submessage]);
+        let value = RtpsMessageWrite::new(&header, &[submessage]);
         #[rustfmt::skip]
         assert_eq!(value.buffer(), vec![
             b'R', b'T', b'P', b'S', // Protocol

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -235,7 +235,7 @@ impl RtpsWriterProxy {
         self.acknack_count = self.acknack_count.wrapping_add(1);
     }
 
-    pub async fn send_message(
+    pub fn send_message(
         &mut self,
         reader_guid: &Guid,
         header: RtpsMessageHeader,

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -308,12 +308,10 @@ impl RtpsWriterProxy {
                 }
             }
 
-            udp_transport_write
-                .write(
-                    &RtpsMessageWrite::new(header, submessages),
-                    self.unicast_locator_list(),
-                )
-                .await;
+            udp_transport_write.write(
+                &RtpsMessageWrite::new(header, submessages),
+                self.unicast_locator_list(),
+            );
         }
     }
 

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -137,7 +137,7 @@ impl RtpsWriterProxy {
 
         // Any number below first_available_seq_num is missing so that is the minimum
         // If there are missing changes, the minimum will be one above the maximum
-        if let Some(&minimum_missing_changes) = self.missing_changes().iter().min() {
+        if let Some(minimum_missing_changes) = self.missing_changes().min() {
             minimum_missing_changes - 1
         } else {
             // If there are no missing changes then the highest received sequence number
@@ -167,11 +167,9 @@ impl RtpsWriterProxy {
         self.first_available_seq_num = first_available_seq_num;
     }
 
-    pub fn missing_changes(&self) -> Vec<SequenceNumber> {
+    pub fn missing_changes(&self) -> impl Iterator<Item = SequenceNumber> {
         // The changes with status ‘MISSING’ represent the set of changes available in the HistoryCache of the RTPS Writer represented by the RTPS WriterProxy that have not been received by the RTPS Reader.
         // return { change IN this.changes_from_writer SUCH-THAT change.status == MISSING};
-        let mut missing_changes = Vec::new();
-
         let highest_received_seq_num = self.highest_received_change_sn;
         let highest_irrelevant_seq_num = self
             .irrelevant_changes
@@ -184,19 +182,18 @@ impl RtpsWriterProxy {
             self.last_available_seq_num,
             max(highest_received_seq_num, highest_irrelevant_seq_num),
         );
+
         // Changes below first_available_seq_num are LOST (or RECEIVED, but in any case not MISSING) and above last_available_seq_num are unknown.
         // In between those two numbers, every change that is not RECEIVED or IRRELEVANT is MISSING
-        let mut seq_num = self.first_available_seq_num;
-        while seq_num <= highest_number {
-            let received = seq_num <= self.highest_received_change_sn;
-
-            let irrelevant = self.irrelevant_changes.contains(&seq_num);
-            if !(irrelevant || received) {
-                missing_changes.push(seq_num)
-            }
-            seq_num += 1;
-        }
-        missing_changes
+        let highest_received_change_sn = self.highest_received_change_sn;
+        let irrelevant_changes = self.irrelevant_changes.clone();
+        (i64::from(self.first_available_seq_num)..=i64::from(highest_number))
+            .map(|x| SequenceNumber::from(x))
+            .filter(move |x| {
+                let received = x <= &highest_received_change_sn;
+                !received
+            })
+            .filter(move |x| !irrelevant_changes.contains(x))
     }
 
     pub fn missing_changes_update(&mut self, last_available_seq_num: SequenceNumber) {
@@ -254,21 +251,23 @@ impl RtpsWriterProxy {
         header: RtpsMessageHeader,
         udp_transport_write: &UdpTransportWrite,
     ) {
-        if self.must_send_acknacks() || !self.missing_changes().is_empty() {
+        if self.must_send_acknacks() || !self.missing_changes().count() == 0 {
             self.set_must_send_acknacks(false);
             self.increment_acknack_count();
 
             let info_dst_submessage =
                 InfoDestinationSubmessageWrite::new(self.remote_writer_guid().prefix());
 
-            let mut missing_changes = self.missing_changes();
-            missing_changes.truncate(256);
+            let missing_changes = self.missing_changes();
 
             let acknack_submessage = AckNackSubmessageWrite::new(
                 true,
                 reader_guid.entity_id(),
                 self.remote_writer_guid().entity_id(),
-                SequenceNumberSet::new(self.available_changes_max() + 1, missing_changes),
+                SequenceNumberSet::new(
+                    self.available_changes_max() + 1,
+                    missing_changes.take(256).collect(),
+                ),
                 self.acknack_count(),
             );
 
@@ -317,6 +316,6 @@ impl RtpsWriterProxy {
 
     pub fn is_historical_data_received(&self) -> bool {
         let at_least_one_heartbeat_received = self.last_received_heartbeat_count > 0;
-        at_least_one_heartbeat_received && self.missing_changes().is_empty()
+        at_least_one_heartbeat_received && self.missing_changes().count() == 0
     }
 }

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -298,7 +298,7 @@ impl RtpsWriterProxy {
             }
 
             udp_transport_write.write(
-                &RtpsMessageWrite::new(header, submessages),
+                &RtpsMessageWrite::new(&header, &submessages),
                 self.unicast_locator_list(),
             );
         }

--- a/dds/src/implementation/rtps_udp_psm/udp_transport.rs
+++ b/dds/src/implementation/rtps_udp_psm/udp_transport.rs
@@ -50,7 +50,7 @@ impl UdpTransportWrite {
 }
 
 impl UdpTransportWrite {
-    pub async fn write(&self, message: &RtpsMessageWrite, destination_locator_list: &[Locator]) {
+    pub fn write(&self, message: &RtpsMessageWrite, destination_locator_list: &[Locator]) {
         let buf = message.buffer();
 
         for &destination_locator in destination_locator_list {


### PR DESCRIPTION
Remove more memory allocations cause by unnecessary .await calls.

Replace the list of irrelevant changes by marking them as received which eliminates the need to keep allocating an ever growing Vec and conforms better to the RTPS standard which states that on irrelevant message received the state goes to received.