### PR TITLE
Replace RtpsSubmessageKind by Boxes

### DIFF
--- a/dds/src/implementation/rtps/messages/submessages/data.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data.rs
@@ -137,7 +137,7 @@ impl DataSubmessageRead {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DataSubmessageWrite<'a> {
+pub struct DataSubmessageWrite {
     inline_qos_flag: SubmessageFlag,
     data_flag: SubmessageFlag,
     key_flag: SubmessageFlag,
@@ -145,11 +145,11 @@ pub struct DataSubmessageWrite<'a> {
     reader_id: EntityId,
     writer_id: EntityId,
     writer_sn: SequenceNumber,
-    inline_qos: &'a ParameterList,
-    serialized_payload: &'a Data,
+    inline_qos: ParameterList,
+    serialized_payload: Data,
 }
 
-impl<'a> DataSubmessageWrite<'a> {
+impl DataSubmessageWrite {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         inline_qos_flag: SubmessageFlag,
@@ -159,8 +159,8 @@ impl<'a> DataSubmessageWrite<'a> {
         reader_id: EntityId,
         writer_id: EntityId,
         writer_sn: SequenceNumber,
-        inline_qos: &'a ParameterList,
-        serialized_payload: &'a Data,
+        inline_qos: ParameterList,
+        serialized_payload: Data,
     ) -> Self {
         Self {
             inline_qos_flag,
@@ -176,7 +176,7 @@ impl<'a> DataSubmessageWrite<'a> {
     }
 }
 
-impl Submessage for DataSubmessageWrite<'_> {
+impl Submessage for DataSubmessageWrite {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::DATA,
@@ -225,8 +225,8 @@ mod tests {
         let reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
         let writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);
         let writer_sn = 5;
-        let inline_qos = &ParameterList::empty();
-        let serialized_payload = &Data::new(vec![].into());
+        let inline_qos = ParameterList::empty();
+        let serialized_payload = Data::new(vec![].into());
         let submessage = DataSubmessageWrite::new(
             inline_qos_flag,
             data_flag,
@@ -261,8 +261,8 @@ mod tests {
         let writer_sn = 5;
         let parameter_1 = Parameter::new(6, vec![10, 11, 12, 13].into());
         let parameter_2 = Parameter::new(7, vec![20, 21, 22, 23].into());
-        let inline_qos = &ParameterList::new(vec![parameter_1, parameter_2]);
-        let serialized_payload = &Data::new(vec![].into());
+        let inline_qos = ParameterList::new(vec![parameter_1, parameter_2]);
+        let serialized_payload = Data::new(vec![].into());
 
         let submessage = DataSubmessageWrite::new(
             inline_qos_flag,
@@ -301,8 +301,8 @@ mod tests {
         let reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
         let writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);
         let writer_sn = 5;
-        let inline_qos = &ParameterList::empty();
-        let serialized_payload = &Data::new(vec![1, 2, 3, 4].into());
+        let inline_qos = ParameterList::empty();
+        let serialized_payload = Data::new(vec![1, 2, 3, 4].into());
         let submessage = DataSubmessageWrite::new(
             inline_qos_flag,
             data_flag,
@@ -336,8 +336,8 @@ mod tests {
         let reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
         let writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);
         let writer_sn = 5;
-        let inline_qos = &ParameterList::empty();
-        let serialized_payload = &Data::new(vec![1, 2, 3].into());
+        let inline_qos = ParameterList::empty();
+        let serialized_payload = Data::new(vec![1, 2, 3].into());
         let submessage = DataSubmessageWrite::new(
             inline_qos_flag,
             data_flag,

--- a/dds/src/implementation/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data_frag.rs
@@ -135,7 +135,7 @@ impl DataFragSubmessageRead {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DataFragSubmessageWrite<'a> {
+pub struct DataFragSubmessageWrite {
     inline_qos_flag: SubmessageFlag,
     non_standard_payload_flag: SubmessageFlag,
     key_flag: SubmessageFlag,
@@ -146,11 +146,11 @@ pub struct DataFragSubmessageWrite<'a> {
     fragments_in_submessage: u16,
     fragment_size: u16,
     data_size: u32,
-    inline_qos: &'a ParameterList,
-    serialized_payload: &'a Data,
+    inline_qos: ParameterList,
+    serialized_payload: Data,
 }
 
-impl<'a> DataFragSubmessageWrite<'a> {
+impl DataFragSubmessageWrite {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         inline_qos_flag: SubmessageFlag,
@@ -163,8 +163,8 @@ impl<'a> DataFragSubmessageWrite<'a> {
         fragments_in_submessage: u16,
         fragment_size: u16,
         data_size: u32,
-        inline_qos: &'a ParameterList,
-        serialized_payload: &'a Data,
+        inline_qos: ParameterList,
+        serialized_payload: Data,
     ) -> Self {
         Self {
             inline_qos_flag,
@@ -183,7 +183,7 @@ impl<'a> DataFragSubmessageWrite<'a> {
     }
 }
 
-impl Submessage for DataFragSubmessageWrite<'_> {
+impl Submessage for DataFragSubmessageWrite {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::DATA_FRAG,
@@ -226,8 +226,8 @@ mod tests {
 
     #[test]
     fn serialize_no_inline_qos_no_serialized_payload() {
-        let inline_qos = &ParameterList::empty();
-        let serialized_payload = &Data::new(vec![].into());
+        let inline_qos = ParameterList::empty();
+        let serialized_payload = Data::new(vec![].into());
         let submessage = DataFragSubmessageWrite::new(
             false,
             false,
@@ -272,8 +272,8 @@ mod tests {
             3,
             5,
             8,
-            &inline_qos,
-            &serialized_payload,
+            inline_qos,
+            serialized_payload,
         );
         #[rustfmt::skip]
         assert_eq!(write_into_bytes_vec(submessage), vec![

--- a/dds/src/implementation/rtps/messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps/messages/submessages/pad.rs
@@ -48,12 +48,12 @@ impl Submessage for PadSubmessageWrite {
 mod tests {
     use super::*;
     use crate::implementation::rtps::messages::overall_structure::{
-        write_into_bytes_vec, RtpsSubmessageWriteKind, SubmessageHeaderRead,
+        write_into_bytes_vec, SubmessageHeaderRead,
     };
 
     #[test]
     fn serialize_pad() {
-        let submessage = RtpsSubmessageWriteKind::Pad(PadSubmessageWrite::new());
+        let submessage = PadSubmessageWrite::new();
         #[rustfmt::skip]
         assert_eq!(write_into_bytes_vec(submessage), vec![
                 0x01, 0b_0000_0001, 0, 0, // Submessage header

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -1,6 +1,5 @@
 use super::{
     messages::{
-        overall_structure::RtpsSubmessageWriteKind,
         submessages::{
             heartbeat::HeartbeatSubmessageWrite, heartbeat_frag::HeartbeatFragSubmessageWrite,
         },
@@ -36,10 +35,10 @@ impl HeartbeatMachine {
         writer_id: EntityId,
         first_sn: SequenceNumber,
         last_sn: SequenceNumber,
-    ) -> RtpsSubmessageWriteKind<'a> {
+    ) -> HeartbeatSubmessageWrite {
         self.count = self.count.wrapping_add(1);
         self.timer.reset();
-        RtpsSubmessageWriteKind::Heartbeat(HeartbeatSubmessageWrite::new(
+        HeartbeatSubmessageWrite::new(
             false,
             false,
             self.reader_id,
@@ -47,7 +46,7 @@ impl HeartbeatMachine {
             first_sn,
             last_sn,
             self.count,
-        ))
+        )
     }
 }
 
@@ -64,20 +63,20 @@ impl HeartbeatFragMachine {
             reader_id,
         }
     }
-    pub fn _submessage<'a>(
+    pub fn _submessage(
         &mut self,
         writer_id: EntityId,
         writer_sn: SequenceNumber,
         last_fragment_num: FragmentNumber,
-    ) -> RtpsSubmessageWriteKind<'a> {
+    ) -> HeartbeatFragSubmessageWrite {
         self.count = self.count.wrapping_add(1);
-        RtpsSubmessageWriteKind::HeartbeatFrag(HeartbeatFragSubmessageWrite::_new(
+        HeartbeatFragSubmessageWrite::_new(
             self.reader_id,
             writer_id,
             writer_sn,
             last_fragment_num,
             self.count,
-        ))
+        )
     }
 }
 

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -30,7 +30,7 @@ impl HeartbeatMachine {
             >= std::time::Duration::from_secs(heartbeat_period.sec() as u64)
                 + std::time::Duration::from_nanos(heartbeat_period.nanosec() as u64)
     }
-    pub fn submessage<'a>(
+    pub fn submessage(
         &mut self,
         writer_id: EntityId,
         first_sn: SequenceNumber,

--- a/dds/src/implementation/rtps/writer_history_cache.rs
+++ b/dds/src/implementation/rtps/writer_history_cache.rs
@@ -44,7 +44,7 @@ pub struct DataFragSubmessagesIter<'a> {
 }
 
 impl<'a> IntoIterator for &'a DataFragSubmessages<'a> {
-    type Item = DataFragSubmessageWrite<'a>;
+    type Item = DataFragSubmessageWrite;
     type IntoIter = DataFragSubmessagesIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -59,7 +59,7 @@ impl<'a> IntoIterator for &'a DataFragSubmessages<'a> {
 }
 
 impl<'a> Iterator for DataFragSubmessagesIter<'a> {
-    type Item = DataFragSubmessageWrite<'a>;
+    type Item = DataFragSubmessageWrite;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos < self.data.len() {
@@ -77,8 +77,8 @@ impl<'a> Iterator for DataFragSubmessagesIter<'a> {
             let fragments_in_submessage = 1;
             let data_size = self.data.iter().map(|d| d.len()).sum::<usize>() as u32;
             let fragment_size = self.data[0].len() as u16;
-            let inline_qos = &self.cache_change.inline_qos;
-            let serialized_payload = self.data[self.pos];
+            let inline_qos = self.cache_change.inline_qos.clone();
+            let serialized_payload = self.data[self.pos].clone();
 
             self.pos += 1;
 
@@ -118,8 +118,8 @@ impl RtpsWriterCacheChange {
             reader_id,
             self.writer_guid().entity_id(),
             self.sequence_number(),
-            &self.inline_qos,
-            &self.data_value[0],
+            self.inline_qos.clone(),
+            self.data_value[0].clone(),
         )
     }
 


### PR DESCRIPTION
The RtpsSubmessageKind enum required a replicative implementation of WriteIntoBytes for that enum. The performance seems not harmed (or slightly better). As a result all <Submessage>Read and <Submessage>Write are now the same and could merged, allowing for less code and lib space. Also no lifetime is necessary any more for and submessage, since the Data and InlineQos can be nowadays simply cloned because of the ArcSlice  