### PR TITLE
Add configuration for the participant announcement time

### DIFF
--- a/dds/src/dds/configuration.rs
+++ b/dds/src/dds/configuration.rs
@@ -34,7 +34,7 @@ impl DustDdsConfiguration {
         self.udp_receive_buffer_size
     }
 
-    /// Interval at which the participant is announced on the network.
+    /// Maximum interval at which the participant is announced on the network.
     pub fn participant_announcement_interval(&self) -> Duration {
         self.participant_announcement_interval
     }
@@ -103,7 +103,7 @@ impl DustDdsConfigurationBuilder {
         self
     }
 
-    /// Set the interval at which the participant is announced on the network. This corresponds to the time
+    /// Set the maximum interval at which the participant is announced on the network. This corresponds to the time
     /// between SPDP messages.
     pub fn participant_announcement_interval(
         mut self,

--- a/dds/src/dds/configuration.rs
+++ b/dds/src/dds/configuration.rs
@@ -1,4 +1,7 @@
-use crate::infrastructure::error::{DdsError, DdsResult};
+use crate::infrastructure::{
+    error::{DdsError, DdsResult},
+    time::Time,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 /// This struct specifies the high-level configuration for the DustDDS library. The configuration can be set for use by the
@@ -8,6 +11,7 @@ pub struct DustDdsConfiguration {
     interface_name: Option<String>,
     fragment_size: usize,
     udp_receive_buffer_size: Option<usize>,
+    participant_announcement_interval: Time,
 }
 
 impl DustDdsConfiguration {
@@ -30,6 +34,11 @@ impl DustDdsConfiguration {
     pub fn udp_receive_buffer_size(&self) -> Option<usize> {
         self.udp_receive_buffer_size
     }
+
+    /// Interval at which the participant is announced on the network.
+    pub fn participant_announcement_interval(&self) -> Time {
+        self.participant_announcement_interval
+    }
 }
 
 impl Default for DustDdsConfiguration {
@@ -39,6 +48,7 @@ impl Default for DustDdsConfiguration {
             interface_name: None,
             fragment_size: 1344,
             udp_receive_buffer_size: None,
+            participant_announcement_interval: Time::new(5, 0),
         }
     }
 }
@@ -91,6 +101,16 @@ impl DustDdsConfigurationBuilder {
     /// Set the value of the SO_RCVBUF option on the UDP socket. [`None`] corresponds to the OS default
     pub fn udp_receive_buffer_size(mut self, udp_receive_buffer_size: Option<usize>) -> Self {
         self.configuration.udp_receive_buffer_size = udp_receive_buffer_size;
+        self
+    }
+
+    /// Set the interval at which the participant is announced on the network. This corresponds to the time
+    /// between SPDP messages.
+    pub fn participant_announcement_interval(
+        mut self,
+        participant_announcement_interval: Time,
+    ) -> Self {
+        self.configuration.participant_announcement_interval = participant_announcement_interval;
         self
     }
 }

--- a/dds/src/dds/configuration.rs
+++ b/dds/src/dds/configuration.rs
@@ -1,7 +1,6 @@
-use crate::infrastructure::{
-    error::{DdsError, DdsResult},
-    time::Time,
-};
+use std::time::Duration;
+
+use crate::infrastructure::error::{DdsError, DdsResult};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 /// This struct specifies the high-level configuration for the DustDDS library. The configuration can be set for use by the
@@ -11,7 +10,7 @@ pub struct DustDdsConfiguration {
     interface_name: Option<String>,
     fragment_size: usize,
     udp_receive_buffer_size: Option<usize>,
-    participant_announcement_interval: Time,
+    participant_announcement_interval: Duration,
 }
 
 impl DustDdsConfiguration {
@@ -36,7 +35,7 @@ impl DustDdsConfiguration {
     }
 
     /// Interval at which the participant is announced on the network.
-    pub fn participant_announcement_interval(&self) -> Time {
+    pub fn participant_announcement_interval(&self) -> Duration {
         self.participant_announcement_interval
     }
 }
@@ -48,7 +47,7 @@ impl Default for DustDdsConfiguration {
             interface_name: None,
             fragment_size: 1344,
             udp_receive_buffer_size: None,
-            participant_announcement_interval: Time::new(5, 0),
+            participant_announcement_interval: Duration::from_secs(5),
         }
     }
 }
@@ -108,7 +107,7 @@ impl DustDdsConfigurationBuilder {
     /// between SPDP messages.
     pub fn participant_announcement_interval(
         mut self,
-        participant_announcement_interval: Time,
+        participant_announcement_interval: Duration,
     ) -> Self {
         self.configuration.participant_announcement_interval = participant_announcement_interval;
         self

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -1328,6 +1328,8 @@ impl DomainParticipantActor {
                 ),
                 discovered_participant_data,
             );
+
+            self.announce_participant().await.ok();
         }
     }
 

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -506,8 +506,13 @@ impl DomainParticipantFactoryActor {
         });
 
         let participant_address_clone = participant_address.clone();
+        let participant_announcement_interval =
+            self.configuration.participant_announcement_interval();
+        let mut interval = tokio::time::interval(tokio::time::Duration::new(
+            participant_announcement_interval.sec() as u64,
+            participant_announcement_interval.nanosec(),
+        ));
         runtime_handle.spawn(async move {
-            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
             loop {
                 if let Ok(p) = participant_address_clone.upgrade() {
                     let r = p.announce_participant().await;

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -505,6 +505,22 @@ impl DomainParticipantFactoryActor {
             }
         });
 
+        let participant_address_clone = participant_address.clone();
+        runtime_handle.spawn(async move {
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
+            loop {
+                if let Ok(p) = participant_address_clone.upgrade() {
+                    let r = p.announce_participant().await;
+                    if r.is_err() {
+                        error!("Error announcing participant: {:?}", r);
+                    }
+                } else {
+                    break;
+                }
+                interval.tick().await;
+            }
+        });
+
         Ok(participant_address)
     }
 

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -506,12 +506,12 @@ impl DomainParticipantFactoryActor {
         });
 
         let participant_address_clone = participant_address.clone();
-        let participant_announcement_interval =
-            self.configuration.participant_announcement_interval();
-        let mut interval = tokio::time::interval(tokio::time::Duration::new(
-            participant_announcement_interval.sec() as u64,
-            participant_announcement_interval.nanosec(),
-        ));
+
+        let mut interval = tokio::time::interval(
+            self.configuration
+                .participant_announcement_interval()
+                .into(),
+        );
         runtime_handle.spawn(async move {
             loop {
                 if let Ok(p) = participant_address_clone.upgrade() {

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -507,11 +507,8 @@ impl DomainParticipantFactoryActor {
 
         let participant_address_clone = participant_address.clone();
 
-        let mut interval = tokio::time::interval(
-            self.configuration
-                .participant_announcement_interval()
-                .into(),
-        );
+        let mut interval =
+            tokio::time::interval(self.configuration.participant_announcement_interval());
         runtime_handle.spawn(async move {
             loop {
                 if let Ok(p) = participant_address_clone.upgrade() {


### PR DESCRIPTION
This PR adds a configuration possibility for the participant announcement interval. To achieve this the announcement task is moved to the top level and a method to announce the participant is created. As a side-effect this simplifies the code structure and the enable function implementation.