### PR TITLE
Trigger message sending on any discovery action

### DIFF
--- a/dds/src/dds/infrastructure/qos.rs
+++ b/dds/src/dds/infrastructure/qos.rs
@@ -133,7 +133,7 @@ impl DataWriterQos {
         }
     }
 
-    pub(crate) fn _check_immutability(&self, other: &Self) -> DdsResult<()> {
+    pub(crate) fn check_immutability(&self, other: &Self) -> DdsResult<()> {
         if self.durability != other.durability
             || self.liveliness != other.liveliness
             || self.reliability != other.reliability

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -428,9 +428,6 @@ impl<Foo> DataReaderAsync<Foo> {
                 q
             }
         };
-        self.reader_address
-            .send_mail_and_await_reply(data_reader_actor::set_qos::new(q))
-            .await??;
 
         if self
             .reader_address
@@ -453,6 +450,12 @@ impl<Foo> DataReaderAsync<Foo> {
                         type_name
                     ))
                 })?;
+            let current_qos = self.get_qos().await?;
+            q.check_immutability(&current_qos)?;
+            self.reader_address
+                .send_mail_and_await_reply(data_reader_actor::set_qos::new(q))
+                .await?;
+
             let discovered_reader_data = self
                 .reader_address
                 .send_mail_and_await_reply(data_reader_actor::as_discovered_reader_data::new(
@@ -479,6 +482,10 @@ impl<Foo> DataReaderAsync<Foo> {
                         discovered_reader_data,
                     ),
                 )
+                .await?;
+        } else {
+            self.reader_address
+                .send_mail_and_await_reply(data_reader_actor::set_qos::new(q))
                 .await?;
         }
 

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1649,15 +1649,8 @@ impl DataReaderActor {
         InstanceHandle::new(self.rtps_reader.guid().into())
     }
 
-    async fn set_qos(&mut self, qos: DataReaderQos) -> DdsResult<()> {
-        if self.enabled {
-            self.qos.check_immutability(&qos)?;
-        }
-
-        qos.is_consistent()?;
+    async fn set_qos(&mut self, qos: DataReaderQos) {
         self.qos = qos;
-
-        Ok(())
     }
 
     async fn get_qos(&self) -> DataReaderQos {

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -97,7 +97,7 @@ fn deleted_readers_are_disposed_from_writer() {
 
     subscriber.delete_datareader(&data_reader).unwrap();
 
-    wait_set.wait(Duration::new(5, 0)).unwrap();
+    wait_set.wait(Duration::new(1, 0)).unwrap();
 
     assert_eq!(data_writer.get_matched_subscriptions().unwrap().len(), 0);
 }


### PR DESCRIPTION
Some tests were failing because the discovery was only triggered on the SPDP regular interval of 5 seconds. This made some tests with a timeout of 5 seconds flaky. This change triggers a message sending whenever any discovery event takes place.