### PR TITLE
Move the Send bound to the trait definition to prevent rust compiler ICE

### DIFF
--- a/dds/src/implementation/utils/actor.rs
+++ b/dds/src/implementation/utils/actor.rs
@@ -24,7 +24,6 @@ where
 impl<A> ActorAddress<A>
 where
     A: ActorHandler,
-    A::Message: Send,
 {
     pub async fn send_actor_message(&self, message: A::Message) -> DdsResult<()> {
         if let Some(s) = self.sender.upgrade() {
@@ -43,7 +42,7 @@ where
 }
 
 pub trait ActorHandler {
-    type Message;
+    type Message: Send;
 
     fn handle_message(&mut self, message: Self::Message) -> impl Future<Output = ()> + Send;
 }
@@ -69,7 +68,6 @@ where
 impl<A> Actor<A>
 where
     A: ActorHandler + Send + 'static,
-    A::Message: Send,
 {
     pub fn spawn(mut actor: A, runtime: &tokio::runtime::Handle) -> Self {
         let (sender, mut mailbox) = tokio::sync::mpsc::channel::<A::Message>(16);


### PR DESCRIPTION
We have observed a compiler ICE which the error output indicates that it happens when the trait bound for Send is being checked. This issue seems to be gone when moving the Send bound from the usage places into the trait definition itself.