### PR TITLE
Add register_type method to DomainParticipant

### DIFF
--- a/dds/README.md
+++ b/dds/README.md
@@ -34,12 +34,8 @@ A basic example on how to use Dust DDS. The publisher side can be implemented as
             .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
             .unwrap();
 
-        participant
-            .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
-            .unwrap();
-
         let topic = participant
-            .create_topic("HelloWorld", "HelloWorldType", QosKind::Default, NoOpListener::new(), NO_STATUS)
+            .create_topic::<HelloWorldType>("HelloWorld", "HelloWorldType", QosKind::Default, NoOpListener::new(), NO_STATUS)
             .unwrap();
 
         let publisher = participant
@@ -83,12 +79,8 @@ The subscriber side can be implemented as:
             .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
             .unwrap();
 
-        participant
-            .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
-            .unwrap();
-
         let topic = participant
-            .create_topic("HelloWorld", "HelloWorldType", QosKind::Default, NoOpListener::new(), NO_STATUS)
+            .create_topic::<HelloWorldType>("HelloWorld", "HelloWorldType", QosKind::Default, NoOpListener::new(), NO_STATUS)
             .unwrap();
 
         let subscriber = participant

--- a/dds/README.md
+++ b/dds/README.md
@@ -16,7 +16,7 @@ A basic example on how to use Dust DDS. The publisher side can be implemented as
     use dust_dds::{
         domain::domain_participant_factory::DomainParticipantFactory,
         infrastructure::{listeners::NoOpListener, qos::QosKind, status::NO_STATUS},
-        topic_definition::type_support::{DdsType, FooTypeSupport}
+        topic_definition::type_support::DdsType,
     };
 
     #[derive(DdsType)]
@@ -61,7 +61,7 @@ The subscriber side can be implemented as:
         domain::domain_participant_factory::DomainParticipantFactory,
         infrastructure::{listeners::NoOpListener, qos::QosKind, status::NO_STATUS},
         subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-        topic_definition::type_support::{DdsType, FooTypeSupport},
+        topic_definition::type_support::DdsType,
     };
 
     #[derive(Debug, DdsType)]

--- a/dds/README.md
+++ b/dds/README.md
@@ -16,7 +16,7 @@ A basic example on how to use Dust DDS. The publisher side can be implemented as
     use dust_dds::{
         domain::domain_participant_factory::DomainParticipantFactory,
         infrastructure::{listeners::NoOpListener, qos::QosKind, status::NO_STATUS},
-        topic_definition::type_support::DdsType,
+        topic_definition::type_support::{DdsType, FooTypeSupport}
     };
 
     #[derive(DdsType)]
@@ -32,6 +32,10 @@ A basic example on how to use Dust DDS. The publisher side can be implemented as
 
         let participant = participant_factory
             .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+            .unwrap();
+
+        participant
+            .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
             .unwrap();
 
         let topic = participant
@@ -61,7 +65,7 @@ The subscriber side can be implemented as:
         domain::domain_participant_factory::DomainParticipantFactory,
         infrastructure::{listeners::NoOpListener, qos::QosKind, status::NO_STATUS},
         subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-        topic_definition::type_support::DdsType,
+        topic_definition::type_support::{DdsType, FooTypeSupport},
     };
 
     #[derive(Debug, DdsType)]
@@ -77,6 +81,10 @@ The subscriber side can be implemented as:
 
         let participant = participant_factory
             .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+            .unwrap();
+
+        participant
+            .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
             .unwrap();
 
         let topic = participant

--- a/dds/benches/benchmark.rs
+++ b/dds/benches/benchmark.rs
@@ -13,7 +13,7 @@ use dust_dds::{
         data_reader_listener::DataReaderListener,
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 #[derive(Clone, Debug, PartialEq, DdsType)]
@@ -27,6 +27,9 @@ pub fn best_effort_write_only(c: &mut Criterion) {
     let domain_id = 200;
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -71,6 +74,9 @@ pub fn best_effort_read_only(c: &mut Criterion) {
     let domain_id = 201;
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -134,6 +140,9 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "TestTopic",
@@ -195,7 +204,6 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
     });
 }
 
-
 #[derive(Clone, Debug, PartialEq, DdsType)]
 struct LargeKeyedData {
     #[dust_dds(key)]
@@ -221,6 +229,9 @@ fn best_effort_write_and_receive_frag(c: &mut Criterion) {
     let participant_factory = DomainParticipantFactory::get_instance();
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    participant
+        .register_type("LargeKeyedData", FooTypeSupport::<LargeKeyedData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -273,7 +284,10 @@ fn best_effort_write_and_receive_frag(c: &mut Criterion) {
         .unwrap();
     wait_set2.wait(Duration::new(20, 0)).unwrap();
 
-    let large_data_sample = LargeKeyedData { id: 1, value: vec![7; 32000] };
+    let large_data_sample = LargeKeyedData {
+        id: 1,
+        value: vec![7; 32000],
+    };
 
     c.bench_function("best_effort_write_and_receive_frag", |b| {
         b.iter(|| {
@@ -284,7 +298,6 @@ fn best_effort_write_and_receive_frag(c: &mut Criterion) {
         })
     });
 }
-
 
 criterion_group!(
     benches,

--- a/dds/benches/benchmark.rs
+++ b/dds/benches/benchmark.rs
@@ -13,7 +13,7 @@ use dust_dds::{
         data_reader_listener::DataReaderListener,
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
     },
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 #[derive(Clone, Debug, PartialEq, DdsType)]
@@ -28,11 +28,8 @@ pub fn best_effort_write_only(c: &mut Criterion) {
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -75,11 +72,8 @@ pub fn best_effort_read_only(c: &mut Criterion) {
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -140,11 +134,8 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "TestTopic",
             "KeyedData",
             QosKind::Default,
@@ -230,11 +221,8 @@ fn best_effort_write_and_receive_frag(c: &mut Criterion) {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("LargeKeyedData", FooTypeSupport::<LargeKeyedData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<LargeKeyedData>(
             "TestTopic",
             "LargeKeyedData",
             QosKind::Default,

--- a/dds/examples/best_effort_publisher.rs
+++ b/dds/examples/best_effort_publisher.rs
@@ -7,7 +7,7 @@ use dust_dds::{
         time::Duration,
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 #[derive(DdsType, Debug)]
@@ -23,15 +23,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type(
-            "BestEffortExampleType",
-            FooTypeSupport::<BestEffortExampleType>::new(),
-        )
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<BestEffortExampleType>(
             "BestEffortExampleTopic",
             "BestEffortExampleType",
             QosKind::Default,

--- a/dds/examples/best_effort_publisher.rs
+++ b/dds/examples/best_effort_publisher.rs
@@ -7,7 +7,7 @@ use dust_dds::{
         time::Duration,
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 #[derive(DdsType, Debug)]
@@ -21,6 +21,13 @@ fn main() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type(
+            "BestEffortExampleType",
+            FooTypeSupport::<BestEffortExampleType>::new(),
+        )
         .unwrap();
 
     let topic = participant

--- a/dds/examples/best_effort_subscriber.rs
+++ b/dds/examples/best_effort_subscriber.rs
@@ -15,12 +15,18 @@ use dust_dds::{
         data_reader_listener::DataReaderListener,
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
     },
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::{DdsType, TypeSupport, TypeSupportInterface},
 };
 
 #[derive(DdsType, Debug)]
 struct BestEffortExampleType {
     id: i32,
+}
+
+impl TypeSupportInterface for BestEffortExampleType {
+    fn get_type_name() -> &'static str {
+        "BestEffortExampleType"
+    }
 }
 
 struct Listener {
@@ -56,17 +62,13 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type(
-            "BestEffortExampleType",
-            FooTypeSupport::<BestEffortExampleType>::new(),
-        )
+    BestEffortExampleType::register_type(&participant, BestEffortExampleType::get_type_name())
         .unwrap();
 
     let topic = participant
         .create_topic(
             "BestEffortExampleTopic",
-            "BestEffortExampleType",
+            BestEffortExampleType::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,

--- a/dds/examples/best_effort_subscriber.rs
+++ b/dds/examples/best_effort_subscriber.rs
@@ -15,18 +15,12 @@ use dust_dds::{
         data_reader_listener::DataReaderListener,
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
     },
-    topic_definition::type_support::{DdsType, TypeSupport, TypeSupportInterface},
+    topic_definition::type_support::DdsType,
 };
 
 #[derive(DdsType, Debug)]
 struct BestEffortExampleType {
     id: i32,
-}
-
-impl TypeSupportInterface for BestEffortExampleType {
-    fn get_type_name() -> &'static str {
-        "BestEffortExampleType"
-    }
 }
 
 struct Listener {
@@ -62,13 +56,10 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    BestEffortExampleType::register_type(&participant, BestEffortExampleType::get_type_name())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<BestEffortExampleType>(
             "BestEffortExampleTopic",
-            BestEffortExampleType::get_type_name(),
+            "BestEffortExampleType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,

--- a/dds/examples/best_effort_subscriber.rs
+++ b/dds/examples/best_effort_subscriber.rs
@@ -15,7 +15,7 @@ use dust_dds::{
         data_reader_listener::DataReaderListener,
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 #[derive(DdsType, Debug)]
@@ -54,6 +54,13 @@ fn main() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type(
+            "BestEffortExampleType",
+            FooTypeSupport::<BestEffortExampleType>::new(),
+        )
         .unwrap();
 
     let topic = participant

--- a/dds/examples/configuration.rs
+++ b/dds/examples/configuration.rs
@@ -2,7 +2,7 @@ use dust_dds::{
     configuration::DustDdsConfigurationBuilder,
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{listeners::NoOpListener, qos::QosKind, status::NO_STATUS},
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 #[derive(DdsType, Debug)]
@@ -30,12 +30,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<HelloWorldType>(
             "HelloWorld",
             "HelloWorldType",
             QosKind::Default,

--- a/dds/examples/configuration.rs
+++ b/dds/examples/configuration.rs
@@ -2,7 +2,7 @@ use dust_dds::{
     configuration::DustDdsConfigurationBuilder,
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{listeners::NoOpListener, qos::QosKind, status::NO_STATUS},
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 #[derive(DdsType, Debug)]
@@ -28,6 +28,10 @@ fn main() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
         .unwrap();
 
     let topic = participant

--- a/dds/examples/hello_world_publisher.rs
+++ b/dds/examples/hello_world_publisher.rs
@@ -11,7 +11,7 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 #[derive(DdsType, Debug)]
@@ -27,6 +27,10 @@ fn main() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
         .unwrap();
 
     let topic = participant

--- a/dds/examples/hello_world_publisher.rs
+++ b/dds/examples/hello_world_publisher.rs
@@ -11,7 +11,7 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 #[derive(DdsType, Debug)]
@@ -29,12 +29,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<HelloWorldType>(
             "HelloWorld",
             "HelloWorldType",
             QosKind::Default,

--- a/dds/examples/hello_world_subscriber.rs
+++ b/dds/examples/hello_world_subscriber.rs
@@ -12,7 +12,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 #[derive(Debug, DdsType)]
@@ -28,6 +28,10 @@ fn main() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
         .unwrap();
 
     let topic = participant

--- a/dds/examples/hello_world_subscriber.rs
+++ b/dds/examples/hello_world_subscriber.rs
@@ -12,7 +12,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 #[derive(Debug, DdsType)]
@@ -30,12 +30,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<HelloWorldType>(
             "HelloWorld",
             "HelloWorldType",
             QosKind::Default,

--- a/dds/examples/tracing.rs
+++ b/dds/examples/tracing.rs
@@ -10,7 +10,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 use tracing::Level;
 use tracing_subscriber::{fmt::format::FmtSpan, FmtSubscriber};
@@ -39,10 +39,14 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("Data", FooTypeSupport::<Data>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
-            "LargeDataTopic",
-            "LargeData",
+            "DataTopic",
+            "Data",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,

--- a/dds/examples/tracing.rs
+++ b/dds/examples/tracing.rs
@@ -10,7 +10,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 use tracing::Level;
 use tracing_subscriber::{fmt::format::FmtSpan, FmtSubscriber};
@@ -39,12 +39,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("Data", FooTypeSupport::<Data>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<Data>(
             "DataTopic",
             "Data",
             QosKind::Default,

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -995,11 +995,10 @@ impl DomainParticipant {
         type_name: &str,
         type_support: Box<dyn TypeSupport + Send + Sync>,
     ) -> DdsResult<()> {
-        self.participant_address.send_mail_and_await_reply_blocking(
-            domain_participant_actor::register_type::new(
+        self.participant_address
+            .send_mail_and_await_reply_blocking(domain_participant_actor::register_type::new(
                 type_name.to_string(),
                 type_support.into(),
-            ),
-        )
+            ))?
     }
 }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -992,11 +992,14 @@ impl DomainParticipant {
     /// (i.e., the value returned by the get_type_name operation) will be used.
     pub fn register_type(
         &self,
-        type_name: String,
+        type_name: &str,
         type_support: Box<dyn TypeSupport + Send + Sync>,
     ) -> DdsResult<()> {
         self.participant_address.send_mail_and_await_reply_blocking(
-            domain_participant_actor::register_type::new(type_name, type_support.into()),
+            domain_participant_actor::register_type::new(
+                type_name.to_string(),
+                type_support.into(),
+            ),
         )
     }
 }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -27,7 +27,7 @@ use crate::{
     topic_definition::{
         topic::Topic,
         topic_listener::TopicListener,
-        type_support::{DdsKey, DdsSerialize},
+        type_support::{DdsKey, DdsSerialize, TypeSupport},
     },
 };
 
@@ -974,5 +974,23 @@ impl DomainParticipant {
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.participant_address
             .send_mail_and_await_reply_blocking(domain_participant_actor::get_instance_handle::new())
+    }
+}
+
+/// This implementation block contains the TypeSupport operations for the [`DomainParticipant`].
+impl DomainParticipant {
+    /// This operation allows an application to communicate to the Service the existence of a data type. The generated implementation
+    /// of that operation embeds all the knowledge that has to be communicated to the middleware in order to make it able to manage
+    /// the contents of data of that data type. This includes in particular the key definition that will allow the Service to distinguish
+    /// different instances of the same type.
+    /// It is a pre-condition error to use the same type_name to register two different TypeSupport with the same DomainParticipant.
+    /// If an application attempts this, the operation will fail and return PRECONDITION_NOT_MET. However, it is allowed to
+    /// register the same TypeSupport multiple times with a DomainParticipant using the same or different values for the type_name.
+    /// If register_type is called multiple times on the same TypeSupport with the same DomainParticipant and type_name the
+    /// second (and subsequent) registrations are ignored but the operation returns OK.
+    /// The application may pass nil as the value for the type_name. In this case the default type-name as defined by the TypeSupport
+    /// (i.e., the value returned by the get_type_name operation) will be used.
+    pub fn register_type(&self, type_name: String, type_support: TypeSupport) -> DdsResult<()> {
+        todo!()
     }
 }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -27,7 +27,7 @@ use crate::{
     topic_definition::{
         topic::Topic,
         topic_listener::TopicListener,
-        type_support::{DdsKey, DdsSerialize, TypeSupport},
+        type_support::{DdsKey, DdsSerialize, DynamicTypeInterface},
     },
 };
 
@@ -977,28 +977,16 @@ impl DomainParticipant {
     }
 }
 
-/// This implementation block contains the TypeSupport operations for the [`DomainParticipant`].
 impl DomainParticipant {
-    /// This operation allows an application to communicate to the Service the existence of a data type. The generated implementation
-    /// of that operation embeds all the knowledge that has to be communicated to the middleware in order to make it able to manage
-    /// the contents of data of that data type. This includes in particular the key definition that will allow the Service to distinguish
-    /// different instances of the same type.
-    /// It is a pre-condition error to use the same type_name to register two different TypeSupport with the same DomainParticipant.
-    /// If an application attempts this, the operation will fail and return PRECONDITION_NOT_MET. However, it is allowed to
-    /// register the same TypeSupport multiple times with a DomainParticipant using the same or different values for the type_name.
-    /// If register_type is called multiple times on the same TypeSupport with the same DomainParticipant and type_name the
-    /// second (and subsequent) registrations are ignored but the operation returns OK.
-    /// The application may pass nil as the value for the type_name. In this case the default type-name as defined by the TypeSupport
-    /// (i.e., the value returned by the get_type_name operation) will be used.
-    pub fn register_type(
+    pub(crate) fn register_type(
         &self,
         type_name: &str,
-        type_support: impl TypeSupport + Send + Sync + 'static,
+        type_support: Box<dyn DynamicTypeInterface + Send + Sync>,
     ) -> DdsResult<()> {
         self.participant_address
             .send_mail_and_await_reply_blocking(domain_participant_actor::register_type::new(
                 type_name.to_string(),
-                Box::new(type_support),
+                type_support,
             ))?
     }
 }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -5,7 +5,7 @@ use crate::{
     implementation::{
         actors::{
             data_reader_actor, data_writer_actor,
-            domain_participant_actor::{self, DomainParticipantActor},
+            domain_participant_actor::{self, DomainParticipantActor, FooTypeSupport},
             publisher_actor, subscriber_actor, topic_actor,
         },
         utils::{
@@ -27,7 +27,7 @@ use crate::{
     topic_definition::{
         topic::Topic,
         topic_listener::TopicListener,
-        type_support::{DdsHasKey, DdsKey, DdsSerialize, DynamicTypeInterface, FooTypeSupport},
+        type_support::{DdsHasKey, DdsKey, DdsSerialize, DynamicTypeInterface},
     },
 };
 

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -993,12 +993,12 @@ impl DomainParticipant {
     pub fn register_type(
         &self,
         type_name: &str,
-        type_support: Box<dyn TypeSupport + Send + Sync>,
+        type_support: impl TypeSupport + Send + Sync + 'static,
     ) -> DdsResult<()> {
         self.participant_address
             .send_mail_and_await_reply_blocking(domain_participant_actor::register_type::new(
                 type_name.to_string(),
-                type_support.into(),
+                Box::new(type_support),
             ))?
     }
 }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -991,6 +991,8 @@ impl DomainParticipant {
     /// The application may pass nil as the value for the type_name. In this case the default type-name as defined by the TypeSupport
     /// (i.e., the value returned by the get_type_name operation) will be used.
     pub fn register_type(&self, type_name: String, type_support: TypeSupport) -> DdsResult<()> {
-        todo!()
+        self.participant_address.send_mail_and_await_reply_blocking(
+            domain_participant_actor::register_type::new(type_name, type_support),
+        )
     }
 }

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -990,9 +990,13 @@ impl DomainParticipant {
     /// second (and subsequent) registrations are ignored but the operation returns OK.
     /// The application may pass nil as the value for the type_name. In this case the default type-name as defined by the TypeSupport
     /// (i.e., the value returned by the get_type_name operation) will be used.
-    pub fn register_type(&self, type_name: String, type_support: TypeSupport) -> DdsResult<()> {
+    pub fn register_type(
+        &self,
+        type_name: String,
+        type_support: Box<dyn TypeSupport + Send + Sync>,
+    ) -> DdsResult<()> {
         self.participant_address.send_mail_and_await_reply_blocking(
-            domain_participant_actor::register_type::new(type_name, type_support),
+            domain_participant_actor::register_type::new(type_name, type_support.into()),
         )
     }
 }

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -210,10 +210,12 @@ where
             .send_mail_and_await_reply_blocking(domain_participant_actor::get_type_support::new(
                 type_name.clone(),
             ))?
-            .ok_or(DdsError::PreconditionNotMet(format!(
-                "Type with name {} not registered with parent domain participant",
-                type_name
-            )))?;
+            .ok_or_else(|| {
+                DdsError::PreconditionNotMet(format!(
+                    "Type with name {} not registered with parent domain participant",
+                    type_name
+                ))
+            })?;
         let has_key = type_support.has_key();
         if has_key {
             let instance_handle = match handle {
@@ -282,10 +284,12 @@ where
             .send_mail_and_await_reply_blocking(domain_participant_actor::get_type_support::new(
                 type_name.clone(),
             ))?
-            .ok_or(DdsError::PreconditionNotMet(format!(
-                "Type with name {} not registered with parent domain participant",
-                type_name
-            )))?;
+            .ok_or_else(|| {
+                DdsError::PreconditionNotMet(format!(
+                    "Type with name {} not registered with parent domain participant",
+                    type_name
+                ))
+            })?;
 
         let mut serialized_foo = Vec::new();
         instance.serialize_data(&mut serialized_foo)?;
@@ -359,10 +363,12 @@ where
             .send_mail_and_await_reply_blocking(domain_participant_actor::get_type_support::new(
                 type_name.clone(),
             ))?
-            .ok_or(DdsError::PreconditionNotMet(format!(
-                "Type with name {} not registered with parent domain participant",
-                type_name
-            )))?;
+            .ok_or_else(|| {
+                DdsError::PreconditionNotMet(format!(
+                    "Type with name {} not registered with parent domain participant",
+                    type_name
+                ))
+            })?;
 
         let mut serialized_data = Vec::new();
         data.serialize_data(&mut serialized_data)?;
@@ -446,10 +452,12 @@ where
             .send_mail_and_await_reply_blocking(domain_participant_actor::get_type_support::new(
                 type_name.clone(),
             ))?
-            .ok_or(DdsError::PreconditionNotMet(format!(
-                "Type with name {} not registered with parent domain participant",
-                type_name
-            )))?;
+            .ok_or_else(|| {
+                DdsError::PreconditionNotMet(format!(
+                    "Type with name {} not registered with parent domain participant",
+                    type_name
+                ))
+            })?;
 
         let mut serialized_foo = Vec::new();
         data.serialize_data(&mut serialized_foo)?;

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -16,8 +16,10 @@ use crate::{
         time::Duration,
     },
     publication::data_writer::DataWriter,
-    topic_definition::topic::Topic,
-    topic_definition::type_support::{DdsHasKey, DdsTypeXml},
+    topic_definition::{
+        topic::Topic,
+        type_support::{DdsHasKey, DdsKey, DdsTypeXml, FooTypeSupport},
+    },
 };
 
 use super::{data_writer_listener::DataWriterListener, publisher_listener::PublisherListener};
@@ -84,8 +86,14 @@ impl Publisher {
         mask: &[StatusKind],
     ) -> DdsResult<DataWriter<Foo>>
     where
-        Foo: DdsHasKey + DdsTypeXml,
+        Foo: DdsHasKey + DdsKey + DdsTypeXml,
     {
+        self.participant_address
+            .send_mail_and_await_reply_blocking(domain_participant_actor::register_type::new(
+                a_topic.get_type_name()?,
+                Box::new(FooTypeSupport::new::<Foo>()),
+            ))?;
+
         let default_unicast_locator_list = self
             .participant_address
             .send_mail_and_await_reply_blocking(

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -88,10 +88,12 @@ impl Publisher {
             .send_mail_and_await_reply_blocking(domain_participant_actor::get_type_support::new(
                 type_name.clone(),
             ))?
-            .ok_or(DdsError::PreconditionNotMet(format!(
-                "Type with name {} not registered with parent domain participant",
-                type_name
-            )))?;
+            .ok_or_else(|| {
+                DdsError::PreconditionNotMet(format!(
+                    "Type with name {} not registered with parent domain participant",
+                    type_name
+                ))
+            })?;
 
         let default_unicast_locator_list = self
             .participant_address

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -16,10 +16,7 @@ use crate::{
         time::Duration,
     },
     publication::data_writer::DataWriter,
-    topic_definition::{
-        topic::Topic,
-        type_support::{DdsHasKey, DdsKey, DdsTypeXml, FooTypeSupport},
-    },
+    topic_definition::topic::Topic,
 };
 
 use super::{data_writer_listener::DataWriterListener, publisher_listener::PublisherListener};
@@ -84,16 +81,17 @@ impl Publisher {
         qos: QosKind<DataWriterQos>,
         a_listener: impl DataWriterListener<Foo = Foo> + Send + 'static,
         mask: &[StatusKind],
-    ) -> DdsResult<DataWriter<Foo>>
-    where
-        Foo: DdsHasKey + DdsKey + DdsTypeXml,
-    {
-        self.participant_address
-            .send_mail_and_await_reply_blocking(domain_participant_actor::register_type::new(
-                a_topic.get_type_name()?,
-                Box::new(FooTypeSupport::new::<Foo>()),
+    ) -> DdsResult<DataWriter<Foo>> {
+        let type_name = a_topic.get_type_name()?;
+        let type_support = self
+            .participant_address
+            .send_mail_and_await_reply_blocking(domain_participant_actor::get_type_support::new(
+                type_name.clone(),
             ))?
-            .ok();
+            .ok_or(DdsError::PreconditionNotMet(format!(
+                "Type with name {} not registered with parent domain participant",
+                type_name
+            )))?;
 
         let default_unicast_locator_list = self
             .participant_address
@@ -112,13 +110,13 @@ impl Publisher {
             )?;
 
         let listener = Box::new(a_listener);
-        let type_xml =
-            Foo::get_type_xml().map_or_else(String::default, |s| format!("<types>{}</types>", s));
+        let has_key = type_support.has_key();
+        let type_xml = String::new(); // Foo::get_type_xml().map_or_else(String::default, |s| format!("<types>{}</types>", s));
         let data_writer_address = self.publisher_address.send_mail_and_await_reply_blocking(
             publisher_actor::create_datawriter::new(
                 a_topic.get_type_name()?,
                 a_topic.get_name()?,
-                Foo::HAS_KEY,
+                has_key,
                 data_max_size_serialized,
                 qos,
                 listener,

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -92,7 +92,8 @@ impl Publisher {
             .send_mail_and_await_reply_blocking(domain_participant_actor::register_type::new(
                 a_topic.get_type_name()?,
                 Box::new(FooTypeSupport::new::<Foo>()),
-            ))?;
+            ))?
+            .ok();
 
         let default_unicast_locator_list = self
             .participant_address

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     topic_definition::{
         topic::Topic,
-        type_support::{DdsHasKey, DdsKey, DdsTypeXml},
+        type_support::{DdsHasKey, DdsKey, DdsTypeXml, TypeSupport},
     },
 };
 
@@ -103,6 +103,14 @@ impl Subscriber {
     where
         Foo: DdsHasKey + DdsKey + DdsTypeXml,
     {
+        self.participant_address
+            .send_mail_and_await_reply_blocking(domain_participant_actor::register_type::new(
+                a_topic.get_type_name()?,
+                TypeSupport {
+                    instance_handle_from_serialized_foo: |_| todo!(),
+                    instance_handle_from_serialized_key: |_| todo!(),
+                },
+            ))?;
         let default_unicast_locator_list = self
             .participant_address
             .send_mail_and_await_reply_blocking(

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     topic_definition::{
         topic::Topic,
-        type_support::{DdsHasKey, DdsKey, DdsTypeXml, TypeSupport},
+        type_support::{DdsHasKey, DdsKey, DdsTypeXml, FooTypeSupport},
     },
 };
 
@@ -106,10 +106,7 @@ impl Subscriber {
         self.participant_address
             .send_mail_and_await_reply_blocking(domain_participant_actor::register_type::new(
                 a_topic.get_type_name()?,
-                TypeSupport {
-                    instance_handle_from_serialized_foo: |_| todo!(),
-                    instance_handle_from_serialized_key: |_| todo!(),
-                },
+                Box::new(FooTypeSupport::new::<Foo>()),
             ))?;
         let default_unicast_locator_list = self
             .participant_address

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -107,7 +107,8 @@ impl Subscriber {
             .send_mail_and_await_reply_blocking(domain_participant_actor::register_type::new(
                 a_topic.get_type_name()?,
                 Box::new(FooTypeSupport::new::<Foo>()),
-            ))?;
+            ))?
+            .ok();
         let default_unicast_locator_list = self
             .participant_address
             .send_mail_and_await_reply_blocking(

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -103,10 +103,12 @@ impl Subscriber {
             .send_mail_and_await_reply_blocking(domain_participant_actor::get_type_support::new(
                 type_name.clone(),
             ))?
-            .ok_or(DdsError::PreconditionNotMet(format!(
-                "Type with name {} not registered with parent domain participant",
-                type_name
-            )))?;
+            .ok_or_else(|| {
+                DdsError::PreconditionNotMet(format!(
+                    "Type with name {} not registered with parent domain participant",
+                    type_name
+                ))
+            })?;
 
         let default_unicast_locator_list = self
             .participant_address

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -25,6 +25,18 @@ use crate::{
 
 pub use dust_dds_derive::{DdsDeserialize, DdsHasKey, DdsSerialize, DdsTypeXml};
 
+pub trait TypeSupportInterface {
+    fn register_type(
+        participant: &dust_dds::domain::domain_participant::DomainParticipant,
+        type_name: &str,
+    ) -> DdsResult<()>
+    where
+        Self: Sized + DdsKey + DdsHasKey + Send + Sync + 'static,
+    {
+        participant.register_type(type_name, FooTypeSupport::<Self>::new())
+    }
+}
+
 pub trait TypeSupport {
     fn has_key(&self) -> bool;
 

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -21,6 +21,8 @@ use crate::{
 
 pub use dust_dds_derive::{DdsDeserialize, DdsHasKey, DdsSerialize, DdsTypeXml};
 
+pub struct TypeSupport;
+
 /// This trait indicates whether the associated type is keyed or not, i.e. if the middleware
 /// should manage different instances of the type.
 ///

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -49,6 +49,12 @@ impl<Foo> FooTypeSupport<Foo> {
     }
 }
 
+impl<Foo> Default for FooTypeSupport<Foo> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
 impl<Foo> TypeSupport for FooTypeSupport<Foo>
 where
     Foo: DdsKey + DdsHasKey,
@@ -59,7 +65,7 @@ where
 
     fn get_serialized_key_from_serialized_foo(&self, serialized_foo: &[u8]) -> DdsResult<Vec<u8>> {
         let mut writer = Vec::new();
-        let foo_key = Foo::get_key_from_serialized_data(&serialized_foo)?;
+        let foo_key = Foo::get_key_from_serialized_data(serialized_foo)?;
         serialize_rtps_classic_cdr_le(&foo_key, &mut writer)?;
         Ok(writer)
     }
@@ -68,8 +74,8 @@ where
         &self,
         serialized_foo: &[u8],
     ) -> DdsResult<InstanceHandle> {
-        let foo_key = Foo::get_key_from_serialized_data(&serialized_foo)?;
-        Ok(get_instance_handle_from_key(&foo_key)?)
+        let foo_key = Foo::get_key_from_serialized_data(serialized_foo)?;
+        get_instance_handle_from_key(&foo_key)
     }
 
     fn instance_handle_from_serialized_key(
@@ -77,7 +83,7 @@ where
         mut serialized_key: &[u8],
     ) -> DdsResult<InstanceHandle> {
         let foo_key = deserialize_rtps_classic_cdr::<Foo::Key>(&mut serialized_key)?;
-        Ok(get_instance_handle_from_key(&foo_key)?)
+        get_instance_handle_from_key(&foo_key)
     }
 }
 

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -9,7 +9,10 @@ use crate::{
             parameter_list_serializer::ParameterListCdrSerializer,
         },
     },
-    infrastructure::error::{DdsError, DdsResult},
+    infrastructure::{
+        error::{DdsError, DdsResult},
+        instance::InstanceHandle,
+    },
     serialized_payload::{
         cdr::{deserialize::CdrDeserialize, serialize::CdrSerialize},
         parameter_list::{
@@ -21,7 +24,10 @@ use crate::{
 
 pub use dust_dds_derive::{DdsDeserialize, DdsHasKey, DdsSerialize, DdsTypeXml};
 
-pub struct TypeSupport;
+pub struct TypeSupport {
+    pub instance_handle_from_serialized_foo: fn(&[u8]) -> DdsResult<InstanceHandle>,
+    pub instance_handle_from_serialized_key: fn(&[u8]) -> DdsResult<InstanceHandle>,
+}
 
 /// This trait indicates whether the associated type is keyed or not, i.e. if the middleware
 /// should manage different instances of the type.

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -1,4 +1,4 @@
-use std::{io::Read, marker::PhantomData};
+use std::io::Read;
 
 use crate::{
     implementation::{
@@ -24,45 +24,6 @@ use crate::{
 };
 
 pub use dust_dds_derive::{DdsDeserialize, DdsHasKey, DdsSerialize, DdsTypeXml};
-
-pub struct TypeSupport<Foo>(PhantomData<Foo>);
-
-impl<Foo> TypeSupport<Foo> {
-    /// This operation allows an application to communicate to the Service the existence of a data type. The generated implementation
-    /// of that operation embeds all the knowledge that has to be communicated to the middleware in order to make it able to manage
-    /// the contents of data of that data type. This includes in particular the key definition that will allow the Service to distinguish
-    /// different instances of the same type.
-    /// It is a pre-condition error to use the same type_name to register two different TypeSupport with the same DomainParticipant.
-    /// If an application attempts this, the operation will fail and return PRECONDITION_NOT_MET. However, it is allowed to
-    /// register the same TypeSupport multiple times with a DomainParticipant using the same or different values for the type_name.
-    /// If register_type is called multiple times on the same TypeSupport with the same DomainParticipant and type_name the
-    /// second (and subsequent) registrations are ignored but the operation returns OK.
-    /// The application may pass nil as the value for the type_name. In this case the default type-name as defined by the TypeSupport
-    /// (i.e., the value returned by the get_type_name operation) will be used.
-    pub fn register_type(
-        participant: &dust_dds::domain::domain_participant::DomainParticipant,
-        type_name: &str,
-    ) -> DdsResult<()>
-    where
-        Foo: DdsHasKey + DdsKey,
-    {
-        participant.register_type(type_name, Box::new(FooTypeSupport::new::<Foo>()))
-    }
-
-    /// This operation returns the default name for the data-type represented by the TypeSupport.
-    pub fn get_type_name() -> &'static str {
-        ""
-    }
-
-    #[doc(hidden)]
-    pub fn register_dynamic_type(
-        participant: &dust_dds::domain::domain_participant::DomainParticipant,
-        type_name: &str,
-        dynamic_type_representation: impl DynamicTypeInterface + Send + Sync + 'static,
-    ) -> DdsResult<()> {
-        participant.register_type(type_name, Box::new(dynamic_type_representation))
-    }
-}
 
 #[doc(hidden)]
 pub trait DynamicTypeInterface {

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -24,6 +24,7 @@ use crate::{
 
 pub use dust_dds_derive::{DdsDeserialize, DdsHasKey, DdsSerialize, DdsTypeXml};
 
+#[derive(Clone, PartialEq)]
 pub struct TypeSupport {
     pub instance_handle_from_serialized_foo: fn(&[u8]) -> DdsResult<InstanceHandle>,
     pub instance_handle_from_serialized_key: fn(&[u8]) -> DdsResult<InstanceHandle>,

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -90,7 +90,7 @@ fn build_instance_handle(
 ) -> DdsResult<InstanceHandle> {
     Ok(match change_kind {
         ChangeKind::Alive | ChangeKind::AliveFiltered => {
-            get_instance_handle_from_key(&type_support.get_key_from_serialized_foo(data)?)?
+            type_support.instance_handle_from_serialized_foo(data)?
         }
         ChangeKind::NotAliveDisposed
         | ChangeKind::NotAliveUnregistered
@@ -102,14 +102,10 @@ fn build_instance_handle(
                 if let Ok(key) = <[u8; 16]>::try_from(p.value()) {
                     InstanceHandle::new(key)
                 } else {
-                    get_instance_handle_from_key(
-                        &type_support.instance_handle_from_serialized_key(data)?,
-                    )?
+                    type_support.instance_handle_from_serialized_key(data)?
                 }
             }
-            None => get_instance_handle_from_key(
-                &type_support.instance_handle_from_serialized_key(data)?,
-            )?,
+            None => type_support.instance_handle_from_serialized_key(data)?,
         },
     })
 }

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1912,10 +1912,12 @@ impl DataReaderActor {
                 self.type_name.clone(),
             ))
             .await?
-            .ok_or(DdsError::PreconditionNotMet(format!(
-                "Type with name {} not registered with domain participant",
-                self.type_name
-            )))?;
+            .ok_or_else(|| {
+                DdsError::PreconditionNotMet(format!(
+                    "Type with name {} not registered with parent domain participant",
+                    self.type_name
+                ))
+            })?;
 
         while let Some(submessage) = message_receiver.next() {
             match submessage {

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -68,7 +68,7 @@ use crate::{
     },
     serialized_payload::cdr::deserialize::CdrDeserialize,
     subscription::sample_info::{InstanceStateKind, SampleInfo, SampleStateKind, ViewStateKind},
-    topic_definition::type_support::{DdsKey, TypeSupport},
+    topic_definition::type_support::{DdsKey, DynamicTypeInterface},
 };
 
 use super::{
@@ -83,7 +83,7 @@ use super::{
 };
 
 fn build_instance_handle(
-    type_support: &Arc<dyn TypeSupport + Send + Sync>,
+    type_support: &Arc<dyn DynamicTypeInterface + Send + Sync>,
     change_kind: ChangeKind,
     data: &[u8],
     inline_qos: &[Parameter],
@@ -363,7 +363,7 @@ impl DataReaderActor {
     async fn on_data_submessage_received(
         &mut self,
         data_submessage: &DataSubmessageRead,
-        type_support: &Arc<dyn TypeSupport + Send + Sync>,
+        type_support: &Arc<dyn DynamicTypeInterface + Send + Sync>,
         source_guid_prefix: GuidPrefix,
         source_timestamp: Option<Time>,
         reception_timestamp: Time,
@@ -515,7 +515,7 @@ impl DataReaderActor {
     async fn on_data_frag_submessage_received(
         &mut self,
         data_frag_submessage: &DataFragSubmessageRead,
-        type_support: &Arc<dyn TypeSupport + Send + Sync>,
+        type_support: &Arc<dyn DynamicTypeInterface + Send + Sync>,
         source_guid_prefix: GuidPrefix,
         source_timestamp: Option<Time>,
         reception_timestamp: Time,
@@ -939,7 +939,7 @@ impl DataReaderActor {
         data: Data,
         source_timestamp: Option<Time>,
         reception_timestamp: Time,
-        type_support: &Arc<dyn TypeSupport + Send + Sync>,
+        type_support: &Arc<dyn DynamicTypeInterface + Send + Sync>,
     ) -> DdsResult<RtpsReaderCacheChange> {
         let change_kind = if key_flag {
             if let Some(p) = inline_qos

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -930,6 +930,7 @@ impl DataReaderActor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn convert_received_data_to_cache_change(
         &mut self,
         writer_guid: Guid,

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -68,7 +68,7 @@ use crate::{
     },
     serialized_payload::cdr::deserialize::CdrDeserialize,
     subscription::sample_info::{InstanceStateKind, SampleInfo, SampleStateKind, ViewStateKind},
-    topic_definition::type_support::{deserialize_rtps_classic_cdr, DdsKey},
+    topic_definition::type_support::{deserialize_rtps_classic_cdr, DdsKey, TypeSupport},
 };
 
 use super::{
@@ -122,15 +122,14 @@ impl InstanceHandleFromSerializedKey {
 }
 
 fn build_instance_handle(
-    instance_handle_from_serialized_foo: &InstanceHandleFromSerializedFoo,
-    instance_handle_from_serialized_key: &InstanceHandleFromSerializedKey,
+    type_support: &TypeSupport,
     change_kind: ChangeKind,
     data: &[u8],
     inline_qos: &[Parameter],
 ) -> DdsResult<InstanceHandle> {
     Ok(match change_kind {
         ChangeKind::Alive | ChangeKind::AliveFiltered => {
-            (instance_handle_from_serialized_foo.0)(data)?
+            (type_support.instance_handle_from_serialized_foo)(data)?
         }
         ChangeKind::NotAliveDisposed
         | ChangeKind::NotAliveUnregistered
@@ -142,10 +141,10 @@ fn build_instance_handle(
                 if let Ok(key) = <[u8; 16]>::try_from(p.value()) {
                     InstanceHandle::new(key)
                 } else {
-                    (instance_handle_from_serialized_key.0)(data)?
+                    (type_support.instance_handle_from_serialized_key)(data)?
                 }
             }
-            None => (instance_handle_from_serialized_key.0)(data)?,
+            None => (type_support.instance_handle_from_serialized_key)(data)?,
         },
     })
 }
@@ -285,8 +284,6 @@ pub struct DataReaderActor {
     matched_writers: Vec<RtpsWriterProxy>,
     changes: Vec<RtpsReaderCacheChange>,
     qos: DataReaderQos,
-    instance_handle_from_serialized_foo: InstanceHandleFromSerializedFoo,
-    instance_handle_from_serialized_key: InstanceHandleFromSerializedKey,
     type_name: String,
     topic_name: String,
     _liveliness_changed_status: LivelinessChangedStatus,
@@ -320,8 +317,6 @@ impl DataReaderActor {
     where
         Foo: DdsKey,
     {
-        let instance_handle_from_serialized_foo = InstanceHandleFromSerializedFoo::new::<Foo>();
-        let instance_handle_from_serialized_key = InstanceHandleFromSerializedKey::new::<Foo>();
         let status_condition = spawn_actor(StatusConditionActor::default());
         let listener = spawn_actor(DataReaderListenerActor::new(listener));
 
@@ -347,8 +342,6 @@ impl DataReaderActor {
             status_kind,
             listener,
             qos,
-            instance_handle_from_serialized_foo,
-            instance_handle_from_serialized_key,
             instances: HashMap::new(),
             instance_deadline_missed_task: HashMap::new(),
             xml_type,
@@ -412,6 +405,7 @@ impl DataReaderActor {
     async fn on_data_submessage_received(
         &mut self,
         data_submessage: &DataSubmessageRead,
+        type_support: &TypeSupport,
         source_guid_prefix: GuidPrefix,
         source_timestamp: Option<Time>,
         reception_timestamp: Time,
@@ -457,6 +451,7 @@ impl DataReaderActor {
                             data_submessage.serialized_payload(),
                             source_timestamp,
                             reception_timestamp,
+                            type_support,
                         ) {
                             Ok(change) => {
                                 self.add_change(
@@ -495,6 +490,7 @@ impl DataReaderActor {
                             data_submessage.serialized_payload(),
                             source_timestamp,
                             reception_timestamp,
+                            type_support,
                         ) {
                             Ok(change) => {
                                 self.add_change(
@@ -525,7 +521,8 @@ impl DataReaderActor {
             }
         } else if message_reader_id == ENTITYID_UNKNOWN
             || (message_reader_id == self.rtps_reader.guid().entity_id()
-                && message_reader_id == ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER) // Additional condition only for discovery interoperability with FastDDS
+                && message_reader_id == ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER)
+        // Additional condition only for discovery interoperability with FastDDS
         {
             // Stateless reader behavior. We add the change if the data is correct. No error is printed
             // because all readers would get changes marked with ENTITYID_UNKNOWN
@@ -536,6 +533,7 @@ impl DataReaderActor {
                 data_submessage.serialized_payload(),
                 source_timestamp,
                 reception_timestamp,
+                type_support,
             ) {
                 self.add_change(
                     change,
@@ -559,6 +557,7 @@ impl DataReaderActor {
     async fn on_data_frag_submessage_received(
         &mut self,
         data_frag_submessage: &DataFragSubmessageRead,
+        type_support: &TypeSupport,
         source_guid_prefix: GuidPrefix,
         source_timestamp: Option<Time>,
         reception_timestamp: Time,
@@ -585,6 +584,7 @@ impl DataReaderActor {
             {
                 self.on_data_submessage_received(
                     &data_submessage,
+                    type_support,
                     source_guid_prefix,
                     source_timestamp,
                     reception_timestamp,
@@ -980,6 +980,7 @@ impl DataReaderActor {
         data: Data,
         source_timestamp: Option<Time>,
         reception_timestamp: Time,
+        type_support: &TypeSupport,
     ) -> DdsResult<RtpsReaderCacheChange> {
         let change_kind = if key_flag {
             if let Some(p) = inline_qos
@@ -1009,8 +1010,7 @@ impl DataReaderActor {
         }?;
 
         let instance_handle = build_instance_handle(
-            &self.instance_handle_from_serialized_foo,
-            &self.instance_handle_from_serialized_key,
+            type_support,
             change_kind,
             data.as_ref(),
             inline_qos.parameter(),
@@ -1935,6 +1935,7 @@ impl DataReaderActor {
     async fn process_rtps_message(
         &mut self,
         message: RtpsMessageRead,
+        type_support: TypeSupport,
         reception_timestamp: Time,
         data_reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
@@ -1952,6 +1953,7 @@ impl DataReaderActor {
                 RtpsSubmessageReadKind::Data(data_submessage) => {
                     self.on_data_submessage_received(
                         &data_submessage,
+                        &type_support,
                         message_receiver.source_guid_prefix(),
                         message_receiver.source_timestamp(),
                         reception_timestamp,
@@ -1967,6 +1969,7 @@ impl DataReaderActor {
                 RtpsSubmessageReadKind::DataFrag(data_frag_submessage) => {
                     self.on_data_frag_submessage_received(
                         &data_frag_submessage,
+                        &type_support,
                         message_receiver.source_guid_prefix(),
                         message_receiver.source_timestamp(),
                         reception_timestamp,

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -1144,7 +1144,7 @@ impl DomainParticipantActor {
         &mut self,
         type_name: String,
         type_support: Box<dyn DynamicTypeInterface + Send + Sync>,
-    ) -> DdsResult<()> {
+    ) {
         self.type_support_actor
             .send_mail_and_await_reply(type_support_actor::register_type::new(
                 type_name,

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -230,16 +230,15 @@ impl DomainParticipantActor {
         };
         let spdp_builtin_participant_reader_guid =
             Guid::new(guid_prefix, ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER);
-        let spdp_builtin_participant_reader =
-            spawn_actor(DataReaderActor::new(
-                create_builtin_stateless_reader(spdp_builtin_participant_reader_guid),
-                "SpdpDiscoveredParticipantData".to_string(),
-                String::from(DCPS_PARTICIPANT),
-                spdp_reader_qos,
-                Box::new(NoOpListener::<SpdpDiscoveredParticipantData>::new()),
-                vec![],
-                String::default(),
-            ));
+        let spdp_builtin_participant_reader = spawn_actor(DataReaderActor::new(
+            create_builtin_stateless_reader(spdp_builtin_participant_reader_guid),
+            "SpdpDiscoveredParticipantData".to_string(),
+            String::from(DCPS_PARTICIPANT),
+            spdp_reader_qos,
+            Box::new(NoOpListener::<SpdpDiscoveredParticipantData>::new()),
+            vec![],
+            String::default(),
+        ));
 
         let sedp_reader_qos = DataReaderQos {
             durability: DurabilityQosPolicy {
@@ -464,19 +463,19 @@ impl DomainParticipantActor {
             HashMap::new();
         type_support_list.insert(
             "SpdpDiscoveredParticipantData".to_string(),
-            Arc::new(FooTypeSupport::new::<SpdpDiscoveredParticipantData>()),
+            Arc::new(FooTypeSupport::<SpdpDiscoveredParticipantData>::new()),
         );
         type_support_list.insert(
             "DiscoveredReaderData".to_string(),
-            Arc::new(FooTypeSupport::new::<DiscoveredReaderData>()),
+            Arc::new(FooTypeSupport::<DiscoveredReaderData>::new()),
         );
         type_support_list.insert(
             "DiscoveredWriterData".to_string(),
-            Arc::new(FooTypeSupport::new::<DiscoveredWriterData>()),
+            Arc::new(FooTypeSupport::<DiscoveredWriterData>::new()),
         );
         type_support_list.insert(
             "DiscoveredTopicData".to_string(),
-            Arc::new(FooTypeSupport::new::<DiscoveredTopicData>()),
+            Arc::new(FooTypeSupport::<DiscoveredTopicData>::new()),
         );
 
         let type_support_actor = spawn_actor(TypeSupportActor::new(type_support_list));

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -231,7 +231,7 @@ impl DomainParticipantActor {
         let spdp_builtin_participant_reader_guid =
             Guid::new(guid_prefix, ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER);
         let spdp_builtin_participant_reader =
-            spawn_actor(DataReaderActor::new::<SpdpDiscoveredParticipantData>(
+            spawn_actor(DataReaderActor::new(
                 create_builtin_stateless_reader(spdp_builtin_participant_reader_guid),
                 "SpdpDiscoveredParticipantData".to_string(),
                 String::from(DCPS_PARTICIPANT),
@@ -257,7 +257,7 @@ impl DomainParticipantActor {
 
         let sedp_builtin_topics_reader_guid =
             Guid::new(guid_prefix, ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR);
-        let sedp_builtin_topics_reader = spawn_actor(DataReaderActor::new::<DiscoveredTopicData>(
+        let sedp_builtin_topics_reader = spawn_actor(DataReaderActor::new(
             create_builtin_stateful_reader(sedp_builtin_topics_reader_guid),
             "DiscoveredTopicData".to_string(),
             String::from(DCPS_TOPIC),
@@ -269,29 +269,27 @@ impl DomainParticipantActor {
 
         let sedp_builtin_publications_reader_guid =
             Guid::new(guid_prefix, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR);
-        let sedp_builtin_publications_reader =
-            spawn_actor(DataReaderActor::new::<DiscoveredWriterData>(
-                create_builtin_stateful_reader(sedp_builtin_publications_reader_guid),
-                "DiscoveredWriterData".to_string(),
-                String::from(DCPS_PUBLICATION),
-                sedp_reader_qos.clone(),
-                Box::new(NoOpListener::<DiscoveredWriterData>::new()),
-                vec![],
-                String::default(),
-            ));
+        let sedp_builtin_publications_reader = spawn_actor(DataReaderActor::new(
+            create_builtin_stateful_reader(sedp_builtin_publications_reader_guid),
+            "DiscoveredWriterData".to_string(),
+            String::from(DCPS_PUBLICATION),
+            sedp_reader_qos.clone(),
+            Box::new(NoOpListener::<DiscoveredWriterData>::new()),
+            vec![],
+            String::default(),
+        ));
 
         let sedp_builtin_subscriptions_reader_guid =
             Guid::new(guid_prefix, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR);
-        let sedp_builtin_subscriptions_reader =
-            spawn_actor(DataReaderActor::new::<DiscoveredReaderData>(
-                create_builtin_stateful_reader(sedp_builtin_subscriptions_reader_guid),
-                "DiscoveredReaderData".to_string(),
-                String::from(DCPS_SUBSCRIPTION),
-                sedp_reader_qos,
-                Box::new(NoOpListener::<DiscoveredReaderData>::new()),
-                vec![],
-                String::default(),
-            ));
+        let sedp_builtin_subscriptions_reader = spawn_actor(DataReaderActor::new(
+            create_builtin_stateful_reader(sedp_builtin_subscriptions_reader_guid),
+            "DiscoveredReaderData".to_string(),
+            String::from(DCPS_SUBSCRIPTION),
+            sedp_reader_qos,
+            Box::new(NoOpListener::<DiscoveredReaderData>::new()),
+            vec![],
+            String::default(),
+        ));
 
         let builtin_subscriber = spawn_actor(SubscriberActor::new(
             SubscriberQos::default(),
@@ -1157,6 +1155,15 @@ impl DomainParticipantActor {
                 type_name,
                 type_support.into(),
             ))
+            .await
+    }
+
+    async fn get_type_support(
+        &mut self,
+        type_name: String,
+    ) -> Option<Arc<dyn TypeSupport + Send + Sync>> {
+        self.type_support_actor
+            .send_mail_and_await_reply(type_support_actor::get_type_support::new(type_name))
             .await
     }
 }

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -1151,7 +1151,7 @@ impl DomainParticipantActor {
         &mut self,
         type_name: String,
         type_support: Box<dyn TypeSupport + Send + Sync>,
-    ) {
+    ) -> DdsResult<()> {
         self.type_support_actor
             .send_mail_and_await_reply(type_support_actor::register_type::new(
                 type_name,

--- a/dds/src/implementation/actors/mod.rs
+++ b/dds/src/implementation/actors/mod.rs
@@ -13,3 +13,4 @@ pub mod status_condition_actor;
 pub mod subscriber_actor;
 pub mod subscriber_listener_actor;
 pub mod topic_actor;
+pub mod type_support_actor;

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -8,6 +8,7 @@ use super::{
     data_reader_actor::{self, DataReaderActor},
     domain_participant_actor::DomainParticipantActor,
     subscriber_listener_actor::SubscriberListenerActor,
+    type_support_actor::TypeSupportActor,
 };
 use crate::{
     implementation::{
@@ -202,15 +203,14 @@ impl SubscriberActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        type_support_actor_address: ActorAddress<TypeSupportActor>,
     ) -> DdsResult<()> {
         let subscriber_mask_listener = (self.listener.address(), self.status_kind.clone());
 
         for data_reader_address in self.data_reader_list.values().map(|a| a.address()) {
-            let type_support = todo!();
             data_reader_address
                 .send_mail_and_await_reply(data_reader_actor::process_rtps_message::new(
                     message.clone(),
-                    type_support,
                     reception_timestamp,
                     data_reader_address.clone(),
                     subscriber_address.clone(),
@@ -218,6 +218,7 @@ impl SubscriberActor {
                     self.status_condition.address().clone(),
                     subscriber_mask_listener.clone(),
                     participant_mask_listener.clone(),
+                    type_support_actor_address.clone(),
                 ))
                 .await??;
         }

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -206,9 +206,11 @@ impl SubscriberActor {
         let subscriber_mask_listener = (self.listener.address(), self.status_kind.clone());
 
         for data_reader_address in self.data_reader_list.values().map(|a| a.address()) {
+            let type_support = todo!();
             data_reader_address
                 .send_mail_and_await_reply(data_reader_actor::process_rtps_message::new(
                     message.clone(),
+                    type_support,
                     reception_timestamp,
                     data_reader_address.clone(),
                     subscriber_address.clone(),

--- a/dds/src/implementation/actors/type_support_actor.rs
+++ b/dds/src/implementation/actors/type_support_actor.rs
@@ -1,26 +1,33 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use dust_dds_derive::actor_interface;
 
 use crate::topic_definition::type_support::TypeSupport;
 
 pub struct TypeSupportActor {
-    type_support_list: HashMap<String, TypeSupport>,
+    type_support_list: HashMap<String, Arc<dyn TypeSupport + Send + Sync>>,
 }
 
 impl TypeSupportActor {
-    pub fn new(type_support_list: HashMap<String, TypeSupport>) -> Self {
+    pub fn new(type_support_list: HashMap<String, Arc<dyn TypeSupport + Send + Sync>>) -> Self {
         Self { type_support_list }
     }
 }
 
 #[actor_interface]
 impl TypeSupportActor {
-    async fn register_type(&mut self, type_name: String, type_support: TypeSupport) {
+    async fn register_type(
+        &mut self,
+        type_name: String,
+        type_support: Arc<dyn TypeSupport + Send + Sync>,
+    ) {
         self.type_support_list.insert(type_name, type_support);
     }
 
-    async fn get_type_support(&self, type_name: String) -> Option<TypeSupport> {
+    async fn get_type_support(
+        &self,
+        type_name: String,
+    ) -> Option<Arc<dyn TypeSupport + Send + Sync>> {
         self.type_support_list.get(&type_name).cloned()
     }
 }

--- a/dds/src/implementation/actors/type_support_actor.rs
+++ b/dds/src/implementation/actors/type_support_actor.rs
@@ -7,15 +7,17 @@ use dust_dds_derive::actor_interface;
 
 use crate::{
     infrastructure::error::{DdsError, DdsResult},
-    topic_definition::type_support::TypeSupport,
+    topic_definition::type_support::DynamicTypeInterface,
 };
 
 pub struct TypeSupportActor {
-    type_support_list: HashMap<String, Arc<dyn TypeSupport + Send + Sync>>,
+    type_support_list: HashMap<String, Arc<dyn DynamicTypeInterface + Send + Sync>>,
 }
 
 impl TypeSupportActor {
-    pub fn new(type_support_list: HashMap<String, Arc<dyn TypeSupport + Send + Sync>>) -> Self {
+    pub fn new(
+        type_support_list: HashMap<String, Arc<dyn DynamicTypeInterface + Send + Sync>>,
+    ) -> Self {
         Self { type_support_list }
     }
 }
@@ -25,7 +27,7 @@ impl TypeSupportActor {
     async fn register_type(
         &mut self,
         type_name: String,
-        type_support: Arc<dyn TypeSupport + Send + Sync>,
+        type_support: Arc<dyn DynamicTypeInterface + Send + Sync>,
     ) -> DdsResult<()> {
         match self.type_support_list.entry(type_name.clone()) {
             Entry::Occupied(_) => Err(DdsError::PreconditionNotMet(format!(
@@ -42,7 +44,7 @@ impl TypeSupportActor {
     async fn get_type_support(
         &self,
         type_name: String,
-    ) -> Option<Arc<dyn TypeSupport + Send + Sync>> {
+    ) -> Option<Arc<dyn DynamicTypeInterface + Send + Sync>> {
         self.type_support_list.get(&type_name).cloned()
     }
 }

--- a/dds/src/implementation/actors/type_support_actor.rs
+++ b/dds/src/implementation/actors/type_support_actor.rs
@@ -1,8 +1,14 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::Arc,
+};
 
 use dust_dds_derive::actor_interface;
 
-use crate::topic_definition::type_support::TypeSupport;
+use crate::{
+    infrastructure::error::{DdsError, DdsResult},
+    topic_definition::type_support::TypeSupport,
+};
 
 pub struct TypeSupportActor {
     type_support_list: HashMap<String, Arc<dyn TypeSupport + Send + Sync>>,
@@ -20,8 +26,17 @@ impl TypeSupportActor {
         &mut self,
         type_name: String,
         type_support: Arc<dyn TypeSupport + Send + Sync>,
-    ) {
-        self.type_support_list.insert(type_name, type_support);
+    ) -> DdsResult<()> {
+        match self.type_support_list.entry(type_name.clone()) {
+            Entry::Occupied(_) => Err(DdsError::PreconditionNotMet(format!(
+                "Type with name {} is already registered",
+                &type_name
+            ))),
+            Entry::Vacant(e) => {
+                e.insert(type_support);
+                Ok(())
+            }
+        }
     }
 
     async fn get_type_support(

--- a/dds/src/implementation/actors/type_support_actor.rs
+++ b/dds/src/implementation/actors/type_support_actor.rs
@@ -1,14 +1,8 @@
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use dust_dds_derive::actor_interface;
 
-use crate::{
-    infrastructure::error::{DdsError, DdsResult},
-    topic_definition::type_support::DynamicTypeInterface,
-};
+use crate::topic_definition::type_support::DynamicTypeInterface;
 
 pub struct TypeSupportActor {
     type_support_list: HashMap<String, Arc<dyn DynamicTypeInterface + Send + Sync>>,
@@ -28,17 +22,8 @@ impl TypeSupportActor {
         &mut self,
         type_name: String,
         type_support: Arc<dyn DynamicTypeInterface + Send + Sync>,
-    ) -> DdsResult<()> {
-        match self.type_support_list.entry(type_name.clone()) {
-            Entry::Occupied(_) => Err(DdsError::PreconditionNotMet(format!(
-                "Type with name {} is already registered",
-                &type_name
-            ))),
-            Entry::Vacant(e) => {
-                e.insert(type_support);
-                Ok(())
-            }
-        }
+    ) {
+        self.type_support_list.insert(type_name, type_support);
     }
 
     async fn get_type_support(

--- a/dds/src/implementation/actors/type_support_actor.rs
+++ b/dds/src/implementation/actors/type_support_actor.rs
@@ -1,0 +1,26 @@
+use std::collections::HashMap;
+
+use dust_dds_derive::actor_interface;
+
+use crate::topic_definition::type_support::TypeSupport;
+
+pub struct TypeSupportActor {
+    type_support_list: HashMap<String, TypeSupport>,
+}
+
+impl TypeSupportActor {
+    pub fn new(type_support_list: HashMap<String, TypeSupport>) -> Self {
+        Self { type_support_list }
+    }
+}
+
+#[actor_interface]
+impl TypeSupportActor {
+    async fn register_type(&mut self, type_name: String, type_support: TypeSupport) {
+        self.type_support_list.insert(type_name, type_support);
+    }
+
+    async fn get_type_support(&self, type_name: String) -> Option<TypeSupport> {
+        self.type_support_list.get(&type_name).cloned()
+    }
+}

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -8,7 +8,7 @@ use dust_dds::{
         time::Duration,
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 mod utils;
@@ -23,7 +23,8 @@ fn writer_discovers_reader_in_same_participant() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -64,7 +65,8 @@ fn deleted_readers_are_disposed_from_writer() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -110,7 +112,8 @@ fn updated_readers_are_announced_to_writer() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -168,7 +171,8 @@ fn reader_discovers_writer_in_same_participant() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -209,7 +213,8 @@ fn deleted_writers_are_disposed_from_reader() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -255,7 +260,8 @@ fn updated_writers_are_announced_to_reader() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -315,6 +321,8 @@ fn two_participants_should_get_subscription_matched() {
     let dp1 = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+    dp1.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic1 = dp1
         .create_topic(
             "topic_name",
@@ -333,6 +341,8 @@ fn two_participants_should_get_subscription_matched() {
 
     let dp2 = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    dp2.register_type("UserType", FooTypeSupport::<UserType>::new())
         .unwrap();
     let topic2 = dp2
         .create_topic(
@@ -371,8 +381,14 @@ fn participant_records_discovered_topics() {
     let participant1 = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+    participant1
+        .register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let participant2 = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    participant2
+        .register_type("UserType", FooTypeSupport::<UserType>::new())
         .unwrap();
 
     let topic_names = ["Topic 1", "Topic 2"];
@@ -448,6 +464,8 @@ fn reader_discovers_disposed_writer_same_participant() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -494,6 +512,8 @@ fn publisher_and_subscriber_different_partition_not_matched() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -554,7 +574,8 @@ fn publisher_and_subscriber_regex_partition_is_matched() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -627,6 +648,8 @@ fn publisher_regex_and_subscriber_partition_is_matched() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -698,7 +721,8 @@ fn publisher_regex_and_subscriber_regex_partition_is_matched() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -771,6 +795,8 @@ fn writer_matched_to_already_existing_reader_with_matched_writer() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = dp
         .create_topic(
             "topic_name",
@@ -822,6 +848,9 @@ fn reader_matched_to_already_existing_writer_with_matched_reader() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
         .unwrap();
 
     let topic = dp

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -8,7 +8,7 @@ use dust_dds::{
         time::Duration,
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 mod utils;
@@ -23,10 +23,8 @@ fn writer_discovers_reader_in_same_participant() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -65,10 +63,8 @@ fn deleted_readers_are_disposed_from_writer() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -112,10 +108,8 @@ fn updated_readers_are_announced_to_writer() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -171,10 +165,8 @@ fn reader_discovers_writer_in_same_participant() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -213,10 +205,8 @@ fn deleted_writers_are_disposed_from_reader() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -260,10 +250,8 @@ fn updated_writers_are_announced_to_reader() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -321,10 +309,8 @@ fn two_participants_should_get_subscription_matched() {
     let dp1 = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp1.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic1 = dp1
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -342,10 +328,8 @@ fn two_participants_should_get_subscription_matched() {
     let dp2 = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp2.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic2 = dp2
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -381,14 +365,8 @@ fn participant_records_discovered_topics() {
     let participant1 = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant1
-        .register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let participant2 = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
-        .unwrap();
-    participant2
-        .register_type("UserType", FooTypeSupport::<UserType>::new())
         .unwrap();
 
     let topic_names = ["Topic 1", "Topic 2"];
@@ -396,7 +374,7 @@ fn participant_records_discovered_topics() {
     for name in topic_names {
         topics.push(
             participant1
-                .create_topic(
+                .create_topic::<UserType>(
                     name,
                     "UserType",
                     QosKind::Default,
@@ -409,7 +387,11 @@ fn participant_records_discovered_topics() {
 
     let mut found_topics = Vec::new();
     for name in topic_names {
-        found_topics.push(participant2.find_topic(name, Duration::new(10, 0)).unwrap());
+        found_topics.push(
+            participant2
+                .find_topic::<UserType>(name, Duration::new(10, 0))
+                .unwrap(),
+        );
     }
 
     let discovered_topic_names: Vec<String> = participant2
@@ -464,10 +446,8 @@ fn reader_discovers_disposed_writer_same_participant() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -512,10 +492,8 @@ fn publisher_and_subscriber_different_partition_not_matched() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -574,10 +552,8 @@ fn publisher_and_subscriber_regex_partition_is_matched() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -647,11 +623,8 @@ fn publisher_regex_and_subscriber_partition_is_matched() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -721,10 +694,8 @@ fn publisher_regex_and_subscriber_regex_partition_is_matched() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -794,11 +765,8 @@ fn writer_matched_to_already_existing_reader_with_matched_writer() {
     let dp = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,
@@ -850,11 +818,8 @@ fn reader_matched_to_already_existing_writer_with_matched_reader() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    dp.register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
-
     let topic = dp
-        .create_topic(
+        .create_topic::<UserType>(
             "topic_name",
             "UserType",
             QosKind::Default,

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -20,7 +20,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsType, FooTypeSupport, TypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 mod utils;
@@ -84,12 +84,10 @@ fn create_delete_topic() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "abc",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -158,12 +156,10 @@ fn not_allowed_to_delete_topic_from_different_participant() {
     let other_participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "abc",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -184,12 +180,11 @@ fn not_allowed_to_delete_publisher_with_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
+
     let writer_topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "Test",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -223,12 +218,10 @@ fn not_allowed_to_delete_subscriber_with_reader() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let reader_topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "Test",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -261,12 +254,10 @@ fn not_allowed_to_delete_topic_attached_to_reader() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let reader_topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "Test",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -299,12 +290,10 @@ fn not_allowed_to_delete_topic_attached_to_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let writer_topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "Test",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -337,12 +326,11 @@ fn allowed_to_delete_publisher_with_created_and_deleted_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
+
     let writer_topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "Test",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -372,12 +360,10 @@ fn allowed_to_delete_subscriber_with_created_and_deleted_reader() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let reader_topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "Test",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -407,12 +393,10 @@ fn allowed_to_delete_topic_with_created_and_deleted_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let writer_topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "Test",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -442,12 +426,10 @@ fn allowed_to_delete_topic_with_created_and_deleted_reader() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let reader_topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "Test",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -547,8 +529,6 @@ fn default_topic_qos() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let topic_data = vec![1, 2, 3];
     let qos = TopicQos {
         topic_data: TopicDataQosPolicy {
@@ -562,9 +542,9 @@ fn default_topic_qos() {
         .unwrap();
 
     let topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "default_topic_qos",
-            TypeSupport::<TestType>::get_type_name(),
+            "TestType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -630,13 +610,11 @@ fn get_discovery_data_from_builtin_reader() {
             NO_STATUS,
         )
         .unwrap();
-    TypeSupport::<MyData>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
 
     let topic = participant
-        .create_topic(
+        .create_topic::<TestType>(
             "topic_name",
-            TypeSupport::<MyData>::get_type_name(),
+            "TestType",
             QosKind::Specific(TopicQos {
                 topic_data: TopicDataQosPolicy {
                     value: topic_user_data.clone(),
@@ -772,12 +750,10 @@ fn ignore_publication() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<MyData>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "MyTopic",
-            TypeSupport::<MyData>::get_type_name(),
+            "MyData",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -846,12 +822,10 @@ fn ignore_subscription() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<MyData>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "MyTopic",
-            TypeSupport::<MyData>::get_type_name(),
+            "MyData",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -20,7 +20,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::{DdsType, FooTypeSupport, TypeSupport},
 };
 
 mod utils;
@@ -84,13 +84,12 @@ fn create_delete_topic() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let topic = participant
         .create_topic(
             "abc",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -159,13 +158,12 @@ fn not_allowed_to_delete_topic_from_different_participant() {
     let other_participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let topic = participant
         .create_topic(
             "abc",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -186,13 +184,12 @@ fn not_allowed_to_delete_publisher_with_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let writer_topic = participant
         .create_topic(
             "Test",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -226,13 +223,12 @@ fn not_allowed_to_delete_subscriber_with_reader() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let reader_topic = participant
         .create_topic(
             "Test",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -265,13 +261,12 @@ fn not_allowed_to_delete_topic_attached_to_reader() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let reader_topic = participant
         .create_topic(
             "Test",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -304,13 +299,12 @@ fn not_allowed_to_delete_topic_attached_to_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let writer_topic = participant
         .create_topic(
             "Test",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -343,13 +337,12 @@ fn allowed_to_delete_publisher_with_created_and_deleted_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let writer_topic = participant
         .create_topic(
             "Test",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -379,13 +372,12 @@ fn allowed_to_delete_subscriber_with_created_and_deleted_reader() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let reader_topic = participant
         .create_topic(
             "Test",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -415,13 +407,12 @@ fn allowed_to_delete_topic_with_created_and_deleted_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let writer_topic = participant
         .create_topic(
             "Test",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -451,13 +442,12 @@ fn allowed_to_delete_topic_with_created_and_deleted_reader() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let reader_topic = participant
         .create_topic(
             "Test",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -557,8 +547,7 @@ fn default_topic_qos() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("TestType", FooTypeSupport::<TestType>::new())
+    TypeSupport::<TestType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let topic_data = vec![1, 2, 3];
     let qos = TopicQos {
@@ -575,7 +564,7 @@ fn default_topic_qos() {
     let topic = participant
         .create_topic(
             "default_topic_qos",
-            "TestType",
+            TypeSupport::<TestType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -641,14 +630,13 @@ fn get_discovery_data_from_builtin_reader() {
             NO_STATUS,
         )
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
+    TypeSupport::<MyData>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
 
     let topic = participant
         .create_topic(
             "topic_name",
-            "MyData",
+            TypeSupport::<MyData>::get_type_name(),
             QosKind::Specific(TopicQos {
                 topic_data: TopicDataQosPolicy {
                     value: topic_user_data.clone(),
@@ -784,13 +772,12 @@ fn ignore_publication() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
+    TypeSupport::<MyData>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",
-            "MyData",
+            TypeSupport::<MyData>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -859,13 +846,12 @@ fn ignore_subscription() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
+    TypeSupport::<MyData>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",
-            "MyData",
+            TypeSupport::<MyData>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -20,7 +20,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 mod utils;
@@ -84,6 +84,9 @@ fn create_delete_topic() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "abc",
@@ -156,7 +159,9 @@ fn not_allowed_to_delete_topic_from_different_participant() {
     let other_participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "abc",
@@ -181,7 +186,9 @@ fn not_allowed_to_delete_publisher_with_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let writer_topic = participant
         .create_topic(
             "Test",
@@ -219,6 +226,9 @@ fn not_allowed_to_delete_subscriber_with_reader() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let reader_topic = participant
         .create_topic(
             "Test",
@@ -255,7 +265,9 @@ fn not_allowed_to_delete_topic_attached_to_reader() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let reader_topic = participant
         .create_topic(
             "Test",
@@ -292,7 +304,9 @@ fn not_allowed_to_delete_topic_attached_to_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let writer_topic = participant
         .create_topic(
             "Test",
@@ -329,7 +343,9 @@ fn allowed_to_delete_publisher_with_created_and_deleted_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let writer_topic = participant
         .create_topic(
             "Test",
@@ -363,7 +379,9 @@ fn allowed_to_delete_subscriber_with_created_and_deleted_reader() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let reader_topic = participant
         .create_topic(
             "Test",
@@ -397,7 +415,9 @@ fn allowed_to_delete_topic_with_created_and_deleted_writer() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let writer_topic = participant
         .create_topic(
             "Test",
@@ -431,7 +451,9 @@ fn allowed_to_delete_topic_with_created_and_deleted_reader() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let reader_topic = participant
         .create_topic(
             "Test",
@@ -535,7 +557,9 @@ fn default_topic_qos() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("TestType", FooTypeSupport::<TestType>::new())
+        .unwrap();
     let topic_data = vec![1, 2, 3];
     let qos = TopicQos {
         topic_data: TopicDataQosPolicy {
@@ -616,6 +640,9 @@ fn get_discovery_data_from_builtin_reader() {
             NoOpListener::new(),
             NO_STATUS,
         )
+        .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
         .unwrap();
 
     let topic = participant
@@ -757,7 +784,9 @@ fn ignore_publication() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -830,7 +859,9 @@ fn ignore_subscription() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",

--- a/dds/tests/domain_participant_factory.rs
+++ b/dds/tests/domain_participant_factory.rs
@@ -9,7 +9,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 mod utils;
@@ -69,11 +69,8 @@ fn not_allowed_to_delete_participant_with_entities() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "Test",
             "KeyedData",
             QosKind::Default,
@@ -107,11 +104,8 @@ fn allowed_to_delete_participant_after_delete_contained_entities() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "Test",
             "KeyedData",
             QosKind::Default,
@@ -152,7 +146,7 @@ fn all_objects_are_dropped() {
             .unwrap();
 
         let topic = participant
-            .create_topic(
+            .create_topic::<KeyedData>(
                 "MyTopic",
                 "KeyedData",
                 QosKind::Default,
@@ -244,7 +238,7 @@ fn objects_are_correctly_dropped() {
             .unwrap();
         {
             let topic = participant
-                .create_topic(
+                .create_topic::<KeyedData>(
                     topic_name,
                     "KeyedData",
                     QosKind::Default,

--- a/dds/tests/domain_participant_factory.rs
+++ b/dds/tests/domain_participant_factory.rs
@@ -9,7 +9,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 mod utils;
@@ -69,7 +69,9 @@ fn not_allowed_to_delete_participant_with_entities() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "Test",
@@ -105,7 +107,9 @@ fn allowed_to_delete_participant_after_delete_contained_entities() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "Test",

--- a/dds/tests/listeners.rs
+++ b/dds/tests/listeners.rs
@@ -29,7 +29,10 @@ use dust_dds::{
         subscriber::Subscriber,
         subscriber_listener::SubscriberListener,
     },
-    topic_definition::{topic_listener::TopicListener, type_support::DdsType},
+    topic_definition::{
+        topic_listener::TopicListener,
+        type_support::{DdsType, FooTypeSupport},
+    },
 };
 
 mod utils;
@@ -72,7 +75,9 @@ fn deadline_missed_listener() {
             &[StatusKind::RequestedDeadlineMissed],
         )
         .unwrap();
-
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -178,6 +183,9 @@ fn sample_rejected_listener() {
             participant_listener,
             &[StatusKind::SampleRejected],
         )
+        .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -296,6 +304,9 @@ fn subscription_matched_listener() {
             &[StatusKind::SubscriptionMatched],
         )
         .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "SampleRejectedListenerTopic",
@@ -391,6 +402,9 @@ fn requested_incompatible_qos_listener() {
             &[StatusKind::RequestedIncompatibleQos],
         )
         .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "SampleRejectedListenerTopic",
@@ -485,6 +499,9 @@ fn publication_matched_listener() {
             participant_listener,
             &[StatusKind::PublicationMatched],
         )
+        .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -582,6 +599,9 @@ fn offered_incompatible_qos_listener() {
             &[StatusKind::OfferedIncompatibleQos],
         )
         .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "SampleRejectedListenerTopic",
@@ -667,7 +687,9 @@ fn on_data_available_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -756,7 +778,9 @@ fn data_on_readers_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -861,7 +885,9 @@ fn data_available_listener_not_called_when_data_on_readers_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -963,7 +989,9 @@ fn participant_deadline_missed_listener() {
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -1065,6 +1093,9 @@ fn participant_sample_rejected_listener() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -1181,6 +1212,9 @@ fn participant_subscription_matched_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "SampleRejectedListenerTopic",
@@ -1272,6 +1306,9 @@ fn participant_requested_incompatible_qos_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "SampleRejectedListenerTopic",
@@ -1361,6 +1398,9 @@ fn publisher_publication_matched_listener() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -1456,6 +1496,9 @@ fn publisher_offered_incompatible_qos_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "SampleRejectedListenerTopic",
@@ -1550,7 +1593,9 @@ fn subscriber_deadline_missed_listener() {
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -1654,6 +1699,9 @@ fn subscriber_sample_rejected_listener() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -1770,6 +1818,9 @@ fn subscriber_subscription_matched_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "SampleRejectedListenerTopic",
@@ -1863,6 +1914,9 @@ fn subscriber_requested_incompatible_qos_listener() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -1959,6 +2013,9 @@ fn data_writer_publication_matched_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "SampleRejectedListenerTopic",
@@ -2051,6 +2108,9 @@ fn data_writer_offered_incompatible_qos_listener() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
         .unwrap();
     let topic = participant
         .create_topic(
@@ -2152,6 +2212,9 @@ fn non_sync_listener_should_be_accepted() {
             NonSyncListener::new(),
             NO_STATUS,
         )
+        .unwrap();
+    participant
+        .register_type("MyData", FooTypeSupport::<MyData>::new())
         .unwrap();
     let topic = participant
         .create_topic(

--- a/dds/tests/listeners.rs
+++ b/dds/tests/listeners.rs
@@ -29,10 +29,7 @@ use dust_dds::{
         subscriber::Subscriber,
         subscriber_listener::SubscriberListener,
     },
-    topic_definition::{
-        topic_listener::TopicListener,
-        type_support::{DdsType, FooTypeSupport},
-    },
+    topic_definition::{topic_listener::TopicListener, type_support::DdsType},
 };
 
 mod utils;
@@ -75,11 +72,9 @@ fn deadline_missed_listener() {
             &[StatusKind::RequestedDeadlineMissed],
         )
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
+
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "MyTopic",
             "MyData",
             QosKind::Default,
@@ -184,11 +179,8 @@ fn sample_rejected_listener() {
             &[StatusKind::SampleRejected],
         )
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -304,11 +296,8 @@ fn subscription_matched_listener() {
             &[StatusKind::SubscriptionMatched],
         )
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -402,11 +391,8 @@ fn requested_incompatible_qos_listener() {
             &[StatusKind::RequestedIncompatibleQos],
         )
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -500,11 +486,8 @@ fn publication_matched_listener() {
             &[StatusKind::PublicationMatched],
         )
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -599,11 +582,8 @@ fn offered_incompatible_qos_listener() {
             &[StatusKind::OfferedIncompatibleQos],
         )
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -687,11 +667,8 @@ fn on_data_available_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "MyTopic",
             "MyData",
             QosKind::Default,
@@ -778,11 +755,8 @@ fn data_on_readers_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "MyTopic",
             "MyData",
             QosKind::Default,
@@ -885,11 +859,8 @@ fn data_available_listener_not_called_when_data_on_readers_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "MyTopic",
             "MyData",
             QosKind::Default,
@@ -989,11 +960,8 @@ fn participant_deadline_missed_listener() {
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "MyTopic",
             "MyData",
             QosKind::Default,
@@ -1094,11 +1062,8 @@ fn participant_sample_rejected_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -1212,11 +1177,8 @@ fn participant_subscription_matched_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -1306,11 +1268,8 @@ fn participant_requested_incompatible_qos_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -1399,11 +1358,8 @@ fn publisher_publication_matched_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -1496,11 +1452,8 @@ fn publisher_offered_incompatible_qos_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -1593,11 +1546,8 @@ fn subscriber_deadline_missed_listener() {
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "MyTopic",
             "MyData",
             QosKind::Default,
@@ -1700,11 +1650,8 @@ fn subscriber_sample_rejected_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -1818,11 +1765,8 @@ fn subscriber_subscription_matched_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -1915,11 +1859,8 @@ fn subscriber_requested_incompatible_qos_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -2013,11 +1954,8 @@ fn data_writer_publication_matched_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -2109,11 +2047,8 @@ fn data_writer_offered_incompatible_qos_listener() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "SampleRejectedListenerTopic",
             "MyData",
             QosKind::Default,
@@ -2213,11 +2148,8 @@ fn non_sync_listener_should_be_accepted() {
             NO_STATUS,
         )
         .unwrap();
-    participant
-        .register_type("MyData", FooTypeSupport::<MyData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<MyData>(
             "NonSync",
             "MyData",
             QosKind::Default,

--- a/dds/tests/publisher_api.rs
+++ b/dds/tests/publisher_api.rs
@@ -6,7 +6,7 @@ use dust_dds::{
         qos_policy::UserDataQosPolicy,
         status::NO_STATUS,
     },
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 mod utils;
@@ -42,11 +42,8 @@ fn default_data_writer_qos() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<UserType>(
             "default_data_writer_qos",
             "UserType",
             QosKind::Default,
@@ -93,11 +90,8 @@ fn different_writers_have_different_instance_handles() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<UserType>(
             "default_data_writer_qos",
             "UserType",
             QosKind::Default,
@@ -148,11 +142,8 @@ fn data_writer_get_topic_should_return_same_topic_as_used_for_creation() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("UserType", FooTypeSupport::<UserType>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<UserType>(
             "default_data_writer_qos",
             "UserType",
             QosKind::Default,

--- a/dds/tests/publisher_api.rs
+++ b/dds/tests/publisher_api.rs
@@ -6,7 +6,7 @@ use dust_dds::{
         qos_policy::UserDataQosPolicy,
         status::NO_STATUS,
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 mod utils;
@@ -42,7 +42,9 @@ fn default_data_writer_qos() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "default_data_writer_qos",
@@ -91,7 +93,9 @@ fn different_writers_have_different_instance_handles() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "default_data_writer_qos",
@@ -144,7 +148,9 @@ fn data_writer_get_topic_should_return_same_topic_as_used_for_creation() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "default_data_writer_qos",

--- a/dds/tests/subscriber_api.rs
+++ b/dds/tests/subscriber_api.rs
@@ -6,7 +6,7 @@ use dust_dds::{
         qos_policy::UserDataQosPolicy,
         status::NO_STATUS,
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 mod utils;
@@ -42,7 +42,9 @@ fn default_data_reader_qos() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "default_data_reader_qos",
@@ -91,7 +93,9 @@ fn different_readers_have_different_instance_handles() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "default_data_writer_qos",
@@ -144,7 +148,9 @@ fn data_reader_get_topicdescription_should_return_same_topic_as_used_for_creatio
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("UserType", FooTypeSupport::<UserType>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "default_data_writer_qos",

--- a/dds/tests/subscriber_api.rs
+++ b/dds/tests/subscriber_api.rs
@@ -6,7 +6,7 @@ use dust_dds::{
         qos_policy::UserDataQosPolicy,
         status::NO_STATUS,
     },
-    topic_definition::type_support::{DdsType, TypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 mod utils;
@@ -42,12 +42,10 @@ fn default_data_reader_qos() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<UserType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<UserType>(
             "default_data_reader_qos",
-            TypeSupport::<UserType>::get_type_name(),
+            "UserType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -92,13 +90,10 @@ fn different_readers_have_different_instance_handles() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<UserType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<UserType>(
             "default_data_writer_qos",
-            TypeSupport::<UserType>::get_type_name(),
+            "UserType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -147,12 +142,10 @@ fn data_reader_get_topicdescription_should_return_same_topic_as_used_for_creatio
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    TypeSupport::<UserType>::register_type(&participant, TypeSupport::<UserType>::get_type_name())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<UserType>(
             "default_data_writer_qos",
-            TypeSupport::<UserType>::get_type_name(),
+            "UserType",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,

--- a/dds/tests/subscriber_api.rs
+++ b/dds/tests/subscriber_api.rs
@@ -6,7 +6,7 @@ use dust_dds::{
         qos_policy::UserDataQosPolicy,
         status::NO_STATUS,
     },
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::{DdsType, TypeSupport},
 };
 
 mod utils;
@@ -42,13 +42,12 @@ fn default_data_reader_qos() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("UserType", FooTypeSupport::<UserType>::new())
+    TypeSupport::<UserType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
     let topic = participant
         .create_topic(
             "default_data_reader_qos",
-            "UserType",
+            TypeSupport::<UserType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -93,13 +92,13 @@ fn different_readers_have_different_instance_handles() {
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("UserType", FooTypeSupport::<UserType>::new())
+    TypeSupport::<UserType>::register_type(&participant, TypeSupport::<TestType>::get_type_name())
         .unwrap();
+
     let topic = participant
         .create_topic(
             "default_data_writer_qos",
-            "UserType",
+            TypeSupport::<UserType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -148,13 +147,12 @@ fn data_reader_get_topicdescription_should_return_same_topic_as_used_for_creatio
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("UserType", FooTypeSupport::<UserType>::new())
+    TypeSupport::<UserType>::register_type(&participant, TypeSupport::<UserType>::get_type_name())
         .unwrap();
     let topic = participant
         .create_topic(
             "default_data_writer_qos",
-            "UserType",
+            TypeSupport::<UserType>::get_type_name(),
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,

--- a/dds/tests/tokio_runtime.rs
+++ b/dds/tests/tokio_runtime.rs
@@ -10,7 +10,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
@@ -29,11 +29,13 @@ async fn dust_dds_should_run_inside_tokio_runtime() {
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-
+    participant
+        .register_type("UserData", FooTypeSupport::<UserData>::new())
+        .unwrap();
     let topic = participant
         .create_topic(
             "LargeDataTopic",
-            "LargeData",
+            "UserData",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,

--- a/dds/tests/tokio_runtime.rs
+++ b/dds/tests/tokio_runtime.rs
@@ -10,7 +10,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
@@ -29,11 +29,8 @@ async fn dust_dds_should_run_inside_tokio_runtime() {
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
-    participant
-        .register_type("UserData", FooTypeSupport::<UserData>::new())
-        .unwrap();
     let topic = participant
-        .create_topic(
+        .create_topic::<UserData>(
             "LargeDataTopic",
             "UserData",
             QosKind::Default,

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -19,7 +19,7 @@ use dust_dds::{
         InstanceStateKind, SampleStateKind, ViewStateKind, ANY_INSTANCE_STATE, ANY_SAMPLE_STATE,
         ANY_VIEW_STATE,
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 mod utils;
@@ -421,7 +421,12 @@ fn writer_with_keep_last_3_should_send_last_3_samples_to_reader() {
         .take(5, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
 
-    assert_eq!(samples.len(), 3, "Received wrong number of samples. Received samples: {:?}", samples);
+    assert_eq!(
+        samples.len(),
+        3,
+        "Received wrong number of samples. Received samples: {:?}",
+        samples
+    );
     assert_eq!(samples[0].data().unwrap(), data3);
     assert_eq!(samples[1].data().unwrap(), data4);
     assert_eq!(samples[2].data().unwrap(), data5);

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -19,7 +19,7 @@ use dust_dds::{
         InstanceStateKind, SampleStateKind, ViewStateKind, ANY_INSTANCE_STATE, ANY_SAMPLE_STATE,
         ANY_VIEW_STATE,
     },
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 mod utils;
@@ -50,12 +50,8 @@ fn large_data_should_be_fragmented() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("LargeData", FooTypeSupport::<LargeData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<LargeData>(
             "LargeDataTopic",
             "LargeData",
             QosKind::Default,
@@ -144,12 +140,8 @@ fn large_data_should_be_fragmented_reliable() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("LargeData", FooTypeSupport::<LargeData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<LargeData>(
             "LargeDataTopic",
             "LargeData",
             QosKind::Default,
@@ -233,12 +225,8 @@ fn writer_with_keep_last_1_should_send_only_last_sample_to_reader() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -341,12 +329,8 @@ fn writer_with_keep_last_3_should_send_last_3_samples_to_reader() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -456,12 +440,8 @@ fn samples_are_taken() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -560,12 +540,8 @@ fn wait_for_samples_to_be_taken_best_effort() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -662,12 +638,8 @@ fn read_only_unread_samples() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -785,12 +757,8 @@ fn read_next_sample() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -873,12 +841,8 @@ fn take_next_sample() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -961,12 +925,8 @@ fn each_key_sample_is_read() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -1071,12 +1031,8 @@ fn read_specific_instance() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -1169,12 +1125,8 @@ fn read_next_instance() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -1295,12 +1247,8 @@ fn take_next_instance() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -1421,12 +1369,8 @@ fn take_specific_instance() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -1518,12 +1462,8 @@ fn take_specific_unknown_instance() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -1613,12 +1553,8 @@ fn write_read_disposed_samples() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -1715,12 +1651,8 @@ fn write_read_sample_view_state() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "OtherTopic",
             "KeyedData",
             QosKind::Default,
@@ -1817,10 +1749,6 @@ fn inconsistent_topic_status_condition() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let best_effort_topic_qos = TopicQos {
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::BestEffort,
@@ -1829,7 +1757,7 @@ fn inconsistent_topic_status_condition() {
         ..Default::default()
     };
     let topic_best_effort = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "Topic",
             "KeyedData",
             QosKind::Specific(best_effort_topic_qos),
@@ -1856,7 +1784,7 @@ fn inconsistent_topic_status_condition() {
         ..Default::default()
     };
     let _topic_reliable = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "Topic",
             "KeyedData",
             QosKind::Specific(reliable_topic_qos),
@@ -1884,12 +1812,8 @@ fn reader_with_minimum_time_separation_qos() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -2004,12 +1928,8 @@ fn transient_local_writer_reader_wait_for_historical_data() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -2106,12 +2026,8 @@ fn volatile_writer_reader_receives_only_new_samples() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -2207,12 +2123,8 @@ fn write_read_unkeyed_topic() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("UserData", FooTypeSupport::<UserData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<UserData>(
             "write_read_unkeyed_topic",
             "UserData",
             QosKind::Default,
@@ -2289,12 +2201,8 @@ fn data_reader_resource_limits() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("UserData", FooTypeSupport::<UserData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<UserData>(
             "data_reader_resource_limits",
             "UserData",
             QosKind::Default,
@@ -2395,12 +2303,8 @@ fn data_reader_order_by_source_timestamp() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("UserData", FooTypeSupport::<UserData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<UserData>(
             "MyTopic",
             "UserData",
             QosKind::Default,
@@ -2504,12 +2408,8 @@ fn data_reader_publication_handle_sample_info() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("UserData", FooTypeSupport::<UserData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<UserData>(
             "MyTopic",
             "UserData",
             QosKind::Default,
@@ -2592,12 +2492,8 @@ fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -2712,12 +2608,8 @@ fn write_read_unregistered_samples_are_also_disposed() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -2816,12 +2708,8 @@ fn transient_local_writer_does_not_deliver_lifespan_expired_data() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,
@@ -2924,12 +2812,8 @@ fn reader_joining_after_writer_writes_many_samples() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<KeyedData>(
             "MyTopic",
             "KeyedData",
             QosKind::Default,

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -51,7 +51,7 @@ fn large_data_should_be_fragmented() {
         .unwrap();
 
     participant
-        .register_type("LargeData", FooTypeSupport::new::<LargeData>())
+        .register_type("LargeData", FooTypeSupport::<LargeData>::new())
         .unwrap();
 
     let topic = participant
@@ -144,6 +144,10 @@ fn large_data_should_be_fragmented_reliable() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("LargeData", FooTypeSupport::<LargeData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "LargeDataTopic",
@@ -227,6 +231,10 @@ fn writer_with_keep_last_1_should_send_only_last_sample_to_reader() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -331,6 +339,10 @@ fn writer_with_keep_last_3_should_send_last_3_samples_to_reader() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -444,6 +456,10 @@ fn samples_are_taken() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -544,6 +560,10 @@ fn wait_for_samples_to_be_taken_best_effort() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -640,6 +660,10 @@ fn read_only_unread_samples() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -761,6 +785,10 @@ fn read_next_sample() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -845,6 +873,10 @@ fn take_next_sample() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -927,6 +959,10 @@ fn each_key_sample_is_read() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -1035,6 +1071,10 @@ fn read_specific_instance() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -1127,6 +1167,10 @@ fn read_next_instance() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -1251,6 +1295,10 @@ fn take_next_instance() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -1373,6 +1421,10 @@ fn take_specific_instance() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -1466,6 +1518,10 @@ fn take_specific_unknown_instance() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -1555,6 +1611,10 @@ fn write_read_disposed_samples() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -1655,6 +1715,10 @@ fn write_read_sample_view_state() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "OtherTopic",
@@ -1753,6 +1817,10 @@ fn inconsistent_topic_status_condition() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let best_effort_topic_qos = TopicQos {
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::BestEffort,
@@ -1814,6 +1882,10 @@ fn reader_with_minimum_time_separation_qos() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -1932,6 +2004,10 @@ fn transient_local_writer_reader_wait_for_historical_data() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -2028,6 +2104,10 @@ fn volatile_writer_reader_receives_only_new_samples() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -2127,6 +2207,10 @@ fn write_read_unkeyed_topic() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("UserData", FooTypeSupport::<UserData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "write_read_unkeyed_topic",
@@ -2204,6 +2288,11 @@ fn data_reader_resource_limits() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+
+    participant
+        .register_type("UserData", FooTypeSupport::<UserData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "data_reader_resource_limits",
@@ -2305,6 +2394,11 @@ fn data_reader_order_by_source_timestamp() {
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+
+    participant
+        .register_type("UserData", FooTypeSupport::<UserData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -2318,6 +2412,7 @@ fn data_reader_order_by_source_timestamp() {
     let publisher = participant
         .create_publisher(QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
+
     let data_writer_qos = DataWriterQos {
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::Reliable,
@@ -2409,6 +2504,10 @@ fn data_reader_publication_handle_sample_info() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("UserData", FooTypeSupport::<UserData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -2491,6 +2590,10 @@ fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -2609,6 +2712,10 @@ fn write_read_unregistered_samples_are_also_disposed() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -2707,6 +2814,10 @@ fn transient_local_writer_does_not_deliver_lifespan_expired_data() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant
@@ -2811,6 +2922,10 @@ fn reader_joining_after_writer_writes_many_samples() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("KeyedData", FooTypeSupport::<KeyedData>::new())
         .unwrap();
 
     let topic = participant

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -50,6 +50,10 @@ fn large_data_should_be_fragmented() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type("LargeData", FooTypeSupport::new::<LargeData>())
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "LargeDataTopic",

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -1,5 +1,7 @@
 mod utils;
 
+use std::ops::Range;
+
 use dust_dds::{
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{
@@ -12,11 +14,9 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    serialized_payload::cdr::{deserialize::CdrDeserialize, serialize::CdrSerialize},
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsDeserialize, DdsSerialize, DdsType, DynamicTypeInterface},
 };
-use dust_dds_derive::{DdsDeserialize, DdsSerialize};
 
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
@@ -208,170 +208,152 @@ fn foo_with_non_consecutive_key_should_read_and_write() {
     assert_eq!(samples[0].data().unwrap(), data);
 }
 
-// #[test]
-// fn foo_with_specialized_type_support_should_read_and_write() {
-//     #[derive(
-//         Clone, Debug, PartialEq, CdrSerialize, CdrDeserialize, DdsSerialize, DdsDeserialize,
-//     )]
-//     struct DynamicType {
-//         value: Vec<u8>,
-//     }
+#[test]
+fn foo_with_specialized_type_support_should_read_and_write() {
+    #[derive(Clone, Debug, PartialEq)]
+    struct DynamicType {
+        value: Vec<u8>,
+    }
 
-//     impl DynamicType {
-//         fn get_type_support(xml_representation: String) -> DynamicTypeSupport {
-//             DynamicTypeSupport { xml_representation }
-//         }
-//     }
+    impl DdsSerialize for DynamicType {
+        fn serialize_data(&self, mut writer: impl std::io::Write) -> DdsResult<()> {
+            writer.write_all(&self.value).unwrap();
+            Ok(())
+        }
+    }
 
-//     struct DynamicTypeSupport {
-//         xml_representation: String,
-//     }
+    impl<'de> DdsDeserialize<'de> for DynamicType {
+        fn deserialize_data(serialized_data: &'de [u8]) -> DdsResult<Self> {
+            Ok(Self {
+                value: serialized_data.to_vec(),
+            })
+        }
+    }
 
-//     impl DynamicTypeInterface for DynamicTypeSupport {
-//         fn has_key(&self) -> bool {
-//             true
-//         }
+    struct DynamicTypeSupport {
+        range: Range<usize>,
+    }
 
-//         fn get_serialized_key_from_serialized_foo(
-//             &self,
-//             serialized_foo: &[u8],
-//         ) -> DdsResult<Vec<u8>> {
-//             Ok(serialized_foo[0..8].to_vec())
-//         }
+    impl DynamicTypeInterface for DynamicTypeSupport {
+        fn has_key(&self) -> bool {
+            true
+        }
 
-//         fn instance_handle_from_serialized_foo(
-//             &self,
-//             serialized_foo: &[u8],
-//         ) -> DdsResult<InstanceHandle> {
-//             Ok(InstanceHandle::new([
-//                 serialized_foo[4],
-//                 serialized_foo[5],
-//                 serialized_foo[6],
-//                 serialized_foo[7],
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//             ]))
-//         }
+        fn get_serialized_key_from_serialized_foo(
+            &self,
+            serialized_foo: &[u8],
+        ) -> DdsResult<Vec<u8>> {
+            Ok(serialized_foo[self.range.clone()].to_vec())
+        }
 
-//         fn instance_handle_from_serialized_key(
-//             &self,
-//             serialized_key: &[u8],
-//         ) -> DdsResult<InstanceHandle> {
-//             Ok(InstanceHandle::new([
-//                 serialized_key[4],
-//                 serialized_key[5],
-//                 serialized_key[6],
-//                 serialized_key[7],
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//                 0,
-//             ]))
-//         }
-//     }
+        fn instance_handle_from_serialized_foo(
+            &self,
+            serialized_foo: &[u8],
+        ) -> DdsResult<InstanceHandle> {
+            let mut handle_array = [0; 16];
+            for (dst_index, src_index) in self.range.clone().enumerate() {
+                handle_array[dst_index] = serialized_foo[src_index];
+            }
+            Ok(InstanceHandle::new(handle_array))
+        }
 
-//     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+        fn instance_handle_from_serialized_key(
+            &self,
+            _serialized_key: &[u8],
+        ) -> DdsResult<InstanceHandle> {
+            unimplemented!("Not used for this test")
+        }
+    }
 
-//     let participant = DomainParticipantFactory::get_instance()
-//         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
-//         .unwrap();
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
-//     let topic = participant
-//         .create_topic(
-//             "MyTopic",
-//             "DynamicType",
-//             QosKind::Default,
-//             NoOpListener::new(),
-//             NO_STATUS,
-//         )
-//         .unwrap();
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
 
-//     let publisher = participant
-//         .create_publisher(QosKind::Default, NoOpListener::new(), NO_STATUS)
-//         .unwrap();
-//     let writer_qos = DataWriterQos {
-//         reliability: ReliabilityQosPolicy {
-//             kind: ReliabilityQosPolicyKind::Reliable,
-//             max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
-//         },
-//         ..Default::default()
-//     };
-//     let writer = publisher
-//         .create_datawriter(
-//             &topic,
-//             QosKind::Specific(writer_qos),
-//             NoOpListener::new(),
-//             NO_STATUS,
-//         )
-//         .unwrap();
+    let topic = participant
+        .create_dynamic_topic(
+            "MyTopic",
+            "DynamicType",
+            QosKind::Default,
+            NoOpListener::new(),
+            NO_STATUS,
+            DynamicTypeSupport { range: 0..4 },
+        )
+        .unwrap();
 
-//     let subscriber = participant
-//         .create_subscriber(QosKind::Default, NoOpListener::new(), NO_STATUS)
-//         .unwrap();
-//     let reader_qos = DataReaderQos {
-//         reliability: ReliabilityQosPolicy {
-//             kind: ReliabilityQosPolicyKind::Reliable,
-//             max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
-//         },
-//         ..Default::default()
-//     };
-//     let reader = subscriber
-//         .create_datareader::<DynamicType>(
-//             &topic,
-//             QosKind::Specific(reader_qos),
-//             NoOpListener::new(),
-//             NO_STATUS,
-//         )
-//         .unwrap();
+    let publisher = participant
+        .create_publisher(QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos),
+            NoOpListener::new(),
+            NO_STATUS,
+        )
+        .unwrap();
 
-//     let cond = writer.get_statuscondition().unwrap();
-//     cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
-//         .unwrap();
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader::<DynamicType>(
+            &topic,
+            QosKind::Specific(reader_qos),
+            NoOpListener::new(),
+            NO_STATUS,
+        )
+        .unwrap();
 
-//     let mut wait_set = WaitSet::new();
-//     wait_set
-//         .attach_condition(Condition::StatusCondition(cond))
-//         .unwrap();
-//     wait_set.wait(Duration::new(10, 0)).unwrap();
+    let cond = writer.get_statuscondition().unwrap();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
 
-//     let data1 = DynamicType {
-//         value: vec![1, 0, 0, 0, 1, 2, 3, 4],
-//     };
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 
-//     let data2 = DynamicType {
-//         value: vec![2, 0, 0, 0, 1, 2, 3, 4],
-//     };
+    let data1 = DynamicType {
+        value: vec![1, 0, 0, 0, 1, 2, 3, 4],
+    };
 
-//     writer.write(&data1, None).unwrap();
-//     writer.write(&data2, None).unwrap();
+    let data2 = DynamicType {
+        value: vec![2, 0, 0, 0, 1, 2, 3, 4],
+    };
 
-//     writer
-//         .wait_for_acknowledgments(Duration::new(10, 0))
-//         .unwrap();
+    writer.write(&data1, None).unwrap();
 
-//     let samples = reader
-//         .take(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
-//         .unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
 
-//     assert_eq!(samples.len(), 2);
-//     assert_eq!(samples[0].data().unwrap(), data1);
-//     assert_eq!(samples[1].data().unwrap(), data2);
-// }
+    writer.write(&data2, None).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 2);
+    assert_eq!(samples[0].data().unwrap(), data1);
+    assert_eq!(samples[1].data().unwrap(), data2);
+}

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -3,6 +3,7 @@ mod utils;
 use dust_dds::{
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{
+        error::DdsResult,
         listeners::NoOpListener,
         qos::{DataReaderQos, DataWriterQos, QosKind},
         qos_policy::{ReliabilityQosPolicy, ReliabilityQosPolicyKind},
@@ -10,9 +11,11 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
+    serialized_payload::cdr::{deserialize::CdrDeserialize, serialize::CdrSerialize},
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, TypeSupport},
 };
+use dust_dds_derive::{DdsDeserialize, DdsSerialize};
 
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
@@ -129,7 +132,7 @@ fn foo_with_non_consecutive_key_should_read_and_write() {
     let topic = participant
         .create_topic(
             "MyTopic",
-            "KeyedData",
+            "NonConsecutiveKey",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -202,4 +205,127 @@ fn foo_with_non_consecutive_key_should_read_and_write() {
 
     assert_eq!(samples.len(), 1);
     assert_eq!(samples[0].data().unwrap(), data);
+}
+
+#[test]
+fn foo_with_specialized_type_support_should_read_and_write() {
+    #[derive(
+        Clone, Debug, PartialEq, CdrSerialize, CdrDeserialize, DdsSerialize, DdsDeserialize,
+    )]
+    struct DynamicType {
+        id: u32,
+        value: Vec<u8>,
+    }
+
+    struct DynamicTypeSupport;
+
+    impl TypeSupport for DynamicTypeSupport {
+        fn has_key(&self) -> bool {
+            todo!()
+        }
+
+        fn get_key_from_serialized_foo(&self, serialized_foo: &[u8]) -> DdsResult<Vec<u8>> {
+            Ok(serialized_foo[4..8].to_vec())
+        }
+
+        fn instance_handle_from_serialized_key(
+            &self,
+            _serialized_key: &[u8],
+        ) -> DdsResult<Vec<u8>> {
+            todo!()
+        }
+    }
+
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("DynamicType", DynamicTypeSupport)
+        .unwrap();
+
+    let topic = participant
+        .create_topic(
+            "MyTopic",
+            "DynamicType",
+            QosKind::Default,
+            NoOpListener::new(),
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos),
+            NoOpListener::new(),
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader::<DynamicType>(
+            &topic,
+            QosKind::Specific(reader_qos),
+            NoOpListener::new(),
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition().unwrap();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data1 = DynamicType {
+        id: 1,
+        value: vec![1, 2, 3, 4],
+    };
+
+    let data2 = DynamicType {
+        id: 2,
+        value: vec![1, 2, 3, 4],
+    };
+
+    writer.write(&data1, None).unwrap();
+    writer.write(&data2, None).unwrap();
+
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 2);
+    assert_eq!(samples[0].data().unwrap(), data1);
+    assert_eq!(samples[1].data().unwrap(), data2);
 }

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -13,7 +13,7 @@ use dust_dds::{
     },
     serialized_payload::cdr::{deserialize::CdrDeserialize, serialize::CdrSerialize},
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsType, TypeSupport},
+    topic_definition::type_support::{DdsType, FooTypeSupport, TypeSupport},
 };
 use dust_dds_derive::{DdsDeserialize, DdsSerialize};
 
@@ -32,6 +32,10 @@ fn foo_with_lifetime_should_read_and_write() {
 
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("BorrowedData", FooTypeSupport::<BorrowedData>::new())
         .unwrap();
 
     let topic = participant
@@ -129,6 +133,13 @@ fn foo_with_non_consecutive_key_should_read_and_write() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
+    participant
+        .register_type(
+            "NonConsecutiveKey",
+            FooTypeSupport::<NonConsecutiveKey>::new(),
+        )
+        .unwrap();
+
     let topic = participant
         .create_topic(
             "MyTopic",
@@ -221,7 +232,7 @@ fn foo_with_specialized_type_support_should_read_and_write() {
 
     impl TypeSupport for DynamicTypeSupport {
         fn has_key(&self) -> bool {
-            todo!()
+            true
         }
 
         fn get_key_from_serialized_foo(&self, serialized_foo: &[u8]) -> DdsResult<Vec<u8>> {

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -240,21 +240,55 @@ fn foo_with_specialized_type_support_should_read_and_write() {
             &self,
             serialized_foo: &[u8],
         ) -> DdsResult<Vec<u8>> {
-            todo!()
+            Ok(serialized_foo[0..8].to_vec())
         }
 
         fn instance_handle_from_serialized_foo(
             &self,
             serialized_foo: &[u8],
         ) -> DdsResult<InstanceHandle> {
-            todo!()
+            Ok(InstanceHandle::new([
+                serialized_foo[4],
+                serialized_foo[5],
+                serialized_foo[6],
+                serialized_foo[7],
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ]))
         }
 
         fn instance_handle_from_serialized_key(
             &self,
             serialized_key: &[u8],
         ) -> DdsResult<InstanceHandle> {
-            todo!()
+            Ok(InstanceHandle::new([
+                serialized_key[4],
+                serialized_key[5],
+                serialized_key[6],
+                serialized_key[7],
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ]))
         }
     }
 

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -4,6 +4,7 @@ use dust_dds::{
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{
         error::DdsResult,
+        instance::InstanceHandle,
         listeners::NoOpListener,
         qos::{DataReaderQos, DataWriterQos, QosKind},
         qos_policy::{ReliabilityQosPolicy, ReliabilityQosPolicyKind},
@@ -41,7 +42,7 @@ fn foo_with_lifetime_should_read_and_write() {
     let topic = participant
         .create_topic(
             "MyTopic",
-            "KeyedData",
+            "BorrowedData",
             QosKind::Default,
             NoOpListener::new(),
             NO_STATUS,
@@ -235,14 +236,24 @@ fn foo_with_specialized_type_support_should_read_and_write() {
             true
         }
 
-        fn get_key_from_serialized_foo(&self, serialized_foo: &[u8]) -> DdsResult<Vec<u8>> {
-            Ok(serialized_foo[4..8].to_vec())
+        fn get_serialized_key_from_serialized_foo(
+            &self,
+            serialized_foo: &[u8],
+        ) -> DdsResult<Vec<u8>> {
+            todo!()
+        }
+
+        fn instance_handle_from_serialized_foo(
+            &self,
+            serialized_foo: &[u8],
+        ) -> DdsResult<InstanceHandle> {
+            todo!()
         }
 
         fn instance_handle_from_serialized_key(
             &self,
-            _serialized_key: &[u8],
-        ) -> DdsResult<Vec<u8>> {
+            serialized_key: &[u8],
+        ) -> DdsResult<InstanceHandle> {
             todo!()
         }
     }

--- a/interoperability_tests/dust_dds_big_data_publisher.rs
+++ b/interoperability_tests/dust_dds_big_data_publisher.rs
@@ -12,6 +12,7 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
+    topic_definition::type_support::FooTypeSupport,
 };
 mod big_data {
     include!("target/idl/big_data.rs");
@@ -22,12 +23,11 @@ fn main() {
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
-        .create_participant(
-            domain_id,
-            QosKind::Default,
-            NoOpListener::new(),
-            NO_STATUS,
-        )
+        .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("BigDataType", FooTypeSupport::<BigDataType>::new())
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/dust_dds_big_data_publisher.rs
+++ b/interoperability_tests/dust_dds_big_data_publisher.rs
@@ -12,7 +12,6 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::FooTypeSupport,
 };
 mod big_data {
     include!("target/idl/big_data.rs");
@@ -26,15 +25,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type(
-            "BigDataType",
-            FooTypeSupport::<big_data::BigDataType>::new(),
-        )
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<big_data::BigDataType>(
             "BigData",
             "BigDataType",
             QosKind::Default,

--- a/interoperability_tests/dust_dds_big_data_publisher.rs
+++ b/interoperability_tests/dust_dds_big_data_publisher.rs
@@ -27,7 +27,10 @@ fn main() {
         .unwrap();
 
     participant
-        .register_type("BigDataType", FooTypeSupport::<BigDataType>::new())
+        .register_type(
+            "BigDataType",
+            FooTypeSupport::<big_data::BigDataType>::new(),
+        )
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/dust_dds_big_data_subscriber.rs
+++ b/interoperability_tests/dust_dds_big_data_subscriber.rs
@@ -12,7 +12,6 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::FooTypeSupport,
 };
 
 mod big_data {
@@ -27,15 +26,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type(
-            "BigDataType",
-            FooTypeSupport::<big_data::BigDataType>::new(),
-        )
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<big_data::BigDataType>(
             "BigData",
             "BigDataType",
             QosKind::Default,

--- a/interoperability_tests/dust_dds_big_data_subscriber.rs
+++ b/interoperability_tests/dust_dds_big_data_subscriber.rs
@@ -12,6 +12,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+    topic_definition::type_support::FooTypeSupport,
 };
 
 mod big_data {
@@ -23,12 +24,11 @@ fn main() {
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
-        .create_participant(
-            domain_id,
-            QosKind::Default,
-            NoOpListener::new(),
-            NO_STATUS,
-        )
+        .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("BigDataType", FooTypeSupport::<BigDataType>::new())
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/dust_dds_big_data_subscriber.rs
+++ b/interoperability_tests/dust_dds_big_data_subscriber.rs
@@ -28,7 +28,10 @@ fn main() {
         .unwrap();
 
     participant
-        .register_type("BigDataType", FooTypeSupport::<BigDataType>::new())
+        .register_type(
+            "BigDataType",
+            FooTypeSupport::<big_data::BigDataType>::new(),
+        )
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/dust_dds_publisher.rs
+++ b/interoperability_tests/dust_dds_publisher.rs
@@ -27,7 +27,10 @@ fn main() {
         .unwrap();
 
     participant
-        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
+        .register_type(
+            "HelloWorldType",
+            FooTypeSupport::<hello_world::HelloWorldType>::new(),
+        )
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/dust_dds_publisher.rs
+++ b/interoperability_tests/dust_dds_publisher.rs
@@ -11,7 +11,6 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::FooTypeSupport,
 };
 
 mod hello_world {
@@ -26,15 +25,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type(
-            "HelloWorldType",
-            FooTypeSupport::<hello_world::HelloWorldType>::new(),
-        )
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<hello_world::HelloWorldType>(
             "HelloWorld",
             "HelloWorldType",
             QosKind::Default,

--- a/interoperability_tests/dust_dds_publisher.rs
+++ b/interoperability_tests/dust_dds_publisher.rs
@@ -11,6 +11,7 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
+    topic_definition::type_support::FooTypeSupport,
 };
 
 mod hello_world {
@@ -22,12 +23,11 @@ fn main() {
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
-        .create_participant(
-            domain_id,
-            QosKind::Default,
-            NoOpListener::new(),
-            NO_STATUS,
-        )
+        .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/dust_dds_subscriber.rs
+++ b/interoperability_tests/dust_dds_subscriber.rs
@@ -11,7 +11,8 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE}, topic_definition::type_support::FooTypeSupport,
+    subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+    topic_definition::type_support::FooTypeSupport,
 };
 
 mod hello_world {
@@ -27,7 +28,10 @@ fn main() {
         .unwrap();
 
     participant
-        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
+        .register_type(
+            "HelloWorldType",
+            FooTypeSupport::<hello_world::HelloWorldType>::new(),
+        )
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/dust_dds_subscriber.rs
+++ b/interoperability_tests/dust_dds_subscriber.rs
@@ -11,7 +11,7 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+    subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE}, topic_definition::type_support::FooTypeSupport,
 };
 
 mod hello_world {
@@ -23,12 +23,11 @@ fn main() {
     let participant_factory = DomainParticipantFactory::get_instance();
 
     let participant = participant_factory
-        .create_participant(
-            domain_id,
-            QosKind::Default,
-            NoOpListener::new(),
-            NO_STATUS,
-        )
+        .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/dust_dds_subscriber.rs
+++ b/interoperability_tests/dust_dds_subscriber.rs
@@ -12,7 +12,6 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::FooTypeSupport,
 };
 
 mod hello_world {
@@ -27,15 +26,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type(
-            "HelloWorldType",
-            FooTypeSupport::<hello_world::HelloWorldType>::new(),
-        )
-        .unwrap();
-
     let topic = participant
-        .find_topic("HelloWorld", Duration::new(120, 0))
+        .find_topic::<hello_world::HelloWorldType>("HelloWorld", Duration::new(120, 0))
         .unwrap();
 
     let subscriber = participant

--- a/interoperability_tests/publisher_multi_machine.rs
+++ b/interoperability_tests/publisher_multi_machine.rs
@@ -11,7 +11,7 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 #[derive(DdsType)]
@@ -27,6 +27,10 @@ fn main() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/publisher_multi_machine.rs
+++ b/interoperability_tests/publisher_multi_machine.rs
@@ -11,7 +11,7 @@ use dust_dds::{
         time::{Duration, DurationKind},
         wait_set::{Condition, WaitSet},
     },
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 #[derive(DdsType)]
@@ -29,12 +29,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<HelloWorldType>(
             "HelloWorld",
             "HelloWorldType",
             QosKind::Default,

--- a/interoperability_tests/subscriber_multi_machine.rs
+++ b/interoperability_tests/subscriber_multi_machine.rs
@@ -12,7 +12,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::DdsType,
+    topic_definition::type_support::{DdsType, FooTypeSupport},
 };
 
 #[derive(Debug, DdsType)]
@@ -28,6 +28,10 @@ fn main() {
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
+        .unwrap();
+
+    participant
+        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
         .unwrap();
 
     let topic = participant

--- a/interoperability_tests/subscriber_multi_machine.rs
+++ b/interoperability_tests/subscriber_multi_machine.rs
@@ -12,7 +12,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     subscription::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    topic_definition::type_support::{DdsType, FooTypeSupport},
+    topic_definition::type_support::DdsType,
 };
 
 #[derive(Debug, DdsType)]
@@ -30,12 +30,8 @@ fn main() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    participant
-        .register_type("HelloWorldType", FooTypeSupport::<HelloWorldType>::new())
-        .unwrap();
-
     let topic = participant
-        .create_topic(
+        .create_topic::<HelloWorldType>(
             "HelloWorld",
             "HelloWorldType",
             QosKind::Default,


### PR DESCRIPTION
This PR adds the register_type method to the DomainParticipant and makes it mandatory to use before creating any data reader or data writer.