### PR TITLE
Use IP address for the host ID part of the GUID

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -83,7 +83,7 @@ impl DomainParticipantFactoryActor {
         let host_id = if let Some(interface) = interface_address_list.first() {
             [interface[12], interface[13], interface[14], interface[15]]
         } else {
-            warn!("Host ID failed to determine from MAC address, use 0 instead");
+            warn!("Failed to get Host ID from IP address, use 0 instead");
             [0; 4]
         };
 

--- a/dds_derive/Cargo.toml
+++ b/dds_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_derive"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds_gen/Cargo.toml
+++ b/dds_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_gen"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",


### PR DESCRIPTION
On some platforms the network interface MAC address cannot be retrieved and would make DustDDS panic. This happens for example on an Android emulator. As such the IP is used.