### PR TITLE
Add stage with compilation times

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -81,6 +81,15 @@ jobs:
 
       - store_artifacts:
           path: /tmp/coverage
+  compilation_times:
+    docker:
+      - image: cimg/rust:1.75.0
+    resource_class: large
+    steps:
+      - checkout
+      - run: cargo build --timings --tests --examples
+      - store_artifacts:
+          path: ./target/cargo-timings
 
   interoperability_tests:
     docker:
@@ -219,6 +228,7 @@ workflows:
       - build_and_push_docker_image
       - build
       - benchmark
+      - compilation_times
       - clippy
       - interoperability_tests:
           requires:
@@ -231,6 +241,7 @@ workflows:
     jobs:
       - build
       - benchmark
+      - compilation_times
       - clippy
       - interoperability_tests
       - multi_machine_tests

--- a/dds/src/dds_async/data_reader_listener.rs
+++ b/dds/src/dds_async/data_reader_listener.rs
@@ -17,7 +17,7 @@ pub trait DataReaderListenerAsync {
         &mut self,
         _the_reader: DataReaderAsync<Self::Foo>,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when this reader reports a sample rejected status.
@@ -26,7 +26,7 @@ pub trait DataReaderListenerAsync {
         _the_reader: DataReaderAsync<Self::Foo>,
         _status: SampleRejectedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
     /// Method that is called when this reader reports a liveliness changed status.
     fn on_liveliness_changed(
@@ -34,7 +34,7 @@ pub trait DataReaderListenerAsync {
         _the_reader: DataReaderAsync<Self::Foo>,
         _status: LivelinessChangedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when this reader reports a requested deadline missed status.
@@ -43,7 +43,7 @@ pub trait DataReaderListenerAsync {
         _the_reader: DataReaderAsync<Self::Foo>,
         _status: RequestedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when this reader reports a requested incompatible QoS status.
@@ -52,7 +52,7 @@ pub trait DataReaderListenerAsync {
         _the_reader: DataReaderAsync<Self::Foo>,
         _status: RequestedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when this reader reports a subscription matched status.
@@ -61,7 +61,7 @@ pub trait DataReaderListenerAsync {
         _the_reader: DataReaderAsync<Self::Foo>,
         _status: SubscriptionMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when this reader reports a sample lost status.
@@ -70,6 +70,6 @@ pub trait DataReaderListenerAsync {
         _the_reader: DataReaderAsync<Self::Foo>,
         _status: SampleLostStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 }

--- a/dds/src/dds_async/data_writer_listener.rs
+++ b/dds/src/dds_async/data_writer_listener.rs
@@ -18,7 +18,7 @@ pub trait DataWriterListenerAsync {
         _the_writer: DataWriterAsync<Self::Foo>,
         _status: LivelinessLostStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
     /// Method that is called when this writer reports an offered deadline missed status.
     fn on_offered_deadline_missed(
@@ -26,7 +26,7 @@ pub trait DataWriterListenerAsync {
         _the_writer: DataWriterAsync<Self::Foo>,
         _status: OfferedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
     /// Method that is called when this writer reports an offered incompatible qos status.
     fn on_offered_incompatible_qos(
@@ -34,7 +34,7 @@ pub trait DataWriterListenerAsync {
         _the_writer: DataWriterAsync<Self::Foo>,
         _status: OfferedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
     /// Method that is called when this writer reports a publication matched status.
     fn on_publication_matched(
@@ -42,6 +42,6 @@ pub trait DataWriterListenerAsync {
         _the_writer: DataWriterAsync<Self::Foo>,
         _status: PublicationMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 }

--- a/dds/src/dds_async/domain_participant_listener.rs
+++ b/dds/src/dds_async/domain_participant_listener.rs
@@ -21,7 +21,7 @@ pub trait DomainParticipantListenerAsync {
         _the_topic: TopicAsync,
         _status: InconsistentTopicStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any writer in the domain participant reports a liveliness lost status.
@@ -30,7 +30,7 @@ pub trait DomainParticipantListenerAsync {
         _the_writer: &dyn AnyDataWriter,
         _status: LivelinessLostStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data writer in the domain participant reports a deadline missed status.
@@ -39,7 +39,7 @@ pub trait DomainParticipantListenerAsync {
         _the_writer: &dyn AnyDataWriter,
         _status: OfferedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data writer in the domain participant reports an offered incompatible QoS status.
@@ -48,7 +48,7 @@ pub trait DomainParticipantListenerAsync {
         _the_writer: &dyn AnyDataWriter,
         _status: OfferedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data reader in the domain participant reports a sample lost status.
@@ -57,7 +57,7 @@ pub trait DomainParticipantListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: SampleLostStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data reader in the domain participant reports a data available status.
@@ -65,7 +65,7 @@ pub trait DomainParticipantListenerAsync {
         &mut self,
         _the_reader: &dyn AnyDataReader,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data reader in the domain participant reports a sample rejected status.
@@ -74,7 +74,7 @@ pub trait DomainParticipantListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: SampleRejectedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data reader in the domain participant reports a liveliness changed status.
@@ -83,7 +83,7 @@ pub trait DomainParticipantListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: LivelinessChangedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data reader in the domain participant reports a requested deadline missed status.
@@ -92,7 +92,7 @@ pub trait DomainParticipantListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: RequestedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data reader in the domain participant reports a requested incompatible QoS status.
@@ -101,7 +101,7 @@ pub trait DomainParticipantListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: RequestedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data writer in the domain participant reports a publication matched status.
@@ -110,7 +110,7 @@ pub trait DomainParticipantListenerAsync {
         _the_writer: &dyn AnyDataWriter,
         _status: PublicationMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any data reader in the domain participant reports a subscription matched status.
@@ -119,6 +119,6 @@ pub trait DomainParticipantListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: SubscriptionMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 }

--- a/dds/src/dds_async/publisher_listener.rs
+++ b/dds/src/dds_async/publisher_listener.rs
@@ -16,7 +16,7 @@ pub trait PublisherListenerAsync {
         _the_writer: &dyn AnyDataWriter,
         _status: LivelinessLostStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any writer belonging to this publisher reports an offered deadline missed status.
@@ -25,7 +25,7 @@ pub trait PublisherListenerAsync {
         _the_writer: &dyn AnyDataWriter,
         _status: OfferedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any writer belonging to this publisher reports an offered incompatible qos status.
@@ -34,7 +34,7 @@ pub trait PublisherListenerAsync {
         _the_writer: &dyn AnyDataWriter,
         _status: OfferedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any writer belonging to this publisher reports a publication matched status.
@@ -43,6 +43,6 @@ pub trait PublisherListenerAsync {
         _the_writer: &dyn AnyDataWriter,
         _status: PublicationMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 }

--- a/dds/src/dds_async/subscriber_listener.rs
+++ b/dds/src/dds_async/subscriber_listener.rs
@@ -17,7 +17,7 @@ pub trait SubscriberListenerAsync {
         &mut self,
         _the_subscriber: SubscriberAsync,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any reader belonging to this subcriber reports new data available.
@@ -25,7 +25,7 @@ pub trait SubscriberListenerAsync {
         &mut self,
         _the_reader: &dyn AnyDataReader,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
     /// Method that is called when any reader belonging to this subcriber reports a sample rejected status.
     fn on_sample_rejected(
@@ -33,7 +33,7 @@ pub trait SubscriberListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: SampleRejectedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a liveliness changed status.
@@ -42,7 +42,7 @@ pub trait SubscriberListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: LivelinessChangedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a requested deadline missed status.
@@ -51,7 +51,7 @@ pub trait SubscriberListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: RequestedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a requested incompatible QoS status.
@@ -60,7 +60,7 @@ pub trait SubscriberListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: RequestedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a subscription matched status.
@@ -69,7 +69,7 @@ pub trait SubscriberListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: SubscriptionMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a sample lost status.
@@ -78,6 +78,6 @@ pub trait SubscriberListenerAsync {
         _the_reader: &dyn AnyDataReader,
         _status: SampleLostStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 }

--- a/dds/src/dds_async/topic_listener.rs
+++ b/dds/src/dds_async/topic_listener.rs
@@ -12,6 +12,6 @@ pub trait TopicListenerAsync {
         _the_topic: TopicAsync,
         _status: InconsistentTopicStatus,
     ) -> impl Future<Output = ()> + Send {
-        async {}
+        std::future::ready(())
     }
 }

--- a/dds/src/implementation/utils/sync_listener.rs
+++ b/dds/src/implementation/utils/sync_listener.rs
@@ -48,7 +48,7 @@ where
         status: InconsistentTopicStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_inconsistent_topic(Topic::new(the_topic), status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_liveliness_lost(
@@ -57,7 +57,7 @@ where
         status: LivelinessLostStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_liveliness_lost(the_writer, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_offered_deadline_missed(
@@ -66,7 +66,7 @@ where
         status: OfferedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_offered_deadline_missed(the_writer, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_offered_incompatible_qos(
@@ -75,7 +75,7 @@ where
         status: OfferedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_offered_incompatible_qos(the_writer, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_sample_lost(
@@ -84,7 +84,7 @@ where
         status: SampleLostStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_sample_lost(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_data_available(
@@ -92,7 +92,7 @@ where
         the_reader: &dyn AnyDataReader,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_data_available(the_reader));
-        async {}
+        std::future::ready(())
     }
 
     fn on_sample_rejected(
@@ -101,7 +101,7 @@ where
         status: SampleRejectedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_sample_rejected(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_liveliness_changed(
@@ -110,7 +110,7 @@ where
         status: LivelinessChangedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_liveliness_changed(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_requested_deadline_missed(
@@ -119,7 +119,7 @@ where
         status: RequestedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_requested_deadline_missed(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_requested_incompatible_qos(
@@ -128,7 +128,7 @@ where
         status: RequestedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_requested_incompatible_qos(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_publication_matched(
@@ -137,7 +137,7 @@ where
         status: PublicationMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_publication_matched(the_writer, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_subscription_matched(
@@ -146,7 +146,7 @@ where
         status: SubscriptionMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_subscription_matched(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 }
 
@@ -160,7 +160,7 @@ where
         status: LivelinessLostStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_liveliness_lost(the_writer, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_offered_deadline_missed(
@@ -169,7 +169,7 @@ where
         status: OfferedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_offered_deadline_missed(the_writer, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_offered_incompatible_qos(
@@ -178,7 +178,7 @@ where
         status: OfferedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_offered_incompatible_qos(the_writer, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_publication_matched(
@@ -187,7 +187,7 @@ where
         status: PublicationMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_publication_matched(the_writer, status));
-        async {}
+        std::future::ready(())
     }
 }
 
@@ -200,7 +200,7 @@ where
         the_subscriber: SubscriberAsync,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_data_on_readers(Subscriber::new(the_subscriber)));
-        async {}
+        std::future::ready(())
     }
 
     fn on_data_available(
@@ -208,7 +208,7 @@ where
         the_reader: &dyn AnyDataReader,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_data_available(the_reader));
-        async {}
+        std::future::ready(())
     }
 
     fn on_sample_rejected(
@@ -217,7 +217,7 @@ where
         status: SampleRejectedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_sample_rejected(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_liveliness_changed(
@@ -226,7 +226,7 @@ where
         status: LivelinessChangedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_liveliness_changed(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_requested_deadline_missed(
@@ -235,7 +235,7 @@ where
         status: RequestedDeadlineMissedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_requested_deadline_missed(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_requested_incompatible_qos(
@@ -244,7 +244,7 @@ where
         status: RequestedIncompatibleQosStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_requested_incompatible_qos(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_subscription_matched(
@@ -253,7 +253,7 @@ where
         status: SubscriptionMatchedStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_subscription_matched(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 
     fn on_sample_lost(
@@ -262,7 +262,7 @@ where
         status: SampleLostStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_sample_lost(the_reader, status));
-        async {}
+        std::future::ready(())
     }
 }
 
@@ -276,7 +276,7 @@ where
         status: InconsistentTopicStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_inconsistent_topic(Topic::new(the_topic), status));
-        async {}
+        std::future::ready(())
     }
 }
 
@@ -291,7 +291,7 @@ where
         the_reader: DataReaderAsync<Self::Foo>,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_data_available(DataReader::new(the_reader)));
-        async {}
+        std::future::ready(())
     }
 
     fn on_sample_rejected(
@@ -303,7 +303,7 @@ where
             self.0
                 .on_sample_rejected(DataReader::new(the_reader), status)
         });
-        async {}
+        std::future::ready(())
     }
 
     fn on_liveliness_changed(
@@ -315,7 +315,7 @@ where
             self.0
                 .on_liveliness_changed(DataReader::new(the_reader), status)
         });
-        async {}
+        std::future::ready(())
     }
 
     fn on_requested_deadline_missed(
@@ -327,7 +327,7 @@ where
             self.0
                 .on_requested_deadline_missed(DataReader::new(the_reader), status)
         });
-        async {}
+        std::future::ready(())
     }
 
     fn on_requested_incompatible_qos(
@@ -339,7 +339,7 @@ where
             self.0
                 .on_requested_incompatible_qos(DataReader::new(the_reader), status)
         });
-        async {}
+        std::future::ready(())
     }
 
     fn on_subscription_matched(
@@ -351,7 +351,7 @@ where
             self.0
                 .on_subscription_matched(DataReader::new(the_reader), status)
         });
-        async {}
+        std::future::ready(())
     }
 
     fn on_sample_lost(
@@ -360,7 +360,7 @@ where
         status: SampleLostStatus,
     ) -> impl Future<Output = ()> + Send {
         tokio::task::block_in_place(|| self.0.on_sample_lost(DataReader::new(the_reader), status));
-        async {}
+        std::future::ready(())
     }
 }
 
@@ -379,7 +379,7 @@ where
             self.0
                 .on_liveliness_lost(DataWriter::new(the_writer), status)
         });
-        async {}
+        std::future::ready(())
     }
 
     fn on_offered_deadline_missed(
@@ -391,7 +391,7 @@ where
             self.0
                 .on_offered_deadline_missed(DataWriter::new(the_writer), status)
         });
-        async {}
+        std::future::ready(())
     }
 
     fn on_offered_incompatible_qos(
@@ -403,7 +403,7 @@ where
             self.0
                 .on_offered_incompatible_qos(DataWriter::new(the_writer), status)
         });
-        async {}
+        std::future::ready(())
     }
 
     fn on_publication_matched(
@@ -415,6 +415,6 @@ where
             self.0
                 .on_publication_matched(DataWriter::new(the_writer), status)
         });
-        async {}
+        std::future::ready(())
     }
 }


### PR DESCRIPTION
This change add a new stage to keep track of compilation times. It also replaces the default trait implementation by a immediately ready future.