### PR TITLE
Add interface list to join multicast group

### DIFF
--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -27,7 +27,7 @@ use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
 use socket2::Socket;
 use std::{
     collections::HashMap,
-    net::{Ipv4Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{
         atomic::{AtomicU32, Ordering},
         Arc, OnceLock,
@@ -89,7 +89,10 @@ impl DomainParticipantFactoryActor {
             get_interface_address_list(self.configuration.interface_name());
 
         let host_id = if let Some(interface) = interface_address_list.first() {
-            [interface[12], interface[13], interface[14], interface[15]]
+            match interface.ip() {
+                IpAddr::V4(a) => a.octets(),
+                IpAddr::V6(_) => unimplemented!("IPv6 not yet implemented"),
+            }
         } else {
             warn!("Failed to get Host ID from IP address, use 0 instead");
             [0; 4]
@@ -134,7 +137,7 @@ impl DomainParticipantFactoryActor {
 
         let default_unicast_locator_list: Vec<Locator> = interface_address_list
             .iter()
-            .map(|a| Locator::new(LOCATOR_KIND_UDP_V4, user_defined_unicast_locator_port, *a))
+            .map(|a| Locator::from_ip_and_port(a, user_defined_unicast_locator_port))
             .collect();
 
         let default_multicast_locator_list = vec![];
@@ -155,7 +158,7 @@ impl DomainParticipantFactoryActor {
             .into();
         let metatraffic_unicast_locator_list: Vec<Locator> = interface_address_list
             .iter()
-            .map(|a| Locator::new(LOCATOR_KIND_UDP_V4, metattrafic_unicast_locator_port, *a))
+            .map(|a| Locator::from_ip_and_port(a, metattrafic_unicast_locator_port))
             .collect();
 
         let metatraffic_multicast_locator_list = vec![Locator::new(
@@ -417,7 +420,7 @@ fn port_builtin_multicast(domain_id: DomainId) -> u16 {
     (PB + DG * domain_id + d0) as u16
 }
 
-fn get_interface_address_list(interface_name: Option<&String>) -> Vec<LocatorAddress> {
+fn get_interface_address_list(interface_name: Option<&String>) -> Vec<Addr> {
     NetworkInterface::show()
         .expect("Could not scan interfaces")
         .into_iter()
@@ -429,15 +432,10 @@ fn get_interface_address_list(interface_name: Option<&String>) -> Vec<LocatorAdd
             }
         })
         .flat_map(|i| {
-            i.addr.into_iter().filter_map(|a| match a {
+            i.addr.into_iter().filter(|a| match a {
                 #[rustfmt::skip]
-                Addr::V4(v4) if !v4.ip.is_loopback() => Some(
-                    [0, 0, 0, 0,
-                        0, 0, 0, 0,
-                        0, 0, 0, 0,
-                        v4.ip.octets()[0], v4.ip.octets()[1], v4.ip.octets()[2], v4.ip.octets()[3]]
-                    ),
-                _ => None,
+                Addr::V4(v4) if !v4.ip.is_loopback() => true,
+                _ => false,
             })
         })
         .collect()
@@ -446,7 +444,7 @@ fn get_interface_address_list(interface_name: Option<&String>) -> Vec<LocatorAdd
 fn get_multicast_socket(
     multicast_address: LocatorAddress,
     port: u16,
-    interface_address_list: &[LocatorAddress],
+    interface_address_list: &[Addr],
 ) -> std::io::Result<tokio::net::UdpSocket> {
     let socket_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, port));
 
@@ -468,15 +466,10 @@ fn get_multicast_socket(
         multicast_address[15],
     );
     for interface_addr in interface_address_list {
-        socket.join_multicast_v4(
-            &addr,
-            &Ipv4Addr::new(
-                interface_addr[12],
-                interface_addr[13],
-                interface_addr[14],
-                interface_addr[15],
-            ),
-        )?;
+        match interface_addr {
+            Addr::V4(a) => socket.join_multicast_v4(&addr, &a.ip)?,
+            Addr::V6(_) => (),
+        }
     }
 
     socket.set_multicast_loop_v4(true)?;

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -2,7 +2,11 @@ use crate::serialized_payload::cdr::{deserialize::CdrDeserialize, serialize::Cdr
 
 use super::messages::overall_structure::{WriteBytes, WriteEndianness};
 use byteorder::ByteOrder;
-use std::ops::{Add, AddAssign, Sub, SubAssign};
+use network_interface::Addr;
+use std::{
+    net::IpAddr,
+    ops::{Add, AddAssign, Sub, SubAssign},
+};
 
 ///
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.5
@@ -323,6 +327,38 @@ impl Locator {
     }
     pub const fn address(&self) -> [Octet; 16] {
         self.address
+    }
+
+    pub fn from_ip_and_port(ip_addr: &Addr, port: u32) -> Self {
+        match ip_addr.ip() {
+            IpAddr::V4(a) => Self {
+                kind: LOCATOR_KIND_UDP_V4,
+                port,
+                address: [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    a.octets()[0],
+                    a.octets()[1],
+                    a.octets()[2],
+                    a.octets()[3],
+                ],
+            },
+            IpAddr::V6(a) => Self {
+                kind: LOCATOR_KIND_UDP_V6,
+                port,
+                address: a.octets(),
+            },
+        }
     }
 }
 


### PR DESCRIPTION
Join the multicast group by using all the IP address of the interfaces in the machine. This prevents windows from not directing the discovery when using shapes demos of different vendors in the same machine.