### PR TITLE
Remove lazy_static dependency

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -25,7 +25,7 @@ RUN git clone --depth 1 --branch v2.5.1 --single-branch https://github.com/ePros
 RUN cd Fast-DDS-Gen && ./gradlew assemble
 
 
-FROM cimg/rust:1.65.0
+FROM cimg/rust:1.70.0
 COPY --from=CycloneDdsBuilder /home/circleci/project/cyclonedds-install /usr/local/
 COPY --from=FastDdsBuilder /home/circleci/project/Fast-DDS-install /usr/local/
 COPY --from=FastDdsGenBuilder /home/circleci/project/Fast-DDS-Gen/share /usr/local/share

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -22,7 +22,7 @@ jobs:
             docker push s2esystems/dust_dds_interoperability:1.65.0
   clippy:
     docker:
-      - image: cimg/rust:1.65.0
+      - image: cimg/rust:1.70.0
     resource_class: large
     steps:
       - checkout
@@ -30,7 +30,7 @@ jobs:
       - run: cargo clippy -- -D warnings
   benchmark:
     docker:
-      - image: cimg/rust:1.65.0
+      - image: cimg/rust:1.70.0
     resource_class: large
     steps:
       - checkout
@@ -43,7 +43,7 @@ jobs:
           path: ./target/criterion
   build:
     docker:
-      - image: cimg/rust:1.65.0
+      - image: cimg/rust:1.70.0
     resource_class: large
     steps:
       - checkout
@@ -148,7 +148,7 @@ jobs:
 
   multi_machine_tests:
     docker:
-      - image: cimg/rust:1.65.0
+      - image: cimg/rust:1.70.0
     steps:
       - checkout
       - setup_remote_docker
@@ -161,12 +161,12 @@ jobs:
           name: Run 2 subscribers with different IPs
           command: |
             # create docker volume (since direct mapping is not possible)
-            docker create -v /var --name storage cimg/rust:1.65.0 /bin/true
+            docker create -v /var --name storage cimg/rust:1.70.0 /bin/true
             docker cp ./target/debug/multiple_subscriber_test_subscriber storage:/var
             docker cp ./target/debug/multiple_subscriber_test_publisher storage:/var
-            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.65.0  /var/multiple_subscriber_test_subscriber
-            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.65.0  /var/multiple_subscriber_test_subscriber
-            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.65.0  /var/multiple_subscriber_test_publisher
+            docker run --detach --name subscriber_1 --volumes-from storage  cimg/rust:1.70.0  /var/multiple_subscriber_test_subscriber
+            docker run --detach --name subscriber_2 --volumes-from storage  cimg/rust:1.70.0  /var/multiple_subscriber_test_subscriber
+            docker run --rm --name publisher --volumes-from storage  cimg/rust:1.70.0  /var/multiple_subscriber_test_publisher
             docker logs subscriber_1 | tee subscriber_1.out
             docker logs subscriber_2 | tee subscriber_2.out
             echo "Received: id: 8, msg: Hello world" | cmp subscriber_1.out

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,4 @@
 [workspace]
 
-members = [
-    "dds",
-    "dds_derive",
-    "dds_gen",
-    "interoperability_tests",
-]
+members = ["dds", "dds_derive", "dds_gen", "interoperability_tests"]
+resolver = "2"

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.7.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",
-	"Pierre Martinet <pmartinet@s2e-systems.com>"
+	"Pierre Martinet <pmartinet@s2e-systems.com>",
 ]
 license = "Apache-2.0"
 edition = "2021"
@@ -18,10 +18,9 @@ categories = ["api-bindings", "network-programming"]
 [dependencies]
 dust_dds_derive = { path = "../dds_derive", version = "0.7" }
 
-md5 = "=0.7.0"  # Chose this crate over other possibilities since it doesn't have any other dependencies
+md5 = "=0.7.0" # Chose this crate over other possibilities since it doesn't have any other dependencies
 
 byteorder = "=1.4.3"
-lazy_static = "=1.4"
 
 socket2 = "=0.4"
 network-interface = "1.0.1"

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -69,14 +69,6 @@ impl DomainParticipant {
     }
 }
 
-impl Drop for DomainParticipant {
-    fn drop(&mut self) {
-        DomainParticipantFactory::get_instance()
-            .delete_participant(self)
-            .ok();
-    }
-}
-
 impl DomainParticipant {
     /// This operation creates a [`Publisher`] with the desired QoS policies and attaches to it the specified [`PublisherListener`].
     /// If the specified QoS policies are not consistent, the operation will fail and no [`Publisher`] will be created.

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 use super::{
-    domain_participant_factory::{DomainId, THE_PARTICIPANT_FACTORY},
+    domain_participant_factory::{DomainId, DomainParticipantFactory},
     domain_participant_listener::DomainParticipantListener,
 };
 
@@ -69,7 +69,9 @@ impl DomainParticipant {
 
 impl Drop for DomainParticipant {
     fn drop(&mut self) {
-        THE_PARTICIPANT_FACTORY.delete_participant(self).ok();
+        DomainParticipantFactory::get_instance()
+            .delete_participant(self)
+            .ok();
     }
 }
 
@@ -818,7 +820,9 @@ impl DomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn set_qos(&self, qos: QosKind<DomainParticipantQos>) -> DdsResult<()> {
         let qos = match qos {
-            QosKind::Default => THE_PARTICIPANT_FACTORY.get_default_participant_qos()?,
+            QosKind::Default => {
+                DomainParticipantFactory::get_instance().get_default_participant_qos()?
+            }
             QosKind::Specific(q) => q,
         };
 

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -98,6 +98,7 @@ impl DomainParticipant {
                 qos,
                 Box::new(a_listener),
                 mask.to_vec(),
+                self.runtime_handle.clone(),
             ))?;
 
         let publisher = Publisher::new(
@@ -171,6 +172,7 @@ impl DomainParticipant {
                     qos,
                     Box::new(a_listener),
                     mask.to_vec(),
+                    self.runtime_handle.clone(),
                 ),
             )?;
 
@@ -266,6 +268,7 @@ impl DomainParticipant {
                 qos,
                 Box::new(a_listener),
                 mask.to_vec(),
+                self.runtime_handle.clone(),
             ))?;
 
         let topic = Topic::new(
@@ -869,7 +872,11 @@ impl DomainParticipant {
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.participant_address.send_mail_and_await_reply_blocking(
-            domain_participant_actor::set_listener::new(Box::new(a_listener), mask.to_vec()),
+            domain_participant_actor::set_listener::new(
+                Box::new(a_listener),
+                mask.to_vec(),
+                self.runtime_handle.clone(),
+            ),
         )
     }
 

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -2,52 +2,23 @@ use super::domain_participant::DomainParticipant;
 use crate::{
     configuration::DustDdsConfiguration,
     domain::domain_participant_listener::DomainParticipantListener,
-    implementation::{
-        actors::{
-            domain_participant_actor::{self, DomainParticipantActor},
-            domain_participant_factory_actor::{self, DomainParticipantFactoryActor},
-        },
-        rtps::{
-            participant::RtpsParticipant,
-            types::{Locator, LOCATOR_KIND_UDP_V4, PROTOCOLVERSION, VENDOR_ID_S2E},
-        },
-        rtps_udp_psm::udp_transport::{UdpTransportRead, UdpTransportWrite},
-        utils::actor::{spawn_actor, Actor, THE_RUNTIME},
-    },
+    implementation::actors::domain_participant_factory_actor::DomainParticipantFactoryActor,
     infrastructure::{
-        error::{DdsError, DdsResult},
-        instance::InstanceHandle,
+        error::DdsResult,
         qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
         status::StatusKind,
     },
 };
-use lazy_static::lazy_static;
-use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
-use socket2::Socket;
-use std::{
-    net::{Ipv4Addr, SocketAddr},
-    sync::{Arc, RwLock},
-};
+
+use std::sync::{Mutex, OnceLock};
 use tracing::warn;
 
 pub type DomainId = i32;
 
-lazy_static! {
-    /// This value can be used as an alias for the singleton factory returned by the operation
-    /// [`DomainParticipantFactory::get_instance()`].
-    pub static ref THE_PARTICIPANT_FACTORY: DomainParticipantFactory = {
-        let participant_factory_actor = spawn_actor(DomainParticipantFactoryActor::new());
-        DomainParticipantFactory(participant_factory_actor)
-    };
-
-    static ref THE_DDS_CONFIGURATION: RwLock<DustDdsConfiguration> = RwLock::new(DustDdsConfiguration::default());
-
-}
-
 /// The sole purpose of this class is to allow the creation and destruction of [`DomainParticipant`] objects.
 /// [`DomainParticipantFactory`] itself has no factory. It is a pre-existing singleton object that can be accessed by means of the
 /// [`DomainParticipantFactory::get_instance`] operation.
-pub struct DomainParticipantFactory(Actor<DomainParticipantFactoryActor>);
+pub struct DomainParticipantFactory(Mutex<DomainParticipantFactoryActor>);
 
 impl DomainParticipantFactory {
     /// This operation creates a new [`DomainParticipant`] object. The [`DomainParticipant`] signifies that the calling application intends
@@ -65,266 +36,10 @@ impl DomainParticipantFactory {
         a_listener: impl DomainParticipantListener + Send + 'static,
         mask: &[StatusKind],
     ) -> DdsResult<DomainParticipant> {
-        let domain_participant_qos = match qos {
-            QosKind::Default => self.0.address().send_mail_and_await_reply_blocking(
-                domain_participant_factory_actor::get_default_participant_qos::new(),
-            )?,
-            QosKind::Specific(q) => q,
-        };
-
-        let mac_address = NetworkInterface::show()
-            .expect("Could not scan interfaces")
-            .into_iter()
-            .filter_map(|i| i.mac_addr)
-            .find(|m| m != "00:00:00:00:00:00")
-            .expect("Could not find any mac address");
-        let mut mac_address_octets = [0u8; 6];
-        for (index, octet_str) in mac_address.split(|c| c == ':' || c == '-').enumerate() {
-            mac_address_octets[index] =
-                u8::from_str_radix(octet_str, 16).expect("All octet strings should be valid");
-        }
-
-        let app_id = std::process::id().to_ne_bytes();
-        let instance_id = self
-            .0
-            .address()
-            .send_mail_and_await_reply_blocking(
-                domain_participant_factory_actor::get_unique_participant_id::new(),
-            )?
-            .to_ne_bytes();
-
-        #[rustfmt::skip]
-        let guid_prefix = [
-            mac_address_octets[2],  mac_address_octets[3], mac_address_octets[4], mac_address_octets[5], // Host ID
-            app_id[0], app_id[1], app_id[2], app_id[3], // App ID
-            instance_id[0], instance_id[1], instance_id[2], instance_id[3], // Instance ID
-        ];
-
-        let interface_address_list =
-            get_interface_address_list(THE_DDS_CONFIGURATION.read().unwrap().interface_name());
-
-        let default_unicast_socket =
-            socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).map_err(
-                |_| DdsError::Error("Failed to create default unicast socket".to_string()),
-            )?;
-        default_unicast_socket
-            .bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)).into())
-            .map_err(|_| DdsError::Error("Failed to bind to default unicast socket".to_string()))?;
-        default_unicast_socket
-            .set_nonblocking(true)
-            .map_err(|_| DdsError::Error("Failed to set socket non-blocking".to_string()))?;
-        if let Some(buffer_size) = THE_DDS_CONFIGURATION
-            .read()
+        self.0
+            .lock()
             .unwrap()
-            .udp_receive_buffer_size()
-        {
-            default_unicast_socket
-                .set_recv_buffer_size(buffer_size)
-                .map_err(|_| {
-                    DdsError::Error(
-                        "Failed to set default unicast socket receive buffer size".to_string(),
-                    )
-                })?;
-        }
-        let default_unicast_socket = std::net::UdpSocket::from(default_unicast_socket);
-
-        let user_defined_unicast_port = default_unicast_socket
-            .local_addr()
-            .map_err(|_| DdsError::Error("Failed to get socket address".to_string()))?
-            .port();
-        let user_defined_unicast_locator_port = user_defined_unicast_port.into();
-
-        let default_unicast_locator_list: Vec<Locator> = interface_address_list
-            .iter()
-            .map(|a| Locator::new(LOCATOR_KIND_UDP_V4, user_defined_unicast_locator_port, *a))
-            .collect();
-
-        let default_multicast_locator_list = vec![];
-
-        let metattrafic_unicast_socket =
-            std::net::UdpSocket::bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
-                .map_err(|_| DdsError::Error("Failed to open metatraffic socket".to_string()))?;
-        metattrafic_unicast_socket
-            .set_nonblocking(true)
-            .map_err(|_| {
-                DdsError::Error("Failed to set metatraffic socket non-blocking".to_string())
-            })?;
-
-        let metattrafic_unicast_locator_port = metattrafic_unicast_socket
-            .local_addr()
-            .map_err(|_| DdsError::Error("Failed to get metatraffic socket address".to_string()))?
-            .port()
-            .into();
-        let metatraffic_unicast_locator_list: Vec<Locator> = interface_address_list
-            .iter()
-            .map(|a| Locator::new(LOCATOR_KIND_UDP_V4, metattrafic_unicast_locator_port, *a))
-            .collect();
-
-        let metatraffic_multicast_locator_list = vec![Locator::new(
-            LOCATOR_KIND_UDP_V4,
-            port_builtin_multicast(domain_id) as u32,
-            DEFAULT_MULTICAST_LOCATOR_ADDRESS,
-        )];
-
-        let spdp_discovery_locator_list = metatraffic_multicast_locator_list.clone();
-
-        let socket = std::net::UdpSocket::bind("0.0.0.0:0000").unwrap();
-        let udp_transport_write = Arc::new(UdpTransportWrite::new(socket));
-
-        let rtps_participant = RtpsParticipant::new(
-            guid_prefix,
-            default_unicast_locator_list,
-            default_multicast_locator_list,
-            metatraffic_unicast_locator_list,
-            metatraffic_multicast_locator_list,
-            PROTOCOLVERSION,
-            VENDOR_ID_S2E,
-        );
-        let participant_guid = rtps_participant.guid();
-
-        let listener = Box::new(a_listener);
-        let status_kind = mask.to_vec();
-
-        let domain_participant = DomainParticipantActor::new(
-            rtps_participant,
-            domain_id,
-            THE_DDS_CONFIGURATION
-                .read()
-                .unwrap()
-                .domain_tag()
-                .to_string(),
-            domain_participant_qos,
-            &spdp_discovery_locator_list,
-            THE_DDS_CONFIGURATION.read().unwrap().fragment_size(),
-            udp_transport_write,
-            listener,
-            status_kind,
-        );
-
-        let participant_actor = spawn_actor(domain_participant);
-        let participant_address = participant_actor.address();
-        self.0.address().send_mail_and_await_reply_blocking(
-            domain_participant_factory_actor::add_participant::new(
-                InstanceHandle::new(participant_guid.into()),
-                participant_actor,
-            ),
-        )?;
-        let domain_participant = DomainParticipant::new(participant_address.clone());
-
-        let participant_address_clone = participant_address.clone();
-        THE_RUNTIME.spawn(async move {
-            let mut metatraffic_multicast_transport = UdpTransportRead::new(
-                get_multicast_socket(
-                    DEFAULT_MULTICAST_LOCATOR_ADDRESS,
-                    port_builtin_multicast(domain_id),
-                )
-                .expect("Should not fail to open socket"),
-            );
-
-            while let Some((_locator, message)) = metatraffic_multicast_transport.read().await {
-                let r = participant_address_clone
-                    .send_mail_and_await_reply(
-                        domain_participant_actor::process_metatraffic_rtps_message::new(
-                            message,
-                            participant_address_clone.clone(),
-                        ),
-                    )
-                    .await;
-                if r.is_err() {
-                    break;
-                }
-
-                let r = participant_address_clone
-                    .send_mail_and_await_reply(
-                        domain_participant_actor::process_builtin_discovery::new(
-                            participant_address_clone.clone(),
-                        ),
-                    )
-                    .await;
-                if r.is_err() {
-                    break;
-                }
-                let r = participant_address_clone
-                    .send_mail(domain_participant_actor::send_message::new())
-                    .await;
-                if r.is_err() {
-                    break;
-                }
-            }
-        });
-
-        let participant_address_clone = participant_address.clone();
-        THE_RUNTIME.spawn(async move {
-            let mut metatraffic_unicast_transport = UdpTransportRead::new(
-                tokio::net::UdpSocket::from_std(metattrafic_unicast_socket)
-                    .expect("Should not fail to open metatraffic unicast transport socket"),
-            );
-
-            while let Some((_locator, message)) = metatraffic_unicast_transport.read().await {
-                let r: DdsResult<()> = async {
-                    participant_address_clone
-                        .send_mail_and_await_reply(
-                            domain_participant_actor::process_metatraffic_rtps_message::new(
-                                message,
-                                participant_address_clone.clone(),
-                            ),
-                        )
-                        .await??;
-                    participant_address_clone
-                        .send_mail_and_await_reply(
-                            domain_participant_actor::process_builtin_discovery::new(
-                                participant_address_clone.clone(),
-                            ),
-                        )
-                        .await?;
-
-                    participant_address_clone
-                        .send_mail(domain_participant_actor::send_message::new())
-                        .await?;
-                    Ok(())
-                }
-                .await;
-
-                if r.is_err() {
-                    break;
-                }
-            }
-        });
-
-        let participant_address_clone = participant_address;
-        THE_RUNTIME.spawn(async move {
-            let mut default_unicast_transport = UdpTransportRead::new(
-                tokio::net::UdpSocket::from_std(default_unicast_socket)
-                    .expect("Should not fail to open default unicast socket"),
-            );
-
-            while let Some((_locator, message)) = default_unicast_transport.read().await {
-                let r = participant_address_clone
-                    .send_mail(
-                        domain_participant_actor::process_user_defined_rtps_message::new(
-                            message,
-                            participant_address_clone.clone(),
-                        ),
-                    )
-                    .await;
-
-                if r.is_err() {
-                    break;
-                }
-            }
-        });
-
-        if self
-            .0
-            .address()
-            .send_mail_and_await_reply_blocking(domain_participant_factory_actor::get_qos::new())?
-            .entity_factory
-            .autoenable_created_entities
-        {
-            domain_participant.enable()?;
-        }
-
-        Ok(domain_participant)
+            .create_participant(domain_id, qos, a_listener, mask)
     }
 
     /// This operation deletes an existing [`DomainParticipant`]. This operation can only be invoked if all domain entities belonging to
@@ -332,35 +47,7 @@ impl DomainParticipantFactory {
     /// participant has been previously deleted this operation returns the error [`DdsError::AlreadyDeleted`].
     #[tracing::instrument(skip(self, participant))]
     pub fn delete_participant(&self, participant: &DomainParticipant) -> DdsResult<()> {
-        let handle = participant.get_instance_handle()?;
-        let participant_list = self.0.address().send_mail_and_await_reply_blocking(
-            domain_participant_factory_actor::get_participant_list::new(),
-        )?;
-        let participant = participant_list
-            .iter()
-            .find(|x| {
-                if let Ok(h) = x.send_mail_and_await_reply_blocking(
-                    domain_participant_actor::get_instance_handle::new(),
-                ) {
-                    h == handle
-                } else {
-                    false
-                }
-            })
-            .ok_or(DdsError::BadParameter)?;
-
-        if participant
-            .send_mail_and_await_reply_blocking(domain_participant_actor::is_empty::new())?
-        {
-            self.0.address().send_mail_and_await_reply_blocking(
-                domain_participant_factory_actor::delete_participant::new(handle),
-            )?;
-            Ok(())
-        } else {
-            Err(DdsError::PreconditionNotMet(
-                "Domain participant still contains other entities".to_string(),
-            ))
-        }
+        self.0.lock().unwrap().delete_participant(participant)
     }
 
     /// This operation returns the [`DomainParticipantFactory`] singleton. The operation is idempotent, that is, it can be called multiple
@@ -368,7 +55,8 @@ impl DomainParticipantFactory {
     /// The pre-defined value [`struct@THE_PARTICIPANT_FACTORY`] can also be used as an alias for the singleton factory returned by this operation.
     #[tracing::instrument]
     pub fn get_instance() -> &'static Self {
-        &THE_PARTICIPANT_FACTORY
+        static PARTICIPANT_FACTORY: OnceLock<DomainParticipantFactory> = OnceLock::new();
+        PARTICIPANT_FACTORY.get_or_init(|| Self(Mutex::new(DomainParticipantFactoryActor::new())))
     }
 
     /// This operation retrieves a previously created [`DomainParticipant`] belonging to the specified domain_id. If no such
@@ -377,24 +65,7 @@ impl DomainParticipantFactory {
     /// specified which one.
     #[tracing::instrument(skip(self))]
     pub fn lookup_participant(&self, domain_id: DomainId) -> DdsResult<Option<DomainParticipant>> {
-        Ok(self
-            .0
-            .address()
-            .send_mail_and_await_reply_blocking(
-                domain_participant_factory_actor::get_participant_list::new(),
-            )?
-            .iter()
-            .find(|&a| {
-                if let Ok(id) = a.send_mail_and_await_reply_blocking(
-                    domain_participant_actor::get_domain_id::new(),
-                ) {
-                    id == domain_id
-                } else {
-                    false
-                }
-            })
-            .cloned()
-            .map(DomainParticipant::new))
+        self.0.lock().unwrap().lookup_participant(domain_id)
     }
 
     /// This operation sets a default value of the [`DomainParticipantQos`] policies which will be used for newly created
@@ -403,14 +74,7 @@ impl DomainParticipantFactory {
     /// return a [`DdsError::InconsistentPolicy`].
     #[tracing::instrument(skip(self))]
     pub fn set_default_participant_qos(&self, qos: QosKind<DomainParticipantQos>) -> DdsResult<()> {
-        let qos = match qos {
-            QosKind::Default => DomainParticipantQos::default(),
-            QosKind::Specific(q) => q,
-        };
-
-        self.0.address().send_mail_and_await_reply_blocking(
-            domain_participant_factory_actor::set_default_participant_qos::new(qos),
-        )
+        self.0.lock().unwrap().set_default_participant_qos(qos)
     }
 
     /// This operation retrieves the default value of the [`DomainParticipantQos`], that is, the QoS policies which will be used for
@@ -420,9 +84,7 @@ impl DomainParticipantFactory {
     /// [`DomainParticipantFactory::set_default_participant_qos`], or else, if the call was never made, the default value of [`DomainParticipantQos`].
     #[tracing::instrument(skip(self))]
     pub fn get_default_participant_qos(&self) -> DdsResult<DomainParticipantQos> {
-        self.0.address().send_mail_and_await_reply_blocking(
-            domain_participant_factory_actor::get_default_participant_qos::new(),
-        )
+        self.0.lock().unwrap().get_default_participant_qos()
     }
 
     /// This operation sets the value of the [`DomainParticipantFactoryQos`] policies. These policies control the behavior of the object
@@ -432,103 +94,24 @@ impl DomainParticipantFactory {
     /// return a [`DdsError::InconsistentPolicy`].
     #[tracing::instrument(skip(self))]
     pub fn set_qos(&self, qos: QosKind<DomainParticipantFactoryQos>) -> DdsResult<()> {
-        let qos = match qos {
-            QosKind::Default => DomainParticipantFactoryQos::default(),
-            QosKind::Specific(q) => q,
-        };
-
-        self.0
-            .address()
-            .send_mail_and_await_reply_blocking(domain_participant_factory_actor::set_qos::new(qos))
+        self.0.lock().unwrap().set_qos(qos)
     }
 
     /// This operation returns the value of the [`DomainParticipantFactoryQos`] policies.
     #[tracing::instrument(skip(self))]
     pub fn get_qos(&self) -> DdsResult<DomainParticipantFactoryQos> {
-        self.0
-            .address()
-            .send_mail_and_await_reply_blocking(domain_participant_factory_actor::get_qos::new())
+        self.0.lock().unwrap().get_qos()
     }
 }
 
 impl DomainParticipantFactory {
     /// Set the configuration of the [`DomainParticipantFactory`] singleton
     pub fn set_configuration(&self, configuration: DustDdsConfiguration) -> DdsResult<()> {
-        *THE_DDS_CONFIGURATION.write().unwrap() = configuration;
-        Ok(())
+        self.0.lock().unwrap().set_configuration(configuration)
     }
 
     /// Get the current configuration of the [`DomainParticipantFactory`] singleton
     pub fn get_configuration(&self) -> DdsResult<DustDdsConfiguration> {
-        Ok(THE_DDS_CONFIGURATION.read().unwrap().clone())
+        self.0.lock().unwrap().get_configuration()
     }
-}
-
-type LocatorAddress = [u8; 16];
-// As of 9.6.1.4.1  Default multicast address
-const DEFAULT_MULTICAST_LOCATOR_ADDRESS: LocatorAddress =
-    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 239, 255, 0, 1];
-
-const PB: i32 = 7400;
-const DG: i32 = 250;
-#[allow(non_upper_case_globals)]
-const d0: i32 = 0;
-
-fn port_builtin_multicast(domain_id: DomainId) -> u16 {
-    (PB + DG * domain_id + d0) as u16
-}
-
-fn get_interface_address_list(interface_name: Option<&String>) -> Vec<LocatorAddress> {
-    NetworkInterface::show()
-        .expect("Could not scan interfaces")
-        .into_iter()
-        .filter(|x| {
-            if let Some(if_name) = interface_name {
-                &x.name == if_name
-            } else {
-                true
-            }
-        })
-        .flat_map(|i| {
-            i.addr.into_iter().filter_map(|a| match a {
-                #[rustfmt::skip]
-                Addr::V4(v4) if !v4.ip.is_loopback() => Some(
-                    [0, 0, 0, 0,
-                        0, 0, 0, 0,
-                        0, 0, 0, 0,
-                        v4.ip.octets()[0], v4.ip.octets()[1], v4.ip.octets()[2], v4.ip.octets()[3]]
-                    ),
-                _ => None,
-            })
-        })
-        .collect()
-}
-
-fn get_multicast_socket(
-    multicast_address: LocatorAddress,
-    port: u16,
-) -> std::io::Result<tokio::net::UdpSocket> {
-    let socket_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, port));
-
-    let socket = Socket::new(
-        socket2::Domain::IPV4,
-        socket2::Type::DGRAM,
-        Some(socket2::Protocol::UDP),
-    )?;
-
-    socket.set_reuse_address(true)?;
-    socket.set_nonblocking(true)?;
-    socket.set_read_timeout(Some(std::time::Duration::from_millis(50)))?;
-
-    socket.bind(&socket_addr.into())?;
-    let addr = Ipv4Addr::new(
-        multicast_address[12],
-        multicast_address[13],
-        multicast_address[14],
-        multicast_address[15],
-    );
-    socket.join_multicast_v4(&addr, &Ipv4Addr::UNSPECIFIED)?;
-    socket.set_multicast_loop_v4(true)?;
-
-    tokio::net::UdpSocket::from_std(socket.into())
 }

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -744,7 +744,11 @@ impl<Foo> DataWriter<Foo> {
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.writer_address.send_mail_and_await_reply_blocking(
-            data_writer_actor::set_listener::new(Box::new(a_listener), mask.to_vec()),
+            data_writer_actor::set_listener::new(
+                Box::new(a_listener),
+                mask.to_vec(),
+                self.runtime_handle.clone(),
+            ),
         )
     }
 }

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -32,6 +32,7 @@ pub struct DataWriter<Foo> {
     writer_address: ActorAddress<DataWriterActor>,
     publisher_address: ActorAddress<PublisherActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
+    runtime_handle: tokio::runtime::Handle,
     phantom: PhantomData<Foo>,
 }
 
@@ -41,6 +42,7 @@ impl<Foo> Clone for DataWriter<Foo> {
             writer_address: self.writer_address.clone(),
             publisher_address: self.publisher_address.clone(),
             participant_address: self.participant_address.clone(),
+            runtime_handle: self.runtime_handle.clone(),
             phantom: self.phantom,
         }
     }
@@ -51,11 +53,13 @@ impl<Foo> DataWriter<Foo> {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) -> Self {
         Self {
             writer_address,
             publisher_address,
             participant_address,
+            runtime_handle,
             phantom: PhantomData,
         }
     }
@@ -525,6 +529,7 @@ impl<Foo> DataWriter<Foo> {
         Ok(Topic::new(
             self.topic_address(),
             self.participant_address.clone(),
+            self.runtime_handle.clone(),
         ))
     }
 
@@ -534,6 +539,7 @@ impl<Foo> DataWriter<Foo> {
         Ok(Publisher::new(
             self.publisher_address.clone(),
             self.participant_address.clone(),
+            self.runtime_handle.clone(),
         ))
     }
 

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -88,27 +88,6 @@ impl<Foo> DataWriter<Foo> {
     }
 }
 
-// impl<Foo> Drop for DataWriter<Foo> {
-//     fn drop(&mut self) {
-//         match &self.0 {
-//             DataWriterNodeKind::Listener(_) => (),
-//             DataWriterNodeKind::UserDefined(dw) => todo!()
-//             // THE_DDS_DOMAIN_PARTICIPANT_FACTORY
-//             //     .get_participant_mut(&dw.guid().prefix(), |dp| {
-//             //         if let Some(dp) = dp {
-//             //             crate::implementation::behavior::user_defined_publisher::delete_datawriter(
-//             //                 dp,
-//             //                 dw.parent_publisher(),
-//             //                 dw.guid(),
-//             //                 dw.parent_publisher(),
-//             //             )
-//             //             .ok();
-//             //         }
-//             //     }),
-//         }
-//     }
-// }
-
 impl<Foo> DataWriter<Foo>
 where
     Foo: DdsSerialize,

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -45,21 +45,6 @@ impl Publisher {
     }
 }
 
-// impl Drop for Publisher {
-//     fn drop(&mut self) {
-//         todo!()
-//         // THE_DDS_DOMAIN_PARTICIPANT_FACTORY.get_participant_mut(&self.0.guid().prefix(), |dp| {
-//         //     if let Some(dp) = dp {
-//         //         crate::implementation::behavior::domain_participant::delete_publisher(
-//         //             dp,
-//         //             self.0.guid(),
-//         //         )
-//         //         .ok();
-//         //     }
-//         // })
-//     }
-// }
-
 impl Publisher {
     /// This operation creates a [`DataWriter`]. The returned [`DataWriter`] will be attached and belongs to the [`Publisher`].
     /// The [`DataWriter`] returned by this operation has an associated [`Topic`] and a type `Foo`.

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -28,16 +28,19 @@ use super::{data_writer_listener::DataWriterListener, publisher_listener::Publis
 pub struct Publisher {
     publisher_address: ActorAddress<PublisherActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
+    runtime_handle: tokio::runtime::Handle,
 }
 
 impl Publisher {
     pub(crate) fn new(
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) -> Self {
         Self {
             publisher_address,
             participant_address,
+            runtime_handle,
         }
     }
 }
@@ -133,6 +136,7 @@ impl Publisher {
             data_writer_address,
             self.publisher_address.clone(),
             self.participant_address.clone(),
+            self.runtime_handle.clone(),
         );
 
         if self
@@ -195,6 +199,7 @@ impl Publisher {
                     dw,
                     self.publisher_address.clone(),
                     self.participant_address.clone(),
+                    self.runtime_handle.clone(),
                 )
             }))
     }
@@ -261,7 +266,10 @@ impl Publisher {
     /// This operation returns the [`DomainParticipant`] to which the [`Publisher`] belongs.
     #[tracing::instrument(skip(self))]
     pub fn get_participant(&self) -> DdsResult<DomainParticipant> {
-        Ok(DomainParticipant::new(self.participant_address.clone()))
+        Ok(DomainParticipant::new(
+            self.participant_address.clone(),
+            self.runtime_handle.clone(),
+        ))
     }
 
     /// This operation deletes all the entities that were created by means of the [`Publisher::create_datawriter`] operations.

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -129,6 +129,7 @@ impl Publisher {
                 default_unicast_locator_list,
                 default_multicast_locator_list,
                 type_xml,
+                self.runtime_handle.clone(),
             ),
         )??;
 
@@ -371,7 +372,11 @@ impl Publisher {
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.publisher_address.send_mail_and_await_reply_blocking(
-            publisher_actor::set_listener::new(Box::new(a_listener), mask.to_vec()),
+            publisher_actor::set_listener::new(
+                Box::new(a_listener),
+                mask.to_vec(),
+                self.runtime_handle.clone(),
+            ),
         )
     }
 

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -745,7 +745,11 @@ impl<Foo> DataReader<Foo> {
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.reader_address.send_mail_and_await_reply_blocking(
-            data_reader_actor::set_listener::new(Box::new(a_listener), mask.to_vec()),
+            data_reader_actor::set_listener::new(
+                Box::new(a_listener),
+                mask.to_vec(),
+                self.runtime_handle.clone(),
+            ),
         )
     }
 }

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -96,6 +96,7 @@ pub struct DataReader<Foo> {
     reader_address: ActorAddress<DataReaderActor>,
     subscriber_address: ActorAddress<SubscriberActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
+    runtime_handle: tokio::runtime::Handle,
     phantom: PhantomData<Foo>,
 }
 
@@ -104,11 +105,13 @@ impl<Foo> DataReader<Foo> {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) -> Self {
         Self {
             reader_address,
             subscriber_address,
             participant_address,
+            runtime_handle,
             phantom: PhantomData,
         }
     }
@@ -143,6 +146,7 @@ impl<Foo> Clone for DataReader<Foo> {
             reader_address: self.reader_address.clone(),
             subscriber_address: self.subscriber_address.clone(),
             participant_address: self.participant_address.clone(),
+            runtime_handle: self.runtime_handle.clone(),
             phantom: self.phantom,
         }
     }
@@ -516,6 +520,7 @@ impl<Foo> DataReader<Foo> {
         Ok(Topic::new(
             self.topic_address(),
             self.participant_address.clone(),
+            self.runtime_handle.clone(),
         ))
     }
 
@@ -525,6 +530,7 @@ impl<Foo> DataReader<Foo> {
         Ok(Subscriber::new(
             self.subscriber_address.clone(),
             self.participant_address.clone(),
+            self.runtime_handle.clone(),
         ))
     }
 

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -152,29 +152,6 @@ impl<Foo> Clone for DataReader<Foo> {
     }
 }
 
-// impl<Foo> Drop for DataReader<Foo> {
-//     fn drop(&mut self) {
-//         todo!()
-//         // match &self.0 {
-//         //     DataReaderNodeKind::BuiltinStateful(_)
-//         //     | DataReaderNodeKind::BuiltinStateless(_)
-//         //     | DataReaderNodeKind::Listener(_) => (),
-
-//         //     DataReaderNodeKind::UserDefined(dr) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
-//         //         .get_participant_mut(&dr.guid().prefix(), |dp| {
-//         //             if let Some(dp) = dp {
-//         //                 crate::implementation::behavior::user_defined_subscriber::delete_datareader(
-//         //                     dp,
-//         //                     dr.parent_subscriber(),
-//         //                     dr.guid(),
-//         //                 )
-//         //                 .ok();
-//         //             }
-//         //         }),
-//         // }
-//     }
-// }
-
 impl<Foo> DataReader<Foo> {
     /// This operation accesses a collection of [`Sample`] from the [`DataReader`]. The size of the returned collection will
     /// be limited to the specified `max_samples`. The properties of the data values collection and the setting of the

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -48,25 +48,6 @@ impl Subscriber {
     }
 }
 
-// impl Drop for Subscriber {
-//     fn drop(&mut self) {
-//         todo!()
-//         // match &self.0 {
-//         //     SubscriberNodeKind::Builtin(_) | SubscriberNodeKind::Listener(_) => (),
-//         //     SubscriberNodeKind::UserDefined(s) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
-//         //         .get_participant_mut(&s.guid().prefix(), |dp| {
-//         //             if let Some(dp) = dp {
-//         //                 crate::implementation::behavior::domain_participant::delete_subscriber(
-//         //                     dp,
-//         //                     s.guid(),
-//         //                 )
-//         //                 .ok();
-//         //             }
-//         //         }),
-//         // }
-//     }
-// }
-
 impl Subscriber {
     /// This operation creates a [`DataReader`]. The returned [`DataReader`] will be attached and belong to the [`Subscriber`].
     /// The [`DataReader`] returned by this operation has an associated [`Topic`] and a type `Foo`.

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -31,16 +31,19 @@ use super::{
 pub struct Subscriber {
     subscriber_address: ActorAddress<SubscriberActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
+    runtime_handle: tokio::runtime::Handle,
 }
 
 impl Subscriber {
     pub(crate) fn new(
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) -> Self {
         Self {
             subscriber_address,
             participant_address,
+            runtime_handle,
         }
     }
 }
@@ -135,6 +138,7 @@ impl Subscriber {
             reader_address,
             self.subscriber_address.clone(),
             self.participant_address.clone(),
+            self.runtime_handle.clone(),
         );
 
         if self
@@ -191,6 +195,7 @@ impl Subscriber {
                     reader_address,
                     self.subscriber_address.clone(),
                     self.participant_address.clone(),
+                    self.runtime_handle.clone(),
                 )
             }))
     }
@@ -207,7 +212,10 @@ impl Subscriber {
     /// This operation returns the [`DomainParticipant`] to which the [`Subscriber`] belongs.
     #[tracing::instrument(skip(self))]
     pub fn get_participant(&self) -> DdsResult<DomainParticipant> {
-        Ok(DomainParticipant::new(self.participant_address.clone()))
+        Ok(DomainParticipant::new(
+            self.participant_address.clone(),
+            self.runtime_handle.clone(),
+        ))
     }
 
     /// This operation allows access to the [`SampleLostStatus`].

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -132,6 +132,7 @@ impl Subscriber {
                 mask.to_vec(),
                 default_unicast_locator_list,
                 default_multicast_locator_list,
+                self.runtime_handle.clone(),
             ))??;
 
         let data_reader = DataReader::new(
@@ -309,7 +310,11 @@ impl Subscriber {
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.subscriber_address.send_mail_and_await_reply_blocking(
-            subscriber_actor::set_listener::new(Box::new(a_listener), mask.to_vec()),
+            subscriber_actor::set_listener::new(
+                Box::new(a_listener),
+                mask.to_vec(),
+                self.runtime_handle.clone(),
+            ),
         )
     }
 

--- a/dds/src/dds/topic_definition/topic.rs
+++ b/dds/src/dds/topic_definition/topic.rs
@@ -19,25 +19,30 @@ use crate::{
     },
 };
 
-use super::{topic_listener::TopicListener, type_support::{DdsSerialize, DdsKey}};
+use super::{
+    topic_listener::TopicListener,
+    type_support::{DdsKey, DdsSerialize},
+};
 
 /// The [`Topic`] represents the fact that both publications and subscriptions are tied to a single data-type. Its attributes
 /// `type_name` defines a unique resulting type for the publication or the subscription. It has also a `name` that allows it to
 /// be retrieved locally.
-#[derive(PartialEq, Eq)]
 pub struct Topic {
     topic_address: ActorAddress<TopicActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
+    runtime_handle: tokio::runtime::Handle,
 }
 
 impl Topic {
     pub(crate) fn new(
         topic_address: ActorAddress<TopicActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) -> Self {
         Self {
             topic_address,
             participant_address,
+            runtime_handle,
         }
     }
 }
@@ -75,7 +80,10 @@ impl Topic {
     /// This operation returns the [`DomainParticipant`] to which the [`Topic`] belongs.
     #[tracing::instrument(skip(self))]
     pub fn get_participant(&self) -> DdsResult<DomainParticipant> {
-        Ok(DomainParticipant::new(self.participant_address.clone()))
+        Ok(DomainParticipant::new(
+            self.participant_address.clone(),
+            self.runtime_handle.clone(),
+        ))
     }
 
     /// The name of the type used to create the [`Topic`]

--- a/dds/src/dds/topic_definition/topic.rs
+++ b/dds/src/dds/topic_definition/topic.rs
@@ -47,25 +47,6 @@ impl Topic {
     }
 }
 
-// impl<Foo> Drop for Topic<Foo> {
-//     fn drop(&mut self) {
-//         todo!()
-//         // match &self.node {
-//         //     TopicNodeKind::Listener(_) => (),
-//         //     TopicNodeKind::UserDefined(t) => THE_DDS_DOMAIN_PARTICIPANT_FACTORY
-//         //         .get_participant_mut(&t.guid().prefix(), |dp| {
-//         //             if let Some(dp) = dp {
-//         //                 crate::implementation::behavior::domain_participant::delete_topic(
-//         //                     dp,
-//         //                     t.guid(),
-//         //                 )
-//         //                 .ok();
-//         //             }
-//         //         }),
-//         // }
-//     }
-// }
-
 impl Topic {
     /// This method allows the application to retrieve the [`InconsistentTopicStatus`] of the [`Topic`].
     #[tracing::instrument(skip(self))]

--- a/dds/src/implementation/actors/any_data_reader_listener.rs
+++ b/dds/src/implementation/actors/any_data_reader_listener.rs
@@ -18,12 +18,14 @@ pub trait AnyDataReaderListener {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
     );
     fn trigger_on_sample_rejected(
         &mut self,
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleRejectedStatus,
     );
     fn trigger_on_liveliness_changed(
@@ -31,6 +33,7 @@ pub trait AnyDataReaderListener {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: LivelinessChangedStatus,
     );
     fn trigger_on_requested_deadline_missed(
@@ -38,6 +41,7 @@ pub trait AnyDataReaderListener {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedDeadlineMissedStatus,
     );
     fn trigger_on_requested_incompatible_qos(
@@ -45,6 +49,7 @@ pub trait AnyDataReaderListener {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedIncompatibleQosStatus,
     );
     fn trigger_on_subscription_matched(
@@ -52,6 +57,7 @@ pub trait AnyDataReaderListener {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SubscriptionMatchedStatus,
     );
     fn trigger_on_sample_lost(
@@ -59,6 +65,7 @@ pub trait AnyDataReaderListener {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleLostStatus,
     );
 }
@@ -72,11 +79,13 @@ where
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) {
         self.on_data_available(&DataReader::new(
             reader_address,
             subscriber_address,
             participant_address,
+            runtime_handle,
         ))
     }
 
@@ -85,10 +94,16 @@ where
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleRejectedStatus,
     ) {
         self.on_sample_rejected(
-            &DataReader::new(reader_address, subscriber_address, participant_address),
+            &DataReader::new(
+                reader_address,
+                subscriber_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         )
     }
@@ -98,10 +113,16 @@ where
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: LivelinessChangedStatus,
     ) {
         self.on_liveliness_changed(
-            &DataReader::new(reader_address, subscriber_address, participant_address),
+            &DataReader::new(
+                reader_address,
+                subscriber_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         )
     }
@@ -111,10 +132,16 @@ where
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedDeadlineMissedStatus,
     ) {
         self.on_requested_deadline_missed(
-            &DataReader::new(reader_address, subscriber_address, participant_address),
+            &DataReader::new(
+                reader_address,
+                subscriber_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         )
     }
@@ -124,10 +151,16 @@ where
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedIncompatibleQosStatus,
     ) {
         self.on_requested_incompatible_qos(
-            &DataReader::new(reader_address, subscriber_address, participant_address),
+            &DataReader::new(
+                reader_address,
+                subscriber_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         )
     }
@@ -137,10 +170,16 @@ where
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SubscriptionMatchedStatus,
     ) {
         self.on_subscription_matched(
-            &DataReader::new(reader_address, subscriber_address, participant_address),
+            &DataReader::new(
+                reader_address,
+                subscriber_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         )
     }
@@ -150,10 +189,16 @@ where
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleLostStatus,
     ) {
         self.on_sample_lost(
-            &DataReader::new(reader_address, subscriber_address, participant_address),
+            &DataReader::new(
+                reader_address,
+                subscriber_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         )
     }

--- a/dds/src/implementation/actors/any_data_writer_listener.rs
+++ b/dds/src/implementation/actors/any_data_writer_listener.rs
@@ -18,6 +18,7 @@ pub trait AnyDataWriterListener {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: LivelinessLostStatus,
     );
     fn trigger_on_offered_deadline_missed(
@@ -25,6 +26,7 @@ pub trait AnyDataWriterListener {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: OfferedDeadlineMissedStatus,
     );
     fn trigger_on_offered_incompatible_qos(
@@ -32,6 +34,7 @@ pub trait AnyDataWriterListener {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: OfferedIncompatibleQosStatus,
     );
     fn trigger_on_publication_matched(
@@ -39,6 +42,7 @@ pub trait AnyDataWriterListener {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: PublicationMatchedStatus,
     );
 }
@@ -52,10 +56,16 @@ where
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: LivelinessLostStatus,
     ) {
         self.on_liveliness_lost(
-            &DataWriter::new(writer_address, publisher_address, participant_address),
+            &DataWriter::new(
+                writer_address,
+                publisher_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         );
     }
@@ -65,10 +75,16 @@ where
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: OfferedDeadlineMissedStatus,
     ) {
         self.on_offered_deadline_missed(
-            &DataWriter::new(writer_address, publisher_address, participant_address),
+            &DataWriter::new(
+                writer_address,
+                publisher_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         );
     }
@@ -78,10 +94,16 @@ where
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: OfferedIncompatibleQosStatus,
     ) {
         self.on_offered_incompatible_qos(
-            &DataWriter::new(writer_address, publisher_address, participant_address),
+            &DataWriter::new(
+                writer_address,
+                publisher_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         );
     }
@@ -91,10 +113,16 @@ where
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: PublicationMatchedStatus,
     ) {
         self.on_publication_matched(
-            &DataWriter::new(writer_address, publisher_address, participant_address),
+            &DataWriter::new(
+                writer_address,
+                publisher_address,
+                participant_address,
+                runtime_handle,
+            ),
             status,
         )
     }

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -2036,11 +2036,9 @@ impl DataReaderActor {
         &mut self,
         listener: Box<dyn AnyDataReaderListener + Send>,
         status_kind: Vec<StatusKind>,
+        runtime_handle: tokio::runtime::Handle,
     ) {
-        self.listener = Actor::spawn(
-            DataReaderListenerActor::new(listener),
-            &tokio::runtime::Handle::current(),
-        );
+        self.listener = Actor::spawn(DataReaderListenerActor::new(listener), &runtime_handle);
         self.status_kind = status_kind;
     }
 

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -330,6 +330,7 @@ impl DataReaderActor {
             ActorAddress<SubscriberListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: &tokio::runtime::Handle,
     ) -> DdsResult<()> {
         subscriber_status_condition
             .send_mail_and_await_reply(status_condition_actor::add_communication_state::new(
@@ -347,6 +348,7 @@ impl DataReaderActor {
                 .send_mail(subscriber_listener_actor::trigger_on_data_on_readers::new(
                     subscriber_address.clone(),
                     participant_address.clone(),
+                    runtime_handle.clone(),
                 ))
                 .await?;
         } else if self.status_kind.contains(&StatusKind::DataAvailable) {
@@ -355,6 +357,7 @@ impl DataReaderActor {
                     data_reader_address.clone(),
                     subscriber_address.clone(),
                     participant_address.clone(),
+                    runtime_handle.clone(),
                 ))
                 .await;
         }
@@ -378,6 +381,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: &tokio::runtime::Handle,
     ) -> DdsResult<()> {
         let writer_guid = Guid::new(source_guid_prefix, data_submessage.writer_id());
         let sequence_number = data_submessage.writer_sn();
@@ -401,6 +405,7 @@ impl DataReaderActor {
                                 participant_address,
                                 subscriber_mask_listener,
                                 participant_mask_listener,
+                                runtime_handle,
                             )
                             .await?;
                         }
@@ -422,6 +427,7 @@ impl DataReaderActor {
                                     subscriber_status_condition,
                                     subscriber_mask_listener,
                                     participant_mask_listener,
+                                    runtime_handle,
                                 )
                                 .await?;
                             }
@@ -461,6 +467,7 @@ impl DataReaderActor {
                                     subscriber_status_condition,
                                     subscriber_mask_listener,
                                     participant_mask_listener,
+                                    runtime_handle,
                                 )
                                 .await?;
                             }
@@ -503,6 +510,7 @@ impl DataReaderActor {
                     subscriber_status_condition,
                     subscriber_mask_listener,
                     participant_mask_listener,
+                    runtime_handle,
                 )
                 .await?;
             }
@@ -530,6 +538,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: &tokio::runtime::Handle,
     ) -> DdsResult<()> {
         let sequence_number = data_frag_submessage.writer_sn();
         let writer_guid = Guid::new(source_guid_prefix, data_frag_submessage.writer_id());
@@ -554,6 +563,7 @@ impl DataReaderActor {
                     subscriber_status_condition,
                     subscriber_mask_listener,
                     participant_mask_listener,
+                    runtime_handle,
                 )
                 .await?;
             }
@@ -692,6 +702,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: &tokio::runtime::Handle,
     ) -> DdsResult<()> {
         self.sample_lost_status.increment();
         self.status_condition
@@ -707,6 +718,7 @@ impl DataReaderActor {
                     data_reader_address.clone(),
                     subscriber_address.clone(),
                     participant_address.clone(),
+                    runtime_handle.clone(),
                     status,
                 ))
                 .await;
@@ -717,6 +729,7 @@ impl DataReaderActor {
                     data_reader_address.clone(),
                     subscriber_address.clone(),
                     participant_address.clone(),
+                    runtime_handle.clone(),
                     status,
                 ))
                 .await?;
@@ -728,6 +741,7 @@ impl DataReaderActor {
                         data_reader_address.clone(),
                         subscriber_address.clone(),
                         participant_address.clone(),
+                        runtime_handle.clone(),
                         status,
                     ),
                 )
@@ -751,6 +765,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: &tokio::runtime::Handle,
     ) {
         self.subscription_matched_status.increment(instance_handle);
         self.status_condition
@@ -767,6 +782,7 @@ impl DataReaderActor {
                         data_reader_address,
                         subscriber_address,
                         participant_address,
+                        runtime_handle.clone(),
                         status,
                     ),
                 )
@@ -779,6 +795,7 @@ impl DataReaderActor {
                         data_reader_address.clone(),
                         subscriber_address.clone(),
                         participant_address.clone(),
+                        runtime_handle.clone(),
                         status,
                     ),
                 )
@@ -792,6 +809,7 @@ impl DataReaderActor {
                         data_reader_address.clone(),
                         subscriber_address.clone(),
                         participant_address.clone(),
+                        runtime_handle.clone(),
                         status,
                     ),
                 )
@@ -816,6 +834,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: &tokio::runtime::Handle,
     ) -> DdsResult<()> {
         self.sample_rejected_status
             .increment(instance_handle, rejected_reason);
@@ -833,6 +852,7 @@ impl DataReaderActor {
                     data_reader_address.clone(),
                     subscriber_address.clone(),
                     participant_address.clone(),
+                    runtime_handle.clone(),
                     status,
                 ))
                 .await;
@@ -844,6 +864,7 @@ impl DataReaderActor {
                     data_reader_address.clone(),
                     subscriber_address.clone(),
                     participant_address.clone(),
+                    runtime_handle.clone(),
                     status,
                 ))
                 .await?;
@@ -855,6 +876,7 @@ impl DataReaderActor {
                         data_reader_address.clone(),
                         subscriber_address.clone(),
                         participant_address.clone(),
+                        runtime_handle.clone(),
                         status,
                     ),
                 )
@@ -878,6 +900,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: &tokio::runtime::Handle,
     ) {
         self.requested_incompatible_qos_status
             .increment(incompatible_qos_policy_list);
@@ -899,6 +922,7 @@ impl DataReaderActor {
                         data_reader_address.clone(),
                         subscriber_address.clone(),
                         participant_address.clone(),
+                        runtime_handle.clone(),
                         status,
                     ),
                 )
@@ -911,6 +935,7 @@ impl DataReaderActor {
                         data_reader_address.clone(),
                         subscriber_address.clone(),
                         participant_address.clone(),
+                        runtime_handle.clone(),
                         status,
                     ),
                 )
@@ -924,6 +949,7 @@ impl DataReaderActor {
                         data_reader_address.clone(),
                         subscriber_address.clone(),
                         participant_address.clone(),
+                        runtime_handle.clone(),
                         status,
                     ),
                 )
@@ -1029,6 +1055,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: &tokio::runtime::Handle,
     ) -> DdsResult<()> {
         if self.is_sample_of_interest_based_on_time(&change) {
             if self.is_max_samples_limit_reached(&change) {
@@ -1040,6 +1067,7 @@ impl DataReaderActor {
                     participant_address,
                     subscriber_mask_listener,
                     participant_mask_listener,
+                    runtime_handle,
                 )
                 .await?;
             } else if self.is_max_instances_limit_reached(&change) {
@@ -1051,6 +1079,7 @@ impl DataReaderActor {
                     participant_address,
                     subscriber_mask_listener,
                     participant_mask_listener,
+                    runtime_handle,
                 )
                 .await?;
             } else if self.is_max_samples_per_instance_limit_reached(&change) {
@@ -1062,6 +1091,7 @@ impl DataReaderActor {
                     participant_address,
                     subscriber_mask_listener,
                     participant_mask_listener,
+                    runtime_handle,
                 )
                 .await?;
             } else {
@@ -1094,6 +1124,7 @@ impl DataReaderActor {
                     participant_address.clone(),
                     subscriber_mask_listener,
                     participant_mask_listener,
+                    runtime_handle.clone(),
                 );
 
                 self.changes.push(change);
@@ -1123,6 +1154,7 @@ impl DataReaderActor {
                     participant_address,
                     subscriber_status_condition,
                     subscriber_mask_listener,
+                    runtime_handle,
                 )
                 .await?;
             }
@@ -1344,6 +1376,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: tokio::runtime::Handle,
     ) {
         if let Some(t) = self
             .instance_deadline_missed_task
@@ -1396,6 +1429,7 @@ impl DataReaderActor {
                                     data_reader_address.clone(),
                                     subscriber_address.clone(),
                                     participant_address.clone(),
+                                    runtime_handle.clone(),
                                     status,
                                 ),
                             )
@@ -1412,6 +1446,7 @@ impl DataReaderActor {
                                     data_reader_address.clone(),
                                     subscriber_address.clone(),
                                     participant_address.clone(),
+                                    runtime_handle.clone(),
                                     status,
                                 ),
                             )
@@ -1427,6 +1462,7 @@ impl DataReaderActor {
                                     data_reader_address.clone(),
                                     subscriber_address.clone(),
                                     participant_address.clone(),
+                                    runtime_handle.clone(),
                                     status,
                                 ),
                             )
@@ -1753,6 +1789,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: tokio::runtime::Handle,
     ) {
         let publication_builtin_topic_data = discovered_writer_data.dds_publication_data();
         if publication_builtin_topic_data.topic_name() == self.topic_name
@@ -1824,6 +1861,7 @@ impl DataReaderActor {
                             participant_address,
                             &subscriber_mask_listener,
                             &participant_mask_listener,
+                            &runtime_handle,
                         )
                         .await;
                     }
@@ -1835,6 +1873,7 @@ impl DataReaderActor {
                             participant_address,
                             &subscriber_mask_listener,
                             &participant_mask_listener,
+                            &runtime_handle,
                         )
                         .await;
                     }
@@ -1848,6 +1887,7 @@ impl DataReaderActor {
                     &participant_address,
                     &subscriber_mask_listener,
                     &participant_mask_listener,
+                    &runtime_handle,
                 )
                 .await;
             }
@@ -1865,6 +1905,7 @@ impl DataReaderActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: tokio::runtime::Handle,
     ) {
         let matched_publication = self
             .matched_publication_list
@@ -1879,6 +1920,7 @@ impl DataReaderActor {
                 participant_address,
                 &subscriber_mask_listener,
                 &participant_mask_listener,
+                &runtime_handle,
             )
             .await;
         }
@@ -1907,6 +1949,7 @@ impl DataReaderActor {
             Vec<StatusKind>,
         ),
         type_support_actor_address: ActorAddress<TypeSupportActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) -> DdsResult<()> {
         let mut message_receiver = MessageReceiver::new(&message);
         let type_support = type_support_actor_address
@@ -1936,6 +1979,7 @@ impl DataReaderActor {
                         &subscriber_status_condition,
                         &subscriber_mask_listener,
                         &participant_mask_listener,
+                        &runtime_handle,
                     )
                     .await?;
                 }
@@ -1952,6 +1996,7 @@ impl DataReaderActor {
                         &subscriber_status_condition,
                         &subscriber_mask_listener,
                         &participant_mask_listener,
+                        &runtime_handle,
                     )
                     .await?;
                 }

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -266,6 +266,7 @@ pub struct DataReaderActor {
 }
 
 impl DataReaderActor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         rtps_reader: RtpsReader,
         type_name: String,
@@ -751,6 +752,7 @@ impl DataReaderActor {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn on_subscription_matched(
         &mut self,
         instance_handle: InstanceHandle,
@@ -886,6 +888,7 @@ impl DataReaderActor {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn on_requested_incompatible_qos(
         &mut self,
         incompatible_qos_policy_list: Vec<QosPolicyId>,
@@ -1365,6 +1368,7 @@ impl DataReaderActor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn start_deadline_missed_task(
         &mut self,
         change_instance_handle: InstanceHandle,
@@ -1894,6 +1898,7 @@ impl DataReaderActor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn remove_matched_writer(
         &mut self,
         discovered_writer_handle: InstanceHandle,

--- a/dds/src/implementation/actors/data_reader_listener_actor.rs
+++ b/dds/src/implementation/actors/data_reader_listener_actor.rs
@@ -30,12 +30,14 @@ impl DataReaderListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.trigger_on_data_available(
                 reader_address,
                 subscriber_address,
                 participant_address,
+                runtime_handle,
             )
         });
     }
@@ -45,6 +47,7 @@ impl DataReaderListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleRejectedStatus,
     ) {
         tokio::task::block_in_place(|| {
@@ -52,6 +55,7 @@ impl DataReaderListenerActor {
                 reader_address,
                 subscriber_address,
                 participant_address,
+                runtime_handle,
                 status,
             )
         });
@@ -62,6 +66,7 @@ impl DataReaderListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleLostStatus,
     ) {
         tokio::task::block_in_place(|| {
@@ -69,6 +74,7 @@ impl DataReaderListenerActor {
                 reader_address,
                 subscriber_address,
                 participant_address,
+                runtime_handle,
                 status,
             )
         })
@@ -79,6 +85,7 @@ impl DataReaderListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedIncompatibleQosStatus,
     ) {
         tokio::task::block_in_place(|| {
@@ -86,6 +93,7 @@ impl DataReaderListenerActor {
                 reader_address,
                 subscriber_address,
                 participant_address,
+                runtime_handle,
                 status,
             )
         });
@@ -96,6 +104,7 @@ impl DataReaderListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SubscriptionMatchedStatus,
     ) {
         tokio::task::block_in_place(|| {
@@ -103,6 +112,7 @@ impl DataReaderListenerActor {
                 reader_address,
                 subscriber_address,
                 participant_address,
+                runtime_handle,
                 status,
             )
         });
@@ -113,6 +123,7 @@ impl DataReaderListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedDeadlineMissedStatus,
     ) {
         tokio::task::block_in_place(|| {
@@ -120,6 +131,7 @@ impl DataReaderListenerActor {
                 reader_address,
                 subscriber_address,
                 participant_address,
+                runtime_handle,
                 status,
             )
         });

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -821,11 +821,9 @@ impl DataWriterActor {
         &mut self,
         listener: Box<dyn AnyDataWriterListener + Send>,
         status_kind: Vec<StatusKind>,
+        runtime_handle: tokio::runtime::Handle,
     ) {
-        self.listener = Actor::spawn(
-            DataWriterListenerActor::new(listener),
-            &tokio::runtime::Handle::current(),
-        );
+        self.listener = Actor::spawn(DataWriterListenerActor::new(listener), &runtime_handle);
         self.status_kind = status_kind;
     }
 }

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -237,6 +237,7 @@ pub struct DataWriterActor {
 }
 
 impl DataWriterActor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         rtps_writer: RtpsWriter,
         type_name: String,
@@ -743,6 +744,7 @@ impl DataWriterActor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn remove_matched_reader(
         &mut self,
         discovered_reader_handle: InstanceHandle,

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -612,6 +612,7 @@ impl DataWriterActor {
         offered_incompatible_qos_participant_listener: Option<
             ActorAddress<DomainParticipantListenerActor>,
         >,
+        runtime_handle: tokio::runtime::Handle,
     ) {
         let is_matched_topic_name = discovered_reader_data
             .subscription_builtin_topic_data()
@@ -722,6 +723,7 @@ impl DataWriterActor {
                         participant_address,
                         publisher_publication_matched_listener,
                         participant_publication_matched_listener,
+                        runtime_handle,
                     )
                     .await;
                 }
@@ -734,6 +736,7 @@ impl DataWriterActor {
                     participant_address,
                     offered_incompatible_qos_publisher_listener,
                     offered_incompatible_qos_participant_listener,
+                    runtime_handle,
                 )
                 .await;
             }
@@ -750,6 +753,7 @@ impl DataWriterActor {
         participant_publication_matched_listener: Option<
             ActorAddress<DomainParticipantListenerActor>,
         >,
+        runtime_handle: tokio::runtime::Handle,
     ) {
         if let Some(r) = self
             .get_matched_subscription_data(discovered_reader_handle)
@@ -766,6 +770,7 @@ impl DataWriterActor {
                 participant_address,
                 publisher_publication_matched_listener,
                 participant_publication_matched_listener,
+                runtime_handle,
             )
             .await;
         }
@@ -999,6 +1004,7 @@ impl DataWriterActor {
         participant_publication_matched_listener: Option<
             ActorAddress<DomainParticipantListenerActor>,
         >,
+        runtime_handle: tokio::runtime::Handle,
     ) {
         self.status_condition
             .send_mail_and_await_reply(status_condition_actor::add_communication_state::new(
@@ -1013,6 +1019,7 @@ impl DataWriterActor {
                         data_writer_address,
                         publisher_address,
                         participant_address,
+                        runtime_handle,
                         status,
                     ),
                 )
@@ -1027,6 +1034,7 @@ impl DataWriterActor {
                         data_writer_address,
                         publisher_address,
                         participant_address,
+                        runtime_handle,
                         status,
                     ),
                 )
@@ -1042,6 +1050,7 @@ impl DataWriterActor {
                         data_writer_address,
                         publisher_address,
                         participant_address,
+                        runtime_handle,
                         status,
                     ),
                 )
@@ -1059,6 +1068,7 @@ impl DataWriterActor {
         offered_incompatible_qos_participant_listener: Option<
             ActorAddress<DomainParticipantListenerActor>,
         >,
+        runtime_handle: tokio::runtime::Handle,
     ) {
         self.status_condition
             .send_mail_and_await_reply(status_condition_actor::add_communication_state::new(
@@ -1077,6 +1087,7 @@ impl DataWriterActor {
                         data_writer_address,
                         publisher_address,
                         participant_address,
+                        runtime_handle,
                         status,
                     ),
                 )
@@ -1091,6 +1102,7 @@ impl DataWriterActor {
                         data_writer_address,
                         publisher_address,
                         participant_address,
+                        runtime_handle,
                         status,
                     ),
                 )
@@ -1106,6 +1118,7 @@ impl DataWriterActor {
                         data_writer_address,
                         publisher_address,
                         participant_address,
+                        runtime_handle,
                         status,
                     ),
                 )

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -42,7 +42,7 @@ use crate::{
         },
         rtps_udp_psm::udp_transport::UdpTransportWrite,
         utils::{
-            actor::{spawn_actor, Actor, ActorAddress},
+            actor::{Actor, ActorAddress},
             instance_handle_from_key::get_instance_handle_from_key,
         },
     },
@@ -245,9 +245,10 @@ impl DataWriterActor {
         status_kind: Vec<StatusKind>,
         qos: DataWriterQos,
         xml_type: String,
+        handle: &tokio::runtime::Handle,
     ) -> Self {
-        let status_condition = spawn_actor(StatusConditionActor::default());
-        let listener = spawn_actor(DataWriterListenerActor::new(listener));
+        let status_condition = Actor::spawn(StatusConditionActor::default(), handle);
+        let listener = Actor::spawn(DataWriterListenerActor::new(listener), handle);
         DataWriterActor {
             rtps_writer,
             reader_locators: Vec::new(),
@@ -816,7 +817,10 @@ impl DataWriterActor {
         listener: Box<dyn AnyDataWriterListener + Send>,
         status_kind: Vec<StatusKind>,
     ) {
-        self.listener = spawn_actor(DataWriterListenerActor::new(listener));
+        self.listener = Actor::spawn(
+            DataWriterListenerActor::new(listener),
+            &tokio::runtime::Handle::current(),
+        );
         self.status_kind = status_kind;
     }
 }

--- a/dds/src/implementation/actors/data_writer_listener_actor.rs
+++ b/dds/src/implementation/actors/data_writer_listener_actor.rs
@@ -27,6 +27,7 @@ impl DataWriterListenerActor {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: OfferedIncompatibleQosStatus,
     ) {
         tokio::task::block_in_place(|| {
@@ -34,6 +35,7 @@ impl DataWriterListenerActor {
                 writer_address,
                 publisher_address,
                 participant_address,
+                runtime_handle,
                 status,
             )
         });
@@ -44,6 +46,7 @@ impl DataWriterListenerActor {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: PublicationMatchedStatus,
     ) {
         tokio::task::block_in_place(|| {
@@ -51,6 +54,7 @@ impl DataWriterListenerActor {
                 writer_address,
                 publisher_address,
                 participant_address,
+                runtime_handle,
                 status,
             )
         });

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -1,12 +1,33 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    net::{Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
-use dust_dds_derive::actor_interface;
+use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
+use socket2::Socket;
+use tokio::runtime::Runtime;
 
 use crate::{
-    implementation::utils::actor::{Actor, ActorAddress},
+    configuration::DustDdsConfiguration,
+    domain::{
+        domain_participant::DomainParticipant, domain_participant_factory::DomainId,
+        domain_participant_listener::DomainParticipantListener,
+    },
+    implementation::{
+        actors::domain_participant_actor,
+        rtps::{
+            participant::RtpsParticipant,
+            types::{Locator, LOCATOR_KIND_UDP_V4, PROTOCOLVERSION, VENDOR_ID_S2E},
+        },
+        rtps_udp_psm::udp_transport::{UdpTransportRead, UdpTransportWrite},
+        utils::actor::{spawn_actor, Actor},
+    },
     infrastructure::{
+        error::{DdsError, DdsResult},
         instance::InstanceHandle,
-        qos::{DomainParticipantFactoryQos, DomainParticipantQos},
+        qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
+        status::StatusKind,
     },
 };
 
@@ -17,6 +38,8 @@ pub struct DomainParticipantFactoryActor {
     domain_participant_counter: u32,
     qos: DomainParticipantFactoryQos,
     default_participant_qos: DomainParticipantQos,
+    configuration: DustDdsConfiguration,
+    runtime: Runtime,
 }
 
 impl Default for DomainParticipantFactoryActor {
@@ -27,56 +50,407 @@ impl Default for DomainParticipantFactoryActor {
 
 impl DomainParticipantFactoryActor {
     pub fn new() -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_stack_size(4 * 1024 * 1024)
+            .build()
+            .expect("Failed to create Tokio runtime");
         Self {
             domain_participant_list: HashMap::new(),
             domain_participant_counter: 0,
             qos: DomainParticipantFactoryQos::default(),
             default_participant_qos: DomainParticipantQos::default(),
+            configuration: DustDdsConfiguration::default(),
+            runtime,
         }
     }
-}
 
-#[actor_interface]
-impl DomainParticipantFactoryActor {
-    async fn add_participant(
+    pub fn create_participant(
         &mut self,
-        instance_handle: InstanceHandle,
-        participant: Actor<DomainParticipantActor>,
-    ) {
-        self.domain_participant_list
-            .insert(instance_handle, participant);
+        domain_id: DomainId,
+        qos: QosKind<DomainParticipantQos>,
+        a_listener: impl DomainParticipantListener + Send + 'static,
+        mask: &[StatusKind],
+    ) -> DdsResult<DomainParticipant> {
+        let domain_participant_qos = match qos {
+            QosKind::Default => self.default_participant_qos.clone(),
+            QosKind::Specific(q) => q,
+        };
+
+        let mac_address = NetworkInterface::show()
+            .expect("Could not scan interfaces")
+            .into_iter()
+            .filter_map(|i| i.mac_addr)
+            .find(|m| m != "00:00:00:00:00:00")
+            .expect("Could not find any mac address");
+        let mut mac_address_octets = [0u8; 6];
+        for (index, octet_str) in mac_address.split(|c| c == ':' || c == '-').enumerate() {
+            mac_address_octets[index] =
+                u8::from_str_radix(octet_str, 16).expect("All octet strings should be valid");
+        }
+
+        let app_id = std::process::id().to_ne_bytes();
+        let instance_id = self.get_unique_participant_id().to_ne_bytes();
+
+        #[rustfmt::skip]
+        let guid_prefix = [
+            mac_address_octets[2],  mac_address_octets[3], mac_address_octets[4], mac_address_octets[5], // Host ID
+            app_id[0], app_id[1], app_id[2], app_id[3], // App ID
+            instance_id[0], instance_id[1], instance_id[2], instance_id[3], // Instance ID
+        ];
+
+        let interface_address_list =
+            get_interface_address_list(self.configuration.interface_name());
+
+        let default_unicast_socket =
+            socket2::Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).map_err(
+                |_| DdsError::Error("Failed to create default unicast socket".to_string()),
+            )?;
+        default_unicast_socket
+            .bind(&SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)).into())
+            .map_err(|_| DdsError::Error("Failed to bind to default unicast socket".to_string()))?;
+        default_unicast_socket
+            .set_nonblocking(true)
+            .map_err(|_| DdsError::Error("Failed to set socket non-blocking".to_string()))?;
+        if let Some(buffer_size) = self.configuration.udp_receive_buffer_size() {
+            default_unicast_socket
+                .set_recv_buffer_size(buffer_size)
+                .map_err(|_| {
+                    DdsError::Error(
+                        "Failed to set default unicast socket receive buffer size".to_string(),
+                    )
+                })?;
+        }
+        let default_unicast_socket = std::net::UdpSocket::from(default_unicast_socket);
+
+        let user_defined_unicast_port = default_unicast_socket
+            .local_addr()
+            .map_err(|_| DdsError::Error("Failed to get socket address".to_string()))?
+            .port();
+        let user_defined_unicast_locator_port = user_defined_unicast_port.into();
+
+        let default_unicast_locator_list: Vec<Locator> = interface_address_list
+            .iter()
+            .map(|a| Locator::new(LOCATOR_KIND_UDP_V4, user_defined_unicast_locator_port, *a))
+            .collect();
+
+        let default_multicast_locator_list = vec![];
+
+        let metattrafic_unicast_socket =
+            std::net::UdpSocket::bind(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+                .map_err(|_| DdsError::Error("Failed to open metatraffic socket".to_string()))?;
+        metattrafic_unicast_socket
+            .set_nonblocking(true)
+            .map_err(|_| {
+                DdsError::Error("Failed to set metatraffic socket non-blocking".to_string())
+            })?;
+
+        let metattrafic_unicast_locator_port = metattrafic_unicast_socket
+            .local_addr()
+            .map_err(|_| DdsError::Error("Failed to get metatraffic socket address".to_string()))?
+            .port()
+            .into();
+        let metatraffic_unicast_locator_list: Vec<Locator> = interface_address_list
+            .iter()
+            .map(|a| Locator::new(LOCATOR_KIND_UDP_V4, metattrafic_unicast_locator_port, *a))
+            .collect();
+
+        let metatraffic_multicast_locator_list = vec![Locator::new(
+            LOCATOR_KIND_UDP_V4,
+            port_builtin_multicast(domain_id) as u32,
+            DEFAULT_MULTICAST_LOCATOR_ADDRESS,
+        )];
+
+        let spdp_discovery_locator_list = metatraffic_multicast_locator_list.clone();
+
+        let socket = std::net::UdpSocket::bind("0.0.0.0:0000").unwrap();
+        let udp_transport_write = Arc::new(UdpTransportWrite::new(socket));
+
+        let rtps_participant = RtpsParticipant::new(
+            guid_prefix,
+            default_unicast_locator_list,
+            default_multicast_locator_list,
+            metatraffic_unicast_locator_list,
+            metatraffic_multicast_locator_list,
+            PROTOCOLVERSION,
+            VENDOR_ID_S2E,
+        );
+        let participant_guid = rtps_participant.guid();
+
+        let listener = Box::new(a_listener);
+        let status_kind = mask.to_vec();
+
+        let domain_participant = DomainParticipantActor::new(
+            rtps_participant,
+            domain_id,
+            self.configuration.domain_tag().to_string(),
+            domain_participant_qos,
+            &spdp_discovery_locator_list,
+            self.configuration.fragment_size(),
+            udp_transport_write,
+            listener,
+            status_kind,
+        );
+
+        let participant_actor = spawn_actor(domain_participant);
+        let participant_address = participant_actor.address();
+        self.domain_participant_list.insert(
+            InstanceHandle::new(participant_guid.into()),
+            participant_actor,
+        );
+
+        let domain_participant = DomainParticipant::new(participant_address.clone());
+
+        let participant_address_clone = participant_address.clone();
+        self.runtime.spawn(async move {
+            let mut metatraffic_multicast_transport = UdpTransportRead::new(
+                get_multicast_socket(
+                    DEFAULT_MULTICAST_LOCATOR_ADDRESS,
+                    port_builtin_multicast(domain_id),
+                )
+                .expect("Should not fail to open socket"),
+            );
+
+            while let Some((_locator, message)) = metatraffic_multicast_transport.read().await {
+                let r = participant_address_clone
+                    .send_mail_and_await_reply(
+                        domain_participant_actor::process_metatraffic_rtps_message::new(
+                            message,
+                            participant_address_clone.clone(),
+                        ),
+                    )
+                    .await;
+                if r.is_err() {
+                    break;
+                }
+
+                let r = participant_address_clone
+                    .send_mail_and_await_reply(
+                        domain_participant_actor::process_builtin_discovery::new(
+                            participant_address_clone.clone(),
+                        ),
+                    )
+                    .await;
+                if r.is_err() {
+                    break;
+                }
+                let r = participant_address_clone
+                    .send_mail(domain_participant_actor::send_message::new())
+                    .await;
+                if r.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let participant_address_clone = participant_address.clone();
+        self.runtime.spawn(async move {
+            let mut metatraffic_unicast_transport = UdpTransportRead::new(
+                tokio::net::UdpSocket::from_std(metattrafic_unicast_socket)
+                    .expect("Should not fail to open metatraffic unicast transport socket"),
+            );
+
+            while let Some((_locator, message)) = metatraffic_unicast_transport.read().await {
+                let r: DdsResult<()> = async {
+                    participant_address_clone
+                        .send_mail_and_await_reply(
+                            domain_participant_actor::process_metatraffic_rtps_message::new(
+                                message,
+                                participant_address_clone.clone(),
+                            ),
+                        )
+                        .await??;
+                    participant_address_clone
+                        .send_mail_and_await_reply(
+                            domain_participant_actor::process_builtin_discovery::new(
+                                participant_address_clone.clone(),
+                            ),
+                        )
+                        .await?;
+
+                    participant_address_clone
+                        .send_mail(domain_participant_actor::send_message::new())
+                        .await?;
+                    Ok(())
+                }
+                .await;
+
+                if r.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let participant_address_clone = participant_address;
+        self.runtime.spawn(async move {
+            let mut default_unicast_transport = UdpTransportRead::new(
+                tokio::net::UdpSocket::from_std(default_unicast_socket)
+                    .expect("Should not fail to open default unicast socket"),
+            );
+
+            while let Some((_locator, message)) = default_unicast_transport.read().await {
+                let r = participant_address_clone
+                    .send_mail(
+                        domain_participant_actor::process_user_defined_rtps_message::new(
+                            message,
+                            participant_address_clone.clone(),
+                        ),
+                    )
+                    .await;
+
+                if r.is_err() {
+                    break;
+                }
+            }
+        });
+
+        if self.qos.entity_factory.autoenable_created_entities {
+            domain_participant.enable()?;
+        }
+
+        Ok(domain_participant)
     }
 
-    async fn get_participant_list(&self) -> Vec<ActorAddress<DomainParticipantActor>> {
-        self.domain_participant_list
+    pub fn delete_participant(&mut self, participant: &DomainParticipant) -> DdsResult<()> {
+        let handle = participant.get_instance_handle()?;
+        let is_participant_empty = self.domain_participant_list[&handle]
+            .send_mail_and_await_reply_blocking(domain_participant_actor::is_empty::new());
+        if is_participant_empty {
+            self.domain_participant_list.remove(&handle);
+            Ok(())
+        } else {
+            Err(DdsError::PreconditionNotMet(
+                "Domain participant still contains other entities".to_string(),
+            ))
+        }
+    }
+
+    pub fn lookup_participant(&self, domain_id: DomainId) -> DdsResult<Option<DomainParticipant>> {
+        Ok(self
+            .domain_participant_list
             .values()
-            .map(|dp| dp.address())
-            .collect()
+            .find(|dp| {
+                dp.send_mail_and_await_reply_blocking(
+                        domain_participant_actor::get_domain_id::new(),
+                    ) == domain_id
+            })
+            .map(|dp| DomainParticipant::new(dp.address())))
     }
 
-    async fn get_unique_participant_id(&mut self) -> u32 {
+    pub fn set_default_participant_qos(
+        &mut self,
+        qos: QosKind<DomainParticipantQos>,
+    ) -> DdsResult<()> {
+        let qos = match qos {
+            QosKind::Default => DomainParticipantQos::default(),
+            QosKind::Specific(q) => q,
+        };
+
+        self.default_participant_qos = qos;
+
+        Ok(())
+    }
+
+    pub fn get_default_participant_qos(&self) -> DdsResult<DomainParticipantQos> {
+        Ok(self.default_participant_qos.clone())
+    }
+
+    pub fn set_qos(&mut self, qos: QosKind<DomainParticipantFactoryQos>) -> DdsResult<()> {
+        let qos = match qos {
+            QosKind::Default => DomainParticipantFactoryQos::default(),
+            QosKind::Specific(q) => q,
+        };
+
+        self.qos = qos;
+
+        Ok(())
+    }
+
+    pub fn get_qos(&self) -> DdsResult<DomainParticipantFactoryQos> {
+        Ok(self.qos.clone())
+    }
+
+    pub fn set_configuration(&mut self, configuration: DustDdsConfiguration) -> DdsResult<()> {
+        self.configuration = configuration;
+        Ok(())
+    }
+
+    pub fn get_configuration(&self) -> DdsResult<DustDdsConfiguration> {
+        Ok(self.configuration.clone())
+    }
+
+    fn get_unique_participant_id(&mut self) -> u32 {
         let counter = self.domain_participant_counter;
         self.domain_participant_counter += 1;
         counter
     }
+}
 
-    async fn delete_participant(&mut self, handle: InstanceHandle) {
-        self.domain_participant_list.remove(&handle);
-    }
+type LocatorAddress = [u8; 16];
+// As of 9.6.1.4.1  Default multicast address
+const DEFAULT_MULTICAST_LOCATOR_ADDRESS: LocatorAddress =
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 239, 255, 0, 1];
 
-    async fn get_qos(&self) -> DomainParticipantFactoryQos {
-        self.qos.clone()
-    }
+const PB: i32 = 7400;
+const DG: i32 = 250;
+#[allow(non_upper_case_globals)]
+const d0: i32 = 0;
 
-    async fn set_qos(&mut self, qos: DomainParticipantFactoryQos) {
-        self.qos = qos;
-    }
+fn port_builtin_multicast(domain_id: DomainId) -> u16 {
+    (PB + DG * domain_id + d0) as u16
+}
 
-    async fn get_default_participant_qos(&self) -> DomainParticipantQos {
-        self.default_participant_qos.clone()
-    }
+fn get_interface_address_list(interface_name: Option<&String>) -> Vec<LocatorAddress> {
+    NetworkInterface::show()
+        .expect("Could not scan interfaces")
+        .into_iter()
+        .filter(|x| {
+            if let Some(if_name) = interface_name {
+                &x.name == if_name
+            } else {
+                true
+            }
+        })
+        .flat_map(|i| {
+            i.addr.into_iter().filter_map(|a| match a {
+                #[rustfmt::skip]
+                Addr::V4(v4) if !v4.ip.is_loopback() => Some(
+                    [0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        0, 0, 0, 0,
+                        v4.ip.octets()[0], v4.ip.octets()[1], v4.ip.octets()[2], v4.ip.octets()[3]]
+                    ),
+                _ => None,
+            })
+        })
+        .collect()
+}
 
-    async fn set_default_participant_qos(&mut self, qos: DomainParticipantQos) {
-        self.default_participant_qos = qos;
-    }
+fn get_multicast_socket(
+    multicast_address: LocatorAddress,
+    port: u16,
+) -> std::io::Result<tokio::net::UdpSocket> {
+    let socket_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, port));
+
+    let socket = Socket::new(
+        socket2::Domain::IPV4,
+        socket2::Type::DGRAM,
+        Some(socket2::Protocol::UDP),
+    )?;
+
+    socket.set_reuse_address(true)?;
+    socket.set_nonblocking(true)?;
+    socket.set_read_timeout(Some(std::time::Duration::from_millis(50)))?;
+
+    socket.bind(&socket_addr.into())?;
+    let addr = Ipv4Addr::new(
+        multicast_address[12],
+        multicast_address[13],
+        multicast_address[14],
+        multicast_address[15],
+    );
+    socket.join_multicast_v4(&addr, &Ipv4Addr::UNSPECIFIED)?;
+    socket.set_multicast_loop_v4(true)?;
+
+    tokio::net::UdpSocket::from_std(socket.into())
 }

--- a/dds/src/implementation/actors/domain_participant_listener_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_listener_actor.rs
@@ -35,11 +35,17 @@ impl DomainParticipantListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleRejectedStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_sample_rejected(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -50,11 +56,17 @@ impl DomainParticipantListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedIncompatibleQosStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_requested_incompatible_qos(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -65,11 +77,17 @@ impl DomainParticipantListenerActor {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: OfferedIncompatibleQosStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_offered_incompatible_qos(
-                &DataWriter::<()>::new(writer_address, publisher_address, participant_address),
+                &DataWriter::<()>::new(
+                    writer_address,
+                    publisher_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -80,11 +98,17 @@ impl DomainParticipantListenerActor {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: PublicationMatchedStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_publication_matched(
-                &DataWriter::<()>::new(writer_address, publisher_address, participant_address),
+                &DataWriter::<()>::new(
+                    writer_address,
+                    publisher_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -95,11 +119,17 @@ impl DomainParticipantListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedDeadlineMissedStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_requested_deadline_missed(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -110,11 +140,17 @@ impl DomainParticipantListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SubscriptionMatchedStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_subscription_matched(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -125,11 +161,17 @@ impl DomainParticipantListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleLostStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_sample_lost(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -279,6 +279,7 @@ impl PublisherActor {
         offered_incompatible_qos_participant_listener: Option<
             ActorAddress<DomainParticipantListenerActor>,
         >,
+        runtime_handle: tokio::runtime::Handle,
     ) {
         if self.is_partition_matched(
             discovered_reader_data
@@ -314,6 +315,7 @@ impl PublisherActor {
                         participant_publication_matched_listener.clone(),
                         offered_incompatible_qos_publisher_listener,
                         offered_incompatible_qos_participant_listener.clone(),
+                        runtime_handle.clone(),
                     ))
                     .await;
             }
@@ -328,6 +330,7 @@ impl PublisherActor {
         participant_publication_matched_listener: Option<
             ActorAddress<DomainParticipantListenerActor>,
         >,
+        runtime_handle: tokio::runtime::Handle,
     ) {
         for data_writer in self.data_writer_list.values() {
             let data_writer_address = data_writer.address();
@@ -345,6 +348,7 @@ impl PublisherActor {
                     participant_address.clone(),
                     publisher_publication_matched_listener,
                     participant_publication_matched_listener.clone(),
+                    runtime_handle.clone(),
                 ))
                 .await;
         }

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -86,6 +86,7 @@ impl PublisherActor {
         default_unicast_locator_list: Vec<Locator>,
         default_multicast_locator_list: Vec<Locator>,
         xml_type: String,
+        runtime_handle: tokio::runtime::Handle,
     ) -> DdsResult<ActorAddress<DataWriterActor>> {
         let qos = match qos {
             QosKind::Default => self.default_datawriter_qos.clone(),
@@ -130,9 +131,9 @@ impl PublisherActor {
             mask,
             qos,
             xml_type,
-            &tokio::runtime::Handle::current(),
+            &runtime_handle,
         );
-        let data_writer_actor = Actor::spawn(data_writer, &tokio::runtime::Handle::current());
+        let data_writer_actor = Actor::spawn(data_writer, &runtime_handle);
         let data_writer_address = data_writer_actor.address();
         self.data_writer_list
             .insert(InstanceHandle::new(guid.into()), data_writer_actor);
@@ -358,11 +359,9 @@ impl PublisherActor {
         &mut self,
         listener: Box<dyn PublisherListener + Send>,
         status_kind: Vec<StatusKind>,
+        runtime_handle: tokio::runtime::Handle,
     ) {
-        self.listener = Actor::spawn(
-            PublisherListenerActor::new(listener),
-            &tokio::runtime::Handle::current(),
-        );
+        self.listener = Actor::spawn(PublisherListenerActor::new(listener), &runtime_handle);
         self.status_kind = status_kind;
     }
 }

--- a/dds/src/implementation/actors/publisher_listener_actor.rs
+++ b/dds/src/implementation/actors/publisher_listener_actor.rs
@@ -28,11 +28,17 @@ impl PublisherListenerActor {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: OfferedIncompatibleQosStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_offered_incompatible_qos(
-                &DataWriter::<()>::new(writer_address, publisher_address, participant_address),
+                &DataWriter::<()>::new(
+                    writer_address,
+                    publisher_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -43,11 +49,17 @@ impl PublisherListenerActor {
         writer_address: ActorAddress<DataWriterActor>,
         publisher_address: ActorAddress<PublisherActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: PublicationMatchedStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_publication_matched(
-                &DataWriter::<()>::new(writer_address, publisher_address, participant_address),
+                &DataWriter::<()>::new(
+                    writer_address,
+                    publisher_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -96,6 +96,7 @@ impl SubscriberActor {
         mask: Vec<StatusKind>,
         default_unicast_locator_list: Vec<Locator>,
         default_multicast_locator_list: Vec<Locator>,
+        runtime_handle: tokio::runtime::Handle,
     ) -> DdsResult<ActorAddress<DataReaderActor>> {
         let qos = match qos {
             QosKind::Default => self.default_data_reader_qos.clone(),
@@ -146,10 +147,10 @@ impl SubscriberActor {
             a_listener,
             status_kind,
             type_xml,
-            &tokio::runtime::Handle::current(),
+            &runtime_handle,
         );
 
-        let reader_actor = Actor::spawn(data_reader, &tokio::runtime::Handle::current());
+        let reader_actor = Actor::spawn(data_reader, &runtime_handle);
         let reader_address = reader_actor.address();
         self.data_reader_list
             .insert(InstanceHandle::new(guid.into()), reader_actor);
@@ -373,11 +374,9 @@ impl SubscriberActor {
         &mut self,
         listener: Box<dyn SubscriberListener + Send>,
         status_kind: Vec<StatusKind>,
+        runtime_handle: tokio::runtime::Handle,
     ) {
-        self.listener = Actor::spawn(
-            SubscriberListenerActor::new(listener),
-            &tokio::runtime::Handle::current(),
-        );
+        self.listener = Actor::spawn(SubscriberListenerActor::new(listener), &runtime_handle);
         self.status_kind = status_kind;
     }
 }

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -86,6 +86,7 @@ impl SubscriberActor {
 
 #[actor_interface]
 impl SubscriberActor {
+    #[allow(clippy::too_many_arguments)]
     async fn create_datareader(
         &mut self,
         type_name: String,
@@ -272,6 +273,7 @@ impl SubscriberActor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn process_rtps_message(
         &self,
         message: RtpsMessageRead,
@@ -306,6 +308,7 @@ impl SubscriberActor {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn add_matched_writer(
         &self,
         discovered_writer_data: DiscoveredWriterData,

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -282,6 +282,7 @@ impl SubscriberActor {
             Vec<StatusKind>,
         ),
         type_support_actor_address: ActorAddress<TypeSupportActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) -> DdsResult<()> {
         let subscriber_mask_listener = (self.listener.address(), self.status_kind.clone());
 
@@ -297,6 +298,7 @@ impl SubscriberActor {
                     subscriber_mask_listener.clone(),
                     participant_mask_listener.clone(),
                     type_support_actor_address.clone(),
+                    runtime_handle.clone(),
                 ))
                 .await??;
         }
@@ -314,6 +316,7 @@ impl SubscriberActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: tokio::runtime::Handle,
     ) {
         if self.is_partition_matched(discovered_writer_data.dds_publication_data().partition()) {
             for data_reader in self.data_reader_list.values() {
@@ -331,6 +334,7 @@ impl SubscriberActor {
                         subscriber_qos,
                         subscriber_mask_listener,
                         participant_mask_listener.clone(),
+                        runtime_handle.clone(),
                     ))
                     .await;
             }
@@ -346,6 +350,7 @@ impl SubscriberActor {
             ActorAddress<DomainParticipantListenerActor>,
             Vec<StatusKind>,
         ),
+        runtime_handle: tokio::runtime::Handle,
     ) {
         for data_reader in self.data_reader_list.values() {
             let data_reader_address = data_reader.address();
@@ -358,6 +363,7 @@ impl SubscriberActor {
                     participant_address.clone(),
                     subscriber_mask_listener,
                     participant_mask_listener.clone(),
+                    runtime_handle.clone(),
                 ))
                 .await;
         }

--- a/dds/src/implementation/actors/subscriber_listener_actor.rs
+++ b/dds/src/implementation/actors/subscriber_listener_actor.rs
@@ -32,10 +32,14 @@ impl SubscriberListenerActor {
         &mut self,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
     ) {
         tokio::task::block_in_place(|| {
-            self.listener
-                .on_data_on_readers(&Subscriber::new(subscriber_address, participant_address))
+            self.listener.on_data_on_readers(&Subscriber::new(
+                subscriber_address,
+                participant_address,
+                runtime_handle,
+            ))
         });
     }
 
@@ -44,11 +48,17 @@ impl SubscriberListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleRejectedStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_sample_rejected(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -59,11 +69,17 @@ impl SubscriberListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedIncompatibleQosStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_requested_incompatible_qos(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -74,11 +90,17 @@ impl SubscriberListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: RequestedDeadlineMissedStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_requested_deadline_missed(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -89,11 +111,17 @@ impl SubscriberListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SubscriptionMatchedStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_subscription_matched(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });
@@ -104,11 +132,17 @@ impl SubscriberListenerActor {
         reader_address: ActorAddress<DataReaderActor>,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant_address: ActorAddress<DomainParticipantActor>,
+        runtime_handle: tokio::runtime::Handle,
         status: SampleLostStatus,
     ) {
         tokio::task::block_in_place(|| {
             self.listener.on_sample_lost(
-                &DataReader::<()>::new(reader_address, subscriber_address, participant_address),
+                &DataReader::<()>::new(
+                    reader_address,
+                    subscriber_address,
+                    participant_address,
+                    runtime_handle,
+                ),
                 status,
             )
         });

--- a/dds/src/implementation/actors/topic_actor.rs
+++ b/dds/src/implementation/actors/topic_actor.rs
@@ -5,7 +5,7 @@ use crate::{
     implementation::{
         data_representation_builtin_endpoints::discovered_topic_data::DiscoveredTopicData,
         rtps::types::Guid,
-        utils::actor::{spawn_actor, Actor, ActorAddress},
+        utils::actor::{Actor, ActorAddress},
     },
     infrastructure::{
         error::DdsResult,
@@ -41,8 +41,14 @@ pub struct TopicActor {
 }
 
 impl TopicActor {
-    pub fn new(guid: Guid, qos: TopicQos, type_name: String, topic_name: &str) -> Self {
-        let status_condition = spawn_actor(StatusConditionActor::default());
+    pub fn new(
+        guid: Guid,
+        qos: TopicQos,
+        type_name: String,
+        topic_name: &str,
+        handle: &tokio::runtime::Handle,
+    ) -> Self {
+        let status_condition = Actor::spawn(StatusConditionActor::default(), handle);
         Self {
             guid,
             qos,

--- a/dds/src/implementation/utils/actor.rs
+++ b/dds/src/implementation/utils/actor.rs
@@ -271,6 +271,49 @@ impl<A> Actor<A> {
                 "Receiver is guaranteed to exist while actor object is alive. Sending must succeed",
             );
     }
+
+    pub fn send_mail_and_await_reply_blocking<M>(&self, mail: M) -> M::Result
+    where
+        A: MailHandler<M> + Send,
+        M: Mail + Send + 'static,
+        M::Result: Send,
+    {
+        let (response_sender, mut response_receiver) = tokio::sync::oneshot::channel();
+
+        let mut send_result = self
+            .sender
+            .try_send(Box::new(ReplyMail::new(mail, response_sender)));
+        // Try sending the mail until it succeeds. This is done instead of calling a tokio::task::block_in_place because this solution
+        // would be only valid when the runtime is multithreaded. For single threaded runtimes this would still cause a panic.
+        while let Err(receive_error) = send_result {
+            match receive_error {
+                tokio::sync::mpsc::error::TrySendError::Full(mail) => {
+                    send_result = self.sender.try_send(mail);
+                }
+
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                    panic!("With actor object it should always be possible to send mail")
+                }
+            }
+        }
+
+        // Receive on a try_recv() loop checking for error instead of a call to recv() to avoid blocking the thread. This would not cause
+        // a Tokio runtime panic since it is using an std channel but it could cause a single-threaded runtime to hang and further tasks not
+        // being executed.
+        let mut receive_result = response_receiver.try_recv();
+        while let Err(receive_error) = receive_result {
+            match receive_error {
+                tokio::sync::oneshot::error::TryRecvError::Empty => {
+                    receive_result = response_receiver.try_recv();
+                }
+
+                tokio::sync::oneshot::error::TryRecvError::Closed => {
+                    panic!("With actor object there should always be a reply")
+                }
+            }
+        }
+        receive_result.expect("Receive result should be Ok")
+    }
 }
 
 impl<A> Drop for Actor<A> {

--- a/dds/src/implementation/utils/actor.rs
+++ b/dds/src/implementation/utils/actor.rs
@@ -3,18 +3,7 @@ use std::sync::{
     Arc,
 };
 
-use lazy_static::lazy_static;
-
 use crate::infrastructure::error::{DdsError, DdsResult};
-
-lazy_static! {
-    pub static ref THE_RUNTIME: tokio::runtime::Runtime =
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .thread_stack_size(4 * 1024 * 1024)
-            .build()
-            .expect("Failed to create Tokio runtime");
-}
 
 pub trait Mail {
     type Result;

--- a/dds/tests/publisher_api.rs
+++ b/dds/tests/publisher_api.rs
@@ -160,5 +160,8 @@ fn data_writer_get_topic_should_return_same_topic_as_used_for_creation() {
         .create_datawriter::<UserType>(&topic, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    assert!(writer.get_topic().unwrap() == topic);
+    assert!(
+        writer.get_topic().unwrap().get_instance_handle().unwrap()
+            == topic.get_instance_handle().unwrap()
+    );
 }

--- a/dds/tests/subscriber_api.rs
+++ b/dds/tests/subscriber_api.rs
@@ -160,5 +160,12 @@ fn data_reader_get_topicdescription_should_return_same_topic_as_used_for_creatio
         .create_datareader::<UserType>(&topic, QosKind::Default, NoOpListener::new(), &[])
         .unwrap();
 
-    assert!(reader.get_topicdescription().unwrap() == topic);
+    assert!(
+        reader
+            .get_topicdescription()
+            .unwrap()
+            .get_instance_handle()
+            .unwrap()
+            == topic.get_instance_handle().unwrap()
+    );
 }


### PR DESCRIPTION
Remove the dependency on lazy_static. To achieve this each of the entities has to get a handle to the runtime to allow spawning tasks and actors. Even though it is more verbose I believe this makes the actual dependency tree clearer and could be beneficial if the architecture changes to have a runtime per participant instead of a single runtime for the whole system.