### PR TITLE
Remove methods from actor address

### DIFF
--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -42,11 +42,11 @@ impl StatusConditionAsync {
     /// Async version of [`set_enabled_statuses`](crate::infrastructure::condition::StatusCondition::set_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn set_enabled_statuses(&self, mask: &[StatusKind]) -> DdsResult<()> {
-        Ok(self
-            .address
+        self.address
             .upgrade()?
             .set_enabled_statuses(mask.to_vec())
-            .await)
+            .await;
+        Ok(())
     }
 
     /// Async version of [`get_entity`](crate::infrastructure::condition::StatusCondition::get_entity).

--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -36,13 +36,17 @@ impl StatusConditionAsync {
     /// Async version of [`get_enabled_statuses`](crate::infrastructure::condition::StatusCondition::get_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn get_enabled_statuses(&self) -> DdsResult<Vec<StatusKind>> {
-        self.address.get_enabled_statuses().await
+        Ok(self.address.upgrade()?.get_enabled_statuses().await)
     }
 
     /// Async version of [`set_enabled_statuses`](crate::infrastructure::condition::StatusCondition::set_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn set_enabled_statuses(&self, mask: &[StatusKind]) -> DdsResult<()> {
-        self.address.set_enabled_statuses(mask.to_vec()).await
+        Ok(self
+            .address
+            .upgrade()?
+            .set_enabled_statuses(mask.to_vec())
+            .await)
     }
 
     /// Async version of [`get_entity`](crate::infrastructure::condition::StatusCondition::get_entity).
@@ -56,6 +60,6 @@ impl StatusConditionAsync {
     /// Async version of [`get_trigger_value`](crate::infrastructure::condition::StatusCondition::get_trigger_value).
     #[tracing::instrument(skip(self))]
     pub async fn get_trigger_value(&self) -> DdsResult<bool> {
-        self.address.get_trigger_value().await
+        Ok(self.address.upgrade()?.get_trigger_value().await)
     }
 }

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -423,11 +423,10 @@ impl<Foo> DataReaderAsync<Foo> {
         &self,
         publication_handle: InstanceHandle,
     ) -> DdsResult<PublicationBuiltinTopicData> {
-        Ok(self
-            .reader_address
+        self.reader_address
             .upgrade()?
             .get_matched_publication_data(publication_handle)
-            .await?)
+            .await
     }
 
     /// Async version of [`get_matched_publications`](crate::subscription::data_reader::DataReader::get_matched_publications).

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -82,11 +82,12 @@ impl<Foo> DataWriterAsync<Foo> {
     }
 
     async fn announce_writer(&self) -> DdsResult<()> {
-        let type_name = self.writer_address.get_type_name().await?;
+        let type_name = self.writer_address.upgrade()?.get_type_name().await;
         let type_support = self
             .participant_address()
+            .upgrade()?
             .get_type_support(type_name.clone())
-            .await?
+            .await
             .ok_or_else(|| {
                 DdsError::PreconditionNotMet(format!(
                     "Type with name {} not registered with parent domain participant",
@@ -95,21 +96,27 @@ impl<Foo> DataWriterAsync<Foo> {
             })?;
         let discovered_writer_data = self
             .writer_address
+            .upgrade()?
             .as_discovered_writer_data(
                 TopicQos::default(),
-                self.publisher_address().get_qos().await?,
+                self.publisher_address().upgrade()?.get_qos().await,
                 self.participant_address()
+                    .upgrade()?
                     .get_default_unicast_locator_list()
-                    .await?,
+                    .await,
                 self.participant_address()
+                    .upgrade()?
                     .get_default_multicast_locator_list()
-                    .await?,
+                    .await,
                 type_support.xml_type(),
             )
-            .await?;
+            .await;
         self.participant_address()
+            .upgrade()?
             .announce_created_or_modified_data_writer(discovered_writer_data)
-            .await
+            .await;
+
+        Ok(())
     }
 }
 
@@ -120,7 +127,11 @@ where
     /// Async version of [`register_instance`](crate::publication::data_writer::DataWriter::register_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn register_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
-        let timestamp = { self.participant_address().get_current_time().await? };
+        let timestamp = self
+            .participant_address()
+            .upgrade()?
+            .get_current_time()
+            .await;
         self.register_instance_w_timestamp(instance, timestamp)
             .await
     }
@@ -142,7 +153,11 @@ where
         instance: &Foo,
         handle: Option<InstanceHandle>,
     ) -> DdsResult<()> {
-        let timestamp = { self.participant_address().get_current_time().await? };
+        let timestamp = self
+            .participant_address()
+            .upgrade()?
+            .get_current_time()
+            .await;
         self.unregister_instance_w_timestamp(instance, handle, timestamp)
             .await
     }
@@ -155,11 +170,12 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        let type_name = self.writer_address.get_type_name().await?;
+        let type_name = self.writer_address.upgrade()?.get_type_name().await;
         let type_support = self
             .participant_address()
+            .upgrade()?
             .get_type_support(type_name.clone())
-            .await?
+            .await
             .ok_or_else(|| {
                 DdsError::PreconditionNotMet(format!(
                     "Type with name {} not registered with parent domain participant",
@@ -199,12 +215,13 @@ where
                 type_support.get_serialized_key_from_serialized_foo(&serialized_foo)?;
 
             self.writer_address
+                .upgrade()?
                 .unregister_instance_w_timestamp(
                     instance_serialized_key,
                     instance_handle,
                     timestamp,
                 )
-                .await?
+                .await
         } else {
             Err(DdsError::IllegalOperation)
         }
@@ -223,11 +240,12 @@ where
     /// Async version of [`lookup_instance`](crate::publication::data_writer::DataWriter::lookup_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn lookup_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
-        let type_name = self.writer_address.get_type_name().await?;
+        let type_name = self.writer_address.upgrade()?.get_type_name().await;
         let type_support = self
             .participant_address()
+            .upgrade()?
             .get_type_support(type_name.clone())
-            .await?
+            .await
             .ok_or_else(|| {
                 DdsError::PreconditionNotMet(format!(
                     "Type with name {} not registered with parent domain participant",
@@ -239,13 +257,20 @@ where
         instance.serialize_data(&mut serialized_foo)?;
         let instance_handle = type_support.instance_handle_from_serialized_foo(&serialized_foo)?;
 
-        self.writer_address.lookup_instance(instance_handle).await?
+        self.writer_address
+            .upgrade()?
+            .lookup_instance(instance_handle)
+            .await
     }
 
     /// Async version of [`write`](crate::publication::data_writer::DataWriter::write).
     #[tracing::instrument(skip(self, data))]
     pub async fn write(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
-        let timestamp = { self.participant_address().get_current_time().await? };
+        let timestamp = self
+            .participant_address()
+            .upgrade()?
+            .get_current_time()
+            .await;
         self.write_w_timestamp(data, handle, timestamp).await
     }
 
@@ -257,11 +282,12 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        let type_name = self.writer_address.get_type_name().await?;
+        let type_name = self.writer_address.upgrade()?.get_type_name().await;
         let type_support = self
             .participant_address()
+            .upgrade()?
             .get_type_support(type_name.clone())
-            .await?
+            .await
             .ok_or_else(|| {
                 DdsError::PreconditionNotMet(format!(
                     "Type with name {} not registered with parent domain participant",
@@ -274,10 +300,11 @@ where
         let key = type_support.instance_handle_from_serialized_foo(&serialized_data)?;
 
         self.writer_address
+            .upgrade()?
             .write_w_timestamp(serialized_data, key, handle, timestamp)
-            .await??;
+            .await?;
 
-        self.participant_address().send_message().await?;
+        self.participant_address().upgrade()?.send_message().await;
 
         Ok(())
     }
@@ -285,7 +312,11 @@ where
     /// Async version of [`dispose`](crate::publication::data_writer::DataWriter::dispose).
     #[tracing::instrument(skip(self, data))]
     pub async fn dispose(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
-        let timestamp = { self.participant_address().get_current_time().await? };
+        let timestamp = self
+            .participant_address()
+            .upgrade()?
+            .get_current_time()
+            .await;
         self.dispose_w_timestamp(data, handle, timestamp).await
     }
 
@@ -322,11 +353,12 @@ where
             }
         }?;
 
-        let type_name = self.writer_address.get_type_name().await?;
+        let type_name = self.writer_address.upgrade()?.get_type_name().await;
         let type_support = self
             .participant_address()
+            .upgrade()?
             .get_type_support(type_name.clone())
-            .await?
+            .await
             .ok_or_else(|| {
                 DdsError::PreconditionNotMet(format!(
                     "Type with name {} not registered with parent domain participant",
@@ -339,8 +371,9 @@ where
         let key = type_support.get_serialized_key_from_serialized_foo(&serialized_foo)?;
 
         self.writer_address
+            .upgrade()?
             .dispose_w_timestamp(key, instance_handle, timestamp)
-            .await?
+            .await
     }
 }
 
@@ -350,7 +383,12 @@ impl<Foo> DataWriterAsync<Foo> {
     pub async fn wait_for_acknowledgments(&self, max_wait: Duration) -> DdsResult<()> {
         tokio::time::timeout(max_wait.into(), async {
             loop {
-                if self.writer_address.are_all_changes_acknowledge().await? {
+                if self
+                    .writer_address
+                    .upgrade()?
+                    .are_all_changes_acknowledge()
+                    .await
+                {
                     return Ok(());
                 }
             }
@@ -384,7 +422,11 @@ impl<Foo> DataWriterAsync<Foo> {
     /// Async version of [`get_publication_matched_status`](crate::publication::data_writer::DataWriter::get_publication_matched_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_publication_matched_status(&self) -> DdsResult<PublicationMatchedStatus> {
-        self.writer_address.get_publication_matched_status().await
+        Ok(self
+            .writer_address
+            .upgrade()?
+            .get_publication_matched_status()
+            .await)
     }
 
     /// Async version of [`get_topic`](crate::publication::data_writer::DataWriter::get_topic).
@@ -412,15 +454,20 @@ impl<Foo> DataWriterAsync<Foo> {
         subscription_handle: InstanceHandle,
     ) -> DdsResult<SubscriptionBuiltinTopicData> {
         self.writer_address
+            .upgrade()?
             .get_matched_subscription_data(subscription_handle)
-            .await?
+            .await
             .ok_or(DdsError::BadParameter)
     }
 
     /// Async version of [`get_matched_subscriptions`](crate::publication::data_writer::DataWriter::get_matched_subscriptions).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_subscriptions(&self) -> DdsResult<Vec<InstanceHandle>> {
-        self.writer_address.get_matched_subscriptions().await
+        Ok(self
+            .writer_address
+            .upgrade()?
+            .get_matched_subscriptions()
+            .await)
     }
 }
 
@@ -431,8 +478,9 @@ impl<Foo> DataWriterAsync<Foo> {
         let q = match qos {
             QosKind::Default => {
                 self.publisher_address()
+                    .upgrade()?
                     .get_default_datawriter_qos()
-                    .await?
+                    .await
             }
             QosKind::Specific(q) => {
                 q.is_consistent()?;
@@ -440,15 +488,15 @@ impl<Foo> DataWriterAsync<Foo> {
             }
         };
 
-        if self.writer_address.is_enabled().await? {
+        if self.writer_address.upgrade()?.is_enabled().await {
             let current_qos = self.get_qos().await?;
             q.check_immutability(&current_qos)?;
 
-            self.writer_address.set_qos(q).await?;
+            self.writer_address.upgrade()?.set_qos(q).await;
 
             self.announce_writer().await?;
         } else {
-            self.writer_address.set_qos(q).await?;
+            self.writer_address.upgrade()?.set_qos(q).await;
         }
 
         Ok(())
@@ -457,7 +505,7 @@ impl<Foo> DataWriterAsync<Foo> {
     /// Async version of [`get_qos`](crate::publication::data_writer::DataWriter::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DataWriterQos> {
-        self.writer_address.get_qos().await
+        Ok(self.writer_address.upgrade()?.get_qos().await)
     }
 
     /// Async version of [`get_statuscondition`](crate::publication::data_writer::DataWriter::get_statuscondition).
@@ -478,8 +526,8 @@ impl<Foo> DataWriterAsync<Foo> {
     /// Async version of [`enable`](crate::publication::data_writer::DataWriter::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        if !self.writer_address.is_enabled().await? {
-            self.writer_address.enable().await?;
+        if !self.writer_address.upgrade()?.is_enabled().await {
+            self.writer_address.upgrade()?.enable().await;
 
             self.announce_writer().await?;
         }
@@ -489,7 +537,7 @@ impl<Foo> DataWriterAsync<Foo> {
     /// Async version of [`get_instance_handle`](crate::publication::data_writer::DataWriter::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        self.writer_address.get_instance_handle().await
+        Ok(self.writer_address.upgrade()?.get_instance_handle().await)
     }
 }
 impl<'a, Foo> DataWriterAsync<Foo>
@@ -504,11 +552,13 @@ where
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.writer_address
+            .upgrade()?
             .set_listener(
                 a_listener.map::<Box<dyn AnyDataWriterListener + Send>, _>(|b| Box::new(b)),
                 mask.to_vec(),
                 self.runtime_handle().clone(),
             )
-            .await
+            .await;
+        Ok(())
     }
 }

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -80,19 +80,21 @@ impl DomainParticipantAsync {
     ) -> DdsResult<PublisherAsync> {
         let (publisher_address, status_condition) = self
             .participant_address
+            .upgrade()?
             .create_user_defined_publisher(
                 qos,
                 a_listener,
                 mask.to_vec(),
                 self.runtime_handle.clone(),
             )
-            .await?;
+            .await;
         let publisher = PublisherAsync::new(publisher_address, status_condition, self.clone());
-        if self.participant_address.is_enabled().await?
+        if self.participant_address.upgrade()?.is_enabled().await
             && self
                 .participant_address
+                .upgrade()?
                 .get_qos()
-                .await?
+                .await
                 .entity_factory
                 .autoenable_created_entities
         {
@@ -106,8 +108,9 @@ impl DomainParticipantAsync {
     #[tracing::instrument(skip(self, a_publisher))]
     pub async fn delete_publisher(&self, a_publisher: &PublisherAsync) -> DdsResult<()> {
         self.participant_address
+            .upgrade()?
             .delete_user_defined_publisher(a_publisher.get_instance_handle().await?)
-            .await?
+            .await
     }
 
     /// Async version of [`create_subscriber`](crate::domain::domain_participant::DomainParticipant::create_subscriber).
@@ -120,13 +123,14 @@ impl DomainParticipantAsync {
     ) -> DdsResult<SubscriberAsync> {
         let (subscriber_address, subscriber_status_condition) = self
             .participant_address
+            .upgrade()?
             .create_user_defined_subscriber(
                 qos,
                 a_listener,
                 mask.to_vec(),
                 self.runtime_handle.clone(),
             )
-            .await?;
+            .await;
 
         let subscriber = SubscriberAsync::new(
             subscriber_address,
@@ -134,11 +138,12 @@ impl DomainParticipantAsync {
             self.clone(),
         );
 
-        if self.participant_address.is_enabled().await?
+        if self.participant_address.upgrade()?.is_enabled().await
             && self
                 .participant_address
+                .upgrade()?
                 .get_qos()
-                .await?
+                .await
                 .entity_factory
                 .autoenable_created_entities
         {
@@ -152,8 +157,9 @@ impl DomainParticipantAsync {
     #[tracing::instrument(skip(self, a_subscriber))]
     pub async fn delete_subscriber(&self, a_subscriber: &SubscriberAsync) -> DdsResult<()> {
         self.participant_address
+            .upgrade()?
             .delete_user_defined_subscriber(a_subscriber.get_instance_handle().await?)
-            .await?
+            .await
     }
 
     /// Async version of [`create_topic`](crate::domain::domain_participant::DomainParticipant::create_topic).
@@ -188,6 +194,7 @@ impl DomainParticipantAsync {
     ) -> DdsResult<TopicAsync> {
         let (topic_address, topic_status_condition) = self
             .participant_address
+            .upgrade()?
             .create_user_defined_topic(
                 topic_name.to_string(),
                 type_name.to_string(),
@@ -197,7 +204,7 @@ impl DomainParticipantAsync {
                 dynamic_type_representation.into(),
                 self.runtime_handle.clone(),
             )
-            .await??;
+            .await?;
         let topic = TopicAsync::new(
             topic_address,
             topic_status_condition,
@@ -205,11 +212,12 @@ impl DomainParticipantAsync {
             topic_name.to_string(),
             self.clone(),
         );
-        if self.participant_address.is_enabled().await?
+        if self.participant_address.upgrade()?.is_enabled().await
             && self
                 .participant_address
+                .upgrade()?
                 .get_qos()
-                .await?
+                .await
                 .entity_factory
                 .autoenable_created_entities
         {
@@ -222,12 +230,13 @@ impl DomainParticipantAsync {
     /// Async version of [`delete_topic`](crate::domain::domain_participant::DomainParticipant::delete_topic).
     #[tracing::instrument(skip(self, a_topic))]
     pub async fn delete_topic(&self, a_topic: &TopicAsync) -> DdsResult<()> {
-        if a_topic.topic_address().is_closed() {
+        if a_topic.topic_address().upgrade().is_err() {
             Err(DdsError::AlreadyDeleted)
         } else {
             self.participant_address
+                .upgrade()?
                 .delete_user_defined_topic(a_topic.get_name())
-                .await?
+                .await
         }
     }
 
@@ -245,12 +254,13 @@ impl DomainParticipantAsync {
             loop {
                 if let Some((topic_address, status_condition_address, type_name)) = self
                     .participant_address
+                    .upgrade()?
                     .find_topic(
                         topic_name.to_owned(),
                         Arc::new(FooTypeSupport::new::<Foo>()),
                         self.runtime_handle.clone(),
                     )
-                    .await??
+                    .await?
                 {
                     return Ok(TopicAsync::new(
                         topic_address,
@@ -271,8 +281,9 @@ impl DomainParticipantAsync {
     pub async fn lookup_topicdescription(&self, topic_name: &str) -> DdsResult<Option<TopicAsync>> {
         if let Some((topic_address, status_condition_address, type_name)) = self
             .participant_address
+            .upgrade()?
             .lookup_topicdescription(topic_name.to_owned())
-            .await?
+            .await
         {
             Ok(Some(TopicAsync::new(
                 topic_address,
@@ -299,25 +310,37 @@ impl DomainParticipantAsync {
     /// Async version of [`ignore_participant`](crate::domain::domain_participant::DomainParticipant::ignore_participant).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_participant(&self, handle: InstanceHandle) -> DdsResult<()> {
-        self.participant_address.ignore_participant(handle).await?
+        self.participant_address
+            .upgrade()?
+            .ignore_participant(handle)
+            .await
     }
 
     /// Async version of [`ignore_topic`](crate::domain::domain_participant::DomainParticipant::ignore_topic).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_topic(&self, handle: InstanceHandle) -> DdsResult<()> {
-        self.participant_address.ignore_topic(handle).await?
+        self.participant_address
+            .upgrade()?
+            .ignore_topic(handle)
+            .await
     }
 
     /// Async version of [`ignore_publication`](crate::domain::domain_participant::DomainParticipant::ignore_publication).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_publication(&self, handle: InstanceHandle) -> DdsResult<()> {
-        self.participant_address.ignore_publication(handle).await?
+        self.participant_address
+            .upgrade()?
+            .ignore_publication(handle)
+            .await
     }
 
     /// Async version of [`ignore_subscription`](crate::domain::domain_participant::DomainParticipant::ignore_subscription).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_subscription(&self, handle: InstanceHandle) -> DdsResult<()> {
-        self.participant_address.ignore_subscription(handle).await?
+        self.participant_address
+            .upgrade()?
+            .ignore_subscription(handle)
+            .await
     }
 
     /// Async version of [`get_domain_id`](crate::domain::domain_participant::DomainParticipant::get_domain_id).
@@ -329,7 +352,10 @@ impl DomainParticipantAsync {
     /// Async version of [`delete_contained_entities`](crate::domain::domain_participant::DomainParticipant::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
-        self.participant_address.delete_contained_entities().await?
+        self.participant_address
+            .upgrade()?
+            .delete_contained_entities()
+            .await
     }
 
     /// Async version of [`assert_liveliness`](crate::domain::domain_participant::DomainParticipant::assert_liveliness).
@@ -342,46 +368,67 @@ impl DomainParticipantAsync {
     #[tracing::instrument(skip(self))]
     pub async fn set_default_publisher_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
         self.participant_address
+            .upgrade()?
             .set_default_publisher_qos(qos)
-            .await?
+            .await
     }
 
     /// Async version of [`get_default_publisher_qos`](crate::domain::domain_participant::DomainParticipant::get_default_publisher_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_publisher_qos(&self) -> DdsResult<PublisherQos> {
-        self.participant_address.get_default_publisher_qos().await
+        Ok(self
+            .participant_address
+            .upgrade()?
+            .get_default_publisher_qos()
+            .await)
     }
 
     /// Async version of [`set_default_subscriber_qos`](crate::domain::domain_participant::DomainParticipant::set_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_subscriber_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
         self.participant_address
+            .upgrade()?
             .set_default_subscriber_qos(qos)
-            .await?
+            .await
     }
 
     /// Async version of [`get_default_subscriber_qos`](crate::domain::domain_participant::DomainParticipant::get_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_subscriber_qos(&self) -> DdsResult<SubscriberQos> {
-        self.participant_address.get_default_subscriber_qos().await
+        Ok(self
+            .participant_address
+            .upgrade()?
+            .get_default_subscriber_qos()
+            .await)
     }
 
     /// Async version of [`set_default_topic_qos`](crate::domain::domain_participant::DomainParticipant::set_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_topic_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
-        self.participant_address.set_default_topic_qos(qos).await?
+        self.participant_address
+            .upgrade()?
+            .set_default_topic_qos(qos)
+            .await
     }
 
     /// Async version of [`get_default_topic_qos`](crate::domain::domain_participant::DomainParticipant::get_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_topic_qos(&self) -> DdsResult<TopicQos> {
-        self.participant_address.get_default_topic_qos().await
+        Ok(self
+            .participant_address
+            .upgrade()?
+            .get_default_topic_qos()
+            .await)
     }
 
     /// Async version of [`get_discovered_participants`](crate::domain::domain_participant::DomainParticipant::get_discovered_participants).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_participants(&self) -> DdsResult<Vec<InstanceHandle>> {
-        self.participant_address.get_discovered_participants().await
+        Ok(self
+            .participant_address
+            .upgrade()?
+            .get_discovered_participants()
+            .await)
     }
 
     /// Async version of [`get_discovered_participant_data`](crate::domain::domain_participant::DomainParticipant::get_discovered_participant_data).
@@ -391,14 +438,19 @@ impl DomainParticipantAsync {
         participant_handle: InstanceHandle,
     ) -> DdsResult<ParticipantBuiltinTopicData> {
         self.participant_address
+            .upgrade()?
             .get_discovered_participant_data(participant_handle)
-            .await?
+            .await
     }
 
     /// Async version of [`get_discovered_topics`](crate::domain::domain_participant::DomainParticipant::get_discovered_topics).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_topics(&self) -> DdsResult<Vec<InstanceHandle>> {
-        self.participant_address.get_discovered_topics().await
+        Ok(self
+            .participant_address
+            .upgrade()?
+            .get_discovered_topics()
+            .await)
     }
 
     /// Async version of [`get_discovered_topic_data`](crate::domain::domain_participant::DomainParticipant::get_discovered_topic_data).
@@ -408,8 +460,9 @@ impl DomainParticipantAsync {
         topic_handle: InstanceHandle,
     ) -> DdsResult<TopicBuiltinTopicData> {
         self.participant_address
+            .upgrade()?
             .get_discovered_topic_data(topic_handle)
-            .await?
+            .await
     }
 
     /// Async version of [`contains_entity`](crate::domain::domain_participant::DomainParticipant::contains_entity).
@@ -421,7 +474,7 @@ impl DomainParticipantAsync {
     /// Async version of [`get_current_time`](crate::domain::domain_participant::DomainParticipant::get_current_time).
     #[tracing::instrument(skip(self))]
     pub async fn get_current_time(&self) -> DdsResult<Time> {
-        self.participant_address.get_current_time().await
+        Ok(self.participant_address.upgrade()?.get_current_time().await)
     }
 }
 
@@ -434,13 +487,13 @@ impl DomainParticipantAsync {
             QosKind::Specific(q) => q,
         };
 
-        self.participant_address.set_qos(qos).await?
+        self.participant_address.upgrade()?.set_qos(qos).await
     }
 
     /// Async version of [`get_qos`](crate::domain::domain_participant::DomainParticipant::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantQos> {
-        self.participant_address.get_qos().await
+        Ok(self.participant_address.upgrade()?.get_qos().await)
     }
 
     /// Async version of [`set_listener`](crate::domain::domain_participant::DomainParticipant::set_listener).
@@ -451,8 +504,10 @@ impl DomainParticipantAsync {
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.participant_address
+            .upgrade()?
             .set_listener(a_listener, mask.to_vec(), self.runtime_handle.clone())
-            .await
+            .await;
+        Ok(())
     }
 
     /// Async version of [`get_statuscondition`](crate::domain::domain_participant::DomainParticipant::get_statuscondition).
@@ -473,39 +528,47 @@ impl DomainParticipantAsync {
     /// Async version of [`enable`](crate::domain::domain_participant::DomainParticipant::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        if !self.participant_address.is_enabled().await? {
+        if !self.participant_address.upgrade()?.is_enabled().await {
             self.participant_address
+                .upgrade()?
                 .get_builtin_publisher()
-                .await?
+                .await
+                .upgrade()?
                 .enable()
-                .await?;
+                .await;
             self.participant_address
+                .upgrade()?
                 .get_built_in_subscriber()
-                .await?
+                .await
+                .upgrade()?
                 .enable()
-                .await?;
+                .await;
 
             for builtin_reader in self
                 .participant_address
+                .upgrade()?
                 .get_built_in_subscriber()
-                .await?
+                .await
+                .upgrade()?
                 .data_reader_list()
-                .await?
+                .await
             {
-                builtin_reader.enable().await?;
+                builtin_reader.upgrade()?.enable().await;
             }
 
             for builtin_writer in self
                 .participant_address
+                .upgrade()?
                 .get_builtin_publisher()
-                .await?
+                .await
+                .upgrade()?
                 .data_writer_list()
-                .await?
+                .await
             {
-                builtin_writer.enable().await?;
+                builtin_writer.upgrade()?.enable().await;
             }
 
-            self.participant_address.enable().await?;
+            self.participant_address.upgrade()?.enable().await;
 
             let domain_participant_address = self.participant_address.clone();
 
@@ -514,24 +577,31 @@ impl DomainParticipantAsync {
                 let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
                 loop {
                     let r: DdsResult<()> = async {
-                        let builtin_publisher =
-                            domain_participant_address.get_builtin_publisher().await?;
-                        let data_writer_list = builtin_publisher.data_writer_list().await?;
+                        let builtin_publisher = domain_participant_address
+                            .upgrade()?
+                            .get_builtin_publisher()
+                            .await;
+                        let data_writer_list =
+                            builtin_publisher.upgrade()?.data_writer_list().await;
                         for data_writer in data_writer_list {
-                            if data_writer.get_type_name().await
-                                == Ok("SpdpDiscoveredParticipantData".to_string())
+                            if data_writer.upgrade()?.get_type_name().await
+                                == "SpdpDiscoveredParticipantData".to_string()
                             {
                                 let spdp_discovered_participant_data = domain_participant_address
+                                    .upgrade()?
                                     .as_spdp_discovered_participant_data()
-                                    .await?;
+                                    .await;
                                 let mut serialized_data = Vec::new();
                                 spdp_discovered_participant_data
                                     .serialize_data(&mut serialized_data)?;
 
-                                let timestamp =
-                                    domain_participant_address.get_current_time().await?;
+                                let timestamp = domain_participant_address
+                                    .upgrade()?
+                                    .get_current_time()
+                                    .await;
 
                                 data_writer
+                                    .upgrade()?
                                     .write_w_timestamp(
                                         serialized_data,
                                         get_instance_handle_from_key(
@@ -541,9 +611,9 @@ impl DomainParticipantAsync {
                                         None,
                                         timestamp,
                                     )
-                                    .await??;
+                                    .await?;
 
-                                domain_participant_address.send_message().await?;
+                                domain_participant_address.upgrade()?.send_message().await;
                             }
                         }
 
@@ -566,6 +636,10 @@ impl DomainParticipantAsync {
     /// Async version of [`get_instance_handle`](crate::domain::domain_participant::DomainParticipant::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        self.participant_address.get_instance_handle().await
+        Ok(self
+            .participant_address
+            .upgrade()?
+            .get_instance_handle()
+            .await)
     }
 }

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -584,8 +584,8 @@ impl DomainParticipantAsync {
                         let data_writer_list =
                             builtin_publisher.upgrade()?.data_writer_list().await;
                         for data_writer in data_writer_list {
-                            if data_writer.upgrade()?.get_type_name().await
-                                == "SpdpDiscoveredParticipantData".to_string()
+                            if &data_writer.upgrade()?.get_type_name().await
+                                == "SpdpDiscoveredParticipantData"
                             {
                                 let spdp_discovered_participant_data = domain_participant_address
                                     .upgrade()?

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -53,10 +53,13 @@ impl DomainParticipantFactoryAsync {
             .domain_participant_factory_actor
             .create_participant(domain_id, qos, a_listener, status_kind, runtime_handle)
             .await?;
-        let status_condition = participant_address.get_statuscondition().await?;
-        let builtin_subscriber = participant_address.get_built_in_subscriber().await?;
+        let status_condition = participant_address.upgrade()?.get_statuscondition().await;
+        let builtin_subscriber = participant_address
+            .upgrade()?
+            .get_built_in_subscriber()
+            .await;
         let builtin_subscriber_status_condition_address =
-            builtin_subscriber.get_statuscondition().await?;
+            builtin_subscriber.upgrade()?.get_statuscondition().await;
         let domain_participant = DomainParticipantAsync::new(
             participant_address.clone(),
             status_condition,
@@ -96,10 +99,10 @@ impl DomainParticipantFactoryAsync {
             .lookup_participant(domain_id)
             .await?
         {
-            let status_condition = dp.get_statuscondition().await?;
-            let builtin_subscriber = dp.get_built_in_subscriber().await?;
+            let status_condition = dp.upgrade()?.get_statuscondition().await;
+            let builtin_subscriber = dp.upgrade()?.get_built_in_subscriber().await;
             let builtin_subscriber_status_condition_address =
-                builtin_subscriber.get_statuscondition().await?;
+                builtin_subscriber.upgrade()?.get_statuscondition().await;
             Ok(Some(DomainParticipantAsync::new(
                 dp,
                 status_condition,

--- a/dds/src/dds_async/publisher.rs
+++ b/dds/src/dds_async/publisher.rs
@@ -73,8 +73,9 @@ impl PublisherAsync {
         let type_support = self
             .participant
             .participant_address()
+            .upgrade()?
             .get_type_support(type_name.clone())
-            .await?
+            .await
             .ok_or_else(|| {
                 DdsError::PreconditionNotMet(format!(
                     "Type with name {} not registered with parent domain participant",
@@ -85,23 +86,27 @@ impl PublisherAsync {
         let default_unicast_locator_list = self
             .participant
             .participant_address()
+            .upgrade()?
             .get_default_unicast_locator_list()
-            .await?;
+            .await;
         let default_multicast_locator_list = self
             .participant
             .participant_address()
+            .upgrade()?
             .get_default_multicast_locator_list()
-            .await?;
+            .await;
         let data_max_size_serialized = self
             .participant
             .participant_address()
+            .upgrade()?
             .data_max_size_serialized()
-            .await?;
+            .await;
 
         let listener = a_listener.map::<Box<dyn AnyDataWriterListener + Send>, _>(|b| Box::new(b));
         let has_key = type_support.has_key();
         let data_writer_address = self
             .publisher_address
+            .upgrade()?
             .create_datawriter(
                 a_topic.get_type_name(),
                 a_topic.get_name(),
@@ -114,8 +119,8 @@ impl PublisherAsync {
                 default_multicast_locator_list,
                 self.participant.runtime_handle().clone(),
             )
-            .await??;
-        let status_condition = data_writer_address.get_statuscondition().await?;
+            .await?;
+        let status_condition = data_writer_address.upgrade()?.get_statuscondition().await;
         let data_writer = DataWriterAsync::new(
             data_writer_address,
             status_condition,
@@ -123,11 +128,12 @@ impl PublisherAsync {
             a_topic.clone(),
         );
 
-        if self.publisher_address.is_enabled().await?
+        if self.publisher_address.upgrade()?.is_enabled().await
             && self
                 .publisher_address
+                .upgrade()?
                 .get_qos()
-                .await?
+                .await
                 .entity_factory
                 .autoenable_created_entities
         {
@@ -148,32 +154,38 @@ impl PublisherAsync {
         let header = self
             .participant
             .participant_address()
+            .upgrade()?
             .get_rtps_message_header()
-            .await?;
+            .await;
         let udp_transport_write = self
             .participant
             .participant_address()
+            .upgrade()?
             .get_udp_transport_write()
-            .await?;
+            .await;
         let now = self
             .participant
             .participant_address()
+            .upgrade()?
             .get_current_time()
-            .await?;
+            .await;
 
         a_datawriter
             .writer_address()
+            .upgrade()?
             .send_message(header, udp_transport_write, now)
-            .await?;
+            .await;
 
         self.publisher_address
+            .upgrade()?
             .delete_datawriter(writer_handle)
-            .await??;
+            .await?;
 
         self.participant
             .participant_address()
+            .upgrade()?
             .announce_deleted_data_writer(writer_handle)
-            .await?
+            .await
     }
 
     /// Async version of [`delete_datawriter`](crate::publication::publisher::Publisher::lookup_datawriter).
@@ -185,8 +197,9 @@ impl PublisherAsync {
         if let Some((topic_address, topic_status_condition, type_name)) = self
             .participant
             .participant_address()
+            .upgrade()?
             .lookup_topicdescription(topic_name.to_string())
-            .await?
+            .await
         {
             let topic = TopicAsync::new(
                 topic_address,
@@ -197,10 +210,11 @@ impl PublisherAsync {
             );
             if let Some(dw) = self
                 .publisher_address
+                .upgrade()?
                 .lookup_datawriter(topic_name.to_string())
-                .await?
+                .await
             {
-                let status_condition = dw.get_statuscondition().await?;
+                let status_condition = dw.upgrade()?.get_statuscondition().await;
                 Ok(Some(DataWriterAsync::new(
                     dw,
                     status_condition,
@@ -254,12 +268,17 @@ impl PublisherAsync {
     /// Async version of [`delete_contained_entities`](crate::publication::publisher::Publisher::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
-        let deleted_writer_handle = self.publisher_address.delete_contained_entities().await?;
+        let deleted_writer_handle = self
+            .publisher_address
+            .upgrade()?
+            .delete_contained_entities()
+            .await;
         for writer_handle in deleted_writer_handle {
             self.participant
                 .participant_address()
+                .upgrade()?
                 .announce_deleted_data_writer(writer_handle)
-                .await??;
+                .await?;
         }
         Ok(())
     }
@@ -268,20 +287,34 @@ impl PublisherAsync {
     #[tracing::instrument(skip(self))]
     pub async fn set_default_datawriter_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
         let qos = match qos {
-            QosKind::Default => self.publisher_address.get_default_datawriter_qos().await?,
+            QosKind::Default => {
+                self.publisher_address
+                    .upgrade()?
+                    .get_default_datawriter_qos()
+                    .await
+            }
             QosKind::Specific(q) => {
                 q.is_consistent()?;
                 q
             }
         };
 
-        self.publisher_address.set_default_datawriter_qos(qos).await
+        self.publisher_address
+            .upgrade()?
+            .set_default_datawriter_qos(qos)
+            .await;
+
+        Ok(())
     }
 
     /// Async version of [`get_default_datawriter_qos`](crate::publication::publisher::Publisher::get_default_datawriter_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_datawriter_qos(&self) -> DdsResult<DataWriterQos> {
-        self.publisher_address.get_default_datawriter_qos().await
+        Ok(self
+            .publisher_address
+            .upgrade()?
+            .get_default_datawriter_qos()
+            .await)
     }
 
     /// Async version of [`copy_from_topic_qos`](crate::publication::publisher::Publisher::copy_from_topic_qos).
@@ -305,7 +338,7 @@ impl PublisherAsync {
     /// Async version of [`get_qos`](crate::publication::publisher::Publisher::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<PublisherQos> {
-        self.publisher_address.get_qos().await
+        Ok(self.publisher_address.upgrade()?.get_qos().await)
     }
 
     /// Async version of [`set_listener`](crate::publication::publisher::Publisher::set_listener).
@@ -316,12 +349,14 @@ impl PublisherAsync {
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.publisher_address
+            .upgrade()?
             .set_listener(
                 a_listener,
                 mask.to_vec(),
                 self.participant.runtime_handle().clone(),
             )
-            .await
+            .await;
+        Ok(())
     }
 
     /// Async version of [`get_statuscondition`](crate::publication::publisher::Publisher::get_statuscondition).
@@ -342,12 +377,17 @@ impl PublisherAsync {
     /// Async version of [`enable`](crate::publication::publisher::Publisher::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        self.publisher_address.enable().await
+        self.publisher_address.upgrade()?.enable().await;
+        Ok(())
     }
 
     /// Async version of [`get_instance_handle`](crate::publication::publisher::Publisher::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        self.publisher_address.get_instance_handle().await
+        Ok(self
+            .publisher_address
+            .upgrade()?
+            .get_instance_handle()
+            .await)
     }
 }

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -179,7 +179,7 @@ async fn announce_topic(
     let builtin_publisher = domain_participant.upgrade()?.get_builtin_publisher().await;
     let data_writer_list = builtin_publisher.upgrade()?.data_writer_list().await;
     for data_writer in data_writer_list {
-        if data_writer.upgrade()?.get_type_name().await == "DiscoveredTopicData".to_string() {
+        if &data_writer.upgrade()?.get_type_name().await == "DiscoveredTopicData" {
             data_writer
                 .upgrade()?
                 .write_w_timestamp(

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -65,7 +65,10 @@ impl TopicAsync {
     /// Async version of [`get_inconsistent_topic_status`](crate::topic_definition::topic::Topic::get_inconsistent_topic_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_inconsistent_topic_status(&self) -> DdsResult<InconsistentTopicStatus> {
-        self.topic_address.get_inconsistent_topic_status().await?
+        self.topic_address
+            .upgrade()?
+            .get_inconsistent_topic_status()
+            .await
     }
 }
 
@@ -94,20 +97,25 @@ impl TopicAsync {
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
         let qos = match qos {
-            QosKind::Default => self.participant_address().get_default_topic_qos().await?,
+            QosKind::Default => {
+                self.participant_address()
+                    .upgrade()?
+                    .get_default_topic_qos()
+                    .await
+            }
             QosKind::Specific(q) => {
                 q.is_consistent()?;
                 q
             }
         };
 
-        self.topic_address.set_qos(qos).await?
+        self.topic_address.upgrade()?.set_qos(qos).await
     }
 
     /// Async version of [`get_qos`](crate::topic_definition::topic::Topic::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<TopicQos> {
-        self.topic_address.get_qos().await
+        Ok(self.topic_address.upgrade()?.get_qos().await)
     }
 
     /// Async version of [`get_statuscondition`](crate::topic_definition::topic::Topic::get_statuscondition).
@@ -128,12 +136,15 @@ impl TopicAsync {
     /// Async version of [`enable`](crate::topic_definition::topic::Topic::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        if !self.topic_address.is_enabled().await? {
-            self.topic_address.enable().await?;
+        if !self.topic_address.upgrade()?.is_enabled().await {
+            self.topic_address.upgrade()?.enable().await;
 
             announce_topic(
                 self.participant_address(),
-                self.topic_address.as_discovered_topic_data().await?,
+                self.topic_address
+                    .upgrade()?
+                    .as_discovered_topic_data()
+                    .await,
             )
             .await?;
         }
@@ -144,7 +155,7 @@ impl TopicAsync {
     /// Async version of [`get_instance_handle`](crate::topic_definition::topic::Topic::get_instance_handle).
     #[tracing::instrument(skip(self))]
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        self.topic_address.get_instance_handle().await
+        Ok(self.topic_address.upgrade()?.get_instance_handle().await)
     }
 
     /// Async version of [`set_listener`](crate::topic_definition::topic::Topic::set_listener).
@@ -164,21 +175,22 @@ async fn announce_topic(
 ) -> DdsResult<()> {
     let mut serialized_data = Vec::new();
     discovered_topic_data.serialize_data(&mut serialized_data)?;
-    let timestamp = domain_participant.get_current_time().await?;
-    let builtin_publisher = domain_participant.get_builtin_publisher().await?;
-    let data_writer_list = builtin_publisher.data_writer_list().await?;
+    let timestamp = domain_participant.upgrade()?.get_current_time().await;
+    let builtin_publisher = domain_participant.upgrade()?.get_builtin_publisher().await;
+    let data_writer_list = builtin_publisher.upgrade()?.data_writer_list().await;
     for data_writer in data_writer_list {
-        if data_writer.get_type_name().await == Ok("DiscoveredTopicData".to_string()) {
+        if data_writer.upgrade()?.get_type_name().await == "DiscoveredTopicData".to_string() {
             data_writer
+                .upgrade()?
                 .write_w_timestamp(
                     serialized_data,
                     get_instance_handle_from_key(&discovered_topic_data.get_key()?)?,
                     None,
                     timestamp,
                 )
-                .await??;
+                .await?;
 
-            domain_participant.send_message().await?;
+            domain_participant.upgrade()?.send_message().await;
             break;
         }
     }

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -1007,17 +1007,19 @@ impl DataWriterActor {
         {
             let status = self.get_publication_matched_status().await;
             publisher_publication_matched_listener
+                .upgrade()
+                .expect("Listener should exist")
                 .trigger_on_publication_matched(status)
-                .await
-                .expect("Listener should exist");
+                .await;
         } else if let Some(participant_publication_matched_listener) =
             participant_publication_matched_listener
         {
             let status = self.get_publication_matched_status().await;
             participant_publication_matched_listener
+                .upgrade()
+                .expect("Listener should exist")
                 .trigger_on_publication_matched(status)
-                .await
-                .expect("Listener should exist");
+                .await;
         }
     }
 
@@ -1063,17 +1065,19 @@ impl DataWriterActor {
         {
             let status = self.get_offered_incompatible_qos_status();
             offered_incompatible_qos_publisher_listener
+                .upgrade()
+                .expect("Listener should exist")
                 .trigger_on_offered_incompatible_qos(status)
-                .await
-                .expect("Listener should exist");
+                .await;
         } else if let Some(offered_incompatible_qos_participant_listener) =
             offered_incompatible_qos_participant_listener
         {
             let status = self.get_offered_incompatible_qos_status();
             offered_incompatible_qos_participant_listener
+                .upgrade()
+                .expect("Listener should exist")
                 .trigger_on_offered_incompatible_qos(status)
-                .await
-                .expect("Listener should exist");
+                .await;
         }
     }
 }

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -239,11 +239,10 @@ impl PublisherActor {
     }
 
     async fn process_rtps_message(&self, message: RtpsMessageRead) {
-        for data_writer_address in self.data_writer_list.values().map(|a| a.address()) {
+        for data_writer_address in self.data_writer_list.values() {
             data_writer_address
                 .process_rtps_message(message.clone())
-                .await
-                .expect("Should not fail to send command");
+                .await;
         }
     }
 

--- a/dds/src/implementation/actors/topic_actor.rs
+++ b/dds/src/implementation/actors/topic_actor.rs
@@ -139,9 +139,8 @@ impl TopicActor {
     async fn get_inconsistent_topic_status(&mut self) -> DdsResult<InconsistentTopicStatus> {
         let status = self.inconsistent_topic_status.read_and_reset();
         self.status_condition
-            .address()
             .remove_communication_state(StatusKind::InconsistentTopic)
-            .await?;
+            .await;
         Ok(status)
     }
 


### PR DESCRIPTION
This change removes the methods from the ActorAddress object and instead provides the upgrade() method that must called before hand to get the actual Actor object. This reduces the amount of code generated and gets rid of the not so understandable ?? constructs. In terms of behavior this is no different than before since the same operation was done behind-the-scenes. The downside is that it is more verbose on the usage.