### PR TITLE
Merge submessage read and write

### DIFF
--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -31,9 +31,8 @@ use crate::{
                 overall_structure::{RtpsMessageHeader, RtpsMessageRead, RtpsSubmessageReadKind},
                 submessage_elements::{Data, Parameter, ParameterList},
                 submessages::{
-                    data::DataSubmessage, data_frag::DataFragSubmessage, gap::GapSubmessageRead,
-                    heartbeat::HeartbeatSubmessageRead,
-                    heartbeat_frag::HeartbeatFragSubmessageRead,
+                    data::DataSubmessage, data_frag::DataFragSubmessage, gap::GapSubmessage,
+                    heartbeat::HeartbeatSubmessage, heartbeat_frag::HeartbeatFragSubmessage,
                 },
             },
             reader::RtpsReaderKind,
@@ -547,7 +546,7 @@ impl DataReaderActor {
 
     fn on_heartbeat_submessage_received(
         &mut self,
-        heartbeat_submessage: &HeartbeatSubmessageRead,
+        heartbeat_submessage: &HeartbeatSubmessage,
         source_guid_prefix: GuidPrefix,
     ) {
         if self.qos.reliability.kind == ReliabilityQosPolicyKind::Reliable {
@@ -583,7 +582,7 @@ impl DataReaderActor {
 
     fn on_heartbeat_frag_submessage_received(
         &mut self,
-        heartbeat_frag_submessage: &HeartbeatFragSubmessageRead,
+        heartbeat_frag_submessage: &HeartbeatFragSubmessage,
         source_guid_prefix: GuidPrefix,
     ) {
         if self.qos.reliability.kind == ReliabilityQosPolicyKind::Reliable {
@@ -647,7 +646,7 @@ impl DataReaderActor {
 
     fn on_gap_submessage_received(
         &mut self,
-        gap_submessage: &GapSubmessageRead,
+        gap_submessage: &GapSubmessage,
         source_guid_prefix: GuidPrefix,
     ) {
         let writer_guid = Guid::new(source_guid_prefix, gap_submessage.writer_id());

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -31,8 +31,8 @@ use crate::{
                 overall_structure::{RtpsMessageHeader, RtpsMessageRead, RtpsSubmessageReadKind},
                 submessage_elements::{Data, Parameter, ParameterList},
                 submessages::{
-                    data::DataSubmessageRead, data_frag::DataFragSubmessageRead,
-                    gap::GapSubmessageRead, heartbeat::HeartbeatSubmessageRead,
+                    data::DataSubmessage, data_frag::DataFragSubmessage, gap::GapSubmessageRead,
+                    heartbeat::HeartbeatSubmessageRead,
                     heartbeat_frag::HeartbeatFragSubmessageRead,
                 },
             },
@@ -362,7 +362,7 @@ impl DataReaderActor {
     #[allow(clippy::too_many_arguments)]
     async fn on_data_submessage_received(
         &mut self,
-        data_submessage: &DataSubmessageRead,
+        data_submessage: &DataSubmessage,
         type_support: &Arc<dyn DynamicTypeInterface + Send + Sync>,
         source_guid_prefix: GuidPrefix,
         source_timestamp: Option<rtps::messages::types::Time>,
@@ -501,7 +501,7 @@ impl DataReaderActor {
     #[allow(clippy::too_many_arguments)]
     async fn on_data_frag_submessage_received(
         &mut self,
-        data_frag_submessage: &DataFragSubmessageRead,
+        data_frag_submessage: &DataFragSubmessage,
         type_support: &Arc<dyn DynamicTypeInterface + Send + Sync>,
         source_guid_prefix: GuidPrefix,
         source_timestamp: Option<rtps::messages::types::Time>,

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -23,7 +23,7 @@ use crate::{
                 },
                 submessage_elements::{ArcSlice, Parameter, ParameterList, SequenceNumberSet},
                 submessages::{
-                    ack_nack::AckNackSubmessageRead, gap::GapSubmessageWrite,
+                    ack_nack::AckNackSubmessage, gap::GapSubmessageWrite,
                     info_destination::InfoDestinationSubmessageWrite,
                     info_timestamp::InfoTimestampSubmessageWrite,
                     nack_frag::NackFragSubmessageRead,
@@ -826,7 +826,7 @@ impl DataWriterActor {
 
     fn on_acknack_submessage_received(
         &mut self,
-        acknack_submessage: &AckNackSubmessageRead,
+        acknack_submessage: &AckNackSubmessage,
         source_guid_prefix: GuidPrefix,
     ) {
         if self.qos.reliability.kind == ReliabilityQosPolicyKind::Reliable {

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -23,10 +23,9 @@ use crate::{
                 },
                 submessage_elements::{ArcSlice, Parameter, ParameterList, SequenceNumberSet},
                 submessages::{
-                    ack_nack::AckNackSubmessage, gap::GapSubmessageWrite,
-                    info_destination::InfoDestinationSubmessageWrite,
-                    info_timestamp::InfoTimestampSubmessageWrite,
-                    nack_frag::NackFragSubmessageRead,
+                    ack_nack::AckNackSubmessage, gap::GapSubmessage,
+                    info_destination::InfoDestinationSubmessage,
+                    info_timestamp::InfoTimestampSubmessage, nack_frag::NackFragSubmessage,
                 },
             },
             reader_locator::RtpsReaderLocator,
@@ -875,7 +874,7 @@ impl DataWriterActor {
                             .change_list()
                             .find(|cc| cc.sequence_number() == unsent_change_seq_num)
                         {
-                            let info_ts_submessage = Box::new(InfoTimestampSubmessageWrite::new(
+                            let info_ts_submessage = Box::new(InfoTimestampSubmessage::new(
                                 false,
                                 cache_change.timestamp(),
                             ));
@@ -889,7 +888,7 @@ impl DataWriterActor {
                                 &[reader_locator.locator()],
                             );
                         } else {
-                            let gap_submessage = Box::new(GapSubmessageWrite::new(
+                            let gap_submessage = Box::new(GapSubmessage::new(
                                 ENTITYID_UNKNOWN,
                                 self.rtps_writer.guid().entity_id(),
                                 unsent_change_seq_num,
@@ -946,7 +945,7 @@ impl DataWriterActor {
 
     fn on_nack_frag_submessage_received(
         &mut self,
-        nackfrag_submessage: &NackFragSubmessageRead,
+        nackfrag_submessage: &NackFragSubmessage,
         source_guid_prefix: GuidPrefix,
     ) {
         if self.qos.reliability.kind == ReliabilityQosPolicyKind::Reliable {
@@ -1147,7 +1146,7 @@ fn send_message_to_reader_proxy_best_effort(
         if next_unsent_change_seq_num > reader_proxy.highest_sent_seq_num() + 1 {
             let gap_start_sequence_number = reader_proxy.highest_sent_seq_num() + 1;
             let gap_end_sequence_number = next_unsent_change_seq_num - 1;
-            let gap_submessage = Box::new(GapSubmessageWrite::new(
+            let gap_submessage = Box::new(GapSubmessage::new(
                 reader_proxy.remote_reader_guid().entity_id(),
                 writer_id,
                 gap_start_sequence_number,
@@ -1169,11 +1168,11 @@ fn send_message_to_reader_proxy_best_effort(
                     reader_proxy.remote_reader_guid().entity_id(),
                 );
                 for data_frag_submessage in cache_change_frag.into_iter() {
-                    let info_dst = Box::new(InfoDestinationSubmessageWrite::new(
+                    let info_dst = Box::new(InfoDestinationSubmessage::new(
                         reader_proxy.remote_reader_guid().prefix(),
                     ));
 
-                    let info_timestamp = Box::new(InfoTimestampSubmessageWrite::new(
+                    let info_timestamp = Box::new(InfoTimestampSubmessage::new(
                         false,
                         cache_change.timestamp(),
                     ));
@@ -1186,11 +1185,11 @@ fn send_message_to_reader_proxy_best_effort(
                     );
                 }
             } else {
-                let info_dst = Box::new(InfoDestinationSubmessageWrite::new(
+                let info_dst = Box::new(InfoDestinationSubmessage::new(
                     reader_proxy.remote_reader_guid().prefix(),
                 ));
 
-                let info_timestamp = Box::new(InfoTimestampSubmessageWrite::new(
+                let info_timestamp = Box::new(InfoTimestampSubmessage::new(
                     false,
                     cache_change.timestamp(),
                 ));
@@ -1207,7 +1206,7 @@ fn send_message_to_reader_proxy_best_effort(
             udp_transport_write.write(
                 &RtpsMessageWrite::new(
                     &header,
-                    &[Box::new(GapSubmessageWrite::new(
+                    &[Box::new(GapSubmessage::new(
                         ENTITYID_UNKNOWN,
                         writer_id,
                         next_unsent_change_seq_num,
@@ -1236,7 +1235,7 @@ fn send_message_to_reader_proxy_reliable(
             if next_unsent_change_seq_num > reader_proxy.highest_sent_seq_num() + 1 {
                 let gap_start_sequence_number = reader_proxy.highest_sent_seq_num() + 1;
                 let gap_end_sequence_number = next_unsent_change_seq_num - 1;
-                let gap_submessage = Box::new(GapSubmessageWrite::new(
+                let gap_submessage = Box::new(GapSubmessage::new(
                     reader_proxy.remote_reader_guid().entity_id(),
                     writer_id,
                     gap_start_sequence_number,
@@ -1324,11 +1323,11 @@ fn send_change_message_reader_proxy_reliable(
                     reader_proxy.remote_reader_guid().entity_id(),
                 );
                 for data_frag_submessage in cache_change_frag.into_iter() {
-                    let info_dst = Box::new(InfoDestinationSubmessageWrite::new(
+                    let info_dst = Box::new(InfoDestinationSubmessage::new(
                         reader_proxy.remote_reader_guid().prefix(),
                     ));
 
-                    let info_timestamp = Box::new(InfoTimestampSubmessageWrite::new(
+                    let info_timestamp = Box::new(InfoTimestampSubmessage::new(
                         false,
                         cache_change.timestamp(),
                     ));
@@ -1341,11 +1340,11 @@ fn send_change_message_reader_proxy_reliable(
                     );
                 }
             } else {
-                let info_dst = Box::new(InfoDestinationSubmessageWrite::new(
+                let info_dst = Box::new(InfoDestinationSubmessage::new(
                     reader_proxy.remote_reader_guid().prefix(),
                 ));
 
-                let info_timestamp = Box::new(InfoTimestampSubmessageWrite::new(
+                let info_timestamp = Box::new(InfoTimestampSubmessage::new(
                     false,
                     cache_change.timestamp(),
                 ));
@@ -1372,11 +1371,11 @@ fn send_change_message_reader_proxy_reliable(
             }
         }
         _ => {
-            let info_dst = Box::new(InfoDestinationSubmessageWrite::new(
+            let info_dst = Box::new(InfoDestinationSubmessage::new(
                 reader_proxy.remote_reader_guid().prefix(),
             ));
 
-            let gap_submessage = Box::new(GapSubmessageWrite::new(
+            let gap_submessage = Box::new(GapSubmessage::new(
                 ENTITYID_UNKNOWN,
                 writer_id,
                 change_seq_num,

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -4,7 +4,7 @@ use crate::{
         messages::{
             submessage_elements::ArcSlice,
             submessages::{
-                ack_nack::AckNackSubmessageRead, data::DataSubmessageRead,
+                ack_nack::AckNackSubmessage, data::DataSubmessageRead,
                 data_frag::DataFragSubmessageRead, gap::GapSubmessageRead,
                 heartbeat::HeartbeatSubmessageRead, heartbeat_frag::HeartbeatFragSubmessageRead,
                 info_destination::InfoDestinationSubmessageRead,
@@ -188,10 +188,8 @@ impl RtpsMessageRead {
                     break;
                 }
                 let submessage = match submessage_header.submessage_id() {
-                    ACKNACK => {
-                        AckNackSubmessageRead::try_from_bytes(&submessage_header, data.as_ref())
-                            .map(RtpsSubmessageReadKind::AckNack)
-                    }
+                    ACKNACK => AckNackSubmessage::try_from_bytes(&submessage_header, data.as_ref())
+                        .map(RtpsSubmessageReadKind::AckNack),
                     DATA => {
                         DataSubmessageRead::try_from_arc_slice(&submessage_header, data.clone())
                             .map(RtpsSubmessageReadKind::Data)
@@ -284,7 +282,7 @@ impl RtpsMessageWrite {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum RtpsSubmessageReadKind {
-    AckNack(AckNackSubmessageRead),
+    AckNack(AckNackSubmessage),
     Data(DataSubmessageRead),
     DataFrag(DataFragSubmessageRead),
     Gap(GapSubmessageRead),

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -5,12 +5,11 @@ use crate::{
             submessage_elements::ArcSlice,
             submessages::{
                 ack_nack::AckNackSubmessage, data::DataSubmessage, data_frag::DataFragSubmessage,
-                gap::GapSubmessageRead, heartbeat::HeartbeatSubmessageRead,
-                heartbeat_frag::HeartbeatFragSubmessageRead,
-                info_destination::InfoDestinationSubmessageRead,
-                info_reply::InfoReplySubmessageRead, info_source::InfoSourceSubmessageRead,
-                info_timestamp::InfoTimestampSubmessageRead, nack_frag::NackFragSubmessageRead,
-                pad::PadSubmessageRead,
+                gap::GapSubmessage, heartbeat::HeartbeatSubmessage,
+                heartbeat_frag::HeartbeatFragSubmessage,
+                info_destination::InfoDestinationSubmessage, info_reply::InfoReplySubmessage,
+                info_source::InfoSourceSubmessage, info_timestamp::InfoTimestampSubmessage,
+                nack_frag::NackFragSubmessage, pad::PadSubmessage,
             },
             types::{
                 ACKNACK, DATA, DATA_FRAG, GAP, HEARTBEAT, HEARTBEAT_FRAG, INFO_DST, INFO_REPLY,
@@ -196,40 +195,37 @@ impl RtpsMessageRead {
                         DataFragSubmessage::try_from_arc_slice(&submessage_header, data.clone())
                             .map(RtpsSubmessageReadKind::DataFrag)
                     }
-                    GAP => GapSubmessageRead::try_from_bytes(&submessage_header, data.as_ref())
+                    GAP => GapSubmessage::try_from_bytes(&submessage_header, data.as_ref())
                         .map(RtpsSubmessageReadKind::Gap),
                     HEARTBEAT => {
-                        HeartbeatSubmessageRead::try_from_bytes(&submessage_header, data.as_ref())
+                        HeartbeatSubmessage::try_from_bytes(&submessage_header, data.as_ref())
                             .map(RtpsSubmessageReadKind::Heartbeat)
                     }
-                    HEARTBEAT_FRAG => HeartbeatFragSubmessageRead::try_from_bytes(
-                        &submessage_header,
-                        data.as_ref(),
-                    )
-                    .map(RtpsSubmessageReadKind::HeartbeatFrag),
-                    INFO_DST => InfoDestinationSubmessageRead::try_from_bytes(
-                        &submessage_header,
-                        data.as_ref(),
-                    )
-                    .map(RtpsSubmessageReadKind::InfoDestination),
+                    HEARTBEAT_FRAG => {
+                        HeartbeatFragSubmessage::try_from_bytes(&submessage_header, data.as_ref())
+                            .map(RtpsSubmessageReadKind::HeartbeatFrag)
+                    }
+                    INFO_DST => {
+                        InfoDestinationSubmessage::try_from_bytes(&submessage_header, data.as_ref())
+                            .map(RtpsSubmessageReadKind::InfoDestination)
+                    }
                     INFO_REPLY => {
-                        InfoReplySubmessageRead::try_from_bytes(&submessage_header, data.as_ref())
+                        InfoReplySubmessage::try_from_bytes(&submessage_header, data.as_ref())
                             .map(RtpsSubmessageReadKind::InfoReply)
                     }
                     INFO_SRC => {
-                        InfoSourceSubmessageRead::try_from_bytes(&submessage_header, data.as_ref())
+                        InfoSourceSubmessage::try_from_bytes(&submessage_header, data.as_ref())
                             .map(RtpsSubmessageReadKind::InfoSource)
                     }
-                    INFO_TS => InfoTimestampSubmessageRead::try_from_bytes(
-                        &submessage_header,
-                        data.as_ref(),
-                    )
-                    .map(RtpsSubmessageReadKind::InfoTimestamp),
+                    INFO_TS => {
+                        InfoTimestampSubmessage::try_from_bytes(&submessage_header, data.as_ref())
+                            .map(RtpsSubmessageReadKind::InfoTimestamp)
+                    }
                     NACK_FRAG => {
-                        NackFragSubmessageRead::try_from_bytes(&submessage_header, data.as_ref())
+                        NackFragSubmessage::try_from_bytes(&submessage_header, data.as_ref())
                             .map(RtpsSubmessageReadKind::NackFrag)
                     }
-                    PAD => PadSubmessageRead::try_from_bytes(&submessage_header, data.as_ref())
+                    PAD => PadSubmessage::try_from_bytes(&submessage_header, data.as_ref())
                         .map(RtpsSubmessageReadKind::Pad),
                     _ => {
                         data.consume(submessage_length);
@@ -283,15 +279,15 @@ pub enum RtpsSubmessageReadKind {
     AckNack(AckNackSubmessage),
     Data(DataSubmessage),
     DataFrag(DataFragSubmessage),
-    Gap(GapSubmessageRead),
-    Heartbeat(HeartbeatSubmessageRead),
-    HeartbeatFrag(HeartbeatFragSubmessageRead),
-    InfoDestination(InfoDestinationSubmessageRead),
-    InfoReply(InfoReplySubmessageRead),
-    InfoSource(InfoSourceSubmessageRead),
-    InfoTimestamp(InfoTimestampSubmessageRead),
-    NackFrag(NackFragSubmessageRead),
-    Pad(PadSubmessageRead),
+    Gap(GapSubmessage),
+    Heartbeat(HeartbeatSubmessage),
+    HeartbeatFrag(HeartbeatFragSubmessage),
+    InfoDestination(InfoDestinationSubmessage),
+    InfoReply(InfoReplySubmessage),
+    InfoSource(InfoSourceSubmessage),
+    InfoTimestamp(InfoTimestampSubmessage),
+    NackFrag(NackFragSubmessage),
+    Pad(PadSubmessage),
 }
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]
 pub struct RtpsMessageHeader {
@@ -374,7 +370,7 @@ mod tests {
     use crate::implementation::rtps::{
         messages::{
             submessage_elements::{Data, Parameter, ParameterList},
-            submessages::{data::DataSubmessage, info_timestamp::InfoTimestampSubmessageWrite},
+            submessages::{data::DataSubmessage, info_timestamp::InfoTimestampSubmessage},
             types::Time,
         },
         types::{EntityId, USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
@@ -458,7 +454,7 @@ mod tests {
             guid_prefix: [3; 12],
         };
         let info_timestamp_submessage =
-            Box::new(InfoTimestampSubmessageWrite::new(false, Time::new(4, 0)));
+            Box::new(InfoTimestampSubmessage::new(false, Time::new(4, 0)));
 
         let inline_qos_flag = true;
         let data_flag = false;

--- a/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
+++ b/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
@@ -1,7 +1,10 @@
 use crate::{
     implementation::rtps::{
         messages::{
-            overall_structure::{Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes, WriteIntoBytes},
+            overall_structure::{
+                Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes,
+                WriteIntoBytes,
+            },
             submessage_elements::SequenceNumberSet,
             types::{Count, SubmessageFlag, SubmessageKind},
         },
@@ -11,7 +14,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct AckNackSubmessageRead {
+pub struct AckNackSubmessage {
     final_flag: SubmessageFlag,
     reader_id: EntityId,
     writer_id: EntityId,
@@ -19,7 +22,7 @@ pub struct AckNackSubmessageRead {
     count: Count,
 }
 
-impl AckNackSubmessageRead {
+impl AckNackSubmessage {
     pub fn try_from_bytes(
         submessage_header: &SubmessageHeaderRead,
         mut data: &[u8],
@@ -55,16 +58,7 @@ impl AckNackSubmessageRead {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct AckNackSubmessageWrite {
-    final_flag: SubmessageFlag,
-    reader_id: EntityId,
-    writer_id: EntityId,
-    reader_sn_state: SequenceNumberSet,
-    count: Count,
-}
-
-impl AckNackSubmessageWrite {
+impl AckNackSubmessage {
     pub fn new(
         final_flag: SubmessageFlag,
         reader_id: EntityId,
@@ -82,7 +76,7 @@ impl AckNackSubmessageWrite {
     }
 }
 
-impl Submessage for AckNackSubmessageWrite {
+impl Submessage for AckNackSubmessage {
     fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
@@ -113,7 +107,7 @@ mod tests {
         let final_flag = false;
         let reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
         let writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);
-        let submessage = AckNackSubmessageWrite::new(
+        let submessage = AckNackSubmessage::new(
             final_flag,
             reader_id,
             writer_id,
@@ -147,7 +141,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let submessage =
-            AckNackSubmessageRead::try_from_bytes(&submessage_header, data.as_ref()).unwrap();
+            AckNackSubmessage::try_from_bytes(&submessage_header, data.as_ref()).unwrap();
         let expected_final_flag = false;
         let expected_reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
         let expected_writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);

--- a/dds/src/implementation/rtps/messages/submessages/data.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct DataSubmessageRead {
+pub struct DataSubmessage {
     inline_qos_flag: bool,
     data_flag: bool,
     key_flag: bool,
@@ -26,7 +26,7 @@ pub struct DataSubmessageRead {
     serialized_payload: Data,
 }
 
-impl DataSubmessageRead {
+impl DataSubmessage {
     pub fn try_from_arc_slice(
         submessage_header: &SubmessageHeaderRead,
         data: ArcSlice,
@@ -136,47 +136,7 @@ impl DataSubmessageRead {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct DataSubmessageWrite {
-    inline_qos_flag: SubmessageFlag,
-    data_flag: SubmessageFlag,
-    key_flag: SubmessageFlag,
-    non_standard_payload_flag: SubmessageFlag,
-    reader_id: EntityId,
-    writer_id: EntityId,
-    writer_sn: SequenceNumber,
-    inline_qos: ParameterList,
-    serialized_payload: Data,
-}
-
-impl DataSubmessageWrite {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        inline_qos_flag: SubmessageFlag,
-        data_flag: SubmessageFlag,
-        key_flag: SubmessageFlag,
-        non_standard_payload_flag: SubmessageFlag,
-        reader_id: EntityId,
-        writer_id: EntityId,
-        writer_sn: SequenceNumber,
-        inline_qos: ParameterList,
-        serialized_payload: Data,
-    ) -> Self {
-        Self {
-            inline_qos_flag,
-            data_flag,
-            key_flag,
-            non_standard_payload_flag,
-            reader_id,
-            writer_id,
-            writer_sn,
-            inline_qos,
-            serialized_payload,
-        }
-    }
-}
-
-impl Submessage for DataSubmessageWrite {
+impl Submessage for DataSubmessage {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::DATA,
@@ -227,7 +187,7 @@ mod tests {
         let writer_sn = 5;
         let inline_qos = ParameterList::empty();
         let serialized_payload = Data::new(vec![].into());
-        let submessage = DataSubmessageWrite::new(
+        let submessage = DataSubmessage::new(
             inline_qos_flag,
             data_flag,
             key_flag,
@@ -264,7 +224,7 @@ mod tests {
         let inline_qos = ParameterList::new(vec![parameter_1, parameter_2]);
         let serialized_payload = Data::new(vec![].into());
 
-        let submessage = DataSubmessageWrite::new(
+        let submessage = DataSubmessage::new(
             inline_qos_flag,
             data_flag,
             key_flag,
@@ -303,7 +263,7 @@ mod tests {
         let writer_sn = 5;
         let inline_qos = ParameterList::empty();
         let serialized_payload = Data::new(vec![1, 2, 3, 4].into());
-        let submessage = DataSubmessageWrite::new(
+        let submessage = DataSubmessage::new(
             inline_qos_flag,
             data_flag,
             key_flag,
@@ -338,7 +298,7 @@ mod tests {
         let writer_sn = 5;
         let inline_qos = ParameterList::empty();
         let serialized_payload = Data::new(vec![1, 2, 3].into());
-        let submessage = DataSubmessageWrite::new(
+        let submessage = DataSubmessage::new(
             inline_qos_flag,
             data_flag,
             key_flag,
@@ -384,7 +344,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let data_submessage =
-            DataSubmessageRead::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
 
         assert_eq!(inline_qos_flag, data_submessage._inline_qos_flag());
         assert_eq!(data_flag, data_submessage._data_flag());
@@ -414,7 +374,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let data_submessage =
-            DataSubmessageRead::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
         assert_eq!(&expected_inline_qos, data_submessage.inline_qos());
         assert_eq!(
             &expected_serialized_payload,
@@ -446,7 +406,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let data_submessage =
-            DataSubmessageRead::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
         assert_eq!(&inline_qos, data_submessage.inline_qos());
         assert_eq!(&serialized_payload, data_submessage.serialized_payload());
     }
@@ -476,7 +436,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let data_submessage =
-            DataSubmessageRead::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
 
         assert_eq!(&expected_inline_qos, data_submessage.inline_qos());
         assert_eq!(
@@ -508,7 +468,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let data_submessage =
-            DataSubmessageRead::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
 
         assert_eq!(&expected_inline_qos, data_submessage.inline_qos());
     }

--- a/dds/src/implementation/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data_frag.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct DataFragSubmessageRead {
+pub struct DataFragSubmessage {
     inline_qos_flag: bool,
     non_standard_payload_flag: SubmessageFlag,
     key_flag: bool,
@@ -29,7 +29,7 @@ pub struct DataFragSubmessageRead {
     serialized_payload: Data,
 }
 
-impl DataFragSubmessageRead {
+impl DataFragSubmessage {
     pub fn try_from_arc_slice(
         submessage_header: &SubmessageHeaderRead,
         data: ArcSlice,
@@ -134,23 +134,7 @@ impl DataFragSubmessageRead {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct DataFragSubmessageWrite {
-    inline_qos_flag: SubmessageFlag,
-    non_standard_payload_flag: SubmessageFlag,
-    key_flag: SubmessageFlag,
-    reader_id: EntityId,
-    writer_id: EntityId,
-    writer_sn: SequenceNumber,
-    fragment_starting_num: FragmentNumber,
-    fragments_in_submessage: u16,
-    fragment_size: u16,
-    data_size: u32,
-    inline_qos: ParameterList,
-    serialized_payload: Data,
-}
-
-impl DataFragSubmessageWrite {
+impl DataFragSubmessage {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         inline_qos_flag: SubmessageFlag,
@@ -183,7 +167,7 @@ impl DataFragSubmessageWrite {
     }
 }
 
-impl Submessage for DataFragSubmessageWrite {
+impl Submessage for DataFragSubmessage {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::DATA_FRAG,
@@ -228,7 +212,7 @@ mod tests {
     fn serialize_no_inline_qos_no_serialized_payload() {
         let inline_qos = ParameterList::empty();
         let serialized_payload = Data::new(vec![].into());
-        let submessage = DataFragSubmessageWrite::new(
+        let submessage = DataFragSubmessage::new(
             false,
             false,
             false,
@@ -261,7 +245,7 @@ mod tests {
     fn serialize_with_inline_qos_with_serialized_payload() {
         let inline_qos = ParameterList::new(vec![Parameter::new(8, vec![71, 72, 73, 74].into())]);
         let serialized_payload = Data::new(vec![1, 2, 3].into());
-        let submessage = DataFragSubmessageWrite::new(
+        let submessage = DataFragSubmessage::new(
             true,
             false,
             false,
@@ -310,7 +294,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let submessage =
-            DataFragSubmessageRead::try_from_arc_slice(&submessage_header, ArcSlice::from(data))
+            DataFragSubmessage::try_from_arc_slice(&submessage_header, ArcSlice::from(data))
                 .unwrap();
 
         let expected_inline_qos_flag = false;
@@ -372,7 +356,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let submessage =
-            DataFragSubmessageRead::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+            DataFragSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
 
         let expected_inline_qos_flag = true;
         let expected_non_standard_payload_flag = false;

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HeartbeatSubmessageRead {
+pub struct HeartbeatSubmessage {
     final_flag: SubmessageFlag,
     liveliness_flag: SubmessageFlag,
     reader_id: EntityId,
@@ -23,7 +23,7 @@ pub struct HeartbeatSubmessageRead {
     count: Count,
 }
 
-impl HeartbeatSubmessageRead {
+impl HeartbeatSubmessage {
     pub fn try_from_bytes(
         submessage_header: &SubmessageHeaderRead,
         mut data: &[u8],
@@ -68,18 +68,8 @@ impl HeartbeatSubmessageRead {
         self.count
     }
 }
-#[derive(Debug, PartialEq, Eq)]
-pub struct HeartbeatSubmessageWrite {
-    final_flag: SubmessageFlag,
-    liveliness_flag: SubmessageFlag,
-    reader_id: EntityId,
-    writer_id: EntityId,
-    first_sn: SequenceNumber,
-    last_sn: SequenceNumber,
-    count: Count,
-}
 
-impl HeartbeatSubmessageWrite {
+impl HeartbeatSubmessage {
     pub fn new(
         final_flag: SubmessageFlag,
         liveliness_flag: SubmessageFlag,
@@ -101,7 +91,7 @@ impl HeartbeatSubmessageWrite {
     }
 }
 
-impl Submessage for HeartbeatSubmessageWrite {
+impl Submessage for HeartbeatSubmessage {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::HEARTBEAT,
@@ -137,7 +127,7 @@ mod tests {
         let first_sn = 5;
         let last_sn = 7;
         let count = 2;
-        let submessage = HeartbeatSubmessageWrite::new(
+        let submessage = HeartbeatSubmessage::new(
             final_flag,
             liveliness_flag,
             reader_id,
@@ -181,7 +171,7 @@ mod tests {
             2, 0, 0, 0, // count: Count: value (long)
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage = HeartbeatSubmessageRead::try_from_bytes(&submessage_header, data).unwrap();
+        let submessage = HeartbeatSubmessage::try_from_bytes(&submessage_header, data).unwrap();
         assert_eq!(expected_final_flag, submessage.final_flag());
         assert_eq!(expected_liveliness_flag, submessage.liveliness_flag());
         assert_eq!(expected_reader_id, submessage._reader_id());

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct HeartbeatFragSubmessageRead {
+pub struct HeartbeatFragSubmessage {
     reader_id: EntityId,
     writer_id: EntityId,
     writer_sn: SequenceNumber,
@@ -21,7 +21,7 @@ pub struct HeartbeatFragSubmessageRead {
     count: Count,
 }
 
-impl HeartbeatFragSubmessageRead {
+impl HeartbeatFragSubmessage {
     pub fn try_from_bytes(
         submessage_header: &SubmessageHeaderRead,
         mut data: &[u8],
@@ -57,15 +57,7 @@ impl HeartbeatFragSubmessageRead {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct HeartbeatFragSubmessageWrite {
-    reader_id: EntityId,
-    writer_id: EntityId,
-    writer_sn: SequenceNumber,
-    last_fragment_num: FragmentNumber,
-    count: Count,
-}
-impl HeartbeatFragSubmessageWrite {
+impl HeartbeatFragSubmessage {
     pub fn _new(
         reader_id: EntityId,
         writer_id: EntityId,
@@ -83,7 +75,7 @@ impl HeartbeatFragSubmessageWrite {
     }
 }
 
-impl Submessage for HeartbeatFragSubmessageWrite {
+impl Submessage for HeartbeatFragSubmessage {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::HEARTBEAT_FRAG, &[], octets_to_next_header)
             .write_into_bytes(&mut buf);
@@ -108,7 +100,7 @@ mod tests {
 
     #[test]
     fn serialize_heart_beat() {
-        let submessage = HeartbeatFragSubmessageWrite::_new(
+        let submessage = HeartbeatFragSubmessage::_new(
             EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
             EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
             5,
@@ -141,8 +133,7 @@ mod tests {
             2, 0, 0, 0, // count: Count
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage =
-            HeartbeatFragSubmessageRead::try_from_bytes(&submessage_header, data).unwrap();
+        let submessage = HeartbeatFragSubmessage::try_from_bytes(&submessage_header, data).unwrap();
 
         let expected_reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
         let expected_writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);

--- a/dds/src/implementation/rtps/messages/submessages/info_destination.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_destination.rs
@@ -13,11 +13,11 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct InfoDestinationSubmessageRead {
+pub struct InfoDestinationSubmessage {
     guid_prefix: GuidPrefix,
 }
 
-impl InfoDestinationSubmessageRead {
+impl InfoDestinationSubmessage {
     pub fn try_from_bytes(
         submessage_header: &SubmessageHeaderRead,
         mut data: &[u8],
@@ -34,18 +34,14 @@ impl InfoDestinationSubmessageRead {
         self.guid_prefix
     }
 }
-#[derive(Debug, PartialEq, Eq)]
-pub struct InfoDestinationSubmessageWrite {
-    guid_prefix: GuidPrefix,
-}
 
-impl InfoDestinationSubmessageWrite {
+impl InfoDestinationSubmessage {
     pub fn new(guid_prefix: GuidPrefix) -> Self {
         Self { guid_prefix }
     }
 }
 
-impl Submessage for InfoDestinationSubmessageWrite {
+impl Submessage for InfoDestinationSubmessage {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::INFO_DST, &[], octets_to_next_header)
             .write_into_bytes(&mut buf);
@@ -66,7 +62,7 @@ mod tests {
     #[test]
     fn serialize_heart_beat() {
         let guid_prefix = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-        let submessage = InfoDestinationSubmessageWrite::new(guid_prefix);
+        let submessage = InfoDestinationSubmessage::new(guid_prefix);
         #[rustfmt::skip]
         assert_eq!(write_into_bytes_vec(submessage), vec![
               0x0e, 0b_0000_0001, 12, 0, // Submessage header
@@ -88,7 +84,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let submessage =
-            InfoDestinationSubmessageRead::try_from_bytes(&submessage_header, data).unwrap();
+            InfoDestinationSubmessage::try_from_bytes(&submessage_header, data).unwrap();
 
         let expected_guid_prefix = GUIDPREFIX_UNKNOWN;
         assert_eq!(expected_guid_prefix, submessage.guid_prefix());

--- a/dds/src/implementation/rtps/messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_reply.rs
@@ -11,13 +11,13 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct InfoReplySubmessageRead {
+pub struct InfoReplySubmessage {
     multicast_flag: SubmessageFlag,
     unicast_locator_list: LocatorList,
     multicast_locator_list: LocatorList,
 }
 
-impl InfoReplySubmessageRead {
+impl InfoReplySubmessage {
     pub fn try_from_bytes(
         submessage_header: &SubmessageHeaderRead,
         mut data: &[u8],
@@ -50,14 +50,7 @@ impl InfoReplySubmessageRead {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct InfoReplySubmessageWrite {
-    multicast_flag: SubmessageFlag,
-    unicast_locator_list: LocatorList,
-    multicast_locator_list: LocatorList,
-}
-
-impl Submessage for InfoReplySubmessageWrite {
+impl Submessage for InfoReplySubmessage {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::INFO_REPLY, &[], octets_to_next_header)
             .write_into_bytes(&mut buf);
@@ -71,7 +64,7 @@ impl Submessage for InfoReplySubmessageWrite {
     }
 }
 
-impl InfoReplySubmessageWrite {
+impl InfoReplySubmessage {
     pub fn _new(
         multicast_flag: SubmessageFlag,
         unicast_locator_list: LocatorList,
@@ -95,7 +88,7 @@ mod tests {
     #[test]
     fn serialize_info_reply() {
         let locator = Locator::new(11, 12, [1; 16]);
-        let submessage = InfoReplySubmessageWrite::_new(
+        let submessage = InfoReplySubmessage::_new(
             false,
             LocatorList::new(vec![locator]),
             LocatorList::new(vec![]),
@@ -128,7 +121,7 @@ mod tests {
             1, 1, 1, 1, //address
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage = InfoReplySubmessageRead::try_from_bytes(&submessage_header, data).unwrap();
+        let submessage = InfoReplySubmessage::try_from_bytes(&submessage_header, data).unwrap();
         let locator = Locator::new(11, 12, [1; 16]);
         let expected_multicast_flag = false;
         let expected_unicast_locator_list = LocatorList::new(vec![locator]);
@@ -166,7 +159,7 @@ mod tests {
             2, 2, 2, 2, //address
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage = InfoReplySubmessageRead::try_from_bytes(&submessage_header, data).unwrap();
+        let submessage = InfoReplySubmessage::try_from_bytes(&submessage_header, data).unwrap();
         let locator1 = Locator::new(11, 12, [1; 16]);
         let locator2 = Locator::new(11, 12, [2; 16]);
         let expected_multicast_flag = true;

--- a/dds/src/implementation/rtps/messages/submessages/info_source.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_source.rs
@@ -13,13 +13,13 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct InfoSourceSubmessageRead {
+pub struct InfoSourceSubmessage {
     protocol_version: ProtocolVersion,
     vendor_id: VendorId,
     guid_prefix: GuidPrefix,
 }
 
-impl InfoSourceSubmessageRead {
+impl InfoSourceSubmessage {
     pub fn try_from_bytes(
         submessage_header: &SubmessageHeaderRead,
         mut data: &[u8],
@@ -46,14 +46,7 @@ impl InfoSourceSubmessageRead {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct InfoSourceSubmessageWrite {
-    protocol_version: ProtocolVersion,
-    vendor_id: VendorId,
-    guid_prefix: GuidPrefix,
-}
-
-impl InfoSourceSubmessageWrite {
+impl InfoSourceSubmessage {
     pub fn _new(
         protocol_version: ProtocolVersion,
         vendor_id: VendorId,
@@ -67,7 +60,7 @@ impl InfoSourceSubmessageWrite {
     }
 }
 
-impl Submessage for InfoSourceSubmessageWrite {
+impl Submessage for InfoSourceSubmessage {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::INFO_SRC, &[], octets_to_next_header)
             .write_into_bytes(&mut buf);
@@ -91,11 +84,8 @@ mod tests {
 
     #[test]
     fn serialize_info_source() {
-        let submessage = InfoSourceSubmessageWrite::_new(
-            PROTOCOLVERSION_1_0,
-            VENDOR_ID_UNKNOWN,
-            GUIDPREFIX_UNKNOWN,
-        );
+        let submessage =
+            InfoSourceSubmessage::_new(PROTOCOLVERSION_1_0, VENDOR_ID_UNKNOWN, GUIDPREFIX_UNKNOWN);
         #[rustfmt::skip]
         assert_eq!(write_into_bytes_vec(submessage), vec![
                 0x0c, 0b_0000_0001, 20, 0, // Submessage header
@@ -120,8 +110,7 @@ mod tests {
             0, 0, 0, 0, //guid_prefix
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage =
-            InfoSourceSubmessageRead::try_from_bytes(&submessage_header, data).unwrap();
+        let submessage = InfoSourceSubmessage::try_from_bytes(&submessage_header, data).unwrap();
 
         let expected_protocol_version = PROTOCOLVERSION_1_0;
         let expected_vendor_id = VENDOR_ID_UNKNOWN;

--- a/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct NackFragSubmessageRead {
+pub struct NackFragSubmessage {
     reader_id: EntityId,
     writer_id: EntityId,
     writer_sn: SequenceNumber,
@@ -22,7 +22,7 @@ pub struct NackFragSubmessageRead {
     count: Count,
 }
 
-impl NackFragSubmessageRead {
+impl NackFragSubmessage {
     pub fn try_from_bytes(
         submessage_header: &SubmessageHeaderRead,
         mut data: &[u8],
@@ -58,16 +58,7 @@ impl NackFragSubmessageRead {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct NackFragSubmessageWrite {
-    reader_id: EntityId,
-    writer_id: EntityId,
-    writer_sn: SequenceNumber,
-    fragment_number_state: FragmentNumberSet,
-    count: Count,
-}
-
-impl NackFragSubmessageWrite {
+impl NackFragSubmessage {
     pub fn new(
         reader_id: EntityId,
         writer_id: EntityId,
@@ -85,7 +76,7 @@ impl NackFragSubmessageWrite {
     }
 }
 
-impl Submessage for NackFragSubmessageWrite {
+impl Submessage for NackFragSubmessage {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::NACK_FRAG, &[], octets_to_next_header)
             .write_into_bytes(&mut buf);
@@ -110,7 +101,7 @@ mod tests {
 
     #[test]
     fn serialize_nack_frag() {
-        let submessage = NackFragSubmessageWrite::new(
+        let submessage = NackFragSubmessage::new(
             EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY),
             EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP),
             4,
@@ -145,7 +136,7 @@ mod tests {
             6, 0, 0, 0, // count
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage = NackFragSubmessageRead::try_from_bytes(&submessage_header, data).unwrap();
+        let submessage = NackFragSubmessage::try_from_bytes(&submessage_header, data).unwrap();
 
         let expected_reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
         let expected_writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);

--- a/dds/src/implementation/rtps/messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps/messages/submessages/pad.rs
@@ -9,9 +9,9 @@ use crate::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct PadSubmessageRead {}
+pub struct PadSubmessage {}
 
-impl PadSubmessageRead {
+impl PadSubmessage {
     pub fn try_from_bytes(
         _submessage_header: &SubmessageHeaderRead,
         _data: &[u8],
@@ -20,22 +20,19 @@ impl PadSubmessageRead {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct PadSubmessageWrite {}
-
-impl PadSubmessageWrite {
+impl PadSubmessage {
     pub fn new() -> Self {
         Self {}
     }
 }
 
-impl Default for PadSubmessageWrite {
+impl Default for PadSubmessage {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Submessage for PadSubmessageWrite {
+impl Submessage for PadSubmessage {
     fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::PAD, &[], octets_to_next_header)
             .write_into_bytes(&mut buf);
@@ -53,7 +50,7 @@ mod tests {
 
     #[test]
     fn serialize_pad() {
-        let submessage = PadSubmessageWrite::new();
+        let submessage = PadSubmessage::new();
         #[rustfmt::skip]
         assert_eq!(write_into_bytes_vec(submessage), vec![
                 0x01, 0b_0000_0001, 0, 0, // Submessage header
@@ -68,7 +65,7 @@ mod tests {
             0x01, 0b_0000_0001, 0, 0, // Submessage header
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage = PadSubmessageRead::try_from_bytes(&submessage_header, data);
+        let submessage = PadSubmessage::try_from_bytes(&submessage_header, data);
 
         assert!(submessage.is_ok())
     }

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -1,8 +1,6 @@
 use super::{
     messages::{
-        submessages::{
-            heartbeat::HeartbeatSubmessageWrite, heartbeat_frag::HeartbeatFragSubmessageWrite,
-        },
+        submessages::{heartbeat::HeartbeatSubmessage, heartbeat_frag::HeartbeatFragSubmessage},
         types::{Count, FragmentNumber},
     },
     types::{EntityId, Guid, Locator, ReliabilityKind, SequenceNumber},
@@ -35,10 +33,10 @@ impl HeartbeatMachine {
         writer_id: EntityId,
         first_sn: SequenceNumber,
         last_sn: SequenceNumber,
-    ) -> HeartbeatSubmessageWrite {
+    ) -> HeartbeatSubmessage {
         self.count = self.count.wrapping_add(1);
         self.timer.reset();
-        HeartbeatSubmessageWrite::new(
+        HeartbeatSubmessage::new(
             false,
             false,
             self.reader_id,
@@ -68,9 +66,9 @@ impl HeartbeatFragMachine {
         writer_id: EntityId,
         writer_sn: SequenceNumber,
         last_fragment_num: FragmentNumber,
-    ) -> HeartbeatFragSubmessageWrite {
+    ) -> HeartbeatFragSubmessage {
         self.count = self.count.wrapping_add(1);
-        HeartbeatFragSubmessageWrite::_new(
+        HeartbeatFragSubmessage::_new(
             self.reader_id,
             writer_id,
             writer_sn,

--- a/dds/src/implementation/rtps/writer_history_cache.rs
+++ b/dds/src/implementation/rtps/writer_history_cache.rs
@@ -2,7 +2,7 @@ use super::{
     messages::{
         self,
         submessage_elements::{Data, ParameterList},
-        submessages::{data::DataSubmessageWrite, data_frag::DataFragSubmessageWrite},
+        submessages::{data::DataSubmessage, data_frag::DataFragSubmessage},
     },
     types::{ChangeKind, EntityId, Guid, SequenceNumber},
 };
@@ -44,7 +44,7 @@ pub struct DataFragSubmessagesIter<'a> {
 }
 
 impl<'a> IntoIterator for &'a DataFragSubmessages<'a> {
-    type Item = DataFragSubmessageWrite;
+    type Item = DataFragSubmessage;
     type IntoIter = DataFragSubmessagesIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -59,7 +59,7 @@ impl<'a> IntoIterator for &'a DataFragSubmessages<'a> {
 }
 
 impl<'a> Iterator for DataFragSubmessagesIter<'a> {
-    type Item = DataFragSubmessageWrite;
+    type Item = DataFragSubmessage;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.pos < self.data.len() {
@@ -82,7 +82,7 @@ impl<'a> Iterator for DataFragSubmessagesIter<'a> {
 
             self.pos += 1;
 
-            Some(DataFragSubmessageWrite::new(
+            Some(DataFragSubmessage::new(
                 inline_qos_flag,
                 non_standard_payload_flag,
                 key_flag,
@@ -103,14 +103,14 @@ impl<'a> Iterator for DataFragSubmessagesIter<'a> {
 }
 
 impl RtpsWriterCacheChange {
-    pub fn as_data_submessage(&self, reader_id: EntityId) -> DataSubmessageWrite {
+    pub fn as_data_submessage(&self, reader_id: EntityId) -> DataSubmessage {
         let (data_flag, key_flag) = match self.kind() {
             ChangeKind::Alive => (true, false),
             ChangeKind::NotAliveDisposed | ChangeKind::NotAliveUnregistered => (false, true),
             _ => todo!(),
         };
 
-        DataSubmessageWrite::new(
+        DataSubmessage::new(
             true,
             data_flag,
             key_flag,

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -10,7 +10,7 @@ use super::{
         submessage_elements::{Data, FragmentNumberSet, SequenceNumberSet},
         submessages::{
             ack_nack::AckNackSubmessage, data::DataSubmessage, data_frag::DataFragSubmessage,
-            info_destination::InfoDestinationSubmessageWrite, nack_frag::NackFragSubmessageWrite,
+            info_destination::InfoDestinationSubmessage, nack_frag::NackFragSubmessage,
         },
         types::Count,
     },
@@ -238,7 +238,7 @@ impl RtpsWriterProxy {
             self.increment_acknack_count();
 
             let info_dst_submessage =
-                InfoDestinationSubmessageWrite::new(self.remote_writer_guid().prefix());
+                InfoDestinationSubmessage::new(self.remote_writer_guid().prefix());
 
             let acknack_submessage = AckNackSubmessage::new(
                 true,
@@ -269,7 +269,7 @@ impl RtpsWriterProxy {
 
                 if !missing_fragment_number.is_empty() {
                     self.nack_frag_count = self.nack_frag_count.wrapping_add(1);
-                    let nack_frag_submessage = NackFragSubmessageWrite::new(
+                    let nack_frag_submessage = NackFragSubmessage::new(
                         reader_guid.entity_id(),
                         self.remote_writer_guid().entity_id(),
                         *seq_num,

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -9,7 +9,7 @@ use super::{
         overall_structure::{RtpsMessageHeader, RtpsMessageWrite, Submessage},
         submessage_elements::{Data, FragmentNumberSet, SequenceNumberSet},
         submessages::{
-            ack_nack::AckNackSubmessageWrite, data::DataSubmessageRead,
+            ack_nack::AckNackSubmessage, data::DataSubmessageRead,
             data_frag::DataFragSubmessageRead, info_destination::InfoDestinationSubmessageWrite,
             nack_frag::NackFragSubmessageWrite,
         },
@@ -241,7 +241,7 @@ impl RtpsWriterProxy {
             let info_dst_submessage =
                 InfoDestinationSubmessageWrite::new(self.remote_writer_guid().prefix());
 
-            let acknack_submessage = AckNackSubmessageWrite::new(
+            let acknack_submessage = AckNackSubmessage::new(
                 true,
                 reader_guid.entity_id(),
                 self.remote_writer_guid().entity_id(),


### PR DESCRIPTION
Since the rep invariant of the submessage read and write are the same: merge the two types. 