### PR TITLE
Re-enable XML information on type discovery

### DIFF
--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -24,7 +24,7 @@ use crate::{
     topic_definition::{
         topic::Topic,
         topic_listener::TopicListener,
-        type_support::{DdsHasKey, DdsKey, DdsSerialize, DynamicTypeInterface},
+        type_support::{DdsHasKey, DdsKey, DdsSerialize, DdsTypeXml, DynamicTypeInterface},
     },
 };
 
@@ -228,7 +228,7 @@ impl DomainParticipant {
         mask: &[StatusKind],
     ) -> DdsResult<Topic>
     where
-        Foo: DdsKey + DdsHasKey,
+        Foo: DdsKey + DdsHasKey + DdsTypeXml,
     {
         let type_support = FooTypeSupport::new::<Foo>();
 
@@ -362,7 +362,7 @@ impl DomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn find_topic<Foo>(&self, topic_name: &str, timeout: Duration) -> DdsResult<Topic>
     where
-        Foo: DdsKey + DdsHasKey,
+        Foo: DdsKey + DdsHasKey + DdsTypeXml,
     {
         let start_time = Instant::now();
 

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -598,6 +598,20 @@ impl<Foo> DataWriter<Foo> {
             .writer_address
             .send_mail_and_await_reply_blocking(data_writer_actor::is_enabled::new())?
         {
+            let type_name = self
+                .writer_address
+                .send_mail_and_await_reply_blocking(data_writer_actor::get_type_name::new())?;
+            let type_support = self
+                .participant_address
+                .send_mail_and_await_reply_blocking(
+                    domain_participant_actor::get_type_support::new(type_name.clone()),
+                )?
+                .ok_or_else(|| {
+                    DdsError::PreconditionNotMet(format!(
+                        "Type with name {} not registered with parent domain participant",
+                        type_name
+                    ))
+                })?;
             let discovered_writer_data = self.writer_address.send_mail_and_await_reply_blocking(
                 data_writer_actor::as_discovered_writer_data::new(
                     TopicQos::default(),
@@ -611,6 +625,7 @@ impl<Foo> DataWriter<Foo> {
                         .send_mail_and_await_reply_blocking(
                             domain_participant_actor::get_default_multicast_locator_list::new(),
                         )?,
+                    type_support.xml_type(),
                 ),
             )?;
             self.participant_address.send_mail_blocking(
@@ -677,6 +692,20 @@ impl<Foo> DataWriter<Foo> {
             .writer_address
             .send_mail_and_await_reply_blocking(data_writer_actor::is_enabled::new())?
         {
+            let type_name = self
+                .writer_address
+                .send_mail_and_await_reply_blocking(data_writer_actor::get_type_name::new())?;
+            let type_support = self
+                .participant_address
+                .send_mail_and_await_reply_blocking(
+                    domain_participant_actor::get_type_support::new(type_name.clone()),
+                )?
+                .ok_or_else(|| {
+                    DdsError::PreconditionNotMet(format!(
+                        "Type with name {} not registered with parent domain participant",
+                        type_name
+                    ))
+                })?;
             self.writer_address
                 .send_mail_and_await_reply_blocking(data_writer_actor::enable::new())?;
             let discovered_writer_data = self.writer_address.send_mail_and_await_reply_blocking(
@@ -692,6 +721,7 @@ impl<Foo> DataWriter<Foo> {
                         .send_mail_and_await_reply_blocking(
                             domain_participant_actor::get_default_multicast_locator_list::new(),
                         )?,
+                    type_support.xml_type(),
                 ),
             )?;
             self.participant_address.send_mail_blocking(

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -101,7 +101,6 @@ impl Publisher {
 
         let listener = Box::new(a_listener);
         let has_key = type_support.has_key();
-        let type_xml = String::new(); // Foo::get_type_xml().map_or_else(String::default, |s| format!("<types>{}</types>", s));
         let data_writer_address = self.publisher_address.send_mail_and_await_reply_blocking(
             publisher_actor::create_datawriter::new(
                 a_topic.get_type_name()?,
@@ -113,7 +112,6 @@ impl Publisher {
                 mask.to_vec(),
                 default_unicast_locator_list,
                 default_multicast_locator_list,
-                type_xml,
                 self.runtime_handle.clone(),
             ),
         )??;

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -2,7 +2,7 @@ use crate::{
     domain::domain_participant::DomainParticipant,
     implementation::{
         actors::{
-            data_reader_actor::{self},
+            data_reader_actor,
             domain_participant_actor::{self, DomainParticipantActor},
             subscriber_actor::{self, SubscriberActor},
         },

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -39,6 +39,8 @@ pub trait DynamicTypeInterface {
         &self,
         serialized_key: &[u8],
     ) -> DdsResult<InstanceHandle>;
+
+    fn xml_type(&self) -> String;
 }
 
 /// This trait indicates whether the associated type is keyed or not, i.e. if the middleware

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -262,7 +262,6 @@ pub struct DataReaderActor {
     status_kind: Vec<StatusKind>,
     instances: HashMap<InstanceHandle, InstanceState>,
     instance_deadline_missed_task: HashMap<InstanceHandle, tokio::task::AbortHandle>,
-    xml_type: String,
 }
 
 impl DataReaderActor {
@@ -274,7 +273,6 @@ impl DataReaderActor {
         qos: DataReaderQos,
         listener: Box<dyn AnyDataReaderListener + Send>,
         status_kind: Vec<StatusKind>,
-        xml_type: String,
         handle: &tokio::runtime::Handle,
     ) -> Self {
         let status_condition = Actor::spawn(StatusConditionActor::default(), handle);
@@ -305,7 +303,6 @@ impl DataReaderActor {
             qos,
             instances: HashMap::new(),
             instance_deadline_missed_task: HashMap::new(),
-            xml_type,
         }
     }
 
@@ -1598,6 +1595,7 @@ impl DataReaderActor {
         subscriber_qos: SubscriberQos,
         default_unicast_locator_list: Vec<Locator>,
         default_multicast_locator_list: Vec<Locator>,
+        xml_type: String,
     ) -> DiscoveredReaderData {
         let guid = self.rtps_reader.guid();
 
@@ -1641,7 +1639,7 @@ impl DataReaderActor {
                 subscriber_qos.partition.clone(),
                 topic_qos.topic_data,
                 subscriber_qos.group_data,
-                self.xml_type.clone(),
+                xml_type,
             ),
         )
     }

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -233,7 +233,6 @@ pub struct DataWriterActor {
     writer_cache: WriterHistoryCache,
     qos: DataWriterQos,
     registered_instance_list: HashSet<InstanceHandle>,
-    xml_type: String,
 }
 
 impl DataWriterActor {
@@ -245,7 +244,6 @@ impl DataWriterActor {
         listener: Box<dyn AnyDataWriterListener + Send>,
         status_kind: Vec<StatusKind>,
         qos: DataWriterQos,
-        xml_type: String,
         handle: &tokio::runtime::Handle,
     ) -> Self {
         let status_condition = Actor::spawn(StatusConditionActor::default(), handle);
@@ -265,7 +263,6 @@ impl DataWriterActor {
             writer_cache: WriterHistoryCache::new(),
             qos,
             registered_instance_list: HashSet::new(),
-            xml_type,
         }
     }
 
@@ -495,6 +492,7 @@ impl DataWriterActor {
         publisher_qos: PublisherQos,
         default_unicast_locator_list: Vec<Locator>,
         default_multicast_locator_list: Vec<Locator>,
+        xml_type: String,
     ) -> DiscoveredWriterData {
         let writer_qos = &self.qos;
         let unicast_locator_list = if self.rtps_writer.unicast_locator_list().is_empty() {
@@ -532,7 +530,7 @@ impl DataWriterActor {
                 publisher_qos.partition.clone(),
                 topic_qos.topic_data,
                 publisher_qos.group_data,
-                self.xml_type.clone(),
+                xml_type,
             ),
             WriterProxy::new(
                 self.rtps_writer.guid(),

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -85,7 +85,6 @@ impl PublisherActor {
         mask: Vec<StatusKind>,
         default_unicast_locator_list: Vec<Locator>,
         default_multicast_locator_list: Vec<Locator>,
-        xml_type: String,
         runtime_handle: tokio::runtime::Handle,
     ) -> DdsResult<ActorAddress<DataWriterActor>> {
         let qos = match qos {
@@ -130,7 +129,6 @@ impl PublisherActor {
             a_listener,
             mask,
             qos,
-            xml_type,
             &runtime_handle,
         );
         let data_writer_actor = Actor::spawn(data_writer, &runtime_handle);

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -138,7 +138,7 @@ impl SubscriberActor {
             DURATION_ZERO,
             false,
         );
-        let type_xml = String::new(); // Foo::get_type_xml().map_or_else(String::default, |s| format!("<types>{}</types>", s));
+
         let status_kind = mask.to_vec();
         let data_reader = DataReaderActor::new(
             rtps_reader,
@@ -147,7 +147,6 @@ impl SubscriberActor {
             qos,
             a_listener,
             status_kind,
-            type_xml,
             &runtime_handle,
         );
 

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -5,7 +5,7 @@ use crate::{
     serialized_payload::parameter_list::{
         deserialize::ParameterListDeserialize, serialize::ParameterListSerialize,
     },
-    topic_definition::type_support::{DdsDeserialize, DdsHasKey, DdsKey, DdsSerialize},
+    topic_definition::type_support::{DdsDeserialize, DdsHasKey, DdsKey, DdsSerialize, DdsTypeXml},
 };
 
 use super::parameter_id_values::{
@@ -122,6 +122,11 @@ impl DdsKey for DiscoveredReaderData {
     }
 }
 
+impl DdsTypeXml for DiscoveredReaderData {
+    fn get_type_xml() -> Option<String> {
+        None
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_topic_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_topic_data.rs
@@ -4,7 +4,7 @@ use crate::{
     serialized_payload::parameter_list::{
         deserialize::ParameterListDeserialize, serialize::ParameterListSerialize,
     },
-    topic_definition::type_support::{DdsDeserialize, DdsHasKey, DdsKey, DdsSerialize},
+    topic_definition::type_support::{DdsDeserialize, DdsHasKey, DdsKey, DdsSerialize, DdsTypeXml},
 };
 
 pub const DCPS_TOPIC: &str = "DCPSTopic";
@@ -52,6 +52,12 @@ impl DdsKey for DiscoveredTopicData {
             .topic_builtin_topic_data
             .key()
             .value)
+    }
+}
+
+impl DdsTypeXml for DiscoveredTopicData {
+    fn get_type_xml() -> Option<String> {
+        None
     }
 }
 

--- a/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -4,7 +4,7 @@ use crate::{
     builtin_topics::PublicationBuiltinTopicData,
     implementation::rtps::types::{EntityId, Guid, Locator},
     infrastructure::error::DdsResult,
-    topic_definition::type_support::{DdsDeserialize, DdsHasKey, DdsKey, DdsSerialize},
+    topic_definition::type_support::{DdsDeserialize, DdsHasKey, DdsKey, DdsSerialize, DdsTypeXml},
 };
 
 use super::parameter_id_values::{
@@ -117,6 +117,12 @@ impl DdsKey for DiscoveredWriterData {
             .dds_publication_data
             .key()
             .value)
+    }
+}
+
+impl DdsTypeXml for DiscoveredWriterData {
+    fn get_type_xml() -> Option<String> {
+        None
     }
 }
 

--- a/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/implementation/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -16,7 +16,7 @@ use crate::{
             deserialize::ParameterListDeserialize, serialize::ParameterListSerialize,
         },
     },
-    topic_definition::type_support::{DdsDeserialize, DdsHasKey, DdsKey, DdsSerialize},
+    topic_definition::type_support::{DdsDeserialize, DdsHasKey, DdsKey, DdsSerialize, DdsTypeXml},
 };
 
 use super::parameter_id_values::{
@@ -27,9 +27,7 @@ use super::parameter_id_values::{
     PID_PARTICIPANT_MANUAL_LIVELINESS_COUNT, PID_PROTOCOL_VERSION, PID_VENDORID,
 };
 
-#[derive(
-    Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize,
-)]
+#[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 struct DomainTag(String);
 impl Default for DomainTag {
     fn default() -> Self {
@@ -237,6 +235,12 @@ impl DdsKey for SpdpDiscoveredParticipantData {
             .dds_participant_data
             .key()
             .value)
+    }
+}
+
+impl DdsTypeXml for SpdpDiscoveredParticipantData {
+    fn get_type_xml() -> Option<String> {
+        None
     }
 }
 

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -263,6 +263,10 @@ fn foo_with_specialized_type_support_should_read_and_write() {
         ) -> DdsResult<InstanceHandle> {
             unimplemented!("Not used for this test")
         }
+
+        fn xml_type(&self) -> String {
+            String::default()
+        }
     }
 
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();


### PR DESCRIPTION
This PR puts back the feature of sending the type XML in the discovery process using the new TypeSupport trait.