### PR TITLE
Fix RTPS time message inconsistency with standard

### DIFF
--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -26,6 +26,7 @@ use crate::{
             cdr_deserializer::ClassicCdrDeserializer, endianness::CdrEndianness,
         },
         rtps::{
+            self,
             message_receiver::MessageReceiver,
             messages::{
                 overall_structure::{RtpsMessageHeader, RtpsMessageRead, RtpsSubmessageReadKind},
@@ -65,7 +66,7 @@ use crate::{
             RequestedIncompatibleQosStatus, SampleLostStatus, SampleRejectedStatus,
             SampleRejectedStatusKind, StatusKind, SubscriptionMatchedStatus,
         },
-        time::{DurationKind, Time},
+        time::DurationKind,
     },
     serialized_payload::cdr::deserialize::CdrDeserialize,
     subscription::sample_info::{InstanceStateKind, SampleInfo, SampleStateKind, ViewStateKind},
@@ -377,8 +378,8 @@ impl DataReaderActor {
         data_submessage: &DataSubmessageRead,
         type_support: &Arc<dyn DynamicTypeInterface + Send + Sync>,
         source_guid_prefix: GuidPrefix,
-        source_timestamp: Option<Time>,
-        reception_timestamp: Time,
+        source_timestamp: Option<rtps::messages::types::Time>,
+        reception_timestamp: rtps::messages::types::Time,
         data_reader_address: &ActorAddress<DataReaderActor>,
         subscriber: &SubscriberAsync,
         subscriber_mask_listener: &(ActorAddress<SubscriberListenerActor>, Vec<StatusKind>),
@@ -519,8 +520,8 @@ impl DataReaderActor {
         data_frag_submessage: &DataFragSubmessageRead,
         type_support: &Arc<dyn DynamicTypeInterface + Send + Sync>,
         source_guid_prefix: GuidPrefix,
-        source_timestamp: Option<Time>,
-        reception_timestamp: Time,
+        source_timestamp: Option<rtps::messages::types::Time>,
+        reception_timestamp: rtps::messages::types::Time,
         data_reader_address: &ActorAddress<DataReaderActor>,
         subscriber: &SubscriberAsync,
         subscriber_mask_listener: &(ActorAddress<SubscriberListenerActor>, Vec<StatusKind>),
@@ -926,8 +927,8 @@ impl DataReaderActor {
         key_flag: bool,
         inline_qos: ParameterList,
         data: Data,
-        source_timestamp: Option<Time>,
-        reception_timestamp: Time,
+        source_timestamp: Option<rtps::messages::types::Time>,
+        reception_timestamp: rtps::messages::types::Time,
         type_support: &Arc<dyn DynamicTypeInterface + Send + Sync>,
     ) -> DdsResult<RtpsReaderCacheChange> {
         let change_kind = if key_flag {
@@ -1232,7 +1233,7 @@ impl DataReaderActor {
                 sample_rank: 0,     // To be filled up after collection is created
                 generation_rank: 0, // To be filled up after collection is created
                 absolute_generation_rank,
-                source_timestamp: cache_change.source_timestamp,
+                source_timestamp: cache_change.source_timestamp.map(Into::into),
                 instance_handle: cache_change.instance_handle,
                 publication_handle: InstanceHandle::new(cache_change.writer_guid.into()),
                 valid_data,
@@ -1862,7 +1863,7 @@ impl DataReaderActor {
     async fn process_rtps_message(
         &mut self,
         message: RtpsMessageRead,
-        reception_timestamp: Time,
+        reception_timestamp: rtps::messages::types::Time,
         data_reader_address: ActorAddress<DataReaderActor>,
         subscriber: SubscriberAsync,
         subscriber_mask_listener: (ActorAddress<SubscriberListenerActor>, Vec<StatusKind>),

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -20,6 +20,7 @@ use crate::{
         },
         data_representation_builtin_endpoints::discovered_writer_data::DiscoveredWriterData,
         rtps::{
+            self,
             endpoint::RtpsEndpoint,
             group::RtpsGroup,
             messages::overall_structure::{RtpsMessageHeader, RtpsMessageRead},
@@ -38,7 +39,7 @@ use crate::{
         qos::{DataReaderQos, QosKind, SubscriberQos},
         qos_policy::PartitionQosPolicy,
         status::StatusKind,
-        time::{Time, DURATION_ZERO},
+        time::DURATION_ZERO,
     },
 };
 
@@ -279,7 +280,7 @@ impl SubscriberActor {
     async fn process_rtps_message(
         &self,
         message: RtpsMessageRead,
-        reception_timestamp: Time,
+        reception_timestamp: rtps::messages::types::Time,
         subscriber_address: ActorAddress<SubscriberActor>,
         participant: DomainParticipantAsync,
         participant_mask_listener: (

--- a/dds/src/implementation/rtps/message_receiver.rs
+++ b/dds/src/implementation/rtps/message_receiver.rs
@@ -1,10 +1,9 @@
-use crate::{
-    implementation::rtps::{
-        messages::overall_structure::{RtpsMessageRead, RtpsSubmessageReadKind},
-        types::{GuidPrefix, Locator, ProtocolVersion, VendorId, GUIDPREFIX_UNKNOWN},
-    },
-    infrastructure::time::{Time, TIME_INVALID},
+use crate::implementation::rtps::{
+    messages::overall_structure::{RtpsMessageRead, RtpsSubmessageReadKind},
+    types::{GuidPrefix, Locator, ProtocolVersion, VendorId, GUIDPREFIX_UNKNOWN},
 };
+
+use super::messages::{self, types::TIME_INVALID};
 
 pub struct MessageReceiver<'a> {
     source_version: ProtocolVersion,
@@ -14,7 +13,7 @@ pub struct MessageReceiver<'a> {
     _unicast_reply_locator_list: Vec<Locator>,
     _multicast_reply_locator_list: Vec<Locator>,
     have_timestamp: bool,
-    timestamp: Time,
+    timestamp: messages::types::Time,
     submessages: std::vec::IntoIter<RtpsSubmessageReadKind<'a>>,
 }
 
@@ -44,8 +43,7 @@ impl<'a> Iterator for MessageReceiver<'a> {
                 RtpsSubmessageReadKind::InfoTimestamp(m) => {
                     if !m.invalidate_flag() {
                         self.have_timestamp = true;
-                        self.timestamp =
-                            Time::new(m.timestamp().seconds() as i32, m.timestamp().fraction());
+                        self.timestamp = m.timestamp();
                     } else {
                         self.have_timestamp = false;
                         self.timestamp = TIME_INVALID;
@@ -97,7 +95,7 @@ impl<'a> MessageReceiver<'a> {
         self._multicast_reply_locator_list.as_ref()
     }
 
-    pub fn source_timestamp(&self) -> Option<Time> {
+    pub fn source_timestamp(&self) -> Option<messages::types::Time> {
         if self.have_timestamp {
             Some(self.timestamp)
         } else {

--- a/dds/src/implementation/rtps/reader_history_cache.rs
+++ b/dds/src/implementation/rtps/reader_history_cache.rs
@@ -1,10 +1,13 @@
 use crate::{
-    infrastructure::{instance::InstanceHandle, time::Time},
+    infrastructure::instance::InstanceHandle,
     subscription::sample_info::{InstanceStateKind, SampleStateKind, ViewStateKind},
 };
 
 use super::{
-    messages::submessage_elements::{Data, ParameterList},
+    messages::{
+        self,
+        submessage_elements::{Data, ParameterList},
+    },
     types::{ChangeKind, Guid},
 };
 
@@ -15,11 +18,11 @@ pub struct RtpsReaderCacheChange {
     pub instance_handle: InstanceHandle,
     pub data: Data,
     pub inline_qos: ParameterList,
-    pub source_timestamp: Option<Time>,
+    pub source_timestamp: Option<messages::types::Time>,
     pub sample_state: SampleStateKind,
     pub disposed_generation_count: i32,
     pub no_writers_generation_count: i32,
-    pub reception_timestamp: Time,
+    pub reception_timestamp: messages::types::Time,
 }
 
 pub struct InstanceState {

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -1,11 +1,11 @@
-use crate::infrastructure::{
-    instance::InstanceHandle,
-    time::{Duration, Time},
-};
+use crate::infrastructure::{instance::InstanceHandle, time::Duration};
 
 use super::{
     endpoint::RtpsEndpoint,
-    messages::submessage_elements::{Data, ParameterList},
+    messages::{
+        self,
+        submessage_elements::{Data, ParameterList},
+    },
     types::{ChangeKind, Guid, Locator, SequenceNumber},
     writer_history_cache::RtpsWriterCacheChange,
 };
@@ -70,7 +70,7 @@ impl RtpsWriter {
         data: Vec<u8>,
         inline_qos: ParameterList,
         handle: InstanceHandle,
-        timestamp: Time,
+        timestamp: messages::types::Time,
     ) -> RtpsWriterCacheChange {
         self.last_change_sequence_number += 1;
         RtpsWriterCacheChange::new(

--- a/dds/src/implementation/rtps/writer_history_cache.rs
+++ b/dds/src/implementation/rtps/writer_history_cache.rs
@@ -1,5 +1,6 @@
 use super::{
     messages::{
+        self,
         submessage_elements::{Data, ParameterList},
         submessages::{data::DataSubmessageWrite, data_frag::DataFragSubmessageWrite},
     },
@@ -8,7 +9,6 @@ use super::{
 use crate::infrastructure::{
     instance::InstanceHandle,
     qos_policy::{HistoryQosPolicy, HistoryQosPolicyKind},
-    time::Time,
 };
 use std::collections::{HashMap, VecDeque};
 
@@ -17,7 +17,7 @@ pub struct RtpsWriterCacheChange {
     writer_guid: Guid,
     sequence_number: SequenceNumber,
     instance_handle: InstanceHandle,
-    timestamp: Time,
+    timestamp: messages::types::Time,
     data_value: Vec<Data>,
     inline_qos: ParameterList,
 }
@@ -134,7 +134,7 @@ impl RtpsWriterCacheChange {
         writer_guid: Guid,
         instance_handle: InstanceHandle,
         sequence_number: SequenceNumber,
-        timestamp: Time,
+        timestamp: messages::types::Time,
         data_value: Vec<Data>,
         inline_qos: ParameterList,
     ) -> Self {
@@ -163,7 +163,7 @@ impl RtpsWriterCacheChange {
         self.sequence_number
     }
 
-    pub fn timestamp(&self) -> Time {
+    pub fn timestamp(&self) -> messages::types::Time {
         self.timestamp
     }
 
@@ -241,10 +241,9 @@ impl WriterHistoryCache {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        implementation::rtps::types::GUID_UNKNOWN,
-        infrastructure::{instance::HANDLE_NIL, time::TIME_INVALID},
-    };
+    use tests::messages::types::TIME_INVALID;
+
+    use crate::{implementation::rtps::types::GUID_UNKNOWN, infrastructure::instance::HANDLE_NIL};
 
     use super::*;
 


### PR DESCRIPTION
RTPS Timestamp messages were being sent with nanoseconds in the fraction field whereas the RTPS standard requires this value to be a fraction scaled in 2^32. This change fixes that inconsistency which was visible when communicating with other implementations.