### PR TITLE
Make get_builtin_subscriber infallible

### DIFF
--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -252,11 +252,8 @@ impl DomainParticipant {
     /// The built-in topics are used to communicate information about other [`DomainParticipant`], [`Topic`], [`DataReader`](crate::subscription::data_reader::DataReader), and [`DataWriter`](crate::publication::data_writer::DataWriter)
     /// objects.
     #[tracing::instrument(skip(self))]
-    pub fn get_builtin_subscriber(&self) -> DdsResult<Subscriber> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_builtin_subscriber())
-            .map(Subscriber::new)
+    pub fn get_builtin_subscriber(&self) -> Subscriber {
+        Subscriber::new(self.participant_async.get_builtin_subscriber())
     }
 
     /// This operation allows an application to instruct the Service to locally ignore a remote domain participant. From that point

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -5,6 +5,7 @@ use crate::{
         actors::{
             domain_participant_actor,
             domain_participant_factory_actor::{self, DomainParticipantFactoryActor},
+            subscriber_actor,
         },
         utils::actor::Actor,
     },
@@ -66,9 +67,17 @@ impl DomainParticipantFactoryAsync {
         let status_condition = participant_address
             .send_mail_and_await_reply(domain_participant_actor::get_statuscondition::new())
             .await?;
+        let builtin_subscriber = participant_address
+            .send_mail_and_await_reply(domain_participant_actor::get_built_in_subscriber::new())
+            .await?;
+        let builtin_subscriber_status_condition_address = builtin_subscriber
+            .send_mail_and_await_reply(subscriber_actor::get_statuscondition::new())
+            .await?;
         let domain_participant = DomainParticipantAsync::new(
             participant_address.clone(),
             status_condition,
+            builtin_subscriber,
+            builtin_subscriber_status_condition_address,
             domain_id,
             self.runtime_handle.clone(),
         );
@@ -110,9 +119,17 @@ impl DomainParticipantFactoryAsync {
             let status_condition = dp
                 .send_mail_and_await_reply(domain_participant_actor::get_statuscondition::new())
                 .await?;
+            let builtin_subscriber = dp
+                .send_mail_and_await_reply(domain_participant_actor::get_built_in_subscriber::new())
+                .await?;
+            let builtin_subscriber_status_condition_address = builtin_subscriber
+                .send_mail_and_await_reply(subscriber_actor::get_statuscondition::new())
+                .await?;
             Ok(Some(DomainParticipantAsync::new(
                 dp,
                 status_condition,
+                builtin_subscriber,
+                builtin_subscriber_status_condition_address,
                 domain_id,
                 self.runtime_handle.clone(),
             )))

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -733,7 +733,6 @@ impl DataReaderActor {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn on_subscription_matched(
         &mut self,
         instance_handle: InstanceHandle,
@@ -851,7 +850,7 @@ impl DataReaderActor {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+
     async fn on_requested_incompatible_qos(
         &mut self,
         incompatible_qos_policy_list: Vec<QosPolicyId>,
@@ -1000,7 +999,6 @@ impl DataReaderActor {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn add_change(
         &mut self,
         change: RtpsReaderCacheChange,
@@ -1828,7 +1826,6 @@ impl DataReaderActor {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn remove_matched_writer(
         &mut self,
         discovered_writer_handle: InstanceHandle,

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -329,13 +329,14 @@ impl DataReaderActor {
         &self,
         data_reader_address: &ActorAddress<DataReaderActor>,
         subscriber: &SubscriberAsync,
-        subscriber_status_condition: &ActorAddress<StatusConditionActor>,
         (subscriber_listener_address, subscriber_listener_mask): &(
             ActorAddress<SubscriberListenerActor>,
             Vec<StatusKind>,
         ),
     ) -> DdsResult<()> {
-        subscriber_status_condition
+        subscriber
+            .get_statuscondition()
+            .address()
             .send_mail_and_await_reply(status_condition_actor::add_communication_state::new(
                 StatusKind::DataOnReaders,
             ))
@@ -383,7 +384,6 @@ impl DataReaderActor {
         reception_timestamp: Time,
         data_reader_address: &ActorAddress<DataReaderActor>,
         subscriber: &SubscriberAsync,
-        subscriber_status_condition: &ActorAddress<StatusConditionActor>,
         subscriber_mask_listener: &(ActorAddress<SubscriberListenerActor>, Vec<StatusKind>),
         participant_mask_listener: &(
             ActorAddress<DomainParticipantListenerActor>,
@@ -428,7 +428,6 @@ impl DataReaderActor {
                                     change,
                                     data_reader_address,
                                     subscriber,
-                                    subscriber_status_condition,
                                     subscriber_mask_listener,
                                     participant_mask_listener,
                                 )
@@ -466,7 +465,6 @@ impl DataReaderActor {
                                     change,
                                     data_reader_address,
                                     subscriber,
-                                    subscriber_status_condition,
                                     subscriber_mask_listener,
                                     participant_mask_listener,
                                 )
@@ -507,7 +505,6 @@ impl DataReaderActor {
                     change,
                     data_reader_address,
                     subscriber,
-                    subscriber_status_condition,
                     subscriber_mask_listener,
                     participant_mask_listener,
                 )
@@ -530,7 +527,6 @@ impl DataReaderActor {
         reception_timestamp: Time,
         data_reader_address: &ActorAddress<DataReaderActor>,
         subscriber: &SubscriberAsync,
-        subscriber_status_condition: &ActorAddress<StatusConditionActor>,
         subscriber_mask_listener: &(ActorAddress<SubscriberListenerActor>, Vec<StatusKind>),
         participant_mask_listener: &(
             ActorAddress<DomainParticipantListenerActor>,
@@ -556,7 +552,6 @@ impl DataReaderActor {
                     reception_timestamp,
                     data_reader_address,
                     subscriber,
-                    subscriber_status_condition,
                     subscriber_mask_listener,
                     participant_mask_listener,
                 )
@@ -1011,7 +1006,6 @@ impl DataReaderActor {
         change: RtpsReaderCacheChange,
         data_reader_address: &ActorAddress<DataReaderActor>,
         subscriber: &SubscriberAsync,
-        subscriber_status_condition: &ActorAddress<StatusConditionActor>,
         subscriber_mask_listener: &(ActorAddress<SubscriberListenerActor>, Vec<StatusKind>),
         participant_mask_listener: &(
             ActorAddress<DomainParticipantListenerActor>,
@@ -1102,13 +1096,8 @@ impl DataReaderActor {
                         .sort_by(|a, b| a.reception_timestamp.cmp(&b.reception_timestamp)),
                 }
 
-                self.on_data_available(
-                    data_reader_address,
-                    subscriber,
-                    subscriber_status_condition,
-                    subscriber_mask_listener,
-                )
-                .await?;
+                self.on_data_available(data_reader_address, subscriber, subscriber_mask_listener)
+                    .await?;
             }
         }
 
@@ -1883,7 +1872,6 @@ impl DataReaderActor {
         reception_timestamp: Time,
         data_reader_address: ActorAddress<DataReaderActor>,
         subscriber: SubscriberAsync,
-        subscriber_status_condition: ActorAddress<StatusConditionActor>,
         subscriber_mask_listener: (ActorAddress<SubscriberListenerActor>, Vec<StatusKind>),
         participant_mask_listener: (
             ActorAddress<DomainParticipantListenerActor>,
@@ -1915,7 +1903,6 @@ impl DataReaderActor {
                         reception_timestamp,
                         &data_reader_address,
                         &subscriber,
-                        &subscriber_status_condition,
                         &subscriber_mask_listener,
                         &participant_mask_listener,
                     )
@@ -1930,7 +1917,6 @@ impl DataReaderActor {
                         reception_timestamp,
                         &data_reader_address,
                         &subscriber,
-                        &subscriber_status_condition,
                         &subscriber_mask_listener,
                         &participant_mask_listener,
                     )

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -740,7 +740,6 @@ impl DataWriterActor {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn remove_matched_reader(
         &mut self,
         discovered_reader_handle: InstanceHandle,

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -32,7 +32,9 @@ use crate::{
     },
 };
 
-use super::domain_participant_listener_actor::DomainParticipantListenerAsyncDyn;
+use super::{
+    domain_participant_listener_actor::DomainParticipantListenerAsyncDyn, subscriber_actor,
+};
 
 pub struct DomainParticipantFactoryActor {
     domain_participant_list: HashMap<InstanceHandle, Actor<DomainParticipantActor>>,
@@ -195,9 +197,17 @@ impl DomainParticipantFactoryActor {
         let status_condition = participant_address
             .send_mail_and_await_reply(domain_participant_actor::get_statuscondition::new())
             .await?;
+        let builtin_subscriber = participant_address
+            .send_mail_and_await_reply(domain_participant_actor::get_built_in_subscriber::new())
+            .await?;
+        let builtin_subscriber_status_condition_address = builtin_subscriber
+            .send_mail_and_await_reply(subscriber_actor::get_statuscondition::new())
+            .await?;
         let participant = DomainParticipantAsync::new(
             participant_address.clone(),
             status_condition.clone(),
+            builtin_subscriber,
+            builtin_subscriber_status_condition_address,
             domain_id,
             runtime_handle.clone(),
         );

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -276,7 +276,6 @@ impl SubscriberActor {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn process_rtps_message(
         &self,
         message: RtpsMessageRead,
@@ -311,7 +310,6 @@ impl SubscriberActor {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn add_matched_writer(
         &self,
         discovered_writer_data: DiscoveredWriterData,

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -302,7 +302,6 @@ impl SubscriberActor {
                         self.status_condition.address(),
                         participant.clone(),
                     ),
-                    self.status_condition.address().clone(),
                     subscriber_mask_listener.clone(),
                     participant_mask_listener.clone(),
                     type_support_actor_address.clone(),

--- a/dds/tests/domain_participant_api.rs
+++ b/dds/tests/domain_participant_api.rs
@@ -570,7 +570,7 @@ fn builtin_reader_access() {
         .create_participant(domain_id, QosKind::Default, NoOpListener::new(), NO_STATUS)
         .unwrap();
 
-    let builtin_subscriber = participant.get_builtin_subscriber().unwrap();
+    let builtin_subscriber = participant.get_builtin_subscriber();
 
     assert!(builtin_subscriber
         .lookup_datareader::<ParticipantBuiltinTopicData>("DCPSParticipant")
@@ -684,7 +684,7 @@ fn get_discovery_data_from_builtin_reader() {
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
-    let builtin_subscriber = participant.get_builtin_subscriber().unwrap();
+    let builtin_subscriber = participant.get_builtin_subscriber();
 
     let participants_reader = builtin_subscriber
         .lookup_datareader::<ParticipantBuiltinTopicData>("DCPSParticipant")


### PR DESCRIPTION
Make get_builtin_subscriber method not fallible. An additional clean-up is done to use the new not fallible methods to get the status condition to reduce function arguments and the clippy allow is removed where not necessary.