### PR TITLE
Update edition and prepare version 0.6

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -38,7 +38,7 @@ jobs:
       - run: git checkout master
       - run: cargo bench --package dust_dds --bench benchmark -- --save-baseline master_baseline
       - run: cargo bench --bench benchmark -- --load-baseline branch_baseline --baseline master_baseline --color never | tee /tmp/output
-      - run: if grep --quiet regressed /tmp/output; then exit 1; fi
+      # Performance regression is not explicitly checked due to measurement instability issues
       - store_artifacts:
           path: ./target/criterion
   build:

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 	"Pierre Martinet <pmartinet@s2e-systems.com>"
 ]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 description = "Data Distribution Service (DDS) implementation"
 homepage = "https://s2e-systems.com/products/dust-dds"

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",
@@ -16,7 +16,7 @@ keywords = ["dds", "rtps", "middleware", "network", "udp"]
 categories = ["api-bindings", "network-programming"]
 
 [dependencies]
-dust_dds_derive = { path = "../dds_derive", version = "0.5" }
+dust_dds_derive = { path = "../dds_derive", version = "0.6" }
 
 derive_more = "=0.99.16"
 md5 = "=0.7.0"  # Chose this crate over other possibilities since it doesn't have any other dependencies

--- a/dds_derive/Cargo.toml
+++ b/dds_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_derive"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds_derive/Cargo.toml
+++ b/dds_derive/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
 	"Stefan Kimmer <skimmer@s2e-systems.com>",
 	"Pierre Martinet <pmartinet@s2e-systems.com>"
 ]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Derive macro for `DdsType` and other traits from `dust-dds`"
 readme = "README.md"

--- a/dds_gen/Cargo.toml
+++ b/dds_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_gen"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",


### PR DESCRIPTION
Remove the performance regression check. Update Rust edition to 2021 and update to version 0.6