### PR TITLE
Add API documentation

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",
@@ -16,7 +16,7 @@ keywords = ["dds", "rtps", "middleware", "network", "udp"]
 categories = ["api-bindings", "network-programming"]
 
 [dependencies]
-dust_dds_derive = { path = "../dds_derive", version = "0.7" }
+dust_dds_derive = { path = "../dds_derive", version = "0.8" }
 
 md5 = "0.7.0" # Chose this crate over other possibilities since it doesn't have any other dependencies
 

--- a/dds/src/dds/builtin_topics.rs
+++ b/dds/src/dds/builtin_topics.rs
@@ -43,6 +43,7 @@ impl From<BuiltInTopicKey> for [u8; 16] {
     }
 }
 
+/// Structure representing a discovered ['DomainParticipant'](crate::domain::domain_participant::DomainParticipant).
 #[derive(
     Debug, PartialEq, Eq, Clone, ParameterListSerialize, ParameterListDeserialize, DdsDeserialize,
 )]
@@ -55,14 +56,16 @@ pub struct ParticipantBuiltinTopicData {
 }
 
 impl ParticipantBuiltinTopicData {
-    pub fn new(key: BuiltInTopicKey, user_data: UserDataQosPolicy) -> Self {
+    pub(crate) fn new(key: BuiltInTopicKey, user_data: UserDataQosPolicy) -> Self {
         Self { key, user_data }
     }
 
+    /// Get the key value of the discovered participant.
     pub fn key(&self) -> &BuiltInTopicKey {
         &self.key
     }
 
+    /// Get the user data value of the discovered participant.
     pub fn user_data(&self) -> &UserDataQosPolicy {
         &self.user_data
     }
@@ -72,6 +75,7 @@ impl DdsHasKey for ParticipantBuiltinTopicData {
     const HAS_KEY: bool = true;
 }
 
+/// Structure representing a discovered ['Topic'](crate::topic_definition::topic::Topic).
 #[derive(
     Debug, PartialEq, Eq, Clone, ParameterListSerialize, ParameterListDeserialize, DdsDeserialize,
 )]
@@ -111,7 +115,7 @@ pub struct TopicBuiltinTopicData {
 
 impl TopicBuiltinTopicData {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         key: BuiltInTopicKey,
         name: String,
         type_name: String,
@@ -147,62 +151,77 @@ impl TopicBuiltinTopicData {
         }
     }
 
+    /// Get the key value of the discovered topic.
     pub fn key(&self) -> &BuiltInTopicKey {
         &self.key
     }
 
+    /// Get the name of the discovered topic.
     pub fn name(&self) -> &str {
         &self.name
     }
 
+    /// Get the type name of the discovered topic.
     pub fn get_type_name(&self) -> &str {
         &self.type_name
     }
 
+    /// Get the durability QoS policy of the discovered topic.
     pub fn durability(&self) -> &DurabilityQosPolicy {
         &self.durability
     }
 
+    /// Get the deadline QoS policy of the discovered topic.
     pub fn deadline(&self) -> &DeadlineQosPolicy {
         &self.deadline
     }
 
+    /// Get the latency budget QoS policy of the discovered topic.
     pub fn latency_budget(&self) -> &LatencyBudgetQosPolicy {
         &self.latency_budget
     }
 
+    /// Get the liveliness QoS policy of the discovered topic.
     pub fn liveliness(&self) -> &LivelinessQosPolicy {
         &self.liveliness
     }
 
+    /// Get the reliability QoS policy of the discovered topic.
     pub fn reliability(&self) -> &ReliabilityQosPolicy {
         &self.reliability
     }
 
+    /// Get the transport priority QoS policy of the discovered topic.
     pub fn transport_priority(&self) -> &TransportPriorityQosPolicy {
         &self.transport_priority
     }
 
+    /// Get the lifespan QoS policy of the discovered topic.
     pub fn lifespan(&self) -> &LifespanQosPolicy {
         &self.lifespan
     }
 
+    /// Get the destination order QoS policy of the discovered topic.
     pub fn destination_order(&self) -> &DestinationOrderQosPolicy {
         &self.destination_order
     }
 
+    /// Get the history QoS policy of the discovered topic.
     pub fn history(&self) -> &HistoryQosPolicy {
         &self.history
     }
 
+    /// Get the resource limits QoS policy of the discovered topic.
     pub fn resource_limits(&self) -> &ResourceLimitsQosPolicy {
         &self.resource_limits
     }
 
+    /// Get the ownership QoS policy of the discovered topic.
     pub fn ownership(&self) -> &OwnershipQosPolicy {
         &self.ownership
     }
 
+    /// Get the topic data QoS policy of the discovered topic.
     pub fn topic_data(&self) -> &TopicDataQosPolicy {
         &self.topic_data
     }
@@ -212,6 +231,7 @@ impl DdsHasKey for TopicBuiltinTopicData {
     const HAS_KEY: bool = true;
 }
 
+/// Structure representing a discovered ['DataWriter'](crate::publication::data_writer::DataWriter).
 #[derive(
     Debug, PartialEq, Eq, Clone, ParameterListSerialize, ParameterListDeserialize, DdsDeserialize,
 )]
@@ -258,7 +278,7 @@ pub struct PublicationBuiltinTopicData {
 
 impl PublicationBuiltinTopicData {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         key: BuiltInTopicKey,
         participant_key: BuiltInTopicKey,
         topic_name: String,
@@ -300,6 +320,7 @@ impl PublicationBuiltinTopicData {
         }
     }
 
+    /// Get the key value of the discovered writer.
     pub fn key(&self) -> &BuiltInTopicKey {
         &self.key
     }
@@ -377,6 +398,7 @@ impl DdsHasKey for PublicationBuiltinTopicData {
     const HAS_KEY: bool = true;
 }
 
+/// Structure representing a discovered ['DataReader'](crate::subscription::data_reader::DataReader).
 #[derive(
     Debug, PartialEq, Eq, Clone, ParameterListSerialize, ParameterListDeserialize, DdsDeserialize,
 )]
@@ -423,7 +445,7 @@ pub struct SubscriptionBuiltinTopicData {
 
 impl SubscriptionBuiltinTopicData {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         key: BuiltInTopicKey,
         participant_key: BuiltInTopicKey,
         topic_name: String,
@@ -465,6 +487,7 @@ impl SubscriptionBuiltinTopicData {
         }
     }
 
+    /// Get the key value of the discovered reader.
     pub fn key(&self) -> &BuiltInTopicKey {
         &self.key
     }

--- a/dds/src/dds/builtin_topics.rs
+++ b/dds/src/dds/builtin_topics.rs
@@ -45,7 +45,7 @@ impl From<BuiltInTopicKey> for [u8; 16] {
     }
 }
 
-/// Structure representing a discovered ['DomainParticipant'](crate::domain::domain_participant::DomainParticipant).
+/// Structure representing a discovered [`DomainParticipant`](crate::domain::domain_participant::DomainParticipant).
 #[derive(
     Debug, PartialEq, Eq, Clone, ParameterListSerialize, ParameterListDeserialize, DdsDeserialize,
 )]
@@ -77,7 +77,7 @@ impl DdsHasKey for ParticipantBuiltinTopicData {
     const HAS_KEY: bool = true;
 }
 
-/// Structure representing a discovered ['Topic'](crate::topic_definition::topic::Topic).
+/// Structure representing a discovered [`Topic`](crate::topic_definition::topic::Topic).
 #[derive(
     Debug, PartialEq, Eq, Clone, ParameterListSerialize, ParameterListDeserialize, DdsDeserialize,
 )]
@@ -233,7 +233,7 @@ impl DdsHasKey for TopicBuiltinTopicData {
     const HAS_KEY: bool = true;
 }
 
-/// Structure representing a discovered ['DataWriter'](crate::publication::data_writer::DataWriter).
+/// Structure representing a discovered [`DataWriter`](crate::publication::data_writer::DataWriter).
 #[derive(
     Debug, PartialEq, Eq, Clone, ParameterListSerialize, ParameterListDeserialize, DdsDeserialize,
 )]
@@ -418,7 +418,7 @@ impl DdsHasKey for PublicationBuiltinTopicData {
     const HAS_KEY: bool = true;
 }
 
-/// Structure representing a discovered ['DataReader'](crate::subscription::data_reader::DataReader).
+/// Structure representing a discovered [`DataReader`](crate::subscription::data_reader::DataReader).
 #[derive(
     Debug, PartialEq, Eq, Clone, ParameterListSerialize, ParameterListDeserialize, DdsDeserialize,
 )]

--- a/dds/src/dds/builtin_topics.rs
+++ b/dds/src/dds/builtin_topics.rs
@@ -26,8 +26,10 @@ use crate::{
     topic_definition::type_support::DdsHasKey,
 };
 
+/// Structure representing the instance handle (or key) of an entity.
 #[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize, Default)]
 pub struct BuiltInTopicKey {
+    /// InstanceHandle value as an array of 16 octets.
     pub value: [u8; 16], // Originally in the DDS idl [i32;3]
 }
 
@@ -325,70 +327,88 @@ impl PublicationBuiltinTopicData {
         &self.key
     }
 
+    /// Get the key value of the parent participant of the discovered writer.
     pub fn participant_key(&self) -> &BuiltInTopicKey {
         &self.participant_key
     }
 
+    /// Get the name of the topic associated with the discovered writer.
     pub fn topic_name(&self) -> &str {
         &self.topic_name
     }
 
+    /// Get the name of the type associated with the discovered writer.
     pub fn get_type_name(&self) -> &str {
         &self.type_name
     }
 
+    /// Get the durability QoS policy of the discovered writer.
     pub fn durability(&self) -> &DurabilityQosPolicy {
         &self.durability
     }
 
+    /// Get the deadline QoS policy of the discovered writer.
     pub fn deadline(&self) -> &DeadlineQosPolicy {
         &self.deadline
     }
 
+    /// Get the latency budget QoS policy of the discovered writer.
     pub fn latency_budget(&self) -> &LatencyBudgetQosPolicy {
         &self.latency_budget
     }
 
+    /// Get the liveliness QoS policy of the discovered writer.
     pub fn liveliness(&self) -> &LivelinessQosPolicy {
         &self.liveliness
     }
 
+    /// Get the reliability QoS policy of the discovered writer.
     pub fn reliability(&self) -> &ReliabilityQosPolicy {
         &self.reliability
     }
 
+    /// Get the lifespan QoS policy of the discovered writer.
     pub fn lifespan(&self) -> &LifespanQosPolicy {
         &self.lifespan
     }
 
+    /// Get the user data QoS policy of the discovered writer.
     pub fn user_data(&self) -> &UserDataQosPolicy {
         &self.user_data
     }
 
+    /// Get the ownership QoS policy of the discovered writer.
     pub fn ownership(&self) -> &OwnershipQosPolicy {
         &self.ownership
     }
 
+    /// Get the destination order QoS policy of the discovered writer.
     pub fn destination_order(&self) -> &DestinationOrderQosPolicy {
         &self.destination_order
     }
 
+    /// Get the presentation QoS policy of the discovered writer.
     pub fn presentation(&self) -> &PresentationQosPolicy {
         &self.presentation
     }
 
+    /// Get the partition QoS policy of the discovered writer.
     pub fn partition(&self) -> &PartitionQosPolicy {
         &self.partition
     }
 
+    /// Get the topic data QoS policy of the topic associated with the discovered writer.
     pub fn topic_data(&self) -> &TopicDataQosPolicy {
         &self.topic_data
     }
 
+    /// Get the group data QoS policy of the discovered writer.
     pub fn group_data(&self) -> &GroupDataQosPolicy {
         &self.group_data
     }
 
+    /// Get the XML type representation of the discovered writer.
+    /// Note: This is only available if matched with a DustDDS reader which transmits this information as part of the discovery.
     pub fn xml_type(&self) -> &str {
         &self.xml_type
     }
@@ -492,70 +512,88 @@ impl SubscriptionBuiltinTopicData {
         &self.key
     }
 
+    /// Get the key value of the parent participant of the discovered reader.
     pub fn participant_key(&self) -> &BuiltInTopicKey {
         &self.participant_key
     }
 
+    /// Get the name of the topic associated with the discovered reader.
     pub fn topic_name(&self) -> &str {
         &self.topic_name
     }
 
+    /// Get the name of the type associated with the discovered reader.
     pub fn get_type_name(&self) -> &str {
         &self.type_name
     }
 
+    /// Get the durability QoS policy of the discovered reader.
     pub fn durability(&self) -> &DurabilityQosPolicy {
         &self.durability
     }
 
+    /// Get the deadline QoS policy of the discovered reader.
     pub fn deadline(&self) -> &DeadlineQosPolicy {
         &self.deadline
     }
 
+    /// Get the latency budget QoS policy of the discovered reader.
     pub fn latency_budget(&self) -> &LatencyBudgetQosPolicy {
         &self.latency_budget
     }
 
+    /// Get the liveliness QoS policy of the discovered reader.
     pub fn liveliness(&self) -> &LivelinessQosPolicy {
         &self.liveliness
     }
 
+    /// Get the reliability QoS policy of the discovered reader.
     pub fn reliability(&self) -> &ReliabilityQosPolicy {
         &self.reliability
     }
 
+    /// Get the ownership QoS policy of the discovered reader.
     pub fn ownership(&self) -> &OwnershipQosPolicy {
         &self.ownership
     }
 
+    /// Get the destination order QoS policy of the discovered reader.
     pub fn destination_order(&self) -> &DestinationOrderQosPolicy {
         &self.destination_order
     }
 
+    /// Get the user data QoS policy of the discovered reader.
     pub fn user_data(&self) -> &UserDataQosPolicy {
         &self.user_data
     }
 
+    /// Get the time based filter QoS policy of the discovered reader.
     pub fn time_based_filter(&self) -> &TimeBasedFilterQosPolicy {
         &self.time_based_filter
     }
 
+    /// Get the presentation QoS policy of the discovered reader.
     pub fn presentation(&self) -> &PresentationQosPolicy {
         &self.presentation
     }
 
+    /// Get the partition QoS policy of the discovered reader.
     pub fn partition(&self) -> &PartitionQosPolicy {
         &self.partition
     }
 
+    /// Get the topic data QoS policy of the topic associated with the discovered reader.
     pub fn topic_data(&self) -> &TopicDataQosPolicy {
         &self.topic_data
     }
 
+    /// Get the group data QoS policy of the discovered reader.
     pub fn group_data(&self) -> &GroupDataQosPolicy {
         &self.group_data
     }
 
+    /// Get the XML type representation of the discovered reader.
+    /// Note: This is only available if matched with a DustDDS writer which transmits this information as part of the discovery.
     pub fn xml_type(&self) -> &str {
         &self.xml_type
     }

--- a/dds/src/dds/configuration.rs
+++ b/dds/src/dds/configuration.rs
@@ -26,7 +26,7 @@ impl DustDdsConfiguration {
         self.fragment_size
     }
 
-    /// Receive buffer size used for UDP socket. ['None'] means the OS default value
+    /// Receive buffer size used for UDP socket. [`None`] means the OS default value
     pub fn udp_receive_buffer_size(&self) -> Option<usize> {
         self.udp_receive_buffer_size
     }
@@ -43,7 +43,7 @@ impl Default for DustDdsConfiguration {
     }
 }
 
-/// Builder for the ['DustDdsConfiguration']
+/// Builder for the [`DustDdsConfiguration`]
 #[derive(Default)]
 pub struct DustDdsConfigurationBuilder {
     configuration: DustDdsConfiguration,
@@ -88,7 +88,7 @@ impl DustDdsConfigurationBuilder {
         self
     }
 
-    /// Set the value of the SO_RCVBUF option on the UDP socket. ['None'] corresponds to the OS default
+    /// Set the value of the SO_RCVBUF option on the UDP socket. [`None`] corresponds to the OS default
     pub fn udp_receive_buffer_size(mut self, udp_receive_buffer_size: Option<usize>) -> Self {
         self.configuration.udp_receive_buffer_size = udp_receive_buffer_size;
         self

--- a/dds/src/dds/configuration.rs
+++ b/dds/src/dds/configuration.rs
@@ -2,7 +2,7 @@ use crate::infrastructure::error::{DdsError, DdsResult};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 /// This struct specifies the high-level configuration for the DustDDS library. The configuration can be set for use by the
-/// [`dust_dds::domain::domain_participant_factory::DomainParticipantFactory::set_configuration`] method.
+/// [`DomainParticipantFactory::set_configuration`](dust_dds::domain::domain_participant_factory::DomainParticipantFactory::set_configuration) method.
 pub struct DustDdsConfiguration {
     domain_tag: String,
     interface_name: Option<String>,

--- a/dds/src/dds/configuration.rs
+++ b/dds/src/dds/configuration.rs
@@ -26,7 +26,7 @@ impl DustDdsConfiguration {
         self.fragment_size
     }
 
-    // Receive buffer size used for UDP socket. ['None'] means the OS default value
+    /// Receive buffer size used for UDP socket. ['None'] means the OS default value
     pub fn udp_receive_buffer_size(&self) -> Option<usize> {
         self.udp_receive_buffer_size
     }

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -55,8 +55,8 @@ impl DomainParticipantFactory {
     }
 
     /// This operation deletes an existing [`DomainParticipant`]. This operation can only be invoked if all domain entities belonging to
-    /// the participant have already been deleted otherwise the error [`DdsError::PreconditionNotMet`] is returned. If the
-    /// participant has been previously deleted this operation returns the error [`DdsError::AlreadyDeleted`].
+    /// the participant have already been deleted otherwise the error [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError::PreconditionNotMet) is returned. If the
+    /// participant has been previously deleted this operation returns the error [`DdsError::AlreadyDeleted`](crate::infrastructure::error::DdsError::AlreadyDeleted).
     #[tracing::instrument(skip(self, participant))]
     pub fn delete_participant(&self, participant: &DomainParticipant) -> DdsResult<()> {
         self.runtime.block_on(
@@ -100,7 +100,7 @@ impl DomainParticipantFactory {
     /// This operation sets a default value of the [`DomainParticipantQos`] policies which will be used for newly created
     /// [`DomainParticipant`] entities in the case where the QoS policies are defaulted in the [`DomainParticipantFactory::create_participant`] operation.
     /// This operation will check that the resulting policies are self consistent; if they are not, the operation will have no effect and
-    /// return a [`DdsError::InconsistentPolicy`].
+    /// return a [`DdsError::InconsistentPolicy`](crate::infrastructure::error::DdsError::InconsistentPolicy).
     #[tracing::instrument(skip(self))]
     pub fn set_default_participant_qos(&self, qos: QosKind<DomainParticipantQos>) -> DdsResult<()> {
         self.runtime.block_on(
@@ -124,7 +124,7 @@ impl DomainParticipantFactory {
     /// a factory for entities.
     /// Note that despite having QoS, the [`DomainParticipantFactory`] is not an Entity.
     /// This operation will check that the resulting policies are self consistent; if they are not, the operation will have no effect and
-    /// return a [`DdsError::InconsistentPolicy`].
+    /// return a [`DdsError::InconsistentPolicy`](crate::infrastructure::error::DdsError::InconsistentPolicy).
     #[tracing::instrument(skip(self))]
     pub fn set_qos(&self, qos: QosKind<DomainParticipantFactoryQos>) -> DdsResult<()> {
         self.runtime

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -13,6 +13,7 @@ use crate::{
 use std::sync::OnceLock;
 use tracing::warn;
 
+/// DomainId type alias
 pub type DomainId = i32;
 
 /// The sole purpose of this class is to allow the creation and destruction of [`DomainParticipant`] objects.
@@ -66,7 +67,6 @@ impl DomainParticipantFactory {
 
     /// This operation returns the [`DomainParticipantFactory`] singleton. The operation is idempotent, that is, it can be called multiple
     /// times without side-effects and it will return the same [`DomainParticipantFactory`] instance.
-    /// The pre-defined value [`struct@THE_PARTICIPANT_FACTORY`] can also be used as an alias for the singleton factory returned by this operation.
     #[tracing::instrument]
     pub fn get_instance() -> &'static Self {
         static PARTICIPANT_FACTORY: OnceLock<DomainParticipantFactory> = OnceLock::new();

--- a/dds/src/dds/domain/domain_participant_listener.rs
+++ b/dds/src/dds/domain/domain_participant_listener.rs
@@ -15,8 +15,10 @@ use crate::{
 /// Service will first attempt to notify the listener attached to the concerned DomainEntity if one is installed. Otherwise, the
 /// DCPS Service will notify the Listener attached to the DomainParticipant.
 pub trait DomainParticipantListener {
+    /// Method that is called when any inconsistent topic is discovered in the domain participant.
     fn on_inconsistent_topic(&mut self, _the_topic: &Topic, _status: InconsistentTopicStatus) {}
 
+    /// Method that is called when any writer in the domain participant reports a liveliness lost status.
     fn on_liveliness_lost(
         &mut self,
         _the_writer: &dyn AnyDataWriter,
@@ -24,6 +26,7 @@ pub trait DomainParticipantListener {
     ) {
     }
 
+    /// Method that is called when any data writer in the domain participant reports a deadline missed status.
     fn on_offered_deadline_missed(
         &mut self,
         _the_writer: &dyn AnyDataWriter,
@@ -31,6 +34,7 @@ pub trait DomainParticipantListener {
     ) {
     }
 
+    /// Method that is called when any data writer in the domain participant reports an offered incompatible QoS status.
     fn on_offered_incompatible_qos(
         &mut self,
         _the_writer: &dyn AnyDataWriter,
@@ -38,10 +42,13 @@ pub trait DomainParticipantListener {
     ) {
     }
 
+    /// Method that is called when any data reader in the domain participant reports a sample lost status.
     fn on_sample_lost(&mut self, _the_reader: &dyn AnyDataReader, _status: SampleLostStatus) {}
 
+    /// Method that is called when any data reader in the domain participant reports a data available status.
     fn on_data_available(&mut self, _the_reader: &dyn AnyDataReader) {}
 
+    /// Method that is called when any data reader in the domain participant reports a sample rejected status.
     fn on_sample_rejected(
         &mut self,
         _the_reader: &dyn AnyDataReader,
@@ -49,6 +56,7 @@ pub trait DomainParticipantListener {
     ) {
     }
 
+    /// Method that is called when any data reader in the domain participant reports a liveliness changed status.
     fn on_liveliness_changed(
         &mut self,
         _the_reader: &dyn AnyDataReader,
@@ -56,6 +64,7 @@ pub trait DomainParticipantListener {
     ) {
     }
 
+    /// Method that is called when any data reader in the domain participant reports a requested deadline missed status.
     fn on_requested_deadline_missed(
         &mut self,
         _the_reader: &dyn AnyDataReader,
@@ -63,6 +72,7 @@ pub trait DomainParticipantListener {
     ) {
     }
 
+    /// Method that is called when any data reader in the domain participant reports a requested incompatible QoS status.
     fn on_requested_incompatible_qos(
         &mut self,
         _the_reader: &dyn AnyDataReader,
@@ -70,6 +80,7 @@ pub trait DomainParticipantListener {
     ) {
     }
 
+    /// Method that is called when any data writer in the domain participant reports a publication matched status.
     fn on_publication_matched(
         &mut self,
         _the_writer: &dyn AnyDataWriter,
@@ -77,6 +88,7 @@ pub trait DomainParticipantListener {
     ) {
     }
 
+    /// Method that is called when any data reader in the domain participant reports a subscription matched status.
     fn on_subscription_matched(
         &mut self,
         _the_reader: &dyn AnyDataReader,

--- a/dds/src/dds/infrastructure/instance.rs
+++ b/dds/src/dds/infrastructure/instance.rs
@@ -3,6 +3,7 @@
 pub struct InstanceHandle([u8; 16]);
 
 impl InstanceHandle {
+    /// InstanceHandle constructor
     pub fn new(bytes: [u8; 16]) -> Self {
         InstanceHandle(bytes)
     }

--- a/dds/src/dds/infrastructure/listeners.rs
+++ b/dds/src/dds/infrastructure/listeners.rs
@@ -11,9 +11,12 @@ use crate::{
     topic_definition::topic_listener::TopicListener,
 };
 
+/// This struct implements the listener traits for all entities and can be used as a convinience when the entity
+/// does not need the listener operations.
 pub struct NoOpListener<Foo = ()>(PhantomData<Foo>);
 
 impl<Foo> NoOpListener<Foo> {
+    /// NoOpListener constructor
     pub const fn new() -> Self {
         Self(PhantomData)
     }

--- a/dds/src/dds/infrastructure/qos.rs
+++ b/dds/src/dds/infrastructure/qos.rs
@@ -19,57 +19,69 @@ use super::{
 /// QoS policies applicable to the [`DomainParticipantFactory`](crate::domain::domain_participant_factory::DomainParticipantFactory)
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct DomainParticipantFactoryQos {
+    /// Value of the entity factory QoS policy.
     pub entity_factory: EntityFactoryQosPolicy,
 }
 
 /// Enumeration representing the kind of Qos to be used
 #[derive(Debug)]
 pub enum QosKind<T> {
+    /// Default QoS variant
     Default,
+    /// Specific QoS variant
     Specific(T),
 }
 
 /// QoS policies applicable to the [`DomainParticipant`](crate::domain::domain_participant::DomainParticipant)
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct DomainParticipantQos {
+    /// Value of the user data QoS policy.
     pub user_data: UserDataQosPolicy,
+    /// Value of the entity factory QoS policy.
     pub entity_factory: EntityFactoryQosPolicy,
 }
 
 /// QoS policies applicable to the [`Publisher`](crate::publication::publisher::Publisher)
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct PublisherQos {
+    /// Value of the presentation QoS policy.
     pub presentation: PresentationQosPolicy,
+    /// Value of the partition QoS policy.
     pub partition: PartitionQosPolicy,
+    /// Value of the group data QoS policy.
     pub group_data: GroupDataQosPolicy,
+    /// Value of the entity factory QoS policy.
     pub entity_factory: EntityFactoryQosPolicy,
-}
-
-impl PublisherQos {
-    pub fn check_immutability(&self, other: &Self) -> DdsResult<()> {
-        if self.presentation != other.presentation {
-            Err(DdsError::ImmutablePolicy)
-        } else {
-            Ok(())
-        }
-    }
 }
 
 /// QoS policies applicable to the [`DataWriter`](crate::publication::data_writer::DataWriter)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DataWriterQos {
+    /// Value of the durability QoS policy.
     pub durability: DurabilityQosPolicy,
+    /// Value of the deadline QoS policy.
     pub deadline: DeadlineQosPolicy,
+    /// Value of the latency budget QoS policy.
     pub latency_budget: LatencyBudgetQosPolicy,
+    /// Value of the liveliness QoS policy.
     pub liveliness: LivelinessQosPolicy,
+    /// Value of the reliability QoS policy.
     pub reliability: ReliabilityQosPolicy,
+    /// Value of the destination order QoS policy.
     pub destination_order: DestinationOrderQosPolicy,
+    /// Value of the history QoS policy.
     pub history: HistoryQosPolicy,
+    /// Value of the resource limits QoS policy.
     pub resource_limits: ResourceLimitsQosPolicy,
+    /// Value of the transport priority QoS policy.
     pub transport_priority: TransportPriorityQosPolicy,
+    /// Value of the lifespan QoS policy.
     pub lifespan: LifespanQosPolicy,
+    /// Value of the user_data QoS policy.
     pub user_data: UserDataQosPolicy,
+    /// Value of the ownership QoS policy.
     pub ownership: OwnershipQosPolicy,
+    /// Value of the writer data lifecycle QoS policy.
     pub writer_data_lifecycle: WriterDataLifecycleQosPolicy,
 }
 
@@ -100,7 +112,7 @@ impl Default for DataWriterQos {
 }
 
 impl DataWriterQos {
-    pub fn is_consistent(&self) -> DdsResult<()> {
+    pub(crate) fn is_consistent(&self) -> DdsResult<()> {
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
         // values to be consistent they must verify that “max_samples >= max_samples_per_instanc
         if self.resource_limits.max_samples < self.resource_limits.max_samples_per_instance {
@@ -121,7 +133,7 @@ impl DataWriterQos {
         }
     }
 
-    pub fn check_immutability(&self, other: &Self) -> DdsResult<()> {
+    pub(crate) fn _check_immutability(&self, other: &Self) -> DdsResult<()> {
         if self.durability != other.durability
             || self.liveliness != other.liveliness
             || self.reliability != other.reliability
@@ -140,14 +152,18 @@ impl DataWriterQos {
 /// QoS policies applicable to the [`Subscriber`](crate::subscription::subscriber::Subscriber)
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct SubscriberQos {
+    /// Value of the presentation QoS policy.
     pub presentation: PresentationQosPolicy,
+    /// Value of the partition QoS policy.
     pub partition: PartitionQosPolicy,
+    /// Value of the group data QoS policy.
     pub group_data: GroupDataQosPolicy,
+    /// Value of the entity factory QoS policy.
     pub entity_factory: EntityFactoryQosPolicy,
 }
 
 impl SubscriberQos {
-    pub fn check_immutability(&self, other: &Self) -> DdsResult<()> {
+    pub(crate) fn check_immutability(&self, other: &Self) -> DdsResult<()> {
         if self.presentation != other.presentation {
             Err(DdsError::ImmutablePolicy)
         } else {
@@ -159,17 +175,29 @@ impl SubscriberQos {
 /// QoS policies applicable to the [`DataReader`](crate::subscription::data_reader::DataReader)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DataReaderQos {
+    /// Value of the durability QoS policy.
     pub durability: DurabilityQosPolicy,
+    /// Value of the deadline QoS policy.
     pub deadline: DeadlineQosPolicy,
+    /// Value of the latency budget QoS policy.
     pub latency_budget: LatencyBudgetQosPolicy,
+    /// Value of the liveliness QoS policy.
     pub liveliness: LivelinessQosPolicy,
+    /// Value of the reliability QoS policy.
     pub reliability: ReliabilityQosPolicy,
+    /// Value of the destination order QoS policy.
     pub destination_order: DestinationOrderQosPolicy,
+    /// Value of the history QoS policy.
     pub history: HistoryQosPolicy,
+    /// Value of the resource limits QoS policy.
     pub resource_limits: ResourceLimitsQosPolicy,
+    /// Value of the user data QoS policy.
     pub user_data: UserDataQosPolicy,
+    /// Value of the ownership QoS policy.
     pub ownership: OwnershipQosPolicy,
+    /// Value of the time based filter QoS policy.
     pub time_based_filter: TimeBasedFilterQosPolicy,
+    /// Value of the reader data lifecycle QoS policy.
     pub reader_data_lifecycle: ReaderDataLifecycleQosPolicy,
 }
 
@@ -199,7 +227,7 @@ impl Default for DataReaderQos {
 }
 
 impl DataReaderQos {
-    pub fn is_consistent(&self) -> DdsResult<()> {
+    pub(crate) fn is_consistent(&self) -> DdsResult<()> {
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
         // values to be consistent they must verify that “max_samples >= max_samples_per_instance.”
         if self.resource_limits.max_samples < self.resource_limits.max_samples_per_instance {
@@ -226,7 +254,7 @@ impl DataReaderQos {
         Ok(())
     }
 
-    pub fn check_immutability(&self, other: &Self) -> DdsResult<()> {
+    pub(crate) fn check_immutability(&self, other: &Self) -> DdsResult<()> {
         if self.durability != other.durability
             || self.liveliness != other.liveliness
             || self.reliability != other.reliability
@@ -245,17 +273,29 @@ impl DataReaderQos {
 /// QoS policies applicable to the [`Topic`](crate::topic_definition::topic::Topic)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TopicQos {
+    /// Value of the topic data QoS policy.
     pub topic_data: TopicDataQosPolicy,
+    /// Value of the durability QoS policy.
     pub durability: DurabilityQosPolicy,
+    /// Value of the deadline QoS policy.
     pub deadline: DeadlineQosPolicy,
+    /// Value of the latency budget QoS policy.
     pub latency_budget: LatencyBudgetQosPolicy,
+    /// Value of the liveliness QoS policy.
     pub liveliness: LivelinessQosPolicy,
+    /// Value of the reliability QoS policy.
     pub reliability: ReliabilityQosPolicy,
+    /// Value of the destination order QoS policy.
     pub destination_order: DestinationOrderQosPolicy,
+    /// Value of the history QoS policy.
     pub history: HistoryQosPolicy,
+    /// Value of the resource limits QoS policy.
     pub resource_limits: ResourceLimitsQosPolicy,
+    /// Value of the transport priority QoS policy.
     pub transport_priority: TransportPriorityQosPolicy,
+    /// Value of the lifespan QoS policy.
     pub lifespan: LifespanQosPolicy,
+    /// Value of the ownership QoS policy.
     pub ownership: OwnershipQosPolicy,
 }
 
@@ -285,7 +325,7 @@ impl Default for TopicQos {
 }
 
 impl TopicQos {
-    pub fn is_consistent(&self) -> DdsResult<()> {
+    pub(crate) fn is_consistent(&self) -> DdsResult<()> {
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
         // values to be consistent they must verify that “max_samples >= max_samples_per_instance.”
         if self.resource_limits.max_samples < self.resource_limits.max_samples_per_instance {
@@ -306,7 +346,7 @@ impl TopicQos {
         }
     }
 
-    pub fn check_immutability(&self, other: &Self) -> DdsResult<()> {
+    pub(crate) fn check_immutability(&self, other: &Self) -> DdsResult<()> {
         if self.durability != other.durability
             || self.liveliness != other.liveliness
             || self.reliability != other.reliability

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -7,11 +7,15 @@ use crate::{
         serializer::CdrSerializer,
     },
 };
-
+/// QosPolicyId type alias
 pub type QosPolicyId = i32;
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+/// Enumeration representing a Length which be either limited or unlimited.
 pub enum Length {
+    /// Unlimited length.
     Unlimited,
+    /// Limited length with the corresponding associated value.
     Limited(u32),
 }
 
@@ -108,6 +112,7 @@ impl PartialOrd<Length> for usize {
 /// Sub clause 2.2.3, Supported QoS provides the list of all QosPolicy, their meaning, characteristics and possible values, as well
 /// as the concrete Entity to which they apply.
 pub trait QosPolicy {
+    /// Get the name of the QoS policy
     fn name(&self) -> &str;
 }
 
@@ -132,33 +137,56 @@ const TRANSPORTPRIORITY_QOS_POLICY_NAME: &str = "TransportPriority";
 const GROUPDATA_QOS_POLICY_NAME: &str = "GroupData";
 const LIFESPAN_QOS_POLICY_NAME: &str = "Lifespan";
 
+/// QosPolicy Id representing an invalid QoS policy
 pub const INVALID_QOS_POLICY_ID: QosPolicyId = 0;
+/// Id for the UserDataQosPolicy
 pub const USERDATA_QOS_POLICY_ID: QosPolicyId = 1;
+/// Id for the DurabilityQosPolicy
 pub const DURABILITY_QOS_POLICY_ID: QosPolicyId = 2;
+/// Id for the PresentationQosPolicy
 pub const PRESENTATION_QOS_POLICY_ID: QosPolicyId = 3;
+/// Id for the DeadlineQosPolicy
 pub const DEADLINE_QOS_POLICY_ID: QosPolicyId = 4;
+/// Id for the LatencyBudgetQosPolicy
 pub const LATENCYBUDGET_QOS_POLICY_ID: QosPolicyId = 5;
+/// Id for the OwnershipQosPolicy
 pub const OWNERSHIP_QOS_POLICY_ID: QosPolicyId = 6;
+/// Id for the LivelinessQosPolicy
 pub const LIVELINESS_QOS_POLICY_ID: QosPolicyId = 8;
+/// Id for the TimeBasedFilterQosPolicy
 pub const TIMEBASEDFILTER_QOS_POLICY_ID: QosPolicyId = 9;
+/// Id for the PartitionQosPolicy
 pub const PARTITION_QOS_POLICY_ID: QosPolicyId = 10;
+/// Id for the ReliabilityQosPolicy
 pub const RELIABILITY_QOS_POLICY_ID: QosPolicyId = 11;
+/// Id for the DestinationOrderQosPolicy
 pub const DESTINATIONORDER_QOS_POLICY_ID: QosPolicyId = 12;
+/// Id for the HistoryQosPolicy
 pub const HISTORY_QOS_POLICY_ID: QosPolicyId = 13;
+/// Id for the ResourceLimitsQosPolicy
 pub const RESOURCELIMITS_QOS_POLICY_ID: QosPolicyId = 14;
+/// Id for the EntityFactoryQosPolicy
 pub const ENTITYFACTORY_QOS_POLICY_ID: QosPolicyId = 15;
+/// Id for the WriterDataLifecycleQosPolicy
 pub const WRITERDATALIFECYCLE_QOS_POLICY_ID: QosPolicyId = 16;
+/// Id for the ReaderDataLifecycleQosPolicy
 pub const READERDATALIFECYCLE_QOS_POLICY_ID: QosPolicyId = 17;
+/// Id for the TopicDataQosPolicy
 pub const TOPICDATA_QOS_POLICY_ID: QosPolicyId = 18;
+/// Id for the GroupDataQosPolicy
 pub const GROUPDATA_QOS_POLICY_ID: QosPolicyId = 19;
+/// Id for the TransportPriorityQosPolicy
 pub const TRANSPORTPRIORITY_QOS_POLICY_ID: QosPolicyId = 20;
+/// Id for the LifespanQosPolicy
 pub const LIFESPAN_QOS_POLICY_ID: QosPolicyId = 21;
+/// Id for the DurabilityServiceQosPolicy
 pub const DURABILITYSERVICE_QOS_POLICY_ID: QosPolicyId = 22;
 
 /// This policy allows the application to attach additional information to the created Entity objects such that when
 /// a remote application discovers their existence it can access that information and use it for its own purposes.
 #[derive(Debug, Default, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct UserDataQosPolicy {
+    /// User data value
     pub value: Vec<u8>,
 }
 
@@ -172,6 +200,7 @@ impl QosPolicy for UserDataQosPolicy {
 /// remote application discovers their existence it can examine the information and use it in an application-defined way.
 #[derive(Debug, Default, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct TopicDataQosPolicy {
+    /// Topic data value
     pub value: Vec<u8>,
 }
 
@@ -189,6 +218,7 @@ impl QosPolicy for TopicDataQosPolicy {
 /// means of the built-in topics.
 #[derive(Debug, Default, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct GroupDataQosPolicy {
+    /// Group data value
     pub value: Vec<u8>,
 }
 
@@ -209,6 +239,7 @@ impl QosPolicy for GroupDataQosPolicy {
 /// This mapping would then be used by the infrastructure when propagating the data written by the [`DataWriter`](crate::publication::data_writer::DataWriter).
 #[derive(Debug, Default, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct TransportPriorityQosPolicy {
+    /// Transport priority value
     pub value: i32,
 }
 
@@ -233,6 +264,7 @@ impl QosPolicy for TransportPriorityQosPolicy {
 /// computation of the ‘expiration time.’
 #[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct LifespanQosPolicy {
+    /// Lifespan duration
     pub duration: DurationKind,
 }
 
@@ -251,8 +283,11 @@ impl Default for LifespanQosPolicy {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+/// Enumeration representing the different types of Durability QoS policies.
 pub enum DurabilityQosPolicyKind {
+    /// Volatile durability QoS policy
     Volatile,
+    /// TransientLocal durability QoS policy
     TransientLocal,
 }
 
@@ -310,6 +345,7 @@ impl PartialOrd for DurabilityQosPolicyKind {
 /// that *Volatile < TransientLocal*.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, CdrSerialize, CdrDeserialize)]
 pub struct DurabilityQosPolicy {
+    /// DurabilityQosPolicy kind to be used for this policy
     pub kind: DurabilityQosPolicyKind,
 }
 
@@ -328,8 +364,11 @@ impl Default for DurabilityQosPolicy {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+/// Enumeration representing the different types of Presentation QoS policy access scope.
 pub enum PresentationQosPolicyAccessScopeKind {
+    /// Access scope per instance
     Instance,
+    /// Access scope per topic
     Topic,
 }
 
@@ -413,8 +452,11 @@ impl PartialOrd for PresentationQosPolicyAccessScopeKind {
 /// 3. Requested ordered_access is FALSE, or else both offered and requested ordered _access are TRUE.
 #[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct PresentationQosPolicy {
+    /// Presentation access scope kind to be used for this policy
     pub access_scope: PresentationQosPolicyAccessScopeKind,
+    /// Coherent access value
     pub coherent_access: bool,
+    /// Ordered access value
     pub ordered_access: bool,
 }
 
@@ -450,6 +492,7 @@ impl Default for PresentationQosPolicy {
 /// to be consistent the settings must be such that *deadline period >= minimum_separation*.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, CdrSerialize, CdrDeserialize)]
 pub struct DeadlineQosPolicy {
+    /// Deadline period value
     pub period: DurationKind,
 }
 
@@ -475,6 +518,7 @@ impl Default for DeadlineQosPolicy {
 /// requested duration* is true.
 #[derive(PartialOrd, PartialEq, Eq, Debug, Clone, CdrSerialize, CdrDeserialize)]
 pub struct LatencyBudgetQosPolicy {
+    /// Latency budget duration value
     pub duration: DurationKind,
 }
 
@@ -492,8 +536,10 @@ impl Default for LatencyBudgetQosPolicy {
     }
 }
 
+/// Enumeration representing the different types of Ownership QoS policies.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum OwnershipQosPolicyKind {
+    /// Shared ownership QoS policy
     Shared,
 }
 
@@ -530,6 +576,7 @@ impl<'de> CdrDeserialize<'de> for OwnershipQosPolicyKind {
 
 #[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct OwnershipQosPolicy {
+    /// Kind of ownership QoS associated with this policy
     pub kind: OwnershipQosPolicyKind,
 }
 
@@ -547,10 +594,14 @@ impl Default for OwnershipQosPolicy {
     }
 }
 
+/// Enumeration representing the different types of Liveliness QoS policies.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum LivelinessQosPolicyKind {
+    /// Automatic liveliness
     Automatic,
+    /// Manual by participant liveliness
     ManualByParticipant,
+    /// Manual by topic liveliness
     ManualByTopic,
 }
 
@@ -629,7 +680,9 @@ impl PartialOrd for LivelinessQosPolicyKind {
 /// Listeners and WaitSets are notified within a [`LivelinessQosPolicy::lease_duration`] from the time the liveliness changed.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, CdrSerialize, CdrDeserialize)]
 pub struct LivelinessQosPolicy {
+    /// Kind of liveliness QoS associated with this policy
     pub kind: LivelinessQosPolicyKind,
+    /// Liveliness duration
     pub lease_duration: DurationKind,
 }
 
@@ -672,6 +725,7 @@ impl Default for LivelinessQosPolicy {
 /// two QoS policies to be consistent they must verify that *[`DeadlineQosPolicy::period`] >= [`TimeBasedFilterQosPolicy::minimum_separation`]*.
 #[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct TimeBasedFilterQosPolicy {
+    /// Minimum separation between samples
     pub minimum_separation: DurationKind,
 }
 
@@ -712,6 +766,7 @@ impl Default for TimeBasedFilterQosPolicy {
 /// the other hand, the same data-instance can be made available (published) or requested (subscribed) on one or more partitions.
 #[derive(Debug, PartialEq, Eq, Clone, Default, CdrSerialize, CdrDeserialize)]
 pub struct PartitionQosPolicy {
+    /// Name of the partition
     pub name: Vec<String>,
 }
 
@@ -721,9 +776,12 @@ impl QosPolicy for PartitionQosPolicy {
     }
 }
 
+/// Enumeration representing the different types of reliability QoS policies.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum ReliabilityQosPolicyKind {
+    /// Best-effort reliability.
     BestEffort,
+    /// Reliable reliability.
     Reliable,
 }
 
@@ -796,7 +854,9 @@ impl PartialOrd for ReliabilityQosPolicyKind {
 /// that *BestEffort < Reliable*.
 #[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct ReliabilityQosPolicy {
+    /// Kind of reliability QoS
     pub kind: ReliabilityQosPolicyKind,
+    /// Maximum blocking time to block. This only applies when kind is set to [`ReliabilityQosPolicyKind::Reliable`]
     pub max_blocking_time: DurationKind,
 }
 
@@ -813,21 +873,25 @@ impl PartialOrd for ReliabilityQosPolicy {
 }
 
 // default for Reliability is differnet for reader and writer, hence
-// add here as constants
+// added here as constants
 const DEFAULT_MAX_BLOCKING_TIME: Duration = Duration::new(0, 100);
-pub const DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS: ReliabilityQosPolicy =
+pub(crate) const DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS: ReliabilityQosPolicy =
     ReliabilityQosPolicy {
         kind: ReliabilityQosPolicyKind::BestEffort,
         max_blocking_time: DurationKind::Finite(DEFAULT_MAX_BLOCKING_TIME),
     };
-pub const DEFAULT_RELIABILITY_QOS_POLICY_DATA_WRITER: ReliabilityQosPolicy = ReliabilityQosPolicy {
-    kind: ReliabilityQosPolicyKind::Reliable,
-    max_blocking_time: DurationKind::Finite(DEFAULT_MAX_BLOCKING_TIME),
-};
+pub(crate) const DEFAULT_RELIABILITY_QOS_POLICY_DATA_WRITER: ReliabilityQosPolicy =
+    ReliabilityQosPolicy {
+        kind: ReliabilityQosPolicyKind::Reliable,
+        max_blocking_time: DurationKind::Finite(DEFAULT_MAX_BLOCKING_TIME),
+    };
 
+/// Enumeration representing the different types of destination order QoS policies.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum DestinationOrderQosPolicyKind {
+    /// Ordered by reception timestamp.
     ByReceptionTimestamp,
+    /// Ordered by source timestamp.
     BySourceTimestamp,
 }
 
@@ -884,6 +948,7 @@ impl PartialOrd for DestinationOrderQosPolicyKind {
 /// ordered such that *DestinationOrderQosPolicyKind::ByReceptionTimestamp < DestinationOrderQosPolicyKind::BySourceTimestamp*.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Clone, CdrSerialize, CdrDeserialize)]
 pub struct DestinationOrderQosPolicy {
+    /// Kind of destination order QoS associated with this policy.
     pub kind: DestinationOrderQosPolicyKind,
 }
 
@@ -901,9 +966,12 @@ impl Default for DestinationOrderQosPolicy {
     }
 }
 
+/// Enumeration representing the different types of history QoS policies.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum HistoryQosPolicyKind {
+    /// Keep number of samples indicated by the associated value.
     KeepLast(i32),
+    /// Keep all samples.
     KeepAll,
 }
 
@@ -953,6 +1021,7 @@ impl<'de> CdrDeserialize<'de> for HistoryQosPolicyKind {
 /// QoS to be consistent, they must verify that *depth <= max_samples_per_instance*.
 #[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct HistoryQosPolicy {
+    /// Kind of history QoS associated with this policy.
     pub kind: HistoryQosPolicyKind,
 }
 
@@ -991,8 +1060,11 @@ impl Default for HistoryQosPolicy {
 /// that *HistoryQosPolicy depth <= [`ResourceLimitsQosPolicy::max_samples_per_instance`]*.
 #[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct ResourceLimitsQosPolicy {
+    /// Maximum number of samples limit.
     pub max_samples: Length,
+    /// Maximum number of instances limit.
     pub max_instances: Length,
+    /// Maximum number of samples per instance limit.
     pub max_samples_per_instance: Length,
 }
 
@@ -1026,6 +1098,7 @@ impl Default for ResourceLimitsQosPolicy {
 /// on newly created entities.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EntityFactoryQosPolicy {
+    /// Value of auto-enable created entities.
     pub autoenable_created_entities: bool,
 }
 
@@ -1061,6 +1134,7 @@ impl Default for EntityFactoryQosPolicy {
 /// [`DataWriter`](crate::publication::data_writer::DataWriter) is deleted.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct WriterDataLifecycleQosPolicy {
+    /// Value of auto-dispose unregistered instances.
     pub autodispose_unregistered_instances: bool,
 }
 
@@ -1100,7 +1174,9 @@ impl Default for WriterDataLifecycleQosPolicy {
 /// samples for the instance.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ReaderDataLifecycleQosPolicy {
+    /// Time duration to auto purge samples with no writer.
     pub autopurge_nowriter_samples_delay: DurationKind,
+    /// Time duration to auto purge disposed samples.
     pub autopurge_disposed_samples_delay: DurationKind,
 }
 

--- a/dds/src/dds/infrastructure/status.rs
+++ b/dds/src/dds/infrastructure/status.rs
@@ -64,11 +64,16 @@ pub struct SampleLostStatus {
     pub total_count_change: i32,
 }
 
+/// Enumeration for the kind of sample rejected kind
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum SampleRejectedStatusKind {
+    /// Sample not rejected
     NotRejected,
+    /// Sample was rejected because the limit of instances configured in the associated QoS was reached
     RejectedByInstancesLimit,
+    /// Sample was rejected because the limit of samples configured in the associated QoS was reached
     RejectedBySamplesLimit,
+    /// Sample was rejected because the limit of samples per instance configured in the associated QoS was reached
     RejectedBySamplesPerInstanceLimit,
 }
 
@@ -168,7 +173,9 @@ pub struct RequestedDeadlineMissedStatus {
 /// Structure associating the QosPolicyId and the number of time it appeared in the related communication status.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct QosPolicyCount {
+    /// The id code for the represented QoS policy
     pub policy_id: QosPolicyId,
+    /// The number of times this QoS policy has appeared in the associated status
     pub count: i32,
 }
 
@@ -229,8 +236,8 @@ pub struct PublicationMatchedStatus {
     /// The number of DataReaders currently matched to the concerned
     /// DataWriter.
     pub current_count: i32,
-    // The change in current_count since the last time the listener was called
-    // or the status was read.
+    /// The change in current_count since the last time the listener was called
+    /// or the status was read.
     pub current_count_change: i32,
 }
 

--- a/dds/src/dds/infrastructure/time.rs
+++ b/dds/src/dds/infrastructure/time.rs
@@ -65,7 +65,7 @@ pub struct Duration {
 }
 
 impl Duration {
-    /// Construct a new ['Duration'] with the corresponding seconds and nanoseconds.
+    /// Construct a new [`Duration`] with the corresponding seconds and nanoseconds.
     pub const fn new(sec: i32, nanosec: u32) -> Self {
         let sec = sec + (nanosec / 1_000_000_000) as i32;
         let nanosec = nanosec % 1_000_000_000;
@@ -119,7 +119,7 @@ pub struct Time {
 }
 
 impl Time {
-    /// Create a new ['Time'] with a number of seconds and nanoseconds
+    /// Create a new [`Time`] with a number of seconds and nanoseconds
     pub const fn new(sec: i32, nanosec: u32) -> Self {
         let sec = sec + (nanosec / 1_000_000_000) as i32;
         let nanosec = nanosec % 1_000_000_000;

--- a/dds/src/dds/infrastructure/time.rs
+++ b/dds/src/dds/infrastructure/time.rs
@@ -5,9 +5,12 @@ use crate::serialized_payload::cdr::{
     serializer::CdrSerializer,
 };
 
+/// Enumeration representing whether a duration is finite or infinite
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum DurationKind {
+    /// Finite duration with the corresponding associated value
     Finite(Duration),
+    /// Infinite duration
     Infinite,
 }
 
@@ -54,6 +57,7 @@ impl PartialOrd<DurationKind> for DurationKind {
     }
 }
 
+/// Structure representing a time interval with a nanosecond resolution.
 #[derive(PartialOrd, PartialEq, Eq, Debug, Clone, Copy, CdrSerialize, CdrDeserialize)]
 pub struct Duration {
     sec: i32,
@@ -61,6 +65,7 @@ pub struct Duration {
 }
 
 impl Duration {
+    /// Construct a new ['Duration'] with the corresponding seconds and nanoseconds.
     pub const fn new(sec: i32, nanosec: u32) -> Self {
         let sec = sec + (nanosec / 1_000_000_000) as i32;
         let nanosec = nanosec % 1_000_000_000;
@@ -106,6 +111,7 @@ impl From<Duration> for std::time::Duration {
     }
 }
 
+/// Structure representing a time in Unix Epoch with a nanosecond resolution.
 #[derive(Clone, PartialEq, Debug, Copy, PartialOrd, Eq, Ord)]
 pub struct Time {
     sec: i32,
@@ -113,16 +119,19 @@ pub struct Time {
 }
 
 impl Time {
+    /// Create a new ['Time'] with a number of seconds and nanoseconds
     pub const fn new(sec: i32, nanosec: u32) -> Self {
         let sec = sec + (nanosec / 1_000_000_000) as i32;
         let nanosec = nanosec % 1_000_000_000;
         Self { sec, nanosec }
     }
 
+    /// Get the number of seconds contained by this time
     pub const fn sec(&self) -> i32 {
         self.sec
     }
 
+    /// Get the number of nanoseconds contained by this time
     pub const fn nanosec(&self) -> u32 {
         self.nanosec
     }

--- a/dds/src/dds/infrastructure/wait_set.rs
+++ b/dds/src/dds/infrastructure/wait_set.rs
@@ -43,9 +43,9 @@ impl WaitSet {
     /// The operation returns the list of all the attached conditions that have a `trigger_value` of [`true`] (i.e., the conditions
     /// that unblocked the wait).
     /// This operation takes a `timeout` argument that specifies the maximum duration for the wait. It this duration is exceeded and
-    /// none of the attached [`Condition`] objects is [`true`], wait will return with [`DdsError::Timeout`].
+    /// none of the attached [`Condition`] objects is [`true`], wait will return with [`DdsError::Timeout`](crate::infrastructure::error::DdsError::Timeout).
     /// It is not allowed for more than one application thread to be waiting on the same [`WaitSet`]. If the wait operation is invoked on a
-    /// [`WaitSet`] that already has a thread blocking on it, the operation will return immediately with the value [`DdsError::PreconditionNotMet`].
+    /// [`WaitSet`] that already has a thread blocking on it, the operation will return immediately with the value [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError::PreconditionNotMet).
     #[tracing::instrument(skip(self))]
     pub fn wait(&self, timeout: Duration) -> DdsResult<Vec<Condition>> {
         Ok(DomainParticipantFactory::get_instance()
@@ -79,7 +79,7 @@ impl WaitSet {
     }
 
     /// Detaches a [`Condition`] from the [`WaitSet`].
-    /// If the [`Condition`] was not attached to the [`WaitSet`], the operation will return [`DdsError::PreconditionNotMet`].
+    /// If the [`Condition`] was not attached to the [`WaitSet`], the operation will return [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError::PreconditionNotMet).
     #[tracing::instrument(skip(self, _cond))]
     pub fn detach_condition(&self, _cond: Condition) -> DdsResult<()> {
         todo!()

--- a/dds/src/dds/infrastructure/wait_set.rs
+++ b/dds/src/dds/infrastructure/wait_set.rs
@@ -9,10 +9,12 @@ use super::condition::StatusCondition;
 /// Enumeration of the different Condition objects that can be associated with a [`WaitSet`].
 #[derive(Clone)]
 pub enum Condition {
+    /// Status condition variant
     StatusCondition(StatusCondition),
 }
 impl Condition {
     #[tracing::instrument(skip(self))]
+    /// This operation retrieves the trigger_value of the Condition.
     pub fn get_trigger_value(&self) -> DdsResult<bool> {
         match self {
             Condition::StatusCondition(c) => c.get_trigger_value(),

--- a/dds/src/dds/mod.rs
+++ b/dds/src/dds/mod.rs
@@ -21,6 +21,6 @@ pub mod subscription;
 /// by the application to define topics and attach qos policies.
 pub mod topic_definition;
 
-/// Contains the ['DustDdsConfiguration'](crate::configuration::DustDdsConfiguration) struct that allow configuring the runtime options
+/// Contains the [`DustDdsConfiguration`](crate::configuration::DustDdsConfiguration) struct that allow configuring the runtime options
 /// of the DustDDS systems
 pub mod configuration;

--- a/dds/src/dds/mod.rs
+++ b/dds/src/dds/mod.rs
@@ -21,4 +21,6 @@ pub mod subscription;
 /// by the application to define topics and attach qos policies.
 pub mod topic_definition;
 
+/// Contains the ['DustDdsConfiguration'](crate::configuration::DustDdsConfiguration) struct that allow configuring the runtime options
+/// of the DustDDS systems
 pub mod configuration;

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -473,6 +473,8 @@ impl<Foo> DataWriter<Foo> {
     }
 }
 
+/// Trait representing a generic data writer. This trait is not meant to be implemented by the user and is used
+/// to represent a generic DataWriter (i.e. without Foo) type on the listeners.
 pub trait AnyDataWriter {}
 
 impl<Foo> AnyDataWriter for DataWriter<Foo> {}

--- a/dds/src/dds/publication/data_writer_listener.rs
+++ b/dds/src/dds/publication/data_writer_listener.rs
@@ -5,27 +5,33 @@ use crate::infrastructure::status::{
 
 use super::data_writer::DataWriter;
 
+/// This trait represents a listener object which can be associated with the ['DataWriter'] entity.
 pub trait DataWriterListener {
+    /// Type of the DataWriter with which this Listener will be associated.
     type Foo;
 
+    /// Method that is called when this writer reports a liveliness lost status.
     fn on_liveliness_lost(
         &mut self,
         _the_writer: &DataWriter<Self::Foo>,
         _status: LivelinessLostStatus,
     ) {
     }
+    /// Method that is called when this writer reports an offered deadline missed status.
     fn on_offered_deadline_missed(
         &mut self,
         _the_writer: &DataWriter<Self::Foo>,
         _status: OfferedDeadlineMissedStatus,
     ) {
     }
+    /// Method that is called when this writer reports an offered incompatible qos status.
     fn on_offered_incompatible_qos(
         &mut self,
         _the_writer: &DataWriter<Self::Foo>,
         _status: OfferedIncompatibleQosStatus,
     ) {
     }
+    /// Method that is called when this writer reports a publication matched status.
     fn on_publication_matched(
         &mut self,
         _the_writer: &DataWriter<Self::Foo>,

--- a/dds/src/dds/publication/data_writer_listener.rs
+++ b/dds/src/dds/publication/data_writer_listener.rs
@@ -5,7 +5,7 @@ use crate::infrastructure::status::{
 
 use super::data_writer::DataWriter;
 
-/// This trait represents a listener object which can be associated with the ['DataWriter'] entity.
+/// This trait represents a listener object which can be associated with the [`DataWriter`] entity.
 pub trait DataWriterListener {
     /// Type of the DataWriter with which this Listener will be associated.
     type Foo;

--- a/dds/src/dds/publication/publisher_listener.rs
+++ b/dds/src/dds/publication/publisher_listener.rs
@@ -5,7 +5,9 @@ use crate::infrastructure::status::{
 
 use super::data_writer::AnyDataWriter;
 
+/// This trait represents a listener object which can be associated with the ['Publisher'](super::publisher::Publisher) entity.
 pub trait PublisherListener {
+    /// Method that is called when any writer belonging to this publisher reports a liveliness lost status.
     fn on_liveliness_lost(
         &mut self,
         _the_writer: &dyn AnyDataWriter,
@@ -13,6 +15,7 @@ pub trait PublisherListener {
     ) {
     }
 
+    /// Method that is called when any writer belonging to this publisher reports an offered deadline missed status.
     fn on_offered_deadline_missed(
         &mut self,
         _the_writer: &dyn AnyDataWriter,
@@ -20,6 +23,7 @@ pub trait PublisherListener {
     ) {
     }
 
+    /// Method that is called when any writer belonging to this publisher reports an offered incompatible qos status.
     fn on_offered_incompatible_qos(
         &mut self,
         _the_writer: &dyn AnyDataWriter,
@@ -27,6 +31,7 @@ pub trait PublisherListener {
     ) {
     }
 
+    /// Method that is called when any writer belonging to this publisher reports a publication matched status.
     fn on_publication_matched(
         &mut self,
         _the_writer: &dyn AnyDataWriter,

--- a/dds/src/dds/publication/publisher_listener.rs
+++ b/dds/src/dds/publication/publisher_listener.rs
@@ -5,7 +5,7 @@ use crate::infrastructure::status::{
 
 use super::data_writer::AnyDataWriter;
 
-/// This trait represents a listener object which can be associated with the ['Publisher'](super::publisher::Publisher) entity.
+/// This trait represents a listener object which can be associated with the [`Publisher`](super::publisher::Publisher) entity.
 pub trait PublisherListener {
     /// Method that is called when any writer belonging to this publisher reports a liveliness lost status.
     fn on_liveliness_lost(

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -48,6 +48,7 @@ impl<'de, Foo> Sample<Foo>
 where
     Foo: DdsDeserialize<'de>,
 {
+    /// Get the Foo value associated with this sample.
     pub fn data(&'de self) -> DdsResult<Foo> {
         match self.data.as_ref() {
             Some(data) => Ok(Foo::deserialize_data(data.as_ref())?),
@@ -57,6 +58,7 @@ where
 }
 
 impl<Foo> Sample<Foo> {
+    /// Get the sample info associated with this sample.
     pub fn sample_info(&self) -> SampleInfo {
         self.sample_info.clone()
     }
@@ -569,6 +571,9 @@ impl<Foo> DataReader<Foo> {
             .block_on(self.reader_async.set_listener(a_listener, mask))
     }
 }
+
+/// Trait representing a generic data reader. This trait is not meant to be implemented by the user and is used
+/// to represent a generic DataReader (i.e. without Foo) type on the listeners.
 pub trait AnyDataReader {}
 
 impl<Foo> AnyDataReader for DataReader<Foo> {}

--- a/dds/src/dds/subscription/data_reader_listener.rs
+++ b/dds/src/dds/subscription/data_reader_listener.rs
@@ -5,7 +5,7 @@ use crate::infrastructure::status::{
 
 use super::data_reader::DataReader;
 
-/// This trait represents a listener object which can be associated with the ['DataReader'] entity.
+/// This trait represents a listener object which can be associated with the [`DataReader`] entity.
 pub trait DataReaderListener {
     /// Type of the DataReader with which this Listener will be associated.
     type Foo;

--- a/dds/src/dds/subscription/data_reader_listener.rs
+++ b/dds/src/dds/subscription/data_reader_listener.rs
@@ -5,38 +5,53 @@ use crate::infrastructure::status::{
 
 use super::data_reader::DataReader;
 
+/// This trait represents a listener object which can be associated with the ['DataReader'] entity.
 pub trait DataReaderListener {
+    /// Type of the DataReader with which this Listener will be associated.
     type Foo;
+
+    /// Method that is called when new data is received by the reader.
     fn on_data_available(&mut self, _the_reader: &DataReader<Self::Foo>) {}
+
+    /// Method that is called when this reader reports a sample rejected status.
     fn on_sample_rejected(
         &mut self,
         _the_reader: &DataReader<Self::Foo>,
         _status: SampleRejectedStatus,
     ) {
     }
+    /// Method that is called when this reader reports a liveliness changed status.
     fn on_liveliness_changed(
         &mut self,
         _the_reader: &DataReader<Self::Foo>,
         _status: LivelinessChangedStatus,
     ) {
     }
+
+    /// Method that is called when this reader reports a requested deadline missed status.
     fn on_requested_deadline_missed(
         &mut self,
         _the_reader: &DataReader<Self::Foo>,
         _status: RequestedDeadlineMissedStatus,
     ) {
     }
+
+    /// Method that is called when this reader reports a requested incompatible QoS status.
     fn on_requested_incompatible_qos(
         &mut self,
         _the_reader: &DataReader<Self::Foo>,
         _status: RequestedIncompatibleQosStatus,
     ) {
     }
+
+    /// Method that is called when this reader reports a subscription matched status.
     fn on_subscription_matched(
         &mut self,
         _the_reader: &DataReader<Self::Foo>,
         _status: SubscriptionMatchedStatus,
     ) {
     }
+
+    /// Method that is called when this reader reports a sample lost status.
     fn on_sample_lost(&mut self, _the_reader: &DataReader<Self::Foo>, _status: SampleLostStatus) {}
 }

--- a/dds/src/dds/subscription/sample_info.rs
+++ b/dds/src/dds/subscription/sample_info.rs
@@ -27,7 +27,7 @@ pub enum ViewStateKind {
 /// Special constant containing a list of all the view states.
 pub const ANY_VIEW_STATE: &[ViewStateKind] = &[ViewStateKind::New, ViewStateKind::NotNew];
 
-// Enumeration of the possible instance states
+/// Enumeration of the possible instance states
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum InstanceStateKind {
     /// This value indicates that  (a) samples have been received for the instance, (b) there are live [`DataWriter`](crate::publication::data_writer::DataWriter)

--- a/dds/src/dds/subscription/subscriber_listener.rs
+++ b/dds/src/dds/subscription/subscriber_listener.rs
@@ -5,7 +5,7 @@ use crate::infrastructure::status::{
 
 use super::{data_reader::AnyDataReader, subscriber::Subscriber};
 
-/// This trait represents a listener object which can be associated with the ['Subscriber'](super::publisher::Publisher) entity.
+/// This trait represents a listener object which can be associated with the [`Subscriber`](super::subscriber::Subscriber) entity.
 pub trait SubscriberListener {
     /// Method that is called when any reader belonging to this subcriber reports new data available. This method is triggered before the on_data_available method.
     fn on_data_on_readers(&mut self, _the_subscriber: &Subscriber) {}

--- a/dds/src/dds/subscription/subscriber_listener.rs
+++ b/dds/src/dds/subscription/subscriber_listener.rs
@@ -5,38 +5,54 @@ use crate::infrastructure::status::{
 
 use super::{data_reader::AnyDataReader, subscriber::Subscriber};
 
+/// This trait represents a listener object which can be associated with the ['Subscriber'](super::publisher::Publisher) entity.
 pub trait SubscriberListener {
+    /// Method that is called when any reader belonging to this subcriber reports new data available. This method is triggered before the on_data_available method.
     fn on_data_on_readers(&mut self, _the_subscriber: &Subscriber) {}
+
+    /// Method that is called when any reader belonging to this subcriber reports new data available.
     fn on_data_available(&mut self, _the_reader: &dyn AnyDataReader) {}
+
+    /// Method that is called when any reader belonging to this subcriber reports a sample rejected status.
     fn on_sample_rejected(
         &mut self,
         _the_reader: &dyn AnyDataReader,
         _status: SampleRejectedStatus,
     ) {
     }
+
+    /// Method that is called when any reader belonging to this subcriber reports a liveliness changed status.
     fn on_liveliness_changed(
         &mut self,
         _the_reader: &dyn AnyDataReader,
         _status: LivelinessChangedStatus,
     ) {
     }
+
+    /// Method that is called when any reader belonging to this subcriber reports a requested deadline missed status.
     fn on_requested_deadline_missed(
         &mut self,
         _the_reader: &dyn AnyDataReader,
         _status: RequestedDeadlineMissedStatus,
     ) {
     }
+
+    /// Method that is called when any reader belonging to this subcriber reports a requested incompatible QoS status.
     fn on_requested_incompatible_qos(
         &mut self,
         _the_reader: &dyn AnyDataReader,
         _status: RequestedIncompatibleQosStatus,
     ) {
     }
+
+    /// Method that is called when any reader belonging to this subcriber reports a subscription matched status.
     fn on_subscription_matched(
         &mut self,
         _the_reader: &dyn AnyDataReader,
         _status: SubscriptionMatchedStatus,
     ) {
     }
+
+    /// Method that is called when any reader belonging to this subcriber reports a sample lost status.
     fn on_sample_lost(&mut self, _the_reader: &dyn AnyDataReader, _status: SampleLostStatus) {}
 }

--- a/dds/src/dds/topic_definition/mod.rs
+++ b/dds/src/dds/topic_definition/mod.rs
@@ -4,5 +4,5 @@ pub mod topic;
 /// Contains the [`TopicListener`](crate::topic_definition::topic_listener::TopicListener) trait.
 pub mod topic_listener;
 
-/// Module containing the classes needed to publish and subscribe types using DustDDS
+/// Contains the classes needed to publish and subscribe types using DustDDS
 pub mod type_support;

--- a/dds/src/dds/topic_definition/topic_listener.rs
+++ b/dds/src/dds/topic_definition/topic_listener.rs
@@ -1,5 +1,7 @@
 use crate::{infrastructure::status::InconsistentTopicStatus, topic_definition::topic::Topic};
 
+/// Listener associated with the ['Topic'] entity.
 pub trait TopicListener {
+    /// Method that is called when an inconsistent version of this topic is discovered.
     fn on_inconsistent_topic(&mut self, _the_topic: &Topic, _status: InconsistentTopicStatus) {}
 }

--- a/dds/src/dds/topic_definition/topic_listener.rs
+++ b/dds/src/dds/topic_definition/topic_listener.rs
@@ -1,6 +1,6 @@
 use crate::{infrastructure::status::InconsistentTopicStatus, topic_definition::topic::Topic};
 
-/// Listener associated with the ['Topic'] entity.
+/// Listener associated with the [`Topic`] entity.
 pub trait TopicListener {
     /// Method that is called when an inconsistent version of this topic is discovered.
     fn on_inconsistent_topic(&mut self, _the_topic: &Topic, _status: InconsistentTopicStatus) {}

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -86,12 +86,12 @@ pub trait DdsDeserialize<'de>: Sized {
 }
 
 /// This trait defines the key associated with the type. The key is used to identify different instances of the type.
-/// The returned key object must implement ['CdrSerialize'] and ['CdrDeserialize'] since CDR is the format always
+/// The returned key object must implement [`CdrSerialize`] and [`CdrDeserialize`] since CDR is the format always
 /// used to transmit the key information on the wire and this can not be modified by the user.
 ///
 /// ## Derivable
 ///
-/// This trait can be automatically derived if all the field marked `#[dust_dds(key)]` implement ['CdrSerialize'] and ['CdrDeserialize']
+/// This trait can be automatically derived if all the field marked `#[dust_dds(key)]` implement [`CdrSerialize`] and [`CdrDeserialize`]
 ///
 pub trait DdsKey {
     /// Type representing the key for the type in which this trait is implemented

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -51,6 +51,7 @@ pub trait DynamicTypeInterface {
 /// This trait can be automatically derived. If the struct has any field marked `#[dust_dds(key)]`
 /// then HAS_KEY will be set to 'true' otherwise will be set to 'false'.
 pub trait DdsHasKey {
+    /// Constant indicating whether the associated type has a key or not.
     const HAS_KEY: bool;
 }
 
@@ -65,6 +66,7 @@ pub trait DdsHasKey {
 /// The format to be used for serializing can be selected by applying the '#[dust_dds(format = ...)]' attribute to the container.
 /// Available format options are "CDR_LE", "CDR_BE", "PL_CDR_LE" and "PL_CDR_BE".
 pub trait DdsSerialize {
+    /// Method to serialize the instance of the type into the provided writer.
     fn serialize_data(&self, writer: impl std::io::Write) -> DdsResult<()>;
 }
 
@@ -79,6 +81,7 @@ pub trait DdsSerialize {
 /// The format to be used for deserializing can be selected by applying the '#[dust_dds(format = ...)]' attribute to the container.
 /// Available format options are "CDR_LE", "CDR_BE", "PL_CDR_LE" and "PL_CDR_BE".
 pub trait DdsDeserialize<'de>: Sized {
+    /// Method to deserialize the bytes into an instance of the type.
     fn deserialize_data(serialized_data: &'de [u8]) -> DdsResult<Self>;
 }
 
@@ -91,10 +94,13 @@ pub trait DdsDeserialize<'de>: Sized {
 /// This trait can be automatically derived if all the field marked `#[dust_dds(key)]` implement ['CdrSerialize'] and ['CdrDeserialize']
 ///
 pub trait DdsKey {
+    /// Type representing the key for the type in which this trait is implemented
     type Key: CdrSerialize + for<'de> CdrDeserialize<'de>;
 
+    /// Method to get the key from an instance of the type.
     fn get_key(&self) -> DdsResult<Self::Key>;
 
+    /// Method to get the key from a serialized instance of the type.
     fn get_key_from_serialized_data(serialized_foo: &[u8]) -> DdsResult<Self::Key>;
 }
 
@@ -106,6 +112,7 @@ pub trait DdsKey {
 ///
 /// This trait can be automatically derived for every DustDDS supported type.
 pub trait DdsTypeXml {
+    /// Method to get the XML representation of a type.
     fn get_type_xml() -> Option<String>;
 }
 

--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -6,7 +6,7 @@ use crate::{
     infrastructure::{error::DdsResult, status::StatusKind},
 };
 
-/// Async version of ['StatusCondition'](crate::infrastructure::condition::StatusCondition).
+/// Async version of [`StatusCondition`](crate::infrastructure::condition::StatusCondition).
 #[derive(Clone)]
 pub struct StatusConditionAsync {
     address: ActorAddress<StatusConditionActor>,
@@ -30,7 +30,7 @@ impl StatusConditionAsync {
 }
 
 impl StatusConditionAsync {
-    /// Async version of ['get_enabled_statuses'](crate::infrastructure::condition::StatusCondition::get_enabled_statuses).
+    /// Async version of [`get_enabled_statuses`](crate::infrastructure::condition::StatusCondition::get_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn get_enabled_statuses(&self) -> DdsResult<Vec<StatusKind>> {
         self.address
@@ -38,7 +38,7 @@ impl StatusConditionAsync {
             .await
     }
 
-    /// Async version of ['set_enabled_statuses'](crate::infrastructure::condition::StatusCondition::set_enabled_statuses).
+    /// Async version of [`set_enabled_statuses`](crate::infrastructure::condition::StatusCondition::set_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn set_enabled_statuses(&self, mask: &[StatusKind]) -> DdsResult<()> {
         self.address
@@ -48,7 +48,7 @@ impl StatusConditionAsync {
             .await
     }
 
-    /// Async version of ['get_entity'](crate::infrastructure::condition::StatusCondition::get_entity).
+    /// Async version of [`get_entity`](crate::infrastructure::condition::StatusCondition::get_entity).
     #[tracing::instrument(skip(self))]
     pub async fn get_entity(&self) {
         todo!()
@@ -56,7 +56,7 @@ impl StatusConditionAsync {
 }
 
 impl StatusConditionAsync {
-    /// Async version of ['get_trigger_value'](crate::infrastructure::condition::StatusCondition::get_trigger_value).
+    /// Async version of [`get_trigger_value`](crate::infrastructure::condition::StatusCondition::get_trigger_value).
     #[tracing::instrument(skip(self))]
     pub async fn get_trigger_value(&self) -> DdsResult<bool> {
         self.address

--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -6,6 +6,7 @@ use crate::{
     infrastructure::{error::DdsResult, status::StatusKind},
 };
 
+/// Async version of ['StatusCondition'](crate::infrastructure::condition::StatusCondition).
 #[derive(Clone)]
 pub struct StatusConditionAsync {
     address: ActorAddress<StatusConditionActor>,
@@ -29,6 +30,7 @@ impl StatusConditionAsync {
 }
 
 impl StatusConditionAsync {
+    /// Async version of ['get_enabled_statuses'](crate::infrastructure::condition::StatusCondition::get_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn get_enabled_statuses(&self) -> DdsResult<Vec<StatusKind>> {
         self.address
@@ -36,6 +38,7 @@ impl StatusConditionAsync {
             .await
     }
 
+    /// Async version of ['set_enabled_statuses'](crate::infrastructure::condition::StatusCondition::set_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn set_enabled_statuses(&self, mask: &[StatusKind]) -> DdsResult<()> {
         self.address
@@ -45,6 +48,7 @@ impl StatusConditionAsync {
             .await
     }
 
+    /// Async version of ['get_entity'](crate::infrastructure::condition::StatusCondition::get_entity).
     #[tracing::instrument(skip(self))]
     pub async fn get_entity(&self) {
         todo!()
@@ -52,6 +56,7 @@ impl StatusConditionAsync {
 }
 
 impl StatusConditionAsync {
+    /// Async version of ['get_trigger_value'](crate::infrastructure::condition::StatusCondition::get_trigger_value).
     #[tracing::instrument(skip(self))]
     pub async fn get_trigger_value(&self) -> DdsResult<bool> {
         self.address

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -36,7 +36,7 @@ use std::marker::PhantomData;
 
 use super::{condition::StatusConditionAsync, subscriber::SubscriberAsync, topic::TopicAsync};
 
-/// Async version of ['DataReader'](crate::subscription::data_reader::DataReader).
+/// Async version of [`DataReader`](crate::subscription::data_reader::DataReader).
 pub struct DataReaderAsync<Foo> {
     reader_address: ActorAddress<DataReaderActor>,
     subscriber_address: ActorAddress<SubscriberActor>,
@@ -107,7 +107,7 @@ impl<Foo> Clone for DataReaderAsync<Foo> {
 }
 
 impl<Foo> DataReaderAsync<Foo> {
-    /// Async version of ['read'](crate::subscription::data_reader::DataReader::read).
+    /// Async version of [`read`](crate::subscription::data_reader::DataReader::read).
     #[tracing::instrument(skip(self))]
     pub async fn read(
         &self,
@@ -133,7 +133,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
-    /// Async version of ['take'](crate::subscription::data_reader::DataReader::take).
+    /// Async version of [`take`](crate::subscription::data_reader::DataReader::take).
     #[tracing::instrument(skip(self))]
     pub async fn take(
         &self,
@@ -159,7 +159,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
-    /// Async version of ['read_next_sample'](crate::subscription::data_reader::DataReader::read_next_sample).
+    /// Async version of [`read_next_sample`](crate::subscription::data_reader::DataReader::read_next_sample).
     #[tracing::instrument(skip(self))]
     pub async fn read_next_sample(&self) -> DdsResult<Sample<Foo>> {
         let mut samples = {
@@ -177,7 +177,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Ok(Sample::new(data, sample_info))
     }
 
-    /// Async version of ['take_next_sample'](crate::subscription::data_reader::DataReader::take_next_sample).
+    /// Async version of [`take_next_sample`](crate::subscription::data_reader::DataReader::take_next_sample).
     #[tracing::instrument(skip(self))]
     pub async fn take_next_sample(&self) -> DdsResult<Sample<Foo>> {
         let mut samples = self
@@ -194,7 +194,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Ok(Sample::new(data, sample_info))
     }
 
-    /// Async version of ['read_instance'](crate::subscription::data_reader::DataReader::read_instance).
+    /// Async version of [`read_instance`](crate::subscription::data_reader::DataReader::read_instance).
     #[tracing::instrument(skip(self))]
     pub async fn read_instance(
         &self,
@@ -220,7 +220,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
-    /// Async version of ['take_instance'](crate::subscription::data_reader::DataReader::take_instance).
+    /// Async version of [`take_instance`](crate::subscription::data_reader::DataReader::take_instance).
     #[tracing::instrument(skip(self))]
     pub async fn take_instance(
         &self,
@@ -246,7 +246,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
-    /// Async version of ['read_next_instance'](crate::subscription::data_reader::DataReader::read_next_instance).
+    /// Async version of [`read_next_instance`](crate::subscription::data_reader::DataReader::read_next_instance).
     #[tracing::instrument(skip(self))]
     pub async fn read_next_instance(
         &self,
@@ -272,7 +272,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
-    /// Async version of ['take_next_instance'](crate::subscription::data_reader::DataReader::take_next_instance).
+    /// Async version of [`take_next_instance`](crate::subscription::data_reader::DataReader::take_next_instance).
     #[tracing::instrument(skip(self))]
     pub async fn take_next_instance(
         &self,
@@ -298,7 +298,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
-    /// Async version of ['get_key_value'](crate::subscription::data_reader::DataReader::get_key_value).
+    /// Async version of [`get_key_value`](crate::subscription::data_reader::DataReader::get_key_value).
     #[tracing::instrument(skip(self, _key_holder))]
     pub async fn get_key_value(
         &self,
@@ -308,7 +308,7 @@ impl<Foo> DataReaderAsync<Foo> {
         todo!()
     }
 
-    /// Async version of ['lookup_instance'](crate::subscription::data_reader::DataReader::lookup_instance).
+    /// Async version of [`lookup_instance`](crate::subscription::data_reader::DataReader::lookup_instance).
     #[tracing::instrument(skip(self, _instance))]
     pub async fn lookup_instance(&self, _instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
         todo!()
@@ -316,13 +316,13 @@ impl<Foo> DataReaderAsync<Foo> {
 }
 
 impl<Foo> DataReaderAsync<Foo> {
-    /// Async version of ['get_liveliness_changed_status'](crate::subscription::data_reader::DataReader::get_liveliness_changed_status).
+    /// Async version of [`get_liveliness_changed_status`](crate::subscription::data_reader::DataReader::get_liveliness_changed_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_liveliness_changed_status(&self) -> DdsResult<LivelinessChangedStatus> {
         todo!()
     }
 
-    /// Async version of ['get_requested_deadline_missed_status'](crate::subscription::data_reader::DataReader::get_requested_deadline_missed_status).
+    /// Async version of [`get_requested_deadline_missed_status`](crate::subscription::data_reader::DataReader::get_requested_deadline_missed_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_requested_deadline_missed_status(
         &self,
@@ -330,7 +330,7 @@ impl<Foo> DataReaderAsync<Foo> {
         todo!()
     }
 
-    /// Async version of ['get_requested_incompatible_qos_status'](crate::subscription::data_reader::DataReader::get_requested_incompatible_qos_status).
+    /// Async version of [`get_requested_incompatible_qos_status`](crate::subscription::data_reader::DataReader::get_requested_incompatible_qos_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_requested_incompatible_qos_status(
         &self,
@@ -338,19 +338,19 @@ impl<Foo> DataReaderAsync<Foo> {
         todo!()
     }
 
-    /// Async version of ['get_sample_lost_status'](crate::subscription::data_reader::DataReader::get_sample_lost_status).
+    /// Async version of [`get_sample_lost_status`](crate::subscription::data_reader::DataReader::get_sample_lost_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_sample_lost_status(&self) -> DdsResult<SampleLostStatus> {
         todo!()
     }
 
-    /// Async version of ['get_sample_rejected_status'](crate::subscription::data_reader::DataReader::get_sample_rejected_status).
+    /// Async version of [`get_sample_rejected_status`](crate::subscription::data_reader::DataReader::get_sample_rejected_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_sample_rejected_status(&self) -> DdsResult<SampleRejectedStatus> {
         todo!()
     }
 
-    /// Async version of ['get_subscription_matched_status'](crate::subscription::data_reader::DataReader::get_subscription_matched_status).
+    /// Async version of [`get_subscription_matched_status`](crate::subscription::data_reader::DataReader::get_subscription_matched_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_subscription_matched_status(&self) -> DdsResult<SubscriptionMatchedStatus> {
         self.reader_address
@@ -358,7 +358,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .await
     }
 
-    /// Async version of ['get_topicdescription'](crate::subscription::data_reader::DataReader::get_topicdescription).
+    /// Async version of [`get_topicdescription`](crate::subscription::data_reader::DataReader::get_topicdescription).
     #[tracing::instrument(skip(self))]
     pub async fn get_topicdescription(&self) -> DdsResult<TopicAsync> {
         Ok(TopicAsync::new(
@@ -368,7 +368,7 @@ impl<Foo> DataReaderAsync<Foo> {
         ))
     }
 
-    /// Async version of ['get_subscriber'](crate::subscription::data_reader::DataReader::get_subscriber).
+    /// Async version of [`get_subscriber`](crate::subscription::data_reader::DataReader::get_subscriber).
     #[tracing::instrument(skip(self))]
     pub async fn get_subscriber(&self) -> DdsResult<SubscriberAsync> {
         Ok(SubscriberAsync::new(
@@ -378,7 +378,7 @@ impl<Foo> DataReaderAsync<Foo> {
         ))
     }
 
-    /// Async version of ['wait_for_historical_data'](crate::subscription::data_reader::DataReader::wait_for_historical_data).
+    /// Async version of [`wait_for_historical_data`](crate::subscription::data_reader::DataReader::wait_for_historical_data).
     #[tracing::instrument(skip(self))]
     pub async fn wait_for_historical_data(&self, max_wait: Duration) -> DdsResult<()> {
         let start_time = std::time::Instant::now();
@@ -396,7 +396,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Err(DdsError::Timeout)
     }
 
-    /// Async version of ['get_matched_publication_data'](crate::subscription::data_reader::DataReader::get_matched_publication_data).
+    /// Async version of [`get_matched_publication_data`](crate::subscription::data_reader::DataReader::get_matched_publication_data).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_publication_data(
         &self,
@@ -409,7 +409,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .await?
     }
 
-    /// Async version of ['get_matched_publications'](crate::subscription::data_reader::DataReader::get_matched_publications).
+    /// Async version of [`get_matched_publications`](crate::subscription::data_reader::DataReader::get_matched_publications).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_publications(&self) -> DdsResult<Vec<InstanceHandle>> {
         self.reader_address
@@ -419,7 +419,7 @@ impl<Foo> DataReaderAsync<Foo> {
 }
 
 impl<Foo> DataReaderAsync<Foo> {
-    /// Async version of ['set_qos'](crate::subscription::data_reader::DataReader::set_qos).
+    /// Async version of [`set_qos`](crate::subscription::data_reader::DataReader::set_qos).
     pub async fn set_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
         let q = match qos {
             QosKind::Default => {
@@ -485,7 +485,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Ok(())
     }
 
-    /// Async version of ['get_qos'](crate::subscription::data_reader::DataReader::get_qos).
+    /// Async version of [`get_qos`](crate::subscription::data_reader::DataReader::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DataReaderQos> {
         self.reader_address
@@ -493,7 +493,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .await
     }
 
-    /// Async version of ['get_statuscondition'](crate::subscription::data_reader::DataReader::get_statuscondition).
+    /// Async version of [`get_statuscondition`](crate::subscription::data_reader::DataReader::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         self.reader_address
@@ -502,13 +502,13 @@ impl<Foo> DataReaderAsync<Foo> {
             .map(|c| StatusConditionAsync::new(c, self.runtime_handle.clone()))
     }
 
-    /// Async version of ['get_status_changes'](crate::subscription::data_reader::DataReader::get_status_changes).
+    /// Async version of [`get_status_changes`](crate::subscription::data_reader::DataReader::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
-    /// Async version of ['enable'](crate::subscription::data_reader::DataReader::enable).
+    /// Async version of [`enable`](crate::subscription::data_reader::DataReader::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -565,7 +565,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Ok(())
     }
 
-    /// Async version of ['get_instance_handle'](crate::subscription::data_reader::DataReader::get_instance_handle).
+    /// Async version of [`get_instance_handle`](crate::subscription::data_reader::DataReader::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.reader_address
@@ -573,7 +573,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .await
     }
 
-    /// Async version of ['set_listener'](crate::subscription::data_reader::DataReader::set_listener).
+    /// Async version of [`set_listener`](crate::subscription::data_reader::DataReader::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -36,6 +36,7 @@ use std::marker::PhantomData;
 
 use super::{condition::StatusConditionAsync, subscriber::SubscriberAsync, topic::TopicAsync};
 
+/// Async version of ['DataReader'](crate::subscription::data_reader::DataReader).
 pub struct DataReaderAsync<Foo> {
     reader_address: ActorAddress<DataReaderActor>,
     subscriber_address: ActorAddress<SubscriberActor>,
@@ -106,6 +107,7 @@ impl<Foo> Clone for DataReaderAsync<Foo> {
 }
 
 impl<Foo> DataReaderAsync<Foo> {
+    /// Async version of ['read'](crate::subscription::data_reader::DataReader::read).
     #[tracing::instrument(skip(self))]
     pub async fn read(
         &self,
@@ -131,6 +133,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
+    /// Async version of ['take'](crate::subscription::data_reader::DataReader::take).
     #[tracing::instrument(skip(self))]
     pub async fn take(
         &self,
@@ -156,6 +159,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
+    /// Async version of ['read_next_sample'](crate::subscription::data_reader::DataReader::read_next_sample).
     #[tracing::instrument(skip(self))]
     pub async fn read_next_sample(&self) -> DdsResult<Sample<Foo>> {
         let mut samples = {
@@ -173,6 +177,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Ok(Sample::new(data, sample_info))
     }
 
+    /// Async version of ['take_next_sample'](crate::subscription::data_reader::DataReader::take_next_sample).
     #[tracing::instrument(skip(self))]
     pub async fn take_next_sample(&self) -> DdsResult<Sample<Foo>> {
         let mut samples = self
@@ -189,6 +194,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Ok(Sample::new(data, sample_info))
     }
 
+    /// Async version of ['read_instance'](crate::subscription::data_reader::DataReader::read_instance).
     #[tracing::instrument(skip(self))]
     pub async fn read_instance(
         &self,
@@ -214,6 +220,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
+    /// Async version of ['take_instance'](crate::subscription::data_reader::DataReader::take_instance).
     #[tracing::instrument(skip(self))]
     pub async fn take_instance(
         &self,
@@ -239,6 +246,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
+    /// Async version of ['read_next_instance'](crate::subscription::data_reader::DataReader::read_next_instance).
     #[tracing::instrument(skip(self))]
     pub async fn read_next_instance(
         &self,
@@ -264,6 +272,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
+    /// Async version of ['take_next_instance'](crate::subscription::data_reader::DataReader::take_next_instance).
     #[tracing::instrument(skip(self))]
     pub async fn take_next_instance(
         &self,
@@ -289,6 +298,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .collect())
     }
 
+    /// Async version of ['get_key_value'](crate::subscription::data_reader::DataReader::get_key_value).
     #[tracing::instrument(skip(self, _key_holder))]
     pub async fn get_key_value(
         &self,
@@ -298,6 +308,7 @@ impl<Foo> DataReaderAsync<Foo> {
         todo!()
     }
 
+    /// Async version of ['lookup_instance'](crate::subscription::data_reader::DataReader::lookup_instance).
     #[tracing::instrument(skip(self, _instance))]
     pub async fn lookup_instance(&self, _instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
         todo!()
@@ -305,11 +316,13 @@ impl<Foo> DataReaderAsync<Foo> {
 }
 
 impl<Foo> DataReaderAsync<Foo> {
+    /// Async version of ['get_liveliness_changed_status'](crate::subscription::data_reader::DataReader::get_liveliness_changed_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_liveliness_changed_status(&self) -> DdsResult<LivelinessChangedStatus> {
         todo!()
     }
 
+    /// Async version of ['get_requested_deadline_missed_status'](crate::subscription::data_reader::DataReader::get_requested_deadline_missed_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_requested_deadline_missed_status(
         &self,
@@ -317,6 +330,7 @@ impl<Foo> DataReaderAsync<Foo> {
         todo!()
     }
 
+    /// Async version of ['get_requested_incompatible_qos_status'](crate::subscription::data_reader::DataReader::get_requested_incompatible_qos_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_requested_incompatible_qos_status(
         &self,
@@ -324,16 +338,19 @@ impl<Foo> DataReaderAsync<Foo> {
         todo!()
     }
 
+    /// Async version of ['get_sample_lost_status'](crate::subscription::data_reader::DataReader::get_sample_lost_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_sample_lost_status(&self) -> DdsResult<SampleLostStatus> {
         todo!()
     }
 
+    /// Async version of ['get_sample_rejected_status'](crate::subscription::data_reader::DataReader::get_sample_rejected_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_sample_rejected_status(&self) -> DdsResult<SampleRejectedStatus> {
         todo!()
     }
 
+    /// Async version of ['get_subscription_matched_status'](crate::subscription::data_reader::DataReader::get_subscription_matched_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_subscription_matched_status(&self) -> DdsResult<SubscriptionMatchedStatus> {
         self.reader_address
@@ -341,6 +358,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .await
     }
 
+    /// Async version of ['get_topicdescription'](crate::subscription::data_reader::DataReader::get_topicdescription).
     #[tracing::instrument(skip(self))]
     pub async fn get_topicdescription(&self) -> DdsResult<TopicAsync> {
         Ok(TopicAsync::new(
@@ -350,6 +368,7 @@ impl<Foo> DataReaderAsync<Foo> {
         ))
     }
 
+    /// Async version of ['get_subscriber'](crate::subscription::data_reader::DataReader::get_subscriber).
     #[tracing::instrument(skip(self))]
     pub async fn get_subscriber(&self) -> DdsResult<SubscriberAsync> {
         Ok(SubscriberAsync::new(
@@ -359,6 +378,7 @@ impl<Foo> DataReaderAsync<Foo> {
         ))
     }
 
+    /// Async version of ['wait_for_historical_data'](crate::subscription::data_reader::DataReader::wait_for_historical_data).
     #[tracing::instrument(skip(self))]
     pub async fn wait_for_historical_data(&self, max_wait: Duration) -> DdsResult<()> {
         let start_time = std::time::Instant::now();
@@ -376,6 +396,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Err(DdsError::Timeout)
     }
 
+    /// Async version of ['get_matched_publication_data'](crate::subscription::data_reader::DataReader::get_matched_publication_data).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_publication_data(
         &self,
@@ -388,6 +409,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .await?
     }
 
+    /// Async version of ['get_matched_publications'](crate::subscription::data_reader::DataReader::get_matched_publications).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_publications(&self) -> DdsResult<Vec<InstanceHandle>> {
         self.reader_address
@@ -397,6 +419,7 @@ impl<Foo> DataReaderAsync<Foo> {
 }
 
 impl<Foo> DataReaderAsync<Foo> {
+    /// Async version of ['set_qos'](crate::subscription::data_reader::DataReader::set_qos).
     pub async fn set_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
         let q = match qos {
             QosKind::Default => {
@@ -462,6 +485,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Ok(())
     }
 
+    /// Async version of ['get_qos'](crate::subscription::data_reader::DataReader::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DataReaderQos> {
         self.reader_address
@@ -469,6 +493,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .await
     }
 
+    /// Async version of ['get_statuscondition'](crate::subscription::data_reader::DataReader::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         self.reader_address
@@ -477,11 +502,13 @@ impl<Foo> DataReaderAsync<Foo> {
             .map(|c| StatusConditionAsync::new(c, self.runtime_handle.clone()))
     }
 
+    /// Async version of ['get_status_changes'](crate::subscription::data_reader::DataReader::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
+    /// Async version of ['enable'](crate::subscription::data_reader::DataReader::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -538,6 +565,7 @@ impl<Foo> DataReaderAsync<Foo> {
         Ok(())
     }
 
+    /// Async version of ['get_instance_handle'](crate::subscription::data_reader::DataReader::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.reader_address
@@ -545,6 +573,7 @@ impl<Foo> DataReaderAsync<Foo> {
             .await
     }
 
+    /// Async version of ['set_listener'](crate::subscription::data_reader::DataReader::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -27,6 +27,7 @@ use crate::{
 
 use super::{condition::StatusConditionAsync, publisher::PublisherAsync, topic::TopicAsync};
 
+/// Async version of ['DataWriter'](crate::publication::data_writer::DataWriter).
 pub struct DataWriterAsync<Foo> {
     writer_address: ActorAddress<DataWriterActor>,
     publisher_address: ActorAddress<PublisherActor>,
@@ -100,6 +101,7 @@ impl<Foo> DataWriterAsync<Foo>
 where
     Foo: DdsSerialize,
 {
+    /// Async version of ['register_instance'](crate::publication::data_writer::DataWriter::register_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn register_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
         let timestamp = {
@@ -111,6 +113,7 @@ where
             .await
     }
 
+    /// Async version of ['register_instance_w_timestamp'](crate::publication::data_writer::DataWriter::register_instance_w_timestamp).
     #[tracing::instrument(skip(self, _instance))]
     pub async fn register_instance_w_timestamp(
         &self,
@@ -120,6 +123,7 @@ where
         todo!()
     }
 
+    /// Async version of ['unregister_instance'](crate::publication::data_writer::DataWriter::unregister_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn unregister_instance(
         &self,
@@ -135,6 +139,7 @@ where
             .await
     }
 
+    /// Async version of ['unregister_instance_w_timestamp'](crate::publication::data_writer::DataWriter::unregister_instance_w_timestamp).
     #[tracing::instrument(skip(self, instance))]
     pub async fn unregister_instance_w_timestamp(
         &self,
@@ -202,6 +207,7 @@ where
         }
     }
 
+    /// Async version of ['get_key_value'](crate::publication::data_writer::DataWriter::get_key_value).
     #[tracing::instrument(skip(self, _key_holder))]
     pub async fn get_key_value(
         &self,
@@ -211,6 +217,7 @@ where
         todo!()
     }
 
+    /// Async version of ['lookup_instance'](crate::publication::data_writer::DataWriter::lookup_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn lookup_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
         let type_name = self
@@ -239,6 +246,7 @@ where
             .await?
     }
 
+    /// Async version of ['write'](crate::publication::data_writer::DataWriter::write).
     #[tracing::instrument(skip(self, data))]
     pub async fn write(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
         let timestamp = {
@@ -249,6 +257,7 @@ where
         self.write_w_timestamp(data, handle, timestamp).await
     }
 
+    /// Async version of ['write_w_timestamp'](crate::publication::data_writer::DataWriter::write_w_timestamp).
     #[tracing::instrument(skip(self, data))]
     pub async fn write_w_timestamp(
         &self,
@@ -293,6 +302,7 @@ where
         Ok(())
     }
 
+    /// Async version of ['dispose'](crate::publication::data_writer::DataWriter::dispose).
     #[tracing::instrument(skip(self, data))]
     pub async fn dispose(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
         let timestamp = {
@@ -303,6 +313,7 @@ where
         self.dispose_w_timestamp(data, handle, timestamp).await
     }
 
+    /// Async version of ['dispose_w_timestamp'](crate::publication::data_writer::DataWriter::dispose_w_timestamp).
     #[tracing::instrument(skip(self, data))]
     pub async fn dispose_w_timestamp(
         &self,
@@ -367,6 +378,7 @@ where
 }
 
 impl<Foo> DataWriterAsync<Foo> {
+    /// Async version of ['wait_for_acknowledgments'](crate::publication::data_writer::DataWriter::wait_for_acknowledgments).
     #[tracing::instrument(skip(self))]
     pub async fn wait_for_acknowledgments(&self, max_wait: Duration) -> DdsResult<()> {
         let start_time = Instant::now();
@@ -384,11 +396,13 @@ impl<Foo> DataWriterAsync<Foo> {
         Err(DdsError::Timeout)
     }
 
+    /// Async version of ['get_liveliness_lost_status'](crate::publication::data_writer::DataWriter::get_liveliness_lost_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_liveliness_lost_status(&self) -> DdsResult<LivelinessLostStatus> {
         todo!()
     }
 
+    /// Async version of ['get_offered_deadline_missed_status'](crate::publication::data_writer::DataWriter::get_offered_deadline_missed_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_offered_deadline_missed_status(
         &self,
@@ -396,6 +410,7 @@ impl<Foo> DataWriterAsync<Foo> {
         todo!()
     }
 
+    /// Async version of ['get_offered_incompatible_qos_status'](crate::publication::data_writer::DataWriter::get_offered_incompatible_qos_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_offered_incompatible_qos_status(
         &self,
@@ -403,6 +418,7 @@ impl<Foo> DataWriterAsync<Foo> {
         todo!()
     }
 
+    /// Async version of ['get_publication_matched_status'](crate::publication::data_writer::DataWriter::get_publication_matched_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_publication_matched_status(&self) -> DdsResult<PublicationMatchedStatus> {
         self.writer_address
@@ -410,6 +426,7 @@ impl<Foo> DataWriterAsync<Foo> {
             .await
     }
 
+    /// Async version of ['get_topic'](crate::publication::data_writer::DataWriter::get_topic).
     #[tracing::instrument(skip(self))]
     pub async fn get_topic(&self) -> DdsResult<TopicAsync> {
         Ok(TopicAsync::new(
@@ -419,6 +436,7 @@ impl<Foo> DataWriterAsync<Foo> {
         ))
     }
 
+    /// Async version of ['get_publisher'](crate::publication::data_writer::DataWriter::get_publisher).
     #[tracing::instrument(skip(self))]
     pub async fn get_publisher(&self) -> DdsResult<PublisherAsync> {
         Ok(PublisherAsync::new(
@@ -428,11 +446,13 @@ impl<Foo> DataWriterAsync<Foo> {
         ))
     }
 
+    /// Async version of ['assert_liveliness'](crate::publication::data_writer::DataWriter::assert_liveliness).
     #[tracing::instrument(skip(self))]
     pub async fn assert_liveliness(&self) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['get_matched_subscription_data'](crate::publication::data_writer::DataWriter::get_matched_subscription_data).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_subscription_data(
         &self,
@@ -446,6 +466,7 @@ impl<Foo> DataWriterAsync<Foo> {
             .ok_or(DdsError::BadParameter)
     }
 
+    /// Async version of ['get_matched_subscriptions'](crate::publication::data_writer::DataWriter::get_matched_subscriptions).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_subscriptions(&self) -> DdsResult<Vec<InstanceHandle>> {
         self.writer_address
@@ -455,6 +476,7 @@ impl<Foo> DataWriterAsync<Foo> {
 }
 
 impl<Foo> DataWriterAsync<Foo> {
+    /// Async version of ['set_qos'](crate::publication::data_writer::DataWriter::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
         let q = match qos {
@@ -525,6 +547,7 @@ impl<Foo> DataWriterAsync<Foo> {
         Ok(())
     }
 
+    /// Async version of ['get_qos'](crate::publication::data_writer::DataWriter::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DataWriterQos> {
         self.writer_address
@@ -532,6 +555,7 @@ impl<Foo> DataWriterAsync<Foo> {
             .await
     }
 
+    /// Async version of ['get_statuscondition'](crate::publication::data_writer::DataWriter::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         self.writer_address
@@ -540,11 +564,13 @@ impl<Foo> DataWriterAsync<Foo> {
             .map(|c| StatusConditionAsync::new(c, self.runtime_handle.clone()))
     }
 
+    /// Async version of ['get_status_changes'](crate::publication::data_writer::DataWriter::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
+    /// Async version of ['enable'](crate::publication::data_writer::DataWriter::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -602,6 +628,7 @@ impl<Foo> DataWriterAsync<Foo> {
         Ok(())
     }
 
+    /// Async version of ['get_instance_handle'](crate::publication::data_writer::DataWriter::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.writer_address
@@ -609,6 +636,7 @@ impl<Foo> DataWriterAsync<Foo> {
             .await
     }
 
+    /// Async version of ['set_listener'](crate::publication::data_writer::DataWriter::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -27,7 +27,7 @@ use crate::{
 
 use super::{condition::StatusConditionAsync, publisher::PublisherAsync, topic::TopicAsync};
 
-/// Async version of ['DataWriter'](crate::publication::data_writer::DataWriter).
+/// Async version of [`DataWriter`](crate::publication::data_writer::DataWriter).
 pub struct DataWriterAsync<Foo> {
     writer_address: ActorAddress<DataWriterActor>,
     publisher_address: ActorAddress<PublisherActor>,
@@ -101,7 +101,7 @@ impl<Foo> DataWriterAsync<Foo>
 where
     Foo: DdsSerialize,
 {
-    /// Async version of ['register_instance'](crate::publication::data_writer::DataWriter::register_instance).
+    /// Async version of [`register_instance`](crate::publication::data_writer::DataWriter::register_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn register_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
         let timestamp = {
@@ -113,7 +113,7 @@ where
             .await
     }
 
-    /// Async version of ['register_instance_w_timestamp'](crate::publication::data_writer::DataWriter::register_instance_w_timestamp).
+    /// Async version of [`register_instance_w_timestamp`](crate::publication::data_writer::DataWriter::register_instance_w_timestamp).
     #[tracing::instrument(skip(self, _instance))]
     pub async fn register_instance_w_timestamp(
         &self,
@@ -123,7 +123,7 @@ where
         todo!()
     }
 
-    /// Async version of ['unregister_instance'](crate::publication::data_writer::DataWriter::unregister_instance).
+    /// Async version of [`unregister_instance`](crate::publication::data_writer::DataWriter::unregister_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn unregister_instance(
         &self,
@@ -139,7 +139,7 @@ where
             .await
     }
 
-    /// Async version of ['unregister_instance_w_timestamp'](crate::publication::data_writer::DataWriter::unregister_instance_w_timestamp).
+    /// Async version of [`unregister_instance_w_timestamp`](crate::publication::data_writer::DataWriter::unregister_instance_w_timestamp).
     #[tracing::instrument(skip(self, instance))]
     pub async fn unregister_instance_w_timestamp(
         &self,
@@ -207,7 +207,7 @@ where
         }
     }
 
-    /// Async version of ['get_key_value'](crate::publication::data_writer::DataWriter::get_key_value).
+    /// Async version of [`get_key_value`](crate::publication::data_writer::DataWriter::get_key_value).
     #[tracing::instrument(skip(self, _key_holder))]
     pub async fn get_key_value(
         &self,
@@ -217,7 +217,7 @@ where
         todo!()
     }
 
-    /// Async version of ['lookup_instance'](crate::publication::data_writer::DataWriter::lookup_instance).
+    /// Async version of [`lookup_instance`](crate::publication::data_writer::DataWriter::lookup_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn lookup_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
         let type_name = self
@@ -246,7 +246,7 @@ where
             .await?
     }
 
-    /// Async version of ['write'](crate::publication::data_writer::DataWriter::write).
+    /// Async version of [`write`](crate::publication::data_writer::DataWriter::write).
     #[tracing::instrument(skip(self, data))]
     pub async fn write(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
         let timestamp = {
@@ -257,7 +257,7 @@ where
         self.write_w_timestamp(data, handle, timestamp).await
     }
 
-    /// Async version of ['write_w_timestamp'](crate::publication::data_writer::DataWriter::write_w_timestamp).
+    /// Async version of [`write_w_timestamp`](crate::publication::data_writer::DataWriter::write_w_timestamp).
     #[tracing::instrument(skip(self, data))]
     pub async fn write_w_timestamp(
         &self,
@@ -302,7 +302,7 @@ where
         Ok(())
     }
 
-    /// Async version of ['dispose'](crate::publication::data_writer::DataWriter::dispose).
+    /// Async version of [`dispose`](crate::publication::data_writer::DataWriter::dispose).
     #[tracing::instrument(skip(self, data))]
     pub async fn dispose(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
         let timestamp = {
@@ -313,7 +313,7 @@ where
         self.dispose_w_timestamp(data, handle, timestamp).await
     }
 
-    /// Async version of ['dispose_w_timestamp'](crate::publication::data_writer::DataWriter::dispose_w_timestamp).
+    /// Async version of [`dispose_w_timestamp`](crate::publication::data_writer::DataWriter::dispose_w_timestamp).
     #[tracing::instrument(skip(self, data))]
     pub async fn dispose_w_timestamp(
         &self,
@@ -378,7 +378,7 @@ where
 }
 
 impl<Foo> DataWriterAsync<Foo> {
-    /// Async version of ['wait_for_acknowledgments'](crate::publication::data_writer::DataWriter::wait_for_acknowledgments).
+    /// Async version of [`wait_for_acknowledgments`](crate::publication::data_writer::DataWriter::wait_for_acknowledgments).
     #[tracing::instrument(skip(self))]
     pub async fn wait_for_acknowledgments(&self, max_wait: Duration) -> DdsResult<()> {
         let start_time = Instant::now();
@@ -396,13 +396,13 @@ impl<Foo> DataWriterAsync<Foo> {
         Err(DdsError::Timeout)
     }
 
-    /// Async version of ['get_liveliness_lost_status'](crate::publication::data_writer::DataWriter::get_liveliness_lost_status).
+    /// Async version of [`get_liveliness_lost_status`](crate::publication::data_writer::DataWriter::get_liveliness_lost_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_liveliness_lost_status(&self) -> DdsResult<LivelinessLostStatus> {
         todo!()
     }
 
-    /// Async version of ['get_offered_deadline_missed_status'](crate::publication::data_writer::DataWriter::get_offered_deadline_missed_status).
+    /// Async version of [`get_offered_deadline_missed_status`](crate::publication::data_writer::DataWriter::get_offered_deadline_missed_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_offered_deadline_missed_status(
         &self,
@@ -410,7 +410,7 @@ impl<Foo> DataWriterAsync<Foo> {
         todo!()
     }
 
-    /// Async version of ['get_offered_incompatible_qos_status'](crate::publication::data_writer::DataWriter::get_offered_incompatible_qos_status).
+    /// Async version of [`get_offered_incompatible_qos_status`](crate::publication::data_writer::DataWriter::get_offered_incompatible_qos_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_offered_incompatible_qos_status(
         &self,
@@ -418,7 +418,7 @@ impl<Foo> DataWriterAsync<Foo> {
         todo!()
     }
 
-    /// Async version of ['get_publication_matched_status'](crate::publication::data_writer::DataWriter::get_publication_matched_status).
+    /// Async version of [`get_publication_matched_status`](crate::publication::data_writer::DataWriter::get_publication_matched_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_publication_matched_status(&self) -> DdsResult<PublicationMatchedStatus> {
         self.writer_address
@@ -426,7 +426,7 @@ impl<Foo> DataWriterAsync<Foo> {
             .await
     }
 
-    /// Async version of ['get_topic'](crate::publication::data_writer::DataWriter::get_topic).
+    /// Async version of [`get_topic`](crate::publication::data_writer::DataWriter::get_topic).
     #[tracing::instrument(skip(self))]
     pub async fn get_topic(&self) -> DdsResult<TopicAsync> {
         Ok(TopicAsync::new(
@@ -436,7 +436,7 @@ impl<Foo> DataWriterAsync<Foo> {
         ))
     }
 
-    /// Async version of ['get_publisher'](crate::publication::data_writer::DataWriter::get_publisher).
+    /// Async version of [`get_publisher`](crate::publication::data_writer::DataWriter::get_publisher).
     #[tracing::instrument(skip(self))]
     pub async fn get_publisher(&self) -> DdsResult<PublisherAsync> {
         Ok(PublisherAsync::new(
@@ -446,13 +446,13 @@ impl<Foo> DataWriterAsync<Foo> {
         ))
     }
 
-    /// Async version of ['assert_liveliness'](crate::publication::data_writer::DataWriter::assert_liveliness).
+    /// Async version of [`assert_liveliness`](crate::publication::data_writer::DataWriter::assert_liveliness).
     #[tracing::instrument(skip(self))]
     pub async fn assert_liveliness(&self) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['get_matched_subscription_data'](crate::publication::data_writer::DataWriter::get_matched_subscription_data).
+    /// Async version of [`get_matched_subscription_data`](crate::publication::data_writer::DataWriter::get_matched_subscription_data).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_subscription_data(
         &self,
@@ -466,7 +466,7 @@ impl<Foo> DataWriterAsync<Foo> {
             .ok_or(DdsError::BadParameter)
     }
 
-    /// Async version of ['get_matched_subscriptions'](crate::publication::data_writer::DataWriter::get_matched_subscriptions).
+    /// Async version of [`get_matched_subscriptions`](crate::publication::data_writer::DataWriter::get_matched_subscriptions).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_subscriptions(&self) -> DdsResult<Vec<InstanceHandle>> {
         self.writer_address
@@ -476,7 +476,7 @@ impl<Foo> DataWriterAsync<Foo> {
 }
 
 impl<Foo> DataWriterAsync<Foo> {
-    /// Async version of ['set_qos'](crate::publication::data_writer::DataWriter::set_qos).
+    /// Async version of [`set_qos`](crate::publication::data_writer::DataWriter::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
         let q = match qos {
@@ -547,7 +547,7 @@ impl<Foo> DataWriterAsync<Foo> {
         Ok(())
     }
 
-    /// Async version of ['get_qos'](crate::publication::data_writer::DataWriter::get_qos).
+    /// Async version of [`get_qos`](crate::publication::data_writer::DataWriter::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DataWriterQos> {
         self.writer_address
@@ -555,7 +555,7 @@ impl<Foo> DataWriterAsync<Foo> {
             .await
     }
 
-    /// Async version of ['get_statuscondition'](crate::publication::data_writer::DataWriter::get_statuscondition).
+    /// Async version of [`get_statuscondition`](crate::publication::data_writer::DataWriter::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         self.writer_address
@@ -564,13 +564,13 @@ impl<Foo> DataWriterAsync<Foo> {
             .map(|c| StatusConditionAsync::new(c, self.runtime_handle.clone()))
     }
 
-    /// Async version of ['get_status_changes'](crate::publication::data_writer::DataWriter::get_status_changes).
+    /// Async version of [`get_status_changes`](crate::publication::data_writer::DataWriter::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
-    /// Async version of ['enable'](crate::publication::data_writer::DataWriter::enable).
+    /// Async version of [`enable`](crate::publication::data_writer::DataWriter::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -628,7 +628,7 @@ impl<Foo> DataWriterAsync<Foo> {
         Ok(())
     }
 
-    /// Async version of ['get_instance_handle'](crate::publication::data_writer::DataWriter::get_instance_handle).
+    /// Async version of [`get_instance_handle`](crate::publication::data_writer::DataWriter::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.writer_address
@@ -636,7 +636,7 @@ impl<Foo> DataWriterAsync<Foo> {
             .await
     }
 
-    /// Async version of ['set_listener'](crate::publication::data_writer::DataWriter::set_listener).
+    /// Async version of [`set_listener`](crate::publication::data_writer::DataWriter::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -35,6 +35,7 @@ use super::{
     topic::TopicAsync,
 };
 
+/// Async version of ['DomainParticipant'](crate::domain::domain_participant::DomainParticipant).
 pub struct DomainParticipantAsync {
     participant_address: ActorAddress<DomainParticipantActor>,
     runtime_handle: tokio::runtime::Handle,
@@ -57,6 +58,7 @@ impl DomainParticipantAsync {
 }
 
 impl DomainParticipantAsync {
+    /// Async version of ['create_publisher'](crate::domain::domain_participant::DomainParticipant::create_publisher).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn create_publisher(
         &self,
@@ -96,6 +98,7 @@ impl DomainParticipantAsync {
         Ok(publisher)
     }
 
+    /// Async version of ['delete_publisher'](crate::domain::domain_participant::DomainParticipant::delete_publisher).
     #[tracing::instrument(skip(self, a_publisher))]
     pub async fn delete_publisher(&self, a_publisher: &PublisherAsync) -> DdsResult<()> {
         if self
@@ -122,6 +125,7 @@ impl DomainParticipantAsync {
             .await?
     }
 
+    /// Async version of ['create_subscriber'](crate::domain::domain_participant::DomainParticipant::create_subscriber).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn create_subscriber(
         &self,
@@ -162,6 +166,7 @@ impl DomainParticipantAsync {
         Ok(subscriber)
     }
 
+    /// Async version of ['delete_subscriber'](crate::domain::domain_participant::DomainParticipant::delete_subscriber).
     #[tracing::instrument(skip(self, a_subscriber))]
     pub async fn delete_subscriber(&self, a_subscriber: &SubscriberAsync) -> DdsResult<()> {
         if self.get_instance_handle().await?
@@ -185,6 +190,7 @@ impl DomainParticipantAsync {
             .await?
     }
 
+    /// Async version of ['create_topic'](crate::domain::domain_participant::DomainParticipant::create_topic).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn create_topic<Foo>(
         &self,
@@ -255,6 +261,7 @@ impl DomainParticipantAsync {
         Ok(topic)
     }
 
+    /// Async version of ['delete_topic'](crate::domain::domain_participant::DomainParticipant::delete_topic).
     #[tracing::instrument(skip(self, a_topic))]
     pub async fn delete_topic(&self, a_topic: &TopicAsync) -> DdsResult<()> {
         if self.get_instance_handle().await?
@@ -330,6 +337,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['find_topic'](crate::domain::domain_participant::DomainParticipant::find_topic).
     #[tracing::instrument(skip(self))]
     pub async fn find_topic<Foo>(
         &self,
@@ -409,6 +417,7 @@ impl DomainParticipantAsync {
         Err(DdsError::Timeout)
     }
 
+    /// Async version of ['lookup_topicdescription'](crate::domain::domain_participant::DomainParticipant::lookup_topicdescription).
     #[tracing::instrument(skip(self))]
     pub async fn lookup_topicdescription(
         &self,
@@ -427,6 +436,7 @@ impl DomainParticipantAsync {
         // })
     }
 
+    /// Async version of ['get_builtin_subscriber'](crate::domain::domain_participant::DomainParticipant::get_builtin_subscriber).
     #[tracing::instrument(skip(self))]
     pub async fn get_builtin_subscriber(&self) -> DdsResult<SubscriberAsync> {
         Ok(SubscriberAsync::new(
@@ -438,6 +448,7 @@ impl DomainParticipantAsync {
         ))
     }
 
+    /// Async version of ['ignore_participant'](crate::domain::domain_participant::DomainParticipant::ignore_participant).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_participant(&self, handle: InstanceHandle) -> DdsResult<()> {
         if self
@@ -455,6 +466,7 @@ impl DomainParticipantAsync {
         }
     }
 
+    /// Async version of ['ignore_topic'](crate::domain::domain_participant::DomainParticipant::ignore_topic).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_topic(&self, handle: InstanceHandle) -> DdsResult<()> {
         if self
@@ -470,6 +482,7 @@ impl DomainParticipantAsync {
         }
     }
 
+    /// Async version of ['ignore_publication'](crate::domain::domain_participant::DomainParticipant::ignore_publication).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_publication(&self, handle: InstanceHandle) -> DdsResult<()> {
         if self
@@ -487,6 +500,7 @@ impl DomainParticipantAsync {
         }
     }
 
+    /// Async version of ['ignore_subscription'](crate::domain::domain_participant::DomainParticipant::ignore_subscription).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_subscription(&self, handle: InstanceHandle) -> DdsResult<()> {
         if self
@@ -504,6 +518,7 @@ impl DomainParticipantAsync {
         }
     }
 
+    /// Async version of ['get_domain_id'](crate::domain::domain_participant::DomainParticipant::get_domain_id).
     #[tracing::instrument(skip(self))]
     pub async fn get_domain_id(&self) -> DdsResult<DomainId> {
         self.participant_address
@@ -511,6 +526,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['delete_contained_entities'](crate::domain::domain_participant::DomainParticipant::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
         for publisher in self
@@ -595,6 +611,7 @@ impl DomainParticipantAsync {
         Ok(())
     }
 
+    /// Async version of ['assert_liveliness'](crate::domain::domain_participant::DomainParticipant::assert_liveliness).
     #[tracing::instrument(skip(self))]
     pub async fn assert_liveliness(&self) -> DdsResult<()> {
         todo!()
@@ -603,6 +620,7 @@ impl DomainParticipantAsync {
         // })
     }
 
+    /// Async version of ['set_default_publisher_qos'](crate::domain::domain_participant::DomainParticipant::set_default_publisher_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_publisher_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -616,6 +634,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['get_default_publisher_qos'](crate::domain::domain_participant::DomainParticipant::get_default_publisher_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_publisher_qos(&self) -> DdsResult<PublisherQos> {
         self.participant_address
@@ -623,6 +642,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['set_default_subscriber_qos'](crate::domain::domain_participant::DomainParticipant::set_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_subscriber_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -637,6 +657,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['get_default_subscriber_qos'](crate::domain::domain_participant::DomainParticipant::get_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_subscriber_qos(&self) -> DdsResult<SubscriberQos> {
         self.participant_address
@@ -644,6 +665,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['set_default_topic_qos'](crate::domain::domain_participant::DomainParticipant::set_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_topic_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -658,6 +680,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['get_default_topic_qos'](crate::domain::domain_participant::DomainParticipant::get_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_topic_qos(&self) -> DdsResult<TopicQos> {
         self.participant_address
@@ -665,6 +688,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['get_discovered_participants'](crate::domain::domain_participant::DomainParticipant::get_discovered_participants).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_participants(&self) -> DdsResult<Vec<InstanceHandle>> {
         self.participant_address
@@ -672,6 +696,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['get_discovered_participant_data'](crate::domain::domain_participant::DomainParticipant::get_discovered_participant_data).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_participant_data(
         &self,
@@ -680,6 +705,7 @@ impl DomainParticipantAsync {
         todo!()
     }
 
+    /// Async version of ['get_discovered_topics'](crate::domain::domain_participant::DomainParticipant::get_discovered_topics).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_topics(&self) -> DdsResult<Vec<InstanceHandle>> {
         self.participant_address
@@ -687,6 +713,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['get_discovered_topic_data'](crate::domain::domain_participant::DomainParticipant::get_discovered_topic_data).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_topic_data(
         &self,
@@ -699,6 +726,7 @@ impl DomainParticipantAsync {
             .await?
     }
 
+    /// Async version of ['contains_entity'](crate::domain::domain_participant::DomainParticipant::contains_entity).
     #[tracing::instrument(skip(self))]
     pub async fn contains_entity(&self, _a_handle: InstanceHandle) -> DdsResult<bool> {
         todo!()
@@ -707,6 +735,8 @@ impl DomainParticipantAsync {
         // })
     }
 
+
+    /// Async version of ['get_current_time'](crate::domain::domain_participant::DomainParticipant::get_current_time).
     #[tracing::instrument(skip(self))]
     pub async fn get_current_time(&self) -> DdsResult<Time> {
         self.participant_address
@@ -716,6 +746,7 @@ impl DomainParticipantAsync {
 }
 
 impl DomainParticipantAsync {
+    /// Async version of ['set_qos'](crate::domain::domain_participant::DomainParticipant::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<DomainParticipantQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -730,6 +761,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['get_qos'](crate::domain::domain_participant::DomainParticipant::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantQos> {
         self.participant_address
@@ -737,6 +769,7 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['set_listener'](crate::domain::domain_participant::DomainParticipant::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,
@@ -752,16 +785,19 @@ impl DomainParticipantAsync {
             .await
     }
 
+    /// Async version of ['get_statuscondition'](crate::domain::domain_participant::DomainParticipant::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         todo!()
     }
 
+    /// Async version of ['get_status_changes'](crate::domain::domain_participant::DomainParticipant::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
+    /// Async version of ['enable'](crate::domain::domain_participant::DomainParticipant::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -874,7 +910,7 @@ impl DomainParticipantAsync {
         Ok(())
     }
 
-    /// This operation returns the [`InstanceHandle`] that represents the Entity.
+    /// Async version of ['get_instance_handle'](crate::domain::domain_participant::DomainParticipant::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.participant_address

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -35,7 +35,7 @@ use super::{
     topic::TopicAsync,
 };
 
-/// Async version of ['DomainParticipant'](crate::domain::domain_participant::DomainParticipant).
+/// Async version of [`DomainParticipant`](crate::domain::domain_participant::DomainParticipant).
 pub struct DomainParticipantAsync {
     participant_address: ActorAddress<DomainParticipantActor>,
     runtime_handle: tokio::runtime::Handle,
@@ -58,7 +58,7 @@ impl DomainParticipantAsync {
 }
 
 impl DomainParticipantAsync {
-    /// Async version of ['create_publisher'](crate::domain::domain_participant::DomainParticipant::create_publisher).
+    /// Async version of [`create_publisher`](crate::domain::domain_participant::DomainParticipant::create_publisher).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn create_publisher(
         &self,
@@ -98,7 +98,7 @@ impl DomainParticipantAsync {
         Ok(publisher)
     }
 
-    /// Async version of ['delete_publisher'](crate::domain::domain_participant::DomainParticipant::delete_publisher).
+    /// Async version of [`delete_publisher`](crate::domain::domain_participant::DomainParticipant::delete_publisher).
     #[tracing::instrument(skip(self, a_publisher))]
     pub async fn delete_publisher(&self, a_publisher: &PublisherAsync) -> DdsResult<()> {
         if self
@@ -125,7 +125,7 @@ impl DomainParticipantAsync {
             .await?
     }
 
-    /// Async version of ['create_subscriber'](crate::domain::domain_participant::DomainParticipant::create_subscriber).
+    /// Async version of [`create_subscriber`](crate::domain::domain_participant::DomainParticipant::create_subscriber).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn create_subscriber(
         &self,
@@ -166,7 +166,7 @@ impl DomainParticipantAsync {
         Ok(subscriber)
     }
 
-    /// Async version of ['delete_subscriber'](crate::domain::domain_participant::DomainParticipant::delete_subscriber).
+    /// Async version of [`delete_subscriber`](crate::domain::domain_participant::DomainParticipant::delete_subscriber).
     #[tracing::instrument(skip(self, a_subscriber))]
     pub async fn delete_subscriber(&self, a_subscriber: &SubscriberAsync) -> DdsResult<()> {
         if self.get_instance_handle().await?
@@ -190,7 +190,7 @@ impl DomainParticipantAsync {
             .await?
     }
 
-    /// Async version of ['create_topic'](crate::domain::domain_participant::DomainParticipant::create_topic).
+    /// Async version of [`create_topic`](crate::domain::domain_participant::DomainParticipant::create_topic).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn create_topic<Foo>(
         &self,
@@ -261,7 +261,7 @@ impl DomainParticipantAsync {
         Ok(topic)
     }
 
-    /// Async version of ['delete_topic'](crate::domain::domain_participant::DomainParticipant::delete_topic).
+    /// Async version of [`delete_topic`](crate::domain::domain_participant::DomainParticipant::delete_topic).
     #[tracing::instrument(skip(self, a_topic))]
     pub async fn delete_topic(&self, a_topic: &TopicAsync) -> DdsResult<()> {
         if self.get_instance_handle().await?
@@ -337,7 +337,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['find_topic'](crate::domain::domain_participant::DomainParticipant::find_topic).
+    /// Async version of [`find_topic`](crate::domain::domain_participant::DomainParticipant::find_topic).
     #[tracing::instrument(skip(self))]
     pub async fn find_topic<Foo>(
         &self,
@@ -417,7 +417,7 @@ impl DomainParticipantAsync {
         Err(DdsError::Timeout)
     }
 
-    /// Async version of ['lookup_topicdescription'](crate::domain::domain_participant::DomainParticipant::lookup_topicdescription).
+    /// Async version of [`lookup_topicdescription`](crate::domain::domain_participant::DomainParticipant::lookup_topicdescription).
     #[tracing::instrument(skip(self))]
     pub async fn lookup_topicdescription(
         &self,
@@ -436,7 +436,7 @@ impl DomainParticipantAsync {
         // })
     }
 
-    /// Async version of ['get_builtin_subscriber'](crate::domain::domain_participant::DomainParticipant::get_builtin_subscriber).
+    /// Async version of [`get_builtin_subscriber`](crate::domain::domain_participant::DomainParticipant::get_builtin_subscriber).
     #[tracing::instrument(skip(self))]
     pub async fn get_builtin_subscriber(&self) -> DdsResult<SubscriberAsync> {
         Ok(SubscriberAsync::new(
@@ -448,7 +448,7 @@ impl DomainParticipantAsync {
         ))
     }
 
-    /// Async version of ['ignore_participant'](crate::domain::domain_participant::DomainParticipant::ignore_participant).
+    /// Async version of [`ignore_participant`](crate::domain::domain_participant::DomainParticipant::ignore_participant).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_participant(&self, handle: InstanceHandle) -> DdsResult<()> {
         if self
@@ -466,7 +466,7 @@ impl DomainParticipantAsync {
         }
     }
 
-    /// Async version of ['ignore_topic'](crate::domain::domain_participant::DomainParticipant::ignore_topic).
+    /// Async version of [`ignore_topic`](crate::domain::domain_participant::DomainParticipant::ignore_topic).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_topic(&self, handle: InstanceHandle) -> DdsResult<()> {
         if self
@@ -482,7 +482,7 @@ impl DomainParticipantAsync {
         }
     }
 
-    /// Async version of ['ignore_publication'](crate::domain::domain_participant::DomainParticipant::ignore_publication).
+    /// Async version of [`ignore_publication`](crate::domain::domain_participant::DomainParticipant::ignore_publication).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_publication(&self, handle: InstanceHandle) -> DdsResult<()> {
         if self
@@ -500,7 +500,7 @@ impl DomainParticipantAsync {
         }
     }
 
-    /// Async version of ['ignore_subscription'](crate::domain::domain_participant::DomainParticipant::ignore_subscription).
+    /// Async version of [`ignore_subscription`](crate::domain::domain_participant::DomainParticipant::ignore_subscription).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_subscription(&self, handle: InstanceHandle) -> DdsResult<()> {
         if self
@@ -518,7 +518,7 @@ impl DomainParticipantAsync {
         }
     }
 
-    /// Async version of ['get_domain_id'](crate::domain::domain_participant::DomainParticipant::get_domain_id).
+    /// Async version of [`get_domain_id`](crate::domain::domain_participant::DomainParticipant::get_domain_id).
     #[tracing::instrument(skip(self))]
     pub async fn get_domain_id(&self) -> DdsResult<DomainId> {
         self.participant_address
@@ -526,7 +526,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['delete_contained_entities'](crate::domain::domain_participant::DomainParticipant::delete_contained_entities).
+    /// Async version of [`delete_contained_entities`](crate::domain::domain_participant::DomainParticipant::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
         for publisher in self
@@ -611,7 +611,7 @@ impl DomainParticipantAsync {
         Ok(())
     }
 
-    /// Async version of ['assert_liveliness'](crate::domain::domain_participant::DomainParticipant::assert_liveliness).
+    /// Async version of [`assert_liveliness`](crate::domain::domain_participant::DomainParticipant::assert_liveliness).
     #[tracing::instrument(skip(self))]
     pub async fn assert_liveliness(&self) -> DdsResult<()> {
         todo!()
@@ -620,7 +620,7 @@ impl DomainParticipantAsync {
         // })
     }
 
-    /// Async version of ['set_default_publisher_qos'](crate::domain::domain_participant::DomainParticipant::set_default_publisher_qos).
+    /// Async version of [`set_default_publisher_qos`](crate::domain::domain_participant::DomainParticipant::set_default_publisher_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_publisher_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -634,7 +634,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['get_default_publisher_qos'](crate::domain::domain_participant::DomainParticipant::get_default_publisher_qos).
+    /// Async version of [`get_default_publisher_qos`](crate::domain::domain_participant::DomainParticipant::get_default_publisher_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_publisher_qos(&self) -> DdsResult<PublisherQos> {
         self.participant_address
@@ -642,7 +642,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['set_default_subscriber_qos'](crate::domain::domain_participant::DomainParticipant::set_default_subscriber_qos).
+    /// Async version of [`set_default_subscriber_qos`](crate::domain::domain_participant::DomainParticipant::set_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_subscriber_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -657,7 +657,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['get_default_subscriber_qos'](crate::domain::domain_participant::DomainParticipant::get_default_subscriber_qos).
+    /// Async version of [`get_default_subscriber_qos`](crate::domain::domain_participant::DomainParticipant::get_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_subscriber_qos(&self) -> DdsResult<SubscriberQos> {
         self.participant_address
@@ -665,7 +665,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['set_default_topic_qos'](crate::domain::domain_participant::DomainParticipant::set_default_topic_qos).
+    /// Async version of [`set_default_topic_qos`](crate::domain::domain_participant::DomainParticipant::set_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_topic_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -680,7 +680,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['get_default_topic_qos'](crate::domain::domain_participant::DomainParticipant::get_default_topic_qos).
+    /// Async version of [`get_default_topic_qos`](crate::domain::domain_participant::DomainParticipant::get_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_topic_qos(&self) -> DdsResult<TopicQos> {
         self.participant_address
@@ -688,7 +688,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['get_discovered_participants'](crate::domain::domain_participant::DomainParticipant::get_discovered_participants).
+    /// Async version of [`get_discovered_participants`](crate::domain::domain_participant::DomainParticipant::get_discovered_participants).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_participants(&self) -> DdsResult<Vec<InstanceHandle>> {
         self.participant_address
@@ -696,7 +696,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['get_discovered_participant_data'](crate::domain::domain_participant::DomainParticipant::get_discovered_participant_data).
+    /// Async version of [`get_discovered_participant_data`](crate::domain::domain_participant::DomainParticipant::get_discovered_participant_data).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_participant_data(
         &self,
@@ -705,7 +705,7 @@ impl DomainParticipantAsync {
         todo!()
     }
 
-    /// Async version of ['get_discovered_topics'](crate::domain::domain_participant::DomainParticipant::get_discovered_topics).
+    /// Async version of [`get_discovered_topics`](crate::domain::domain_participant::DomainParticipant::get_discovered_topics).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_topics(&self) -> DdsResult<Vec<InstanceHandle>> {
         self.participant_address
@@ -713,7 +713,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['get_discovered_topic_data'](crate::domain::domain_participant::DomainParticipant::get_discovered_topic_data).
+    /// Async version of [`get_discovered_topic_data`](crate::domain::domain_participant::DomainParticipant::get_discovered_topic_data).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_topic_data(
         &self,
@@ -726,7 +726,7 @@ impl DomainParticipantAsync {
             .await?
     }
 
-    /// Async version of ['contains_entity'](crate::domain::domain_participant::DomainParticipant::contains_entity).
+    /// Async version of [`contains_entity`](crate::domain::domain_participant::DomainParticipant::contains_entity).
     #[tracing::instrument(skip(self))]
     pub async fn contains_entity(&self, _a_handle: InstanceHandle) -> DdsResult<bool> {
         todo!()
@@ -736,7 +736,7 @@ impl DomainParticipantAsync {
     }
 
 
-    /// Async version of ['get_current_time'](crate::domain::domain_participant::DomainParticipant::get_current_time).
+    /// Async version of [`get_current_time`](crate::domain::domain_participant::DomainParticipant::get_current_time).
     #[tracing::instrument(skip(self))]
     pub async fn get_current_time(&self) -> DdsResult<Time> {
         self.participant_address
@@ -746,7 +746,7 @@ impl DomainParticipantAsync {
 }
 
 impl DomainParticipantAsync {
-    /// Async version of ['set_qos'](crate::domain::domain_participant::DomainParticipant::set_qos).
+    /// Async version of [`set_qos`](crate::domain::domain_participant::DomainParticipant::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<DomainParticipantQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -761,7 +761,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['get_qos'](crate::domain::domain_participant::DomainParticipant::get_qos).
+    /// Async version of [`get_qos`](crate::domain::domain_participant::DomainParticipant::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantQos> {
         self.participant_address
@@ -769,7 +769,7 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['set_listener'](crate::domain::domain_participant::DomainParticipant::set_listener).
+    /// Async version of [`set_listener`](crate::domain::domain_participant::DomainParticipant::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,
@@ -785,19 +785,19 @@ impl DomainParticipantAsync {
             .await
     }
 
-    /// Async version of ['get_statuscondition'](crate::domain::domain_participant::DomainParticipant::get_statuscondition).
+    /// Async version of [`get_statuscondition`](crate::domain::domain_participant::DomainParticipant::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         todo!()
     }
 
-    /// Async version of ['get_status_changes'](crate::domain::domain_participant::DomainParticipant::get_status_changes).
+    /// Async version of [`get_status_changes`](crate::domain::domain_participant::DomainParticipant::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
-    /// Async version of ['enable'](crate::domain::domain_participant::DomainParticipant::enable).
+    /// Async version of [`enable`](crate::domain::domain_participant::DomainParticipant::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -910,7 +910,7 @@ impl DomainParticipantAsync {
         Ok(())
     }
 
-    /// Async version of ['get_instance_handle'](crate::domain::domain_participant::DomainParticipant::get_instance_handle).
+    /// Async version of [`get_instance_handle`](crate::domain::domain_participant::DomainParticipant::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.participant_address

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -17,9 +17,9 @@ use crate::{
 
 use super::domain_participant::DomainParticipantAsync;
 
-/// Async version of ['DomainParticipantFactory'](crate::domain::domain_participant_factory::DomainParticipantFactory).
-/// Unlike the sync version, the ['DomainParticipantFactoryAsync'] is not a singleton and can be created by means of
-/// a constructor by passing a handle to a ['Tokio'](https://crates.io/crates/tokio) runtime. This allows the factory
+/// Async version of [`DomainParticipantFactory`](crate::domain::domain_participant_factory::DomainParticipantFactory).
+/// Unlike the sync version, the [`DomainParticipantFactoryAsync`] is not a singleton and can be created by means of
+/// a constructor by passing a handle to a [`Tokio`](https://crates.io/crates/tokio) runtime. This allows the factory
 /// to spin tasks on an existing runtime which can be shared with other things outside Dust DDS.
 pub struct DomainParticipantFactoryAsync {
     domain_participant_factory_actor: Actor<DomainParticipantFactoryActor>,
@@ -27,7 +27,7 @@ pub struct DomainParticipantFactoryAsync {
 }
 
 impl DomainParticipantFactoryAsync {
-    /// Create a new ['DomainParticipantFactoryAsync'].
+    /// Create a new [`DomainParticipantFactoryAsync`].
     /// All the tasks of Dust DDS will be spawned on the runtime which is given as an argument.
     pub fn new(runtime_handle: tokio::runtime::Handle) -> Self {
         let domain_participant_factory_actor =
@@ -39,7 +39,7 @@ impl DomainParticipantFactoryAsync {
         }
     }
 
-    /// Async version of ['create_participant'](crate::domain::domain_participant_factory::DomainParticipantFactory::create_participant).
+    /// Async version of [`create_participant`](crate::domain::domain_participant_factory::DomainParticipantFactory::create_participant).
     pub async fn create_participant(
         &self,
         domain_id: DomainId,
@@ -76,7 +76,7 @@ impl DomainParticipantFactoryAsync {
         Ok(domain_participant)
     }
 
-    /// Async version of ['delete_participant'](crate::domain::domain_participant_factory::DomainParticipantFactory::delete_participant).
+    /// Async version of [`delete_participant`](crate::domain::domain_participant_factory::DomainParticipantFactory::delete_participant).
     pub async fn delete_participant(&self, participant: &DomainParticipantAsync) -> DdsResult<()> {
         let handle = participant.get_instance_handle().await?;
         self.domain_participant_factory_actor
@@ -86,7 +86,7 @@ impl DomainParticipantFactoryAsync {
             .await
     }
 
-    /// Async version of ['lookup_participant'](crate::domain::domain_participant_factory::DomainParticipantFactory::lookup_participant).
+    /// Async version of [`lookup_participant`](crate::domain::domain_participant_factory::DomainParticipantFactory::lookup_participant).
     pub async fn lookup_participant(
         &self,
         domain_id: DomainId,
@@ -100,7 +100,7 @@ impl DomainParticipantFactoryAsync {
             .map(|dp| DomainParticipantAsync::new(dp, self.runtime_handle.clone())))
     }
 
-    /// Async version of ['set_default_participant_qos'](crate::domain::domain_participant_factory::DomainParticipantFactory::set_default_participant_qos).
+    /// Async version of [`set_default_participant_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::set_default_participant_qos).
     pub async fn set_default_participant_qos(
         &self,
         qos: QosKind<DomainParticipantQos>,
@@ -112,7 +112,7 @@ impl DomainParticipantFactoryAsync {
             .await
     }
 
-    /// Async version of ['get_default_participant_qos'](crate::domain::domain_participant_factory::DomainParticipantFactory::get_default_participant_qos).
+    /// Async version of [`get_default_participant_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::get_default_participant_qos).
     pub async fn get_default_participant_qos(&self) -> DdsResult<DomainParticipantQos> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(
@@ -121,21 +121,21 @@ impl DomainParticipantFactoryAsync {
             .await
     }
 
-    /// Async version of ['set_qos'](crate::domain::domain_participant_factory::DomainParticipantFactory::set_qos).
+    /// Async version of [`set_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::set_qos).
     pub async fn set_qos(&self, qos: QosKind<DomainParticipantFactoryQos>) -> DdsResult<()> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(domain_participant_factory_actor::set_qos::new(qos))
             .await
     }
 
-    /// Async version of ['get_qos'](crate::domain::domain_participant_factory::DomainParticipantFactory::get_qos).
+    /// Async version of [`get_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::get_qos).
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantFactoryQos> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(domain_participant_factory_actor::get_qos::new())
             .await
     }
 
-    /// Async version of ['set_configuration'](crate::domain::domain_participant_factory::DomainParticipantFactory::set_configuration).
+    /// Async version of [`set_configuration`](crate::domain::domain_participant_factory::DomainParticipantFactory::set_configuration).
     pub async fn set_configuration(&self, configuration: DustDdsConfiguration) -> DdsResult<()> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(domain_participant_factory_actor::set_configuration::new(
@@ -144,7 +144,7 @@ impl DomainParticipantFactoryAsync {
             .await
     }
 
-    /// Async version of ['get_configuration'](crate::domain::domain_participant_factory::DomainParticipantFactory::get_configuration).
+    /// Async version of [`get_configuration`](crate::domain::domain_participant_factory::DomainParticipantFactory::get_configuration).
     pub async fn get_configuration(&self) -> DdsResult<DustDdsConfiguration> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(domain_participant_factory_actor::get_configuration::new())

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -17,12 +17,18 @@ use crate::{
 
 use super::domain_participant::DomainParticipantAsync;
 
+/// Async version of ['DomainParticipantFactory'](crate::domain::domain_participant_factory::DomainParticipantFactory).
+/// Unlike the sync version, the ['DomainParticipantFactoryAsync'] is not a singleton and can be created by means of
+/// a constructor by passing a handle to a ['Tokio'](https://crates.io/crates/tokio) runtime. This allows the factory
+/// to spin tasks on an existing runtime which can be shared with other things outside Dust DDS.
 pub struct DomainParticipantFactoryAsync {
     domain_participant_factory_actor: Actor<DomainParticipantFactoryActor>,
     runtime_handle: tokio::runtime::Handle,
 }
 
 impl DomainParticipantFactoryAsync {
+    /// Create a new ['DomainParticipantFactoryAsync'].
+    /// All the tasks of Dust DDS will be spawned on the runtime which is given as an argument.
     pub fn new(runtime_handle: tokio::runtime::Handle) -> Self {
         let domain_participant_factory_actor =
             Actor::spawn(DomainParticipantFactoryActor::new(), &runtime_handle);
@@ -33,6 +39,7 @@ impl DomainParticipantFactoryAsync {
         }
     }
 
+    /// Async version of ['create_participant'](crate::domain::domain_participant_factory::DomainParticipantFactory::create_participant).
     pub async fn create_participant(
         &self,
         domain_id: DomainId,
@@ -69,6 +76,7 @@ impl DomainParticipantFactoryAsync {
         Ok(domain_participant)
     }
 
+    /// Async version of ['delete_participant'](crate::domain::domain_participant_factory::DomainParticipantFactory::delete_participant).
     pub async fn delete_participant(&self, participant: &DomainParticipantAsync) -> DdsResult<()> {
         let handle = participant.get_instance_handle().await?;
         self.domain_participant_factory_actor
@@ -78,6 +86,7 @@ impl DomainParticipantFactoryAsync {
             .await
     }
 
+    /// Async version of ['lookup_participant'](crate::domain::domain_participant_factory::DomainParticipantFactory::lookup_participant).
     pub async fn lookup_participant(
         &self,
         domain_id: DomainId,
@@ -91,6 +100,7 @@ impl DomainParticipantFactoryAsync {
             .map(|dp| DomainParticipantAsync::new(dp, self.runtime_handle.clone())))
     }
 
+    /// Async version of ['set_default_participant_qos'](crate::domain::domain_participant_factory::DomainParticipantFactory::set_default_participant_qos).
     pub async fn set_default_participant_qos(
         &self,
         qos: QosKind<DomainParticipantQos>,
@@ -102,6 +112,7 @@ impl DomainParticipantFactoryAsync {
             .await
     }
 
+    /// Async version of ['get_default_participant_qos'](crate::domain::domain_participant_factory::DomainParticipantFactory::get_default_participant_qos).
     pub async fn get_default_participant_qos(&self) -> DdsResult<DomainParticipantQos> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(
@@ -110,18 +121,21 @@ impl DomainParticipantFactoryAsync {
             .await
     }
 
+    /// Async version of ['set_qos'](crate::domain::domain_participant_factory::DomainParticipantFactory::set_qos).
     pub async fn set_qos(&self, qos: QosKind<DomainParticipantFactoryQos>) -> DdsResult<()> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(domain_participant_factory_actor::set_qos::new(qos))
             .await
     }
 
+    /// Async version of ['get_qos'](crate::domain::domain_participant_factory::DomainParticipantFactory::get_qos).
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantFactoryQos> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(domain_participant_factory_actor::get_qos::new())
             .await
     }
 
+    /// Async version of ['set_configuration'](crate::domain::domain_participant_factory::DomainParticipantFactory::set_configuration).
     pub async fn set_configuration(&self, configuration: DustDdsConfiguration) -> DdsResult<()> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(domain_participant_factory_actor::set_configuration::new(
@@ -130,6 +144,7 @@ impl DomainParticipantFactoryAsync {
             .await
     }
 
+    /// Async version of ['get_configuration'](crate::domain::domain_participant_factory::DomainParticipantFactory::get_configuration).
     pub async fn get_configuration(&self) -> DdsResult<DustDdsConfiguration> {
         self.domain_participant_factory_actor
             .send_mail_and_await_reply(domain_participant_factory_actor::get_configuration::new())

--- a/dds/src/dds_async/mod.rs
+++ b/dds/src/dds_async/mod.rs
@@ -1,9 +1,18 @@
+/// Classes related to the async status conditions.
 pub mod condition;
+/// Classes related to the async data reader.
 pub mod data_reader;
+/// Classes related to the async data writer.
 pub mod data_writer;
+/// Classes related to the async domain participant.
 pub mod domain_participant;
+/// Classes related to the async domain participant factory.
 pub mod domain_participant_factory;
+/// Classes related to the async publisher.
 pub mod publisher;
+/// Classes related to the async subscriber.
 pub mod subscriber;
+/// Classes related to the async topic.
 pub mod topic;
+/// Classes related to the async wait set.
 pub mod wait_set;

--- a/dds/src/dds_async/publisher.rs
+++ b/dds/src/dds_async/publisher.rs
@@ -19,9 +19,11 @@ use crate::{
 };
 
 use super::{
-    condition::StatusConditionAsync, data_writer::DataWriterAsync, domain_participant::DomainParticipantAsync, topic::TopicAsync
+    condition::StatusConditionAsync, data_writer::DataWriterAsync,
+    domain_participant::DomainParticipantAsync, topic::TopicAsync,
 };
 
+/// Async version of ['Publisher'](crate::publication::publisher::Publisher).
 pub struct PublisherAsync {
     publisher_address: ActorAddress<PublisherActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
@@ -47,6 +49,7 @@ impl PublisherAsync {
 }
 
 impl PublisherAsync {
+    /// Async version of ['create_datawriter'](crate::publication::publisher::Publisher::create_datawriter).
     #[tracing::instrument(skip(self, a_topic, a_listener))]
     pub async fn create_datawriter<Foo>(
         &self,
@@ -128,6 +131,7 @@ impl PublisherAsync {
         Ok(data_writer)
     }
 
+    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::delete_datawriter).
     #[tracing::instrument(skip(self, a_datawriter))]
     pub async fn delete_datawriter<Foo>(
         &self,
@@ -160,6 +164,7 @@ impl PublisherAsync {
             .await?
     }
 
+    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::lookup_datawriter).
     #[tracing::instrument(skip(self))]
     pub async fn lookup_datawriter<Foo>(
         &self,
@@ -181,31 +186,37 @@ impl PublisherAsync {
             }))
     }
 
+    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::suspend_publications).
     #[tracing::instrument(skip(self))]
     pub async fn suspend_publications(&self) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::resume_publications).
     #[tracing::instrument(skip(self))]
     pub async fn resume_publications(&self) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::begin_coherent_changes).
     #[tracing::instrument(skip(self))]
     pub async fn begin_coherent_changes(&self) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::end_coherent_changes).
     #[tracing::instrument(skip(self))]
     pub async fn end_coherent_changes(&self) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::wait_for_acknowledgments).
     #[tracing::instrument(skip(self))]
     pub async fn wait_for_acknowledgments(&self, _max_wait: Duration) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['get_participant'](crate::publication::publisher::Publisher::get_participant).
     #[tracing::instrument(skip(self))]
     pub async fn get_participant(&self) -> DdsResult<DomainParticipantAsync> {
         Ok(DomainParticipantAsync::new(
@@ -214,11 +225,13 @@ impl PublisherAsync {
         ))
     }
 
+    /// Async version of ['delete_contained_entities'](crate::publication::publisher::Publisher::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['set_default_datawriter_qos'](crate::publication::publisher::Publisher::set_default_datawriter_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_datawriter_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -238,6 +251,7 @@ impl PublisherAsync {
             .await
     }
 
+    /// Async version of ['get_default_datawriter_qos'](crate::publication::publisher::Publisher::get_default_datawriter_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_datawriter_qos(&self) -> DdsResult<DataWriterQos> {
         self.publisher_address
@@ -245,6 +259,7 @@ impl PublisherAsync {
             .await
     }
 
+    /// Async version of ['copy_from_topic_qos'](crate::publication::publisher::Publisher::copy_from_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn copy_from_topic_qos(
         &self,
@@ -256,11 +271,13 @@ impl PublisherAsync {
 }
 
 impl PublisherAsync {
+    /// Async version of ['set_qos'](crate::publication::publisher::Publisher::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, _qos: QosKind<PublisherQos>) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['get_qos'](crate::publication::publisher::Publisher::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<PublisherQos> {
         self.publisher_address
@@ -268,6 +285,7 @@ impl PublisherAsync {
             .await
     }
 
+    /// Async version of ['set_listener'](crate::publication::publisher::Publisher::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,
@@ -283,16 +301,19 @@ impl PublisherAsync {
             .await
     }
 
+    /// Async version of ['get_statuscondition'](crate::publication::publisher::Publisher::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         todo!()
     }
 
+    /// Async version of ['get_status_changes'](crate::publication::publisher::Publisher::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
+    /// Async version of ['enable'](crate::publication::publisher::Publisher::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         self.publisher_address
@@ -300,6 +321,7 @@ impl PublisherAsync {
             .await
     }
 
+    /// Async version of ['get_instance_handle'](crate::publication::publisher::Publisher::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.publisher_address

--- a/dds/src/dds_async/publisher.rs
+++ b/dds/src/dds_async/publisher.rs
@@ -23,7 +23,7 @@ use super::{
     domain_participant::DomainParticipantAsync, topic::TopicAsync,
 };
 
-/// Async version of ['Publisher'](crate::publication::publisher::Publisher).
+/// Async version of [`Publisher`](crate::publication::publisher::Publisher).
 pub struct PublisherAsync {
     publisher_address: ActorAddress<PublisherActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
@@ -49,7 +49,7 @@ impl PublisherAsync {
 }
 
 impl PublisherAsync {
-    /// Async version of ['create_datawriter'](crate::publication::publisher::Publisher::create_datawriter).
+    /// Async version of [`create_datawriter`](crate::publication::publisher::Publisher::create_datawriter).
     #[tracing::instrument(skip(self, a_topic, a_listener))]
     pub async fn create_datawriter<Foo>(
         &self,
@@ -131,7 +131,7 @@ impl PublisherAsync {
         Ok(data_writer)
     }
 
-    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::delete_datawriter).
+    /// Async version of [`delete_datawriter`](crate::publication::publisher::Publisher::delete_datawriter).
     #[tracing::instrument(skip(self, a_datawriter))]
     pub async fn delete_datawriter<Foo>(
         &self,
@@ -164,7 +164,7 @@ impl PublisherAsync {
             .await?
     }
 
-    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::lookup_datawriter).
+    /// Async version of [`delete_datawriter`](crate::publication::publisher::Publisher::lookup_datawriter).
     #[tracing::instrument(skip(self))]
     pub async fn lookup_datawriter<Foo>(
         &self,
@@ -186,37 +186,37 @@ impl PublisherAsync {
             }))
     }
 
-    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::suspend_publications).
+    /// Async version of [`delete_datawriter`](crate::publication::publisher::Publisher::suspend_publications).
     #[tracing::instrument(skip(self))]
     pub async fn suspend_publications(&self) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::resume_publications).
+    /// Async version of [`delete_datawriter`](crate::publication::publisher::Publisher::resume_publications).
     #[tracing::instrument(skip(self))]
     pub async fn resume_publications(&self) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::begin_coherent_changes).
+    /// Async version of [`delete_datawriter`](crate::publication::publisher::Publisher::begin_coherent_changes).
     #[tracing::instrument(skip(self))]
     pub async fn begin_coherent_changes(&self) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::end_coherent_changes).
+    /// Async version of [`delete_datawriter`](crate::publication::publisher::Publisher::end_coherent_changes).
     #[tracing::instrument(skip(self))]
     pub async fn end_coherent_changes(&self) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['delete_datawriter'](crate::publication::publisher::Publisher::wait_for_acknowledgments).
+    /// Async version of [`delete_datawriter`](crate::publication::publisher::Publisher::wait_for_acknowledgments).
     #[tracing::instrument(skip(self))]
     pub async fn wait_for_acknowledgments(&self, _max_wait: Duration) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['get_participant'](crate::publication::publisher::Publisher::get_participant).
+    /// Async version of [`get_participant`](crate::publication::publisher::Publisher::get_participant).
     #[tracing::instrument(skip(self))]
     pub async fn get_participant(&self) -> DdsResult<DomainParticipantAsync> {
         Ok(DomainParticipantAsync::new(
@@ -225,13 +225,13 @@ impl PublisherAsync {
         ))
     }
 
-    /// Async version of ['delete_contained_entities'](crate::publication::publisher::Publisher::delete_contained_entities).
+    /// Async version of [`delete_contained_entities`](crate::publication::publisher::Publisher::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['set_default_datawriter_qos'](crate::publication::publisher::Publisher::set_default_datawriter_qos).
+    /// Async version of [`set_default_datawriter_qos`](crate::publication::publisher::Publisher::set_default_datawriter_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_datawriter_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -251,7 +251,7 @@ impl PublisherAsync {
             .await
     }
 
-    /// Async version of ['get_default_datawriter_qos'](crate::publication::publisher::Publisher::get_default_datawriter_qos).
+    /// Async version of [`get_default_datawriter_qos`](crate::publication::publisher::Publisher::get_default_datawriter_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_datawriter_qos(&self) -> DdsResult<DataWriterQos> {
         self.publisher_address
@@ -259,7 +259,7 @@ impl PublisherAsync {
             .await
     }
 
-    /// Async version of ['copy_from_topic_qos'](crate::publication::publisher::Publisher::copy_from_topic_qos).
+    /// Async version of [`copy_from_topic_qos`](crate::publication::publisher::Publisher::copy_from_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn copy_from_topic_qos(
         &self,
@@ -271,13 +271,13 @@ impl PublisherAsync {
 }
 
 impl PublisherAsync {
-    /// Async version of ['set_qos'](crate::publication::publisher::Publisher::set_qos).
+    /// Async version of [`set_qos`](crate::publication::publisher::Publisher::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, _qos: QosKind<PublisherQos>) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['get_qos'](crate::publication::publisher::Publisher::get_qos).
+    /// Async version of [`get_qos`](crate::publication::publisher::Publisher::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<PublisherQos> {
         self.publisher_address
@@ -285,7 +285,7 @@ impl PublisherAsync {
             .await
     }
 
-    /// Async version of ['set_listener'](crate::publication::publisher::Publisher::set_listener).
+    /// Async version of [`set_listener`](crate::publication::publisher::Publisher::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,
@@ -301,19 +301,19 @@ impl PublisherAsync {
             .await
     }
 
-    /// Async version of ['get_statuscondition'](crate::publication::publisher::Publisher::get_statuscondition).
+    /// Async version of [`get_statuscondition`](crate::publication::publisher::Publisher::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         todo!()
     }
 
-    /// Async version of ['get_status_changes'](crate::publication::publisher::Publisher::get_status_changes).
+    /// Async version of [`get_status_changes`](crate::publication::publisher::Publisher::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
-    /// Async version of ['enable'](crate::publication::publisher::Publisher::enable).
+    /// Async version of [`enable`](crate::publication::publisher::Publisher::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         self.publisher_address
@@ -321,7 +321,7 @@ impl PublisherAsync {
             .await
     }
 
-    /// Async version of ['get_instance_handle'](crate::publication::publisher::Publisher::get_instance_handle).
+    /// Async version of [`get_instance_handle`](crate::publication::publisher::Publisher::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.publisher_address

--- a/dds/src/dds_async/subscriber.rs
+++ b/dds/src/dds_async/subscriber.rs
@@ -23,6 +23,7 @@ use super::{
     domain_participant::DomainParticipantAsync, topic::TopicAsync,
 };
 
+/// Async version of ['Subscriber'](crate::subscription::subscriber::Subscriber).
 pub struct SubscriberAsync {
     subscriber_address: ActorAddress<SubscriberActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
@@ -48,6 +49,7 @@ impl SubscriberAsync {
 }
 
 impl SubscriberAsync {
+    /// Async version of ['create_datareader'](crate::subscription::subscriber::Subscriber::create_datareader).
     #[tracing::instrument(skip(self, a_topic, a_listener))]
     pub async fn create_datareader<Foo>(
         &self,
@@ -127,6 +129,7 @@ impl SubscriberAsync {
         Ok(data_reader)
     }
 
+    /// Async version of ['delete_datareader'](crate::subscription::subscriber::Subscriber::delete_datareader).
     #[tracing::instrument(skip(self, a_datareader))]
     pub async fn delete_datareader<Foo>(
         &self,
@@ -156,6 +159,7 @@ impl SubscriberAsync {
             .await?
     }
 
+    /// Async version of ['lookup_datareader'](crate::subscription::subscriber::Subscriber::lookup_datareader).
     #[tracing::instrument(skip(self))]
     pub async fn lookup_datareader<Foo>(
         &self,
@@ -177,11 +181,13 @@ impl SubscriberAsync {
             }))
     }
 
+    /// Async version of ['notify_datareaders'](crate::subscription::subscriber::Subscriber::notify_datareaders).
     #[tracing::instrument(skip(self))]
     pub async fn notify_datareaders(&self) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['get_participant'](crate::subscription::subscriber::Subscriber::get_participant).
     #[tracing::instrument(skip(self))]
     pub async fn get_participant(&self) -> DdsResult<DomainParticipantAsync> {
         Ok(DomainParticipantAsync::new(
@@ -190,16 +196,19 @@ impl SubscriberAsync {
         ))
     }
 
+    /// Async version of ['get_sample_lost_status'](crate::subscription::subscriber::Subscriber::get_sample_lost_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_sample_lost_status(&self) -> DdsResult<SampleLostStatus> {
         todo!()
     }
 
+    /// Async version of ['delete_contained_entities'](crate::subscription::subscriber::Subscriber::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['set_default_datareader_qos'](crate::subscription::subscriber::Subscriber::set_default_datareader_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_datareader_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
         self.subscriber_address
@@ -207,6 +216,7 @@ impl SubscriberAsync {
             .await?
     }
 
+    /// Async version of ['get_default_datareader_qos'](crate::subscription::subscriber::Subscriber::get_default_datareader_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_datareader_qos(&self) -> DdsResult<DataReaderQos> {
         self.subscriber_address
@@ -214,6 +224,7 @@ impl SubscriberAsync {
             .await
     }
 
+    /// Async version of ['copy_from_topic_qos'](crate::subscription::subscriber::Subscriber::copy_from_topic_qos).
     #[tracing::instrument]
     pub async fn copy_from_topic_qos(
         _a_datareader_qos: &mut DataReaderQos,
@@ -222,11 +233,13 @@ impl SubscriberAsync {
         todo!()
     }
 
+    /// Async version of ['set_qos'](crate::subscription::subscriber::Subscriber::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, _qos: QosKind<SubscriberQos>) -> DdsResult<()> {
         todo!()
     }
 
+    /// Async version of ['get_qos'](crate::subscription::subscriber::Subscriber::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<SubscriberQos> {
         self.subscriber_address
@@ -234,6 +247,7 @@ impl SubscriberAsync {
             .await
     }
 
+    /// Async version of ['set_listener'](crate::subscription::subscriber::Subscriber::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,
@@ -249,6 +263,7 @@ impl SubscriberAsync {
             .await
     }
 
+    /// Async version of ['get_statuscondition'](crate::subscription::subscriber::Subscriber::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         self.subscriber_address
@@ -257,11 +272,13 @@ impl SubscriberAsync {
             .map(|c| StatusConditionAsync::new(c, self.runtime_handle.clone()))
     }
 
+    /// Async version of ['get_status_changes'](crate::subscription::subscriber::Subscriber::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
+    /// Async version of ['enable'](crate::subscription::subscriber::Subscriber::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -295,6 +312,7 @@ impl SubscriberAsync {
         Ok(())
     }
 
+    /// Async version of ['get_instance_handle'](crate::subscription::subscriber::Subscriber::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.subscriber_address

--- a/dds/src/dds_async/subscriber.rs
+++ b/dds/src/dds_async/subscriber.rs
@@ -23,7 +23,7 @@ use super::{
     domain_participant::DomainParticipantAsync, topic::TopicAsync,
 };
 
-/// Async version of ['Subscriber'](crate::subscription::subscriber::Subscriber).
+/// Async version of [`Subscriber`](crate::subscription::subscriber::Subscriber).
 pub struct SubscriberAsync {
     subscriber_address: ActorAddress<SubscriberActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
@@ -49,7 +49,7 @@ impl SubscriberAsync {
 }
 
 impl SubscriberAsync {
-    /// Async version of ['create_datareader'](crate::subscription::subscriber::Subscriber::create_datareader).
+    /// Async version of [`create_datareader`](crate::subscription::subscriber::Subscriber::create_datareader).
     #[tracing::instrument(skip(self, a_topic, a_listener))]
     pub async fn create_datareader<Foo>(
         &self,
@@ -129,7 +129,7 @@ impl SubscriberAsync {
         Ok(data_reader)
     }
 
-    /// Async version of ['delete_datareader'](crate::subscription::subscriber::Subscriber::delete_datareader).
+    /// Async version of [`delete_datareader`](crate::subscription::subscriber::Subscriber::delete_datareader).
     #[tracing::instrument(skip(self, a_datareader))]
     pub async fn delete_datareader<Foo>(
         &self,
@@ -159,7 +159,7 @@ impl SubscriberAsync {
             .await?
     }
 
-    /// Async version of ['lookup_datareader'](crate::subscription::subscriber::Subscriber::lookup_datareader).
+    /// Async version of [`lookup_datareader`](crate::subscription::subscriber::Subscriber::lookup_datareader).
     #[tracing::instrument(skip(self))]
     pub async fn lookup_datareader<Foo>(
         &self,
@@ -181,13 +181,13 @@ impl SubscriberAsync {
             }))
     }
 
-    /// Async version of ['notify_datareaders'](crate::subscription::subscriber::Subscriber::notify_datareaders).
+    /// Async version of [`notify_datareaders`](crate::subscription::subscriber::Subscriber::notify_datareaders).
     #[tracing::instrument(skip(self))]
     pub async fn notify_datareaders(&self) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['get_participant'](crate::subscription::subscriber::Subscriber::get_participant).
+    /// Async version of [`get_participant`](crate::subscription::subscriber::Subscriber::get_participant).
     #[tracing::instrument(skip(self))]
     pub async fn get_participant(&self) -> DdsResult<DomainParticipantAsync> {
         Ok(DomainParticipantAsync::new(
@@ -196,19 +196,19 @@ impl SubscriberAsync {
         ))
     }
 
-    /// Async version of ['get_sample_lost_status'](crate::subscription::subscriber::Subscriber::get_sample_lost_status).
+    /// Async version of [`get_sample_lost_status`](crate::subscription::subscriber::Subscriber::get_sample_lost_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_sample_lost_status(&self) -> DdsResult<SampleLostStatus> {
         todo!()
     }
 
-    /// Async version of ['delete_contained_entities'](crate::subscription::subscriber::Subscriber::delete_contained_entities).
+    /// Async version of [`delete_contained_entities`](crate::subscription::subscriber::Subscriber::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['set_default_datareader_qos'](crate::subscription::subscriber::Subscriber::set_default_datareader_qos).
+    /// Async version of [`set_default_datareader_qos`](crate::subscription::subscriber::Subscriber::set_default_datareader_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_datareader_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
         self.subscriber_address
@@ -216,7 +216,7 @@ impl SubscriberAsync {
             .await?
     }
 
-    /// Async version of ['get_default_datareader_qos'](crate::subscription::subscriber::Subscriber::get_default_datareader_qos).
+    /// Async version of [`get_default_datareader_qos`](crate::subscription::subscriber::Subscriber::get_default_datareader_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_datareader_qos(&self) -> DdsResult<DataReaderQos> {
         self.subscriber_address
@@ -224,7 +224,7 @@ impl SubscriberAsync {
             .await
     }
 
-    /// Async version of ['copy_from_topic_qos'](crate::subscription::subscriber::Subscriber::copy_from_topic_qos).
+    /// Async version of [`copy_from_topic_qos`](crate::subscription::subscriber::Subscriber::copy_from_topic_qos).
     #[tracing::instrument]
     pub async fn copy_from_topic_qos(
         _a_datareader_qos: &mut DataReaderQos,
@@ -233,13 +233,13 @@ impl SubscriberAsync {
         todo!()
     }
 
-    /// Async version of ['set_qos'](crate::subscription::subscriber::Subscriber::set_qos).
+    /// Async version of [`set_qos`](crate::subscription::subscriber::Subscriber::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, _qos: QosKind<SubscriberQos>) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['get_qos'](crate::subscription::subscriber::Subscriber::get_qos).
+    /// Async version of [`get_qos`](crate::subscription::subscriber::Subscriber::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<SubscriberQos> {
         self.subscriber_address
@@ -247,7 +247,7 @@ impl SubscriberAsync {
             .await
     }
 
-    /// Async version of ['set_listener'](crate::subscription::subscriber::Subscriber::set_listener).
+    /// Async version of [`set_listener`](crate::subscription::subscriber::Subscriber::set_listener).
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,
@@ -263,7 +263,7 @@ impl SubscriberAsync {
             .await
     }
 
-    /// Async version of ['get_statuscondition'](crate::subscription::subscriber::Subscriber::get_statuscondition).
+    /// Async version of [`get_statuscondition`](crate::subscription::subscriber::Subscriber::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         self.subscriber_address
@@ -272,13 +272,13 @@ impl SubscriberAsync {
             .map(|c| StatusConditionAsync::new(c, self.runtime_handle.clone()))
     }
 
-    /// Async version of ['get_status_changes'](crate::subscription::subscriber::Subscriber::get_status_changes).
+    /// Async version of [`get_status_changes`](crate::subscription::subscriber::Subscriber::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
-    /// Async version of ['enable'](crate::subscription::subscriber::Subscriber::enable).
+    /// Async version of [`enable`](crate::subscription::subscriber::Subscriber::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -312,7 +312,7 @@ impl SubscriberAsync {
         Ok(())
     }
 
-    /// Async version of ['get_instance_handle'](crate::subscription::subscriber::Subscriber::get_instance_handle).
+    /// Async version of [`get_instance_handle`](crate::subscription::subscriber::Subscriber::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.subscriber_address

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -23,6 +23,7 @@ use crate::{
 
 use super::{condition::StatusConditionAsync, domain_participant::DomainParticipantAsync};
 
+/// Async version of ['Topic'](crate::topic_definition::topic::Topic).
 pub struct TopicAsync {
     topic_address: ActorAddress<TopicActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
@@ -48,6 +49,7 @@ impl TopicAsync {
 }
 
 impl TopicAsync {
+    /// Async version of ['get_inconsistent_topic_status'](crate::topic_definition::topic::Topic::get_inconsistent_topic_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_inconsistent_topic_status(&self) -> DdsResult<InconsistentTopicStatus> {
         self.topic_address
@@ -57,6 +59,7 @@ impl TopicAsync {
 }
 
 impl TopicAsync {
+    /// Async version of ['get_participant'](crate::topic_definition::topic::Topic::get_participant).
     #[tracing::instrument(skip(self))]
     pub async fn get_participant(&self) -> DdsResult<DomainParticipantAsync> {
         Ok(DomainParticipantAsync::new(
@@ -65,6 +68,7 @@ impl TopicAsync {
         ))
     }
 
+    /// Async version of ['get_type_name'](crate::topic_definition::topic::Topic::get_type_name).
     #[tracing::instrument(skip(self))]
     pub async fn get_type_name(&self) -> DdsResult<String> {
         self.topic_address
@@ -72,6 +76,7 @@ impl TopicAsync {
             .await
     }
 
+    /// Async version of ['get_name'](crate::topic_definition::topic::Topic::get_name).
     #[tracing::instrument(skip(self))]
     pub async fn get_name(&self) -> DdsResult<String> {
         self.topic_address
@@ -81,6 +86,7 @@ impl TopicAsync {
 }
 
 impl TopicAsync {
+    /// Async version of ['set_qos'](crate::topic_definition::topic::Topic::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -111,6 +117,7 @@ impl TopicAsync {
             .await
     }
 
+    /// Async version of ['get_qos'](crate::topic_definition::topic::Topic::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<TopicQos> {
         self.topic_address
@@ -118,6 +125,7 @@ impl TopicAsync {
             .await
     }
 
+    /// Async version of ['get_statuscondition'](crate::topic_definition::topic::Topic::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         self.topic_address
@@ -126,11 +134,13 @@ impl TopicAsync {
             .map(|c| StatusConditionAsync::new(c, self.runtime_handle.clone()))
     }
 
+    /// Async version of ['get_status_changes'](crate::topic_definition::topic::Topic::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
+    /// Async version of ['enable'](crate::topic_definition::topic::Topic::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -154,6 +164,7 @@ impl TopicAsync {
         Ok(())
     }
 
+    /// Async version of ['get_instance_handle'](crate::topic_definition::topic::Topic::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.topic_address
@@ -161,6 +172,7 @@ impl TopicAsync {
             .await
     }
 
+    /// Async version of ['set_listener'](crate::topic_definition::topic::Topic::set_listener).
     #[tracing::instrument(skip(self, _a_listener))]
     pub async fn set_listener(
         &self,

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::{condition::StatusConditionAsync, domain_participant::DomainParticipantAsync};
 
-/// Async version of ['Topic'](crate::topic_definition::topic::Topic).
+/// Async version of [`Topic`](crate::topic_definition::topic::Topic).
 pub struct TopicAsync {
     topic_address: ActorAddress<TopicActor>,
     participant_address: ActorAddress<DomainParticipantActor>,
@@ -49,7 +49,7 @@ impl TopicAsync {
 }
 
 impl TopicAsync {
-    /// Async version of ['get_inconsistent_topic_status'](crate::topic_definition::topic::Topic::get_inconsistent_topic_status).
+    /// Async version of [`get_inconsistent_topic_status`](crate::topic_definition::topic::Topic::get_inconsistent_topic_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_inconsistent_topic_status(&self) -> DdsResult<InconsistentTopicStatus> {
         self.topic_address
@@ -59,7 +59,7 @@ impl TopicAsync {
 }
 
 impl TopicAsync {
-    /// Async version of ['get_participant'](crate::topic_definition::topic::Topic::get_participant).
+    /// Async version of [`get_participant`](crate::topic_definition::topic::Topic::get_participant).
     #[tracing::instrument(skip(self))]
     pub async fn get_participant(&self) -> DdsResult<DomainParticipantAsync> {
         Ok(DomainParticipantAsync::new(
@@ -68,7 +68,7 @@ impl TopicAsync {
         ))
     }
 
-    /// Async version of ['get_type_name'](crate::topic_definition::topic::Topic::get_type_name).
+    /// Async version of [`get_type_name`](crate::topic_definition::topic::Topic::get_type_name).
     #[tracing::instrument(skip(self))]
     pub async fn get_type_name(&self) -> DdsResult<String> {
         self.topic_address
@@ -76,7 +76,7 @@ impl TopicAsync {
             .await
     }
 
-    /// Async version of ['get_name'](crate::topic_definition::topic::Topic::get_name).
+    /// Async version of [`get_name`](crate::topic_definition::topic::Topic::get_name).
     #[tracing::instrument(skip(self))]
     pub async fn get_name(&self) -> DdsResult<String> {
         self.topic_address
@@ -86,7 +86,7 @@ impl TopicAsync {
 }
 
 impl TopicAsync {
-    /// Async version of ['set_qos'](crate::topic_definition::topic::Topic::set_qos).
+    /// Async version of [`set_qos`](crate::topic_definition::topic::Topic::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
         let qos = match qos {
@@ -117,7 +117,7 @@ impl TopicAsync {
             .await
     }
 
-    /// Async version of ['get_qos'](crate::topic_definition::topic::Topic::get_qos).
+    /// Async version of [`get_qos`](crate::topic_definition::topic::Topic::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<TopicQos> {
         self.topic_address
@@ -125,7 +125,7 @@ impl TopicAsync {
             .await
     }
 
-    /// Async version of ['get_statuscondition'](crate::topic_definition::topic::Topic::get_statuscondition).
+    /// Async version of [`get_statuscondition`](crate::topic_definition::topic::Topic::get_statuscondition).
     #[tracing::instrument(skip(self))]
     pub async fn get_statuscondition(&self) -> DdsResult<StatusConditionAsync> {
         self.topic_address
@@ -134,13 +134,13 @@ impl TopicAsync {
             .map(|c| StatusConditionAsync::new(c, self.runtime_handle.clone()))
     }
 
-    /// Async version of ['get_status_changes'](crate::topic_definition::topic::Topic::get_status_changes).
+    /// Async version of [`get_status_changes`](crate::topic_definition::topic::Topic::get_status_changes).
     #[tracing::instrument(skip(self))]
     pub async fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
         todo!()
     }
 
-    /// Async version of ['enable'](crate::topic_definition::topic::Topic::enable).
+    /// Async version of [`enable`](crate::topic_definition::topic::Topic::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
@@ -164,7 +164,7 @@ impl TopicAsync {
         Ok(())
     }
 
-    /// Async version of ['get_instance_handle'](crate::topic_definition::topic::Topic::get_instance_handle).
+    /// Async version of [`get_instance_handle`](crate::topic_definition::topic::Topic::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         self.topic_address
@@ -172,7 +172,7 @@ impl TopicAsync {
             .await
     }
 
-    /// Async version of ['set_listener'](crate::topic_definition::topic::Topic::set_listener).
+    /// Async version of [`set_listener`](crate::topic_definition::topic::Topic::set_listener).
     #[tracing::instrument(skip(self, _a_listener))]
     pub async fn set_listener(
         &self,

--- a/dds/src/dds_async/wait_set.rs
+++ b/dds/src/dds_async/wait_set.rs
@@ -7,11 +7,14 @@ use crate::infrastructure::{
 
 use super::condition::StatusConditionAsync;
 
+/// Async version of ['Condition'](crate::infrastructure::wait_set::Condition).
 #[derive(Clone)]
 pub enum ConditionAsync {
+    /// Status condition variant
     StatusCondition(StatusConditionAsync),
 }
 impl ConditionAsync {
+    /// Async version of ['get_trigger_value'](crate::infrastructure::wait_set::Condition::get_trigger_value).
     #[tracing::instrument(skip(self))]
     pub async fn get_trigger_value(&self) -> DdsResult<bool> {
         match self {
@@ -20,26 +23,20 @@ impl ConditionAsync {
     }
 }
 
+/// Async version of ['WaitSet'](crate::infrastructure::wait_set::WaitSet).
 #[derive(Default)]
 pub struct WaitSetAsync {
     conditions: Vec<ConditionAsync>,
 }
 
 impl WaitSetAsync {
-    /// Create a new [`WaitSet`]
+    /// Create a new [`WaitSetAsync`]
     #[tracing::instrument]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// This operation allows an application thread to wait for the occurrence of certain conditions. If none of the conditions attached
-    /// to the [`WaitSet`] have a `trigger_value` of [`true`], the wait operation will block suspending the calling thread.
-    /// The operation returns the list of all the attached conditions that have a `trigger_value` of [`true`] (i.e., the conditions
-    /// that unblocked the wait).
-    /// This operation takes a `timeout` argument that specifies the maximum duration for the wait. It this duration is exceeded and
-    /// none of the attached [`Condition`] objects is [`true`], wait will return with [`DdsError::Timeout`].
-    /// It is not allowed for more than one application thread to be waiting on the same [`WaitSet`]. If the wait operation is invoked on a
-    /// [`WaitSet`] that already has a thread blocking on it, the operation will return immediately with the value [`DdsError::PreconditionNotMet`].
+    /// Async version of ['wait'](crate::infrastructure::wait_set::WaitSet::wait).
     #[tracing::instrument(skip(self))]
     pub async fn wait(&self, timeout: Duration) -> DdsResult<Vec<ConditionAsync>> {
         let start_time = Instant::now();
@@ -64,24 +61,20 @@ impl WaitSetAsync {
         Err(DdsError::Timeout)
     }
 
-    /// Attaches a [`Condition`] to the [`WaitSet`].
-    /// It is possible to attach a [`Condition`] on a WaitSet that is currently being waited upon (via the [`WaitSet::wait`] operation). In this case, if the
-    /// [`Condition`] has a `trigger_value` of [`true`], then attaching the condition will unblock the [`WaitSet`].
-    /// Adding a [`Condition`] that is already attached to the [`WaitSet`] has no effect.
+    /// Async version of ['attach_condition'](crate::infrastructure::wait_set::WaitSet::attach_condition).
     #[tracing::instrument(skip(self, cond))]
     pub async fn attach_condition(&mut self, cond: ConditionAsync) -> DdsResult<()> {
         self.conditions.push(cond);
         Ok(())
     }
 
-    /// Detaches a [`Condition`] from the [`WaitSet`].
-    /// If the [`Condition`] was not attached to the [`WaitSet`], the operation will return [`DdsError::PreconditionNotMet`].
+    /// Async version of ['detach_condition'](crate::infrastructure::wait_set::WaitSet::detach_condition).
     #[tracing::instrument(skip(self, _cond))]
     pub async fn detach_condition(&self, _cond: ConditionAsync) -> DdsResult<()> {
         todo!()
     }
 
-    /// This operation retrieves the list of attached conditions.
+    /// Async version of ['get_conditions'](crate::infrastructure::wait_set::WaitSet::get_conditions).
     #[tracing::instrument(skip(self))]
     pub async fn get_conditions(&self) -> DdsResult<Vec<ConditionAsync>> {
         Ok(self.conditions.clone())

--- a/dds/src/dds_async/wait_set.rs
+++ b/dds/src/dds_async/wait_set.rs
@@ -7,14 +7,14 @@ use crate::infrastructure::{
 
 use super::condition::StatusConditionAsync;
 
-/// Async version of ['Condition'](crate::infrastructure::wait_set::Condition).
+/// Async version of [`Condition`](crate::infrastructure::wait_set::Condition).
 #[derive(Clone)]
 pub enum ConditionAsync {
     /// Status condition variant
     StatusCondition(StatusConditionAsync),
 }
 impl ConditionAsync {
-    /// Async version of ['get_trigger_value'](crate::infrastructure::wait_set::Condition::get_trigger_value).
+    /// Async version of [`get_trigger_value`](crate::infrastructure::wait_set::Condition::get_trigger_value).
     #[tracing::instrument(skip(self))]
     pub async fn get_trigger_value(&self) -> DdsResult<bool> {
         match self {
@@ -23,7 +23,7 @@ impl ConditionAsync {
     }
 }
 
-/// Async version of ['WaitSet'](crate::infrastructure::wait_set::WaitSet).
+/// Async version of [`WaitSet`](crate::infrastructure::wait_set::WaitSet).
 #[derive(Default)]
 pub struct WaitSetAsync {
     conditions: Vec<ConditionAsync>,
@@ -36,7 +36,7 @@ impl WaitSetAsync {
         Self::default()
     }
 
-    /// Async version of ['wait'](crate::infrastructure::wait_set::WaitSet::wait).
+    /// Async version of [`wait`](crate::infrastructure::wait_set::WaitSet::wait).
     #[tracing::instrument(skip(self))]
     pub async fn wait(&self, timeout: Duration) -> DdsResult<Vec<ConditionAsync>> {
         let start_time = Instant::now();
@@ -61,20 +61,20 @@ impl WaitSetAsync {
         Err(DdsError::Timeout)
     }
 
-    /// Async version of ['attach_condition'](crate::infrastructure::wait_set::WaitSet::attach_condition).
+    /// Async version of [`attach_condition`](crate::infrastructure::wait_set::WaitSet::attach_condition).
     #[tracing::instrument(skip(self, cond))]
     pub async fn attach_condition(&mut self, cond: ConditionAsync) -> DdsResult<()> {
         self.conditions.push(cond);
         Ok(())
     }
 
-    /// Async version of ['detach_condition'](crate::infrastructure::wait_set::WaitSet::detach_condition).
+    /// Async version of [`detach_condition`](crate::infrastructure::wait_set::WaitSet::detach_condition).
     #[tracing::instrument(skip(self, _cond))]
     pub async fn detach_condition(&self, _cond: ConditionAsync) -> DdsResult<()> {
         todo!()
     }
 
-    /// Async version of ['get_conditions'](crate::infrastructure::wait_set::WaitSet::get_conditions).
+    /// Async version of [`get_conditions`](crate::infrastructure::wait_set::WaitSet::get_conditions).
     #[tracing::instrument(skip(self))]
     pub async fn get_conditions(&self) -> DdsResult<Vec<ConditionAsync>> {
         Ok(self.conditions.clone())

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -21,7 +21,7 @@ use crate::{
         utils::actor::{Actor, ActorAddress},
     },
     infrastructure::{
-        error::DdsResult,
+        error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{DataWriterQos, PublisherQos, QosKind},
         qos_policy::PartitionQosPolicy,
@@ -412,5 +412,15 @@ impl PublisherActor {
             || is_any_name_matched
             || is_any_received_regex_matched_with_partition_qos
             || is_any_local_regex_matched_with_received_partition_qos
+    }
+}
+
+impl PublisherQos {
+    fn check_immutability(&self, other: &Self) -> DdsResult<()> {
+        if self.presentation != other.presentation {
+            Err(DdsError::ImmutablePolicy)
+        } else {
+            Ok(())
+        }
     }
 }

--- a/dds/src/implementation/payload_serializer_deserializer/cdr_deserializer.rs
+++ b/dds/src/implementation/payload_serializer_deserializer/cdr_deserializer.rs
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn deserialize_char_array() {
-        let v = ['A', 'B', 'C', 'D', 'E'];
+        let v = [`A', 'B', 'C', 'D', 'E`];
         assert_eq!(
             deserialize_be::<[char; 5]>(&[0x41, 0x42, 0x43, 0x44, 0x45]).unwrap(),
             v

--- a/dds/src/implementation/payload_serializer_deserializer/cdr_deserializer.rs
+++ b/dds/src/implementation/payload_serializer_deserializer/cdr_deserializer.rs
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn deserialize_char_array() {
-        let v = [`A', 'B', 'C', 'D', 'E`];
+        let v = ['A', 'B', 'C', 'D', 'E'];
         assert_eq!(
             deserialize_be::<[char; 5]>(&[0x41, 0x42, 0x43, 0x44, 0x45]).unwrap(),
             v

--- a/dds/src/implementation/payload_serializer_deserializer/cdr_serializer.rs
+++ b/dds/src/implementation/payload_serializer_deserializer/cdr_serializer.rs
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn serialize_char_array() {
-        let v = [`A', 'B', 'C', 'D', 'E`];
+        let v = ['A', 'B', 'C', 'D', 'E'];
         assert_eq!(
             serialize_be::<_>(&v).unwrap(),
             vec![0x41, 0x42, 0x43, 0x44, 0x45]
@@ -702,7 +702,7 @@ mod tests {
 
     #[test]
     fn serialize_char_sequence() {
-        let v = vec![`A', 'B', 'C', 'D', 'E`];
+        let v = vec!['A', 'B', 'C', 'D', 'E'];
         assert_eq!(
             serialize_be::<_>(&v).unwrap(),
             vec![

--- a/dds/src/implementation/payload_serializer_deserializer/cdr_serializer.rs
+++ b/dds/src/implementation/payload_serializer_deserializer/cdr_serializer.rs
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn serialize_char_array() {
-        let v = ['A', 'B', 'C', 'D', 'E'];
+        let v = [`A', 'B', 'C', 'D', 'E`];
         assert_eq!(
             serialize_be::<_>(&v).unwrap(),
             vec![0x41, 0x42, 0x43, 0x44, 0x45]
@@ -702,7 +702,7 @@ mod tests {
 
     #[test]
     fn serialize_char_sequence() {
-        let v = vec!['A', 'B', 'C', 'D', 'E'];
+        let v = vec![`A', 'B', 'C', 'D', 'E`];
         assert_eq!(
             serialize_be::<_>(&v).unwrap(),
             vec![

--- a/dds/src/lib.rs
+++ b/dds/src/lib.rs
@@ -1,6 +1,7 @@
+#![forbid(unsafe_code)]
+#![forbid(missing_docs)]
 #![doc = include_str!("../README.md")]
 mod dds;
-#[forbid(unsafe_code)]
 /// Module containing the traits and classes needed to represent types in the formats defined in the RTPS standard
 pub mod serialized_payload;
 pub use dds::*;

--- a/dds/src/lib.rs
+++ b/dds/src/lib.rs
@@ -2,10 +2,10 @@
 #![forbid(missing_docs)]
 #![doc = include_str!("../README.md")]
 mod dds;
-/// Module containing the traits and classes needed to represent types in the formats defined in the RTPS standard
+/// Contains the traits and classes needed to represent types in the formats defined in the RTPS standard
 pub mod serialized_payload;
 pub use dds::*;
-/// Module containing the async API
+/// Contains the async version of the DDS API.
 pub mod dds_async;
 mod implementation;
 

--- a/dds/src/serialized_payload/cdr/deserialize.rs
+++ b/dds/src/serialized_payload/cdr/deserialize.rs
@@ -2,7 +2,9 @@ pub use dust_dds_derive::CdrDeserialize;
 
 use super::deserializer::CdrDeserializer;
 
+/// A trait representing a structure that can be deserialized from a CDR format.
 pub trait CdrDeserialize<'de>: Sized {
+    /// Method to deserialize this value using the given deserializer.
     fn deserialize(deserializer: &mut impl CdrDeserializer<'de>) -> Result<Self, std::io::Error>;
 }
 

--- a/dds/src/serialized_payload/cdr/deserializer.rs
+++ b/dds/src/serialized_payload/cdr/deserializer.rs
@@ -1,43 +1,62 @@
 use super::deserialize::CdrDeserialize;
 
+/// A trait representing an object with the capability of deserializing a value from a CDR format.
 pub trait CdrDeserializer<'de> {
+    /// Deserialize a ['bool'] value.
     fn deserialize_bool(&mut self) -> Result<bool, std::io::Error>;
 
+    /// Deserialize an ['i8'] value.
     fn deserialize_i8(&mut self) -> Result<i8, std::io::Error>;
 
+    /// Deserialize an ['i16'] value.
     fn deserialize_i16(&mut self) -> Result<i16, std::io::Error>;
 
+    /// Deserialize an ['i32'] value.
     fn deserialize_i32(&mut self) -> Result<i32, std::io::Error>;
 
+    /// Deserialize an ['i64'] value.
     fn deserialize_i64(&mut self) -> Result<i64, std::io::Error>;
 
+    /// Deserialize a ['u8'] value.
     fn deserialize_u8(&mut self) -> Result<u8, std::io::Error>;
 
+    /// Deserialize a ['u16'] value.
     fn deserialize_u16(&mut self) -> Result<u16, std::io::Error>;
 
+    /// Deserialize a ['u32'] value.
     fn deserialize_u32(&mut self) -> Result<u32, std::io::Error>;
 
+    /// Deserialize a ['u64'] value.
     fn deserialize_u64(&mut self) -> Result<u64, std::io::Error>;
 
+    /// Deserialize an ['f32'] value.
     fn deserialize_f32(&mut self) -> Result<f32, std::io::Error>;
 
+    /// Deserialize an ['f64'] value.
     fn deserialize_f64(&mut self) -> Result<f64, std::io::Error>;
 
+    /// Deserialize a ['char'] value.
     fn deserialize_char(&mut self) -> Result<char, std::io::Error>;
 
+    /// Deserialize a ['String'] value.
     fn deserialize_string(&mut self) -> Result<String, std::io::Error>;
 
+    /// Deserialize a variable sized sequence of values.
     fn deserialize_seq<T>(&mut self) -> Result<Vec<T>, std::io::Error>
     where
         T: CdrDeserialize<'de>;
 
+    /// Deserialize an array of values.
     fn deserialize_array<const N: usize, T>(&mut self) -> Result<[T; N], std::io::Error>
     where
         T: CdrDeserialize<'de>;
 
+    /// Deserialize a variable sized sequence of bytes by borrowing from the original byte array.
     fn deserialize_bytes(&mut self) -> Result<&'de [u8], std::io::Error>;
 
+    /// Deserialize an array of bytes by borrowing from the original byte array.
     fn deserialize_byte_array<const N: usize>(&mut self) -> Result<&'de [u8; N], std::io::Error>;
 
+    /// Deserialize a unit value.
     fn deserialize_unit(&mut self) -> Result<(), std::io::Error>;
 }

--- a/dds/src/serialized_payload/cdr/deserializer.rs
+++ b/dds/src/serialized_payload/cdr/deserializer.rs
@@ -2,43 +2,43 @@ use super::deserialize::CdrDeserialize;
 
 /// A trait representing an object with the capability of deserializing a value from a CDR format.
 pub trait CdrDeserializer<'de> {
-    /// Deserialize a ['bool'] value.
+    /// Deserialize a [`bool`] value.
     fn deserialize_bool(&mut self) -> Result<bool, std::io::Error>;
 
-    /// Deserialize an ['i8'] value.
+    /// Deserialize an [`i8`] value.
     fn deserialize_i8(&mut self) -> Result<i8, std::io::Error>;
 
-    /// Deserialize an ['i16'] value.
+    /// Deserialize an [`i16`] value.
     fn deserialize_i16(&mut self) -> Result<i16, std::io::Error>;
 
-    /// Deserialize an ['i32'] value.
+    /// Deserialize an [`i32`] value.
     fn deserialize_i32(&mut self) -> Result<i32, std::io::Error>;
 
-    /// Deserialize an ['i64'] value.
+    /// Deserialize an [`i64`] value.
     fn deserialize_i64(&mut self) -> Result<i64, std::io::Error>;
 
-    /// Deserialize a ['u8'] value.
+    /// Deserialize a [`u8`] value.
     fn deserialize_u8(&mut self) -> Result<u8, std::io::Error>;
 
-    /// Deserialize a ['u16'] value.
+    /// Deserialize a [`u16`] value.
     fn deserialize_u16(&mut self) -> Result<u16, std::io::Error>;
 
-    /// Deserialize a ['u32'] value.
+    /// Deserialize a [`u32`] value.
     fn deserialize_u32(&mut self) -> Result<u32, std::io::Error>;
 
-    /// Deserialize a ['u64'] value.
+    /// Deserialize a [`u64`] value.
     fn deserialize_u64(&mut self) -> Result<u64, std::io::Error>;
 
-    /// Deserialize an ['f32'] value.
+    /// Deserialize an [`f32`] value.
     fn deserialize_f32(&mut self) -> Result<f32, std::io::Error>;
 
-    /// Deserialize an ['f64'] value.
+    /// Deserialize an [`f64`] value.
     fn deserialize_f64(&mut self) -> Result<f64, std::io::Error>;
 
-    /// Deserialize a ['char'] value.
+    /// Deserialize a [`char`] value.
     fn deserialize_char(&mut self) -> Result<char, std::io::Error>;
 
-    /// Deserialize a ['String'] value.
+    /// Deserialize a [`String`] value.
     fn deserialize_string(&mut self) -> Result<String, std::io::Error>;
 
     /// Deserialize a variable sized sequence of values.

--- a/dds/src/serialized_payload/cdr/mod.rs
+++ b/dds/src/serialized_payload/cdr/mod.rs
@@ -1,8 +1,8 @@
-/// Module containing the trait for the CDR Deserialize.
+/// Contains the trait for the CDR Deserialize.
 pub mod deserialize;
-/// Module containing the trait for the CDR Deserializer.
+/// Contains the trait for the CDR Deserializer.
 pub mod deserializer;
-/// Module containing the trait for the CDR Serialize.
+/// Contains the trait for the CDR Serialize.
 pub mod serialize;
-/// Module containing the trait for the CDR Serializer.
+/// Contains the trait for the CDR Serializer.
 pub mod serializer;

--- a/dds/src/serialized_payload/cdr/mod.rs
+++ b/dds/src/serialized_payload/cdr/mod.rs
@@ -1,4 +1,8 @@
+/// Module containing the trait for the CDR Deserialize.
 pub mod deserialize;
+/// Module containing the trait for the CDR Deserializer.
 pub mod deserializer;
+/// Module containing the trait for the CDR Serialize.
 pub mod serialize;
+/// Module containing the trait for the CDR Serializer.
 pub mod serializer;

--- a/dds/src/serialized_payload/cdr/serialize.rs
+++ b/dds/src/serialized_payload/cdr/serialize.rs
@@ -2,7 +2,9 @@ pub use dust_dds_derive::CdrSerialize;
 
 use super::serializer::CdrSerializer;
 
+/// A trait representing a structure that can be serialized into a CDR format.
 pub trait CdrSerialize {
+    /// Method to serialize this value using the given serializer.
     fn serialize(&self, serializer: &mut impl CdrSerializer) -> Result<(), std::io::Error>;
 }
 

--- a/dds/src/serialized_payload/cdr/serializer.rs
+++ b/dds/src/serialized_payload/cdr/serializer.rs
@@ -2,43 +2,43 @@ use super::serialize::CdrSerialize;
 
 /// A trait representing an object with the capability of serializing a value into a CDR format.
 pub trait CdrSerializer {
-    /// Serialize a ['bool'] value.
+    /// Serialize a [`bool`] value.
     fn serialize_bool(&mut self, v: bool) -> Result<(), std::io::Error>;
 
-    /// Serialize an ['i8'] value.
+    /// Serialize an [`i8`] value.
     fn serialize_i8(&mut self, v: i8) -> Result<(), std::io::Error>;
 
-    /// Serialize an ['i16'] value.
+    /// Serialize an [`i16`] value.
     fn serialize_i16(&mut self, v: i16) -> Result<(), std::io::Error>;
 
-    /// Serialize an ['i32'] value.
+    /// Serialize an [`i32`] value.
     fn serialize_i32(&mut self, v: i32) -> Result<(), std::io::Error>;
 
-    /// Serialize an ['i64'] value.
+    /// Serialize an [`i64`] value.
     fn serialize_i64(&mut self, v: i64) -> Result<(), std::io::Error>;
 
-    /// Serialize a ['u8'] value.
+    /// Serialize a [`u8`] value.
     fn serialize_u8(&mut self, v: u8) -> Result<(), std::io::Error>;
 
-    /// Serialize a ['u16'] value.
+    /// Serialize a [`u16`] value.
     fn serialize_u16(&mut self, v: u16) -> Result<(), std::io::Error>;
 
-    /// Serialize a ['u32'] value.
+    /// Serialize a [`u32`] value.
     fn serialize_u32(&mut self, v: u32) -> Result<(), std::io::Error>;
 
-    /// Serialize a ['u64'] value.
+    /// Serialize a [`u64`] value.
     fn serialize_u64(&mut self, v: u64) -> Result<(), std::io::Error>;
 
-    /// Serialize an ['f32'] value.
+    /// Serialize an [`f32`] value.
     fn serialize_f32(&mut self, v: f32) -> Result<(), std::io::Error>;
 
-    /// Serialize an ['f64'] value.
+    /// Serialize an [`f64`] value.
     fn serialize_f64(&mut self, v: f64) -> Result<(), std::io::Error>;
 
-    /// Serialize a ['char'] value.
+    /// Serialize a [`char`] value.
     fn serialize_char(&mut self, v: char) -> Result<(), std::io::Error>;
 
-    /// Serialize a ['str'] value.
+    /// Serialize a [`str`] value.
     fn serialize_str(&mut self, v: &str) -> Result<(), std::io::Error>;
 
     /// Serialize an unknown sized sequence of values.

--- a/dds/src/serialized_payload/cdr/serializer.rs
+++ b/dds/src/serialized_payload/cdr/serializer.rs
@@ -1,35 +1,55 @@
 use super::serialize::CdrSerialize;
 
+/// A trait representing an object with the capability of serializing a value into a CDR format.
 pub trait CdrSerializer {
+    /// Serialize a ['bool'] value.
     fn serialize_bool(&mut self, v: bool) -> Result<(), std::io::Error>;
 
+    /// Serialize an ['i8'] value.
     fn serialize_i8(&mut self, v: i8) -> Result<(), std::io::Error>;
 
+    /// Serialize an ['i16'] value.
     fn serialize_i16(&mut self, v: i16) -> Result<(), std::io::Error>;
 
+    /// Serialize an ['i32'] value.
     fn serialize_i32(&mut self, v: i32) -> Result<(), std::io::Error>;
 
+    /// Serialize an ['i64'] value.
     fn serialize_i64(&mut self, v: i64) -> Result<(), std::io::Error>;
 
+    /// Serialize a ['u8'] value.
     fn serialize_u8(&mut self, v: u8) -> Result<(), std::io::Error>;
 
+    /// Serialize a ['u16'] value.
     fn serialize_u16(&mut self, v: u16) -> Result<(), std::io::Error>;
 
+    /// Serialize a ['u32'] value.
     fn serialize_u32(&mut self, v: u32) -> Result<(), std::io::Error>;
 
+    /// Serialize a ['u64'] value.
     fn serialize_u64(&mut self, v: u64) -> Result<(), std::io::Error>;
 
+    /// Serialize an ['f32'] value.
     fn serialize_f32(&mut self, v: f32) -> Result<(), std::io::Error>;
 
+    /// Serialize an ['f64'] value.
     fn serialize_f64(&mut self, v: f64) -> Result<(), std::io::Error>;
 
+    /// Serialize a ['char'] value.
     fn serialize_char(&mut self, v: char) -> Result<(), std::io::Error>;
 
+    /// Serialize a ['str'] value.
     fn serialize_str(&mut self, v: &str) -> Result<(), std::io::Error>;
 
+    /// Serialize an unknown sized sequence of values.
     fn serialize_seq(&mut self, v: &[impl CdrSerialize]) -> Result<(), std::io::Error>;
 
-    fn serialize_array<const N: usize>(&mut self, v: &[impl CdrSerialize; N]) -> Result<(), std::io::Error>;
+    /// Serialize an array value.
+    fn serialize_array<const N: usize>(
+        &mut self,
+        v: &[impl CdrSerialize; N],
+    ) -> Result<(), std::io::Error>;
 
+    /// Serialize a unit value.
     fn serialize_unit(&mut self) -> Result<(), std::io::Error>;
 }

--- a/dds/src/serialized_payload/mod.rs
+++ b/dds/src/serialized_payload/mod.rs
@@ -1,5 +1,5 @@
 /// Module containing the methods, structures and traits representing the CDR serialization and deserialization.
 pub mod cdr;
 
-/// Module containing  the methods, structures and traits representing the CDR Parameter List serialization and deserialization
+/// Module containing the methods, structures and traits representing the CDR Parameter List serialization and deserialization
 pub mod parameter_list;

--- a/dds/src/serialized_payload/mod.rs
+++ b/dds/src/serialized_payload/mod.rs
@@ -1,2 +1,5 @@
+/// Module containing the methods, structures and traits representing the CDR serialization and deserialization.
 pub mod cdr;
+
+/// Module containing  the methods, structures and traits representing the CDR Parameter List serialization and deserialization
 pub mod parameter_list;

--- a/dds/src/serialized_payload/mod.rs
+++ b/dds/src/serialized_payload/mod.rs
@@ -1,5 +1,5 @@
-/// Module containing the methods, structures and traits representing the CDR serialization and deserialization.
+/// Contains the methods, structures and traits representing the CDR serialization and deserialization.
 pub mod cdr;
 
-/// Module containing the methods, structures and traits representing the CDR Parameter List serialization and deserialization
+/// Contains the methods, structures and traits representing the CDR Parameter List serialization and deserialization
 pub mod parameter_list;

--- a/dds/src/serialized_payload/parameter_list/deserialize.rs
+++ b/dds/src/serialized_payload/parameter_list/deserialize.rs
@@ -2,7 +2,9 @@ use super::deserializer::ParameterListDeserializer;
 
 pub use dust_dds_derive::ParameterListDeserialize;
 
+/// A trait representing a structure that can be deserialized from a CDR parameter list format.
 pub trait ParameterListDeserialize<'de>: Sized {
+    /// Method to deserialize this value using the given deserializer.
     fn deserialize(
         pl_deserializer: &mut impl ParameterListDeserializer<'de>,
     ) -> Result<Self, std::io::Error>;

--- a/dds/src/serialized_payload/parameter_list/deserializer.rs
+++ b/dds/src/serialized_payload/parameter_list/deserializer.rs
@@ -1,14 +1,19 @@
 use crate::serialized_payload::cdr::deserialize::CdrDeserialize;
 
+/// A trait representing an object with the capability of deserializing a value from a CDR parameter list format.
+/// The parameters of a CDR Parameter List must be themselves ['CdrDeserialize'].
 pub trait ParameterListDeserializer<'de> {
+    /// Method to deserialize a parameter without default.
     fn read<T>(&self, id: i16) -> Result<T, std::io::Error>
     where
         T: CdrDeserialize<'de>;
 
+    /// Method to deserialize a parameter with default.
     fn read_with_default<T>(&self, id: i16, default: T) -> Result<T, std::io::Error>
     where
         T: CdrDeserialize<'de>;
 
+    /// Method to deserialize a collection of parameter of a given type.
     fn read_collection<T>(&self, id: i16) -> Result<Vec<T>, std::io::Error>
     where
         T: CdrDeserialize<'de>;

--- a/dds/src/serialized_payload/parameter_list/deserializer.rs
+++ b/dds/src/serialized_payload/parameter_list/deserializer.rs
@@ -1,7 +1,7 @@
 use crate::serialized_payload::cdr::deserialize::CdrDeserialize;
 
 /// A trait representing an object with the capability of deserializing a value from a CDR parameter list format.
-/// The parameters of a CDR Parameter List must be themselves ['CdrDeserialize'].
+/// The parameters of a CDR Parameter List must be themselves [`CdrDeserialize`].
 pub trait ParameterListDeserializer<'de> {
     /// Method to deserialize a parameter without default.
     fn read<T>(&self, id: i16) -> Result<T, std::io::Error>

--- a/dds/src/serialized_payload/parameter_list/mod.rs
+++ b/dds/src/serialized_payload/parameter_list/mod.rs
@@ -1,4 +1,8 @@
+/// Module containing the trait for the CDR ParameterList Deserialize
 pub mod deserialize;
+/// Module containing the trait for the CDR ParameterList Deserializer
 pub mod deserializer;
+/// Module containing the trait for the CDR ParameterList Serialize
 pub mod serialize;
+/// Module containing the trait for the CDR ParameterList Serializer
 pub mod serializer;

--- a/dds/src/serialized_payload/parameter_list/mod.rs
+++ b/dds/src/serialized_payload/parameter_list/mod.rs
@@ -1,8 +1,8 @@
-/// Module containing the trait for the CDR ParameterList Deserialize
+/// Contains the trait for the CDR ParameterList Deserialize
 pub mod deserialize;
-/// Module containing the trait for the CDR ParameterList Deserializer
+/// Contains the trait for the CDR ParameterList Deserializer
 pub mod deserializer;
-/// Module containing the trait for the CDR ParameterList Serialize
+/// Contains the trait for the CDR ParameterList Serialize
 pub mod serialize;
-/// Module containing the trait for the CDR ParameterList Serializer
+/// Contains the trait for the CDR ParameterList Serializer
 pub mod serializer;

--- a/dds/src/serialized_payload/parameter_list/serialize.rs
+++ b/dds/src/serialized_payload/parameter_list/serialize.rs
@@ -2,7 +2,9 @@ use super::serializer::ParameterListSerializer;
 
 pub use dust_dds_derive::ParameterListSerialize;
 
+/// A trait representing a structure that can be serialized into a CDR parameter list format.
 pub trait ParameterListSerialize {
+    /// Method to serialize this value using the given serializer.
     fn serialize(
         &self,
         serializer: &mut impl ParameterListSerializer,

--- a/dds/src/serialized_payload/parameter_list/serializer.rs
+++ b/dds/src/serialized_payload/parameter_list/serializer.rs
@@ -2,11 +2,15 @@ use crate::serialized_payload::cdr::serialize::CdrSerialize;
 
 pub use dust_dds_derive::ParameterListDeserialize;
 
+/// A trait representing an object with the capability of serializing a value into a CDR parameter list format.
+/// All the parameters of a CDR Parameter List must be themselves ['CdrSerialize'].
 pub trait ParameterListSerializer {
+    /// Method to serialize a parameter without default.
     fn write<T>(&mut self, id: i16, value: &T) -> Result<(), std::io::Error>
     where
         T: CdrSerialize;
 
+    /// Method to serialize a parameter with default.
     fn write_with_default<T>(
         &mut self,
         id: i16,
@@ -16,6 +20,7 @@ pub trait ParameterListSerializer {
     where
         T: CdrSerialize + PartialEq;
 
+    /// Method to serialize a collection of parameters of a given type.
     fn write_collection<T>(&mut self, id: i16, value_list: &[T]) -> Result<(), std::io::Error>
     where
         T: CdrSerialize;

--- a/dds/src/serialized_payload/parameter_list/serializer.rs
+++ b/dds/src/serialized_payload/parameter_list/serializer.rs
@@ -3,7 +3,7 @@ use crate::serialized_payload::cdr::serialize::CdrSerialize;
 pub use dust_dds_derive::ParameterListDeserialize;
 
 /// A trait representing an object with the capability of serializing a value into a CDR parameter list format.
-/// All the parameters of a CDR Parameter List must be themselves ['CdrSerialize'].
+/// All the parameters of a CDR Parameter List must be themselves [`CdrSerialize`].
 pub trait ParameterListSerializer {
     /// Method to serialize a parameter without default.
     fn write<T>(&mut self, id: i16, value: &T) -> Result<(), std::io::Error>

--- a/dds_derive/Cargo.toml
+++ b/dds_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_derive"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds_gen/Cargo.toml
+++ b/dds_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_gen"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds_gen/src/generator/rust.rs
+++ b/dds_gen/src/generator/rust.rs
@@ -373,11 +373,11 @@ fn member(pair: IdlPair, writer: &mut String) {
                     .expect("Identifier must exist according to grammar");
                 generate_rust_source(identifier, writer);
                 writer.push(':');
-                writer.push('[');
+                writer.push('[`);
                 generate_rust_source(type_spec.clone(), writer);
                 writer.push(';');
                 generate_rust_source(fixed_array_size, writer);
-                writer.push(']');
+                writer.push(`]');
             }
             Rule::simple_declarator => {
                 generate_rust_source(array_or_simple_declarator, writer);

--- a/dds_gen/src/generator/rust.rs
+++ b/dds_gen/src/generator/rust.rs
@@ -373,11 +373,11 @@ fn member(pair: IdlPair, writer: &mut String) {
                     .expect("Identifier must exist according to grammar");
                 generate_rust_source(identifier, writer);
                 writer.push(':');
-                writer.push('[`);
+                writer.push('[');
                 generate_rust_source(type_spec.clone(), writer);
                 writer.push(';');
                 generate_rust_source(fixed_array_size, writer);
-                writer.push(`]');
+                writer.push(']');
             }
             Rule::simple_declarator => {
                 generate_rust_source(array_or_simple_declarator, writer);


### PR DESCRIPTION
Add missing documentation to the API. To find all the missing documentations I have added a "#![forbid(missing_docs)]" to the top level file. This gives a compiler error in case any item is part of the public API and is not documented. In some cases some somewhat obvious things have to be documented but in general it helps to make really clear what belongs to the public API and also to avoid errors where // is used instead of ///. The version number is bumped up to 0.8.0 as part of this change.