### PR TITLE
Add DDS XML type representation

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",
@@ -16,7 +16,7 @@ keywords = ["dds", "rtps", "middleware", "network", "udp"]
 categories = ["api-bindings", "network-programming"]
 
 [dependencies]
-dust_dds_derive = { path = "../dds_derive", version = "0.6" }
+dust_dds_derive = { path = "../dds_derive", version = "0.7" }
 
 derive_more = "=0.99.16"
 md5 = "=0.7.0"  # Chose this crate over other possibilities since it doesn't have any other dependencies

--- a/dds/src/dds/builtin_topics.rs
+++ b/dds/src/dds/builtin_topics.rs
@@ -6,7 +6,7 @@ use crate::{
         PID_HISTORY, PID_LATENCY_BUDGET, PID_LIFESPAN, PID_LIVELINESS, PID_OWNERSHIP,
         PID_PARTICIPANT_GUID, PID_PARTITION, PID_PRESENTATION, PID_RELIABILITY,
         PID_RESOURCE_LIMITS, PID_TIME_BASED_FILTER, PID_TOPIC_DATA, PID_TOPIC_NAME,
-        PID_TRANSPORT_PRIORITY, PID_TYPE_NAME, PID_USER_DATA,
+        PID_TRANSPORT_PRIORITY, PID_TYPE_NAME, PID_TYPE_REPRESENTATION, PID_USER_DATA,
     },
     infrastructure::qos_policy::{
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
@@ -252,6 +252,8 @@ pub struct PublicationBuiltinTopicData {
     topic_data: TopicDataQosPolicy,
     #[parameter(id = PID_GROUP_DATA, default=Default::default())]
     group_data: GroupDataQosPolicy,
+    #[parameter(id = PID_TYPE_REPRESENTATION, default=Default::default())]
+    xml_type: String,
 }
 
 impl PublicationBuiltinTopicData {
@@ -274,6 +276,7 @@ impl PublicationBuiltinTopicData {
         partition: PartitionQosPolicy,
         topic_data: TopicDataQosPolicy,
         group_data: GroupDataQosPolicy,
+        xml_type: String,
     ) -> Self {
         Self {
             key,
@@ -293,6 +296,7 @@ impl PublicationBuiltinTopicData {
             partition,
             topic_data,
             group_data,
+            xml_type,
         }
     }
 
@@ -363,6 +367,10 @@ impl PublicationBuiltinTopicData {
     pub fn group_data(&self) -> &GroupDataQosPolicy {
         &self.group_data
     }
+
+    pub fn xml_type(&self) -> &str {
+        &self.xml_type
+    }
 }
 
 impl DdsHasKey for PublicationBuiltinTopicData {
@@ -409,6 +417,8 @@ pub struct SubscriptionBuiltinTopicData {
     topic_data: TopicDataQosPolicy,
     #[parameter(id = PID_GROUP_DATA, default = Default::default())]
     group_data: GroupDataQosPolicy,
+    #[parameter(id = PID_TYPE_REPRESENTATION, default=Default::default())]
+    xml_type: String,
 }
 
 impl SubscriptionBuiltinTopicData {
@@ -431,6 +441,7 @@ impl SubscriptionBuiltinTopicData {
         partition: PartitionQosPolicy,
         topic_data: TopicDataQosPolicy,
         group_data: GroupDataQosPolicy,
+        xml_type: String,
     ) -> Self {
         Self {
             key,
@@ -450,6 +461,7 @@ impl SubscriptionBuiltinTopicData {
             partition,
             topic_data,
             group_data,
+            xml_type,
         }
     }
 
@@ -519,6 +531,10 @@ impl SubscriptionBuiltinTopicData {
 
     pub fn group_data(&self) -> &GroupDataQosPolicy {
         &self.group_data
+    }
+
+    pub fn xml_type(&self) -> &str {
+        &self.xml_type
     }
 }
 

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     publication::data_writer::DataWriter,
     topic_definition::topic::Topic,
-    topic_definition::type_support::DdsHasKey,
+    topic_definition::type_support::{DdsHasKey, DdsTypeXml},
 };
 
 use super::{data_writer_listener::DataWriterListener, publisher_listener::PublisherListener};
@@ -84,7 +84,7 @@ impl Publisher {
         mask: &[StatusKind],
     ) -> DdsResult<DataWriter<Foo>>
     where
-        Foo: DdsHasKey,
+        Foo: DdsHasKey + DdsTypeXml,
     {
         let default_unicast_locator_list = self
             .participant_address
@@ -114,6 +114,7 @@ impl Publisher {
                 mask.to_vec(),
                 default_unicast_locator_list,
                 default_multicast_locator_list,
+                Foo::get_type_xml(),
             ),
         )??;
 

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -103,7 +103,8 @@ impl Publisher {
             )?;
 
         let listener = Box::new(a_listener);
-        let type_xml = format!("<types>{}</types>", Foo::get_type_xml());
+        let type_xml =
+            Foo::get_type_xml().map_or_else(String::default, |s| format!("<types>{}</types>", s));
         let data_writer_address = self.publisher_address.send_mail_and_await_reply_blocking(
             publisher_actor::create_datawriter::new(
                 a_topic.get_type_name()?,

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -103,6 +103,7 @@ impl Publisher {
             )?;
 
         let listener = Box::new(a_listener);
+        let type_xml = format!("<types>{}</types>", Foo::get_type_xml());
         let data_writer_address = self.publisher_address.send_mail_and_await_reply_blocking(
             publisher_actor::create_datawriter::new(
                 a_topic.get_type_name()?,
@@ -114,7 +115,7 @@ impl Publisher {
                 mask.to_vec(),
                 default_unicast_locator_list,
                 default_multicast_locator_list,
-                Foo::get_type_xml(),
+                type_xml,
             ),
         )??;
 

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     topic_definition::{
         topic::Topic,
-        type_support::{DdsHasKey, DdsKey},
+        type_support::{DdsHasKey, DdsKey, DdsTypeXml},
     },
 };
 
@@ -101,7 +101,7 @@ impl Subscriber {
         mask: &[StatusKind],
     ) -> DdsResult<DataReader<Foo>>
     where
-        Foo: DdsHasKey + DdsKey,
+        Foo: DdsHasKey + DdsKey + DdsTypeXml,
     {
         let default_unicast_locator_list = self
             .participant_address
@@ -168,6 +168,7 @@ impl Subscriber {
             qos,
             listener,
             status_kind,
+            Foo::get_type_xml(),
         );
 
         let reader_actor = spawn_actor(data_reader);

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -158,7 +158,7 @@ impl Subscriber {
             DURATION_ZERO,
             false,
         );
-
+        let type_xml = format!("<types>{}</types>", Foo::get_type_xml());
         let listener = Box::new(a_listener);
         let status_kind = mask.to_vec();
         let data_reader = DataReaderActor::new::<Foo>(
@@ -168,7 +168,7 @@ impl Subscriber {
             qos,
             listener,
             status_kind,
-            Foo::get_type_xml(),
+            type_xml,
         );
 
         let reader_actor = spawn_actor(data_reader);

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -158,7 +158,8 @@ impl Subscriber {
             DURATION_ZERO,
             false,
         );
-        let type_xml = format!("<types>{}</types>", Foo::get_type_xml());
+        let type_xml =
+            Foo::get_type_xml().map_or_else(String::default, |s| format!("<types>{}</types>", s));
         let listener = Box::new(a_listener);
         let status_kind = mask.to_vec();
         let data_reader = DataReaderActor::new::<Foo>(

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 
-pub use dust_dds_derive::{DdsDeserialize, DdsHasKey, DdsSerialize};
+pub use dust_dds_derive::{DdsDeserialize, DdsHasKey, DdsSerialize, DdsTypeXml};
 
 /// This trait indicates whether the associated type is keyed or not, i.e. if the middleware
 /// should manage different instances of the type.

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -60,12 +60,13 @@ pub trait DdsDeserialize<'de>: Sized {
     fn deserialize_data(serialized_data: &'de [u8]) -> DdsResult<Self>;
 }
 
-/// This trait defines the key associated with the type.
-///
-/// The key identifies the different instances of the type.
-///
+/// This trait defines the key associated with the type. The key is used to identify different instances of the type.
+/// The returned key object must implement ['CdrSerialize'] and ['CdrDeserialize'] since CDR is the format always
+/// used to transmit the key information on the wire and this can not be modified by the user.
 ///
 /// ## Derivable
+///
+/// This trait can be automatically derived if all the field marked `#[dust_dds(key)]` implement ['CdrSerialize'] and ['CdrDeserialize']
 ///
 pub trait DdsKey {
     type Key: CdrSerialize + for<'de> CdrDeserialize<'de>;
@@ -75,8 +76,15 @@ pub trait DdsKey {
     fn get_key_from_serialized_data(serialized_foo: &[u8]) -> DdsResult<Self::Key>;
 }
 
+/// This trait defines the optional type representation for a user type. The type representation
+/// returned by the function in this trait must follow the description in 7.3.2 XML Type Representation
+/// of the [OMG DDS-XTypes standard](https://www.omg.org/spec/DDS-XTypes/1.3/).
+///
+/// ## Derivable
+///
+/// This trait can be automatically derived for every DustDDS supported type.
 pub trait DdsTypeXml {
-    fn get_type_xml() -> String;
+    fn get_type_xml() -> Option<String>;
 }
 
 /// This is a convenience derive to allow the user to easily derive all the different traits needed for a type to be used for

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -75,6 +75,10 @@ pub trait DdsKey {
     fn get_key_from_serialized_data(serialized_foo: &[u8]) -> DdsResult<Self::Key>;
 }
 
+pub trait DdsTypeXml {
+    fn get_type_xml() -> String;
+}
+
 /// This is a convenience derive to allow the user to easily derive all the different traits needed for a type to be used for
 /// communication with DustDDS. If the individual traits are manually derived then this derive should not be used.
 ///

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -304,6 +304,7 @@ pub struct DataReaderActor {
     status_kind: Vec<StatusKind>,
     instances: HashMap<InstanceHandle, InstanceState>,
     instance_deadline_missed_task: HashMap<InstanceHandle, tokio::task::AbortHandle>,
+    xml_type: String,
 }
 
 impl DataReaderActor {
@@ -314,6 +315,7 @@ impl DataReaderActor {
         qos: DataReaderQos,
         listener: Box<dyn AnyDataReaderListener + Send>,
         status_kind: Vec<StatusKind>,
+        xml_type: String,
     ) -> Self
     where
         Foo: DdsKey,
@@ -349,6 +351,7 @@ impl DataReaderActor {
             instance_handle_from_serialized_key,
             instances: HashMap::new(),
             instance_deadline_missed_task: HashMap::new(),
+            xml_type,
         }
     }
 
@@ -1636,6 +1639,7 @@ impl DataReaderActor {
                 subscriber_qos.partition.clone(),
                 topic_qos.topic_data,
                 subscriber_qos.group_data,
+                self.xml_type.clone(),
             ),
         )
     }

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -233,6 +233,7 @@ pub struct DataWriterActor {
     writer_cache: WriterHistoryCache,
     qos: DataWriterQos,
     registered_instance_list: HashSet<InstanceHandle>,
+    xml_type: String,
 }
 
 impl DataWriterActor {
@@ -243,6 +244,7 @@ impl DataWriterActor {
         listener: Box<dyn AnyDataWriterListener + Send>,
         status_kind: Vec<StatusKind>,
         qos: DataWriterQos,
+        xml_type: String,
     ) -> Self {
         let status_condition = spawn_actor(StatusConditionActor::default());
         let listener = spawn_actor(DataWriterListenerActor::new(listener));
@@ -261,6 +263,7 @@ impl DataWriterActor {
             writer_cache: WriterHistoryCache::new(),
             qos,
             registered_instance_list: HashSet::new(),
+            xml_type,
         }
     }
 
@@ -527,6 +530,7 @@ impl DataWriterActor {
                 publisher_qos.partition.clone(),
                 topic_qos.topic_data,
                 publisher_qos.group_data,
+                self.xml_type.clone(),
             ),
             WriterProxy::new(
                 self.rtps_writer.guid(),

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -233,6 +233,7 @@ impl DomainParticipantActor {
                 spdp_reader_qos,
                 Box::new(NoOpListener::<SpdpDiscoveredParticipantData>::new()),
                 vec![],
+                String::default(),
             ));
 
         let sedp_reader_qos = DataReaderQos {
@@ -258,6 +259,7 @@ impl DomainParticipantActor {
             sedp_reader_qos.clone(),
             Box::new(NoOpListener::<DiscoveredTopicData>::new()),
             vec![],
+            String::default(),
         ));
 
         let sedp_builtin_publications_reader_guid =
@@ -270,6 +272,7 @@ impl DomainParticipantActor {
                 sedp_reader_qos.clone(),
                 Box::new(NoOpListener::<DiscoveredWriterData>::new()),
                 vec![],
+                String::default(),
             ));
 
         let sedp_builtin_subscriptions_reader_guid =
@@ -282,6 +285,7 @@ impl DomainParticipantActor {
                 sedp_reader_qos,
                 Box::new(NoOpListener::<DiscoveredReaderData>::new()),
                 vec![],
+                String::default(),
             ));
 
         let builtin_subscriber = spawn_actor(SubscriberActor::new(
@@ -346,6 +350,7 @@ impl DomainParticipantActor {
             Box::new(NoOpListener::<SpdpDiscoveredParticipantData>::new()),
             vec![],
             spdp_writer_qos,
+            String::default(),
         ));
 
         for reader_locator in spdp_discovery_locator_list
@@ -382,6 +387,7 @@ impl DomainParticipantActor {
             Box::new(NoOpListener::<DiscoveredTopicData>::new()),
             vec![],
             sedp_writer_qos.clone(),
+            String::default(),
         );
         let sedp_builtin_topics_writer_actor = spawn_actor(sedp_builtin_topics_writer);
 
@@ -394,6 +400,7 @@ impl DomainParticipantActor {
             Box::new(NoOpListener::<DiscoveredWriterData>::new()),
             vec![],
             sedp_writer_qos.clone(),
+            String::default(),
         );
         let sedp_builtin_publications_writer_actor = spawn_actor(sedp_builtin_publications_writer);
 
@@ -406,6 +413,7 @@ impl DomainParticipantActor {
             Box::new(NoOpListener::<DiscoveredReaderData>::new()),
             vec![],
             sedp_writer_qos,
+            String::default(),
         );
         let sedp_builtin_subscriptions_writer_actor =
             spawn_actor(sedp_builtin_subscriptions_writer);

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -84,6 +84,7 @@ impl PublisherActor {
         mask: Vec<StatusKind>,
         default_unicast_locator_list: Vec<Locator>,
         default_multicast_locator_list: Vec<Locator>,
+        xml_type: String,
     ) -> DdsResult<ActorAddress<DataWriterActor>> {
         let qos = match qos {
             QosKind::Default => self.default_datawriter_qos.clone(),
@@ -127,6 +128,7 @@ impl PublisherActor {
             a_listener,
             mask,
             qos,
+            xml_type,
         );
         let data_writer_actor = spawn_actor(data_writer);
         let data_writer_address = data_writer_actor.address();

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -174,6 +174,7 @@ mod tests {
                 PartitionQosPolicy::default(),
                 TopicDataQosPolicy::default(),
                 GroupDataQosPolicy::default(),
+                String::default(),
             ),
         };
 
@@ -240,6 +241,7 @@ mod tests {
                 PartitionQosPolicy::default(),
                 TopicDataQosPolicy::default(),
                 GroupDataQosPolicy::default(),
+                String::default(),
             ),
         };
 

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -161,6 +161,7 @@ mod tests {
                 PartitionQosPolicy::default(),
                 TopicDataQosPolicy::default(),
                 GroupDataQosPolicy::default(),
+                String::default(),
             ),
             WriterProxy::new(
                 Guid::new(
@@ -226,6 +227,7 @@ mod tests {
                 PartitionQosPolicy::default(),
                 TopicDataQosPolicy::default(),
                 GroupDataQosPolicy::default(),
+                String::default(),
             ),
             WriterProxy::new(
                 // must correspond to publication_builtin_topic_data.key

--- a/dds/src/implementation/data_representation_builtin_endpoints/parameter_id_values.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/parameter_id_values.rs
@@ -1,5 +1,8 @@
 use crate::{
-    implementation::rtps::{types::{EntityId, ENTITYID_UNKNOWN}, messages::types::ParameterId},
+    implementation::rtps::{
+        messages::types::ParameterId,
+        types::{EntityId, ENTITYID_UNKNOWN},
+    },
     infrastructure::time::Duration,
 };
 
@@ -55,6 +58,9 @@ pub const PID_DATA_MAX_SIZE_SERIALIZED: ParameterId = PID_TYPE_MAX_SIZE_SERIALIZ
 // Following PID is listed in "Table 9.19 – Deprecated ParameterId Values" but
 // also in "Table 9.14 - ParameterId mapping and default values"
 pub const PID_GROUP_ENTITYID: ParameterId = 0x0053;
+
+#[allow(overflowing_literals)]
+pub const PID_TYPE_REPRESENTATION: ParameterId = 0x8010;
 
 // Constant value from Table 9.14 - ParameterId mapping and default values
 // that are not N/A and not See DDS specification

--- a/dds_derive/Cargo.toml
+++ b/dds_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_derive"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds_derive/Cargo.toml
+++ b/dds_derive/Cargo.toml
@@ -22,3 +22,4 @@ proc-macro = true
 quote = "1.0"
 proc-macro2 = "1.0"
 syn = { version = "2.0", features=["full", "extra-traits"] }
+xml-rs = "0.8.19"

--- a/dds_derive/src/derive/dds_type_xml.rs
+++ b/dds_derive/src/derive/dds_type_xml.rs
@@ -108,14 +108,14 @@ pub fn expand_dds_type_xml(input: &DeriveInput) -> syn::Result<TokenStream> {
                         "Type not supported for automatic XML derive",
                     )),
                 }?;
-                xml_writer.write(field_element).expect(&format!(
-                    "Failed to write member start element for {}",
-                    field_name
-                ));
-                xml_writer.write(XmlEvent::end_element()).expect(&format!(
-                    "Failed to write member end element for {}",
-                    field_name
-                ));
+                xml_writer.write(field_element).unwrap_or_else(|_| {
+                    panic!("Failed to write member start element for {}", field_name)
+                });
+                xml_writer
+                    .write(XmlEvent::end_element())
+                    .unwrap_or_else(|_| {
+                        panic!("Failed to write member end element for {}", field_name)
+                    });
             }
             xml_writer
                 .write(XmlEvent::end_element())

--- a/dds_derive/src/derive/dds_type_xml.rs
+++ b/dds_derive/src/derive/dds_type_xml.rs
@@ -204,8 +204,8 @@ mod tests {
         let result = syn::parse2::<ItemImpl>(expand_dds_type_xml(&input).unwrap()).unwrap();
         let expected = syn::parse2::<ItemImpl>(
             r#"impl dust_dds::topic_definition::type_support::DdsTypeXml for TestStruct {
-                fn get_type_xml() -> String {
-                    "<struct name=\"TestStruct\"><member name=\"id\" type=\"uint8\" /><member name=\"value_list\" type=\"uint8\" sequenceMaxLength=\"-1\" /></struct>".to_string()
+                fn get_type_xml() -> Option<String> {
+                    Some("<struct name=\"TestStruct\"><member name=\"id\" type=\"uint8\" /><member name=\"value_list\" type=\"uint8\" sequenceMaxLength=\"-1\" /></struct>".to_string())
                 }
             }"#
             .parse()

--- a/dds_derive/src/derive/dds_type_xml.rs
+++ b/dds_derive/src/derive/dds_type_xml.rs
@@ -1,0 +1,145 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::DeriveInput;
+use xml::{writer::XmlEvent, EmitterConfig, EventWriter};
+
+pub fn expand_dds_type_xml(input: &DeriveInput) -> syn::Result<TokenStream> {
+    match &input.data {
+        syn::Data::Struct(data_struct) => {
+            let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+            let ident = &input.ident;
+            let mut output_xml = Vec::new();
+            let mut xml_writer = EventWriter::new_with_config(
+                &mut output_xml,
+                EmitterConfig::new().write_document_declaration(false),
+            );
+            xml_writer
+                .write(XmlEvent::start_element("struct").attr("name", &ident.to_string()))
+                .expect("Failed to write struct XML element");
+            for (field_index, field) in data_struct.fields.iter().enumerate() {
+                let field_name = match &field.ident {
+                    Some(ident) => ident.to_string(),
+                    None => field_index.to_string(),
+                };
+
+                let field_type = match &field.ty {
+                    syn::Type::Array(_) => todo!(),
+                    syn::Type::BareFn(_) => todo!(),
+                    syn::Type::Group(_) => todo!(),
+                    syn::Type::ImplTrait(_) => todo!(),
+                    syn::Type::Infer(_) => todo!(),
+                    syn::Type::Macro(_) => todo!(),
+                    syn::Type::Never(_) => todo!(),
+                    syn::Type::Paren(_) => todo!(),
+                    syn::Type::Path(p) => match p.path.get_ident() {
+                        Some(i) => match i.to_string().as_str() {
+                            "bool" => "boolean",
+                            "char" => "char8",
+                            "i32" => "int32",
+                            "u32" => "uint32",
+                            "i8" => "int8",
+                            "u8" => "uint8",
+                            "i16" => "int16",
+                            "u16" => "uint16",
+                            "i64" => "int64",
+                            "u64" => "uint64",
+                            "f32" => "float32",
+                            "f64" => "float64",
+                            "f128" => unimplemented!("Type not valid for XML"),
+                            "String" => "string",
+                            _ => todo!(),
+                        },
+                        None => todo!(),
+                    },
+                    syn::Type::Ptr(_) => todo!(),
+                    syn::Type::Reference(_) => todo!(),
+                    syn::Type::Slice(_) => todo!(),
+                    syn::Type::TraitObject(_) => todo!(),
+                    syn::Type::Tuple(_) => todo!(),
+                    syn::Type::Verbatim(_) => todo!(),
+                    _ => todo!(),
+                };
+                xml_writer
+                    .write(
+                        XmlEvent::start_element("member")
+                            .attr("name", &field_name)
+                            .attr("type", field_type),
+                    )
+                    .expect(&format!(
+                        "Failed to write member start element for {}",
+                        field_name
+                    ));
+                xml_writer.write(XmlEvent::end_element()).expect(&format!(
+                    "Failed to write member end element for {}",
+                    field_name
+                ));
+            }
+            xml_writer
+                .write(XmlEvent::end_element())
+                .expect("Failed to write struct XML end element");
+            let output_xml_string =
+                String::from_utf8(output_xml).expect("Failed to convert XML to string");
+
+            Ok(quote! {
+                impl #impl_generics dust_dds::topic_definition::type_support::DdsTypeXml for #ident #type_generics #where_clause {
+                    fn get_type_xml() -> String {
+                        #output_xml_string.to_string()
+                    }
+                }
+            })
+        }
+        syn::Data::Enum(data_enum) => Err(syn::Error::new(
+            data_enum.enum_token.span,
+            "Enum not supported",
+        )),
+        syn::Data::Union(data_union) => Err(syn::Error::new(
+            data_union.union_token.span,
+            "Union not supported",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::ToTokens;
+    use syn::ItemImpl;
+
+    use super::*;
+
+    #[test]
+    fn struct_with_key_field_should_be_has_key_true() {
+        let input = syn::parse2::<DeriveInput>(
+            "
+            struct TestStruct {
+                #[dust_dds(key)]
+                id: u8,
+                name: String,
+                value: f32,
+            }
+        "
+            .parse()
+            .unwrap(),
+        )
+        .unwrap();
+
+        let result = syn::parse2::<ItemImpl>(expand_dds_type_xml(&input).unwrap()).unwrap();
+        let expected = syn::parse2::<ItemImpl>(
+            r#"impl dust_dds::topic_definition::type_support::DdsTypeXml for TestStruct {
+                fn get_type_xml() -> String {
+                    "<struct name=\"TestStruct\"><member name=\"id\" type=\"uint8\" /><member name=\"name\" type=\"string\" /><member name=\"value\" type=\"float32\" /></struct>".to_string()
+                }
+            }"#
+            .parse()
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            expected,
+            "\n\n Result: {:?} \n Expected: {:?}",
+            result.clone().into_token_stream().to_string(),
+            expected.clone().into_token_stream().to_string()
+        );
+    }
+}

--- a/dds_derive/src/derive/mod.rs
+++ b/dds_derive/src/derive/mod.rs
@@ -2,4 +2,5 @@ pub mod cdr_deserialize;
 pub mod cdr_serialize;
 pub mod dds_key;
 pub mod dds_serialize_data;
+pub mod dds_type_xml;
 pub mod parameter_list;

--- a/dds_derive/src/lib.rs
+++ b/dds_derive/src/lib.rs
@@ -5,6 +5,7 @@ use derive::{
     cdr_serialize::expand_cdr_serialize,
     dds_key::{expand_dds_key, expand_has_key},
     dds_serialize_data::{expand_dds_deserialize_data, expand_dds_serialize_data},
+    dds_type_xml::expand_dds_type_xml,
     parameter_list::{expand_parameter_list_deserialize, expand_parameter_list_serialize},
 };
 use proc_macro::TokenStream;
@@ -75,6 +76,14 @@ pub fn derive_dds_key(input: TokenStream) -> TokenStream {
         .into()
 }
 
+#[proc_macro_derive(DdsTypeXml, attributes(dust_dds))]
+pub fn derive_dds_type_xml(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input);
+    expand_dds_type_xml(&input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
 #[proc_macro_derive(DdsType, attributes(dust_dds))]
 pub fn derive_dds_type(input: TokenStream) -> TokenStream {
     let mut output = TokenStream::new();
@@ -84,7 +93,8 @@ pub fn derive_dds_type(input: TokenStream) -> TokenStream {
     output.extend(derive_dds_serialize(input.clone()));
     output.extend(derive_dds_deserialize(input.clone()));
     output.extend(derive_dds_key(input.clone()));
-    output.extend(derive_dds_has_key(input));
+    output.extend(derive_dds_has_key(input.clone()));
+    output.extend(derive_dds_type_xml(input));
 
     output
 }

--- a/dds_gen/Cargo.toml
+++ b/dds_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_gen"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",


### PR DESCRIPTION
Add DDS XML type representation to the custom types and transmit that information with the reader and writer discovery data using a vendor specific parameter.