### PR TITLE
Send pending writer messages before delete

### DIFF
--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -66,6 +66,10 @@ impl<Foo> DataReaderAsync<Foo> {
         self.subscriber.subscriber_address()
     }
 
+    pub(crate) fn reader_address(&self) -> &ActorAddress<DataReaderActor> {
+        &self.reader_address
+    }
+
     pub(crate) fn runtime_handle(&self) -> &tokio::runtime::Handle {
         self.subscriber.runtime_handle()
     }

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -77,6 +77,10 @@ impl<Foo> DataWriterAsync<Foo> {
         self.publisher.runtime_handle()
     }
 
+    pub(crate) fn writer_address(&self) -> &ActorAddress<DataWriterActor> {
+        &self.writer_address
+    }
+
     async fn announce_writer(&self) -> DdsResult<()> {
         let type_name = self.writer_address.get_type_name().await?;
         let type_support = self

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -1163,6 +1163,18 @@ impl DomainParticipantActor {
     pub fn get_statuscondition(&self) -> ActorAddress<StatusConditionActor> {
         self.status_condition.address()
     }
+
+    fn get_udp_transport_write(&self) -> Arc<UdpTransportWrite> {
+        self.udp_transport_write.clone()
+    }
+
+    fn get_rtps_message_header(&self) -> RtpsMessageHeader {
+        RtpsMessageHeader::new(
+            self.rtps_participant.protocol_version(),
+            self.rtps_participant.vendor_id(),
+            self.rtps_participant.guid().prefix(),
+        )
+    }
 }
 
 impl DomainParticipantActor {

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -154,6 +154,17 @@ impl PublisherActor {
         Ok(data_writer_address)
     }
 
+    fn delete_datawriter(&mut self, handle: InstanceHandle) -> DdsResult<()> {
+        let removed_writer = self.data_writer_list.remove(&handle);
+        if removed_writer.is_some() {
+            Ok(())
+        } else {
+            Err(DdsError::PreconditionNotMet(
+                "Data writer can only be deleted from its parent publisher".to_string(),
+            ))
+        }
+    }
+
     async fn lookup_datawriter(&self, topic_name: String) -> Option<ActorAddress<DataWriterActor>> {
         for dw in self.data_writer_list.values() {
             if dw.get_topic_name().await == topic_name {
@@ -178,11 +189,6 @@ impl PublisherActor {
 
     fn delete_contained_entities(&mut self) -> Vec<InstanceHandle> {
         self.data_writer_list.drain().map(|(h, _)| h).collect()
-    }
-
-    #[allow(clippy::unused_unit)]
-    fn datawriter_delete(&mut self, handle: InstanceHandle) -> () {
-        self.data_writer_list.remove(&handle);
     }
 
     #[allow(clippy::unused_unit)]

--- a/dds/tests/listeners.rs
+++ b/dds/tests/listeners.rs
@@ -1452,7 +1452,7 @@ fn subscriber_deadline_missed_listener() {
     writer.write(&data1, None).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(1, 0))
+        .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
     let status = receiver

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1464,12 +1464,12 @@ fn write_read_disposed_samples_when_writer_is_immediately_deleted() {
     let start_loop_time = std::time::Instant::now();
     let wait_for_disposed_timeout = std::time::Duration::from_secs(10);
     let samples = loop {
-        let samples = reader
-            .read(2, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
-            .unwrap();
-        if samples.len() == 2 {
-            break samples;
+        if let Ok(samples) = reader.read(2, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE) {
+            if samples.len() == 2 {
+                break samples;
+            }
         }
+
         if start_loop_time.elapsed() > wait_for_disposed_timeout {
             panic!("Disposed sample not received within expected time.")
         }


### PR DESCRIPTION
Send pending writer messages before delete. This allows disposing and unregistering samples and immediately deleting the datawriter