### PR TITLE
Remove dependency of DDS types in RTPS

### DIFF
--- a/dds/src/dds/infrastructure/instance.rs
+++ b/dds/src/dds/infrastructure/instance.rs
@@ -4,8 +4,20 @@ pub struct InstanceHandle([u8; 16]);
 
 impl InstanceHandle {
     /// InstanceHandle constructor
-    pub fn new(bytes: [u8; 16]) -> Self {
+    pub const fn new(bytes: [u8; 16]) -> Self {
         InstanceHandle(bytes)
+    }
+}
+
+impl From<crate::implementation::rtps::behavior_types::InstanceHandle> for InstanceHandle {
+    fn from(value: crate::implementation::rtps::behavior_types::InstanceHandle) -> Self {
+        Self(value.0)
+    }
+}
+
+impl From<InstanceHandle> for crate::implementation::rtps::behavior_types::InstanceHandle {
+    fn from(value: InstanceHandle) -> Self {
+        crate::implementation::rtps::behavior_types::InstanceHandle(value.0)
     }
 }
 

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -1,12 +1,14 @@
 use core::cmp::Ordering;
 
 use crate::{
-    infrastructure::time::{Duration, DurationKind, DURATION_ZERO},
+    infrastructure::time::{Duration, DurationKind},
     serialized_payload::cdr::{
         deserialize::CdrDeserialize, deserializer::CdrDeserializer, serialize::CdrSerialize,
         serializer::CdrSerializer,
     },
 };
+
+use super::time::{DURATION_ZERO_NSEC, DURATION_ZERO_SEC};
 /// QosPolicyId type alias
 pub type QosPolicyId = i32;
 
@@ -531,7 +533,7 @@ impl QosPolicy for LatencyBudgetQosPolicy {
 impl Default for LatencyBudgetQosPolicy {
     fn default() -> Self {
         Self {
-            duration: DurationKind::Finite(DURATION_ZERO),
+            duration: DurationKind::Finite(Duration::new(DURATION_ZERO_SEC, DURATION_ZERO_NSEC)),
         }
     }
 }
@@ -738,7 +740,10 @@ impl QosPolicy for TimeBasedFilterQosPolicy {
 impl Default for TimeBasedFilterQosPolicy {
     fn default() -> Self {
         Self {
-            minimum_separation: DurationKind::Finite(DURATION_ZERO),
+            minimum_separation: DurationKind::Finite(Duration::new(
+                DURATION_ZERO_SEC,
+                DURATION_ZERO_NSEC,
+            )),
         }
     }
 }

--- a/dds/src/dds/infrastructure/time.rs
+++ b/dds/src/dds/infrastructure/time.rs
@@ -163,14 +163,14 @@ impl Sub<Time> for Time {
     }
 }
 
-/// Special constant value representing a zero duration seconds
+/// Pre-defined value representing a zero duration seconds
 pub const DURATION_ZERO_SEC: i32 = 0;
-/// Special constant value representing a zero duration nano seconds
+/// Pre-defined value representing a zero duration nano seconds
 pub const DURATION_ZERO_NSEC: u32 = 0;
 
-/// Special constant value representing an invalid time
+/// Pre-defined value representing an invalid time
 pub const TIME_INVALID_SEC: i32 = -1;
-/// Special constant value representing an invalid time nano seconds
+/// v value representing an invalid time nano seconds
 pub const TIME_INVALID_NSEC: u32 = 0xffffffff;
 
 #[cfg(test)]

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1106,7 +1106,7 @@ impl DataReaderActor {
         if let Some(Some(t)) = closest_timestamp_before_received_sample {
             if let Some(sample_source_time) = change.source_timestamp {
                 let sample_separation = sample_source_time - t;
-                DurationKind::Finite(sample_separation)
+                DurationKind::Finite(sample_separation.into())
                     >= self.qos.time_based_filter.minimum_separation
             } else {
                 true

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -47,6 +47,7 @@ use crate::{
         },
     },
     infrastructure::{
+        self,
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{DataReaderQos, SubscriberQos, TopicQos},
@@ -1105,8 +1106,9 @@ impl DataReaderActor {
 
         if let Some(Some(t)) = closest_timestamp_before_received_sample {
             if let Some(sample_source_time) = change.source_timestamp {
-                let sample_separation = sample_source_time - t;
-                DurationKind::Finite(sample_separation.into())
+                let sample_separation = infrastructure::time::Duration::from(sample_source_time)
+                    - infrastructure::time::Duration::from(t);
+                DurationKind::Finite(sample_separation)
                     >= self.qos.time_based_filter.minimum_separation
             } else {
                 true

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1099,7 +1099,7 @@ impl DataReaderActor {
         let closest_timestamp_before_received_sample = self
             .changes
             .iter()
-            .filter(|cc| cc.instance_handle == change.instance_handle.into())
+            .filter(|cc| cc.instance_handle == change.instance_handle)
             .filter(|cc| cc.source_timestamp <= change.source_timestamp)
             .map(|cc| cc.source_timestamp)
             .max();

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -422,7 +422,7 @@ impl DataWriterActor {
             ChangeKind::NotAliveUnregistered,
             instance_serialized_key,
             inline_qos,
-            handle,
+            handle.into(),
             timestamp.into(),
         );
 
@@ -471,7 +471,7 @@ impl DataWriterActor {
             ChangeKind::NotAliveDisposed,
             instance_serialized_key,
             inline_qos,
-            handle,
+            handle.into(),
             timestamp.into(),
         );
 
@@ -558,7 +558,7 @@ impl DataWriterActor {
             ChangeKind::Alive,
             serialized_data,
             ParameterList::empty(),
-            handle,
+            handle.into(),
             timestamp.into(),
         );
 

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -351,7 +351,7 @@ impl DataWriterActor {
     }
 
     fn heartbeat_period(&self) -> Duration {
-        self.rtps_writer.heartbeat_period()
+        self.rtps_writer.heartbeat_period().into()
     }
 
     #[allow(clippy::unused_unit)]
@@ -901,7 +901,7 @@ impl DataWriterActor {
                         reader_proxy,
                         self.rtps_writer.guid().entity_id(),
                         &self.writer_cache,
-                        self.rtps_writer.heartbeat_period(),
+                        self.rtps_writer.heartbeat_period().into(),
                         udp_transport_write,
                         header,
                     )
@@ -1250,7 +1250,7 @@ fn send_message_to_reader_proxy_reliable(
         // Idle
     } else if reader_proxy
         .heartbeat_machine()
-        .is_time_for_heartbeat(heartbeat_period)
+        .is_time_for_heartbeat(heartbeat_period.into())
     {
         let first_sn = writer_cache.get_seq_num_min().unwrap_or(1);
         let last_sn = writer_cache.get_seq_num_max().unwrap_or(0);

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -14,6 +14,7 @@ use crate::{
             spdp_discovered_participant_data::DCPS_PARTICIPANT,
         },
         rtps::{
+            behavior_types::DURATION_ZERO,
             discovery_types::{
                 ENTITYID_SEDP_BUILTIN_PUBLICATIONS_ANNOUNCER,
                 ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR,
@@ -48,7 +49,7 @@ use crate::{
             ReliabilityQosPolicy, ReliabilityQosPolicyKind,
         },
         status::StatusKind,
-        time::{Duration, DurationKind, DURATION_ZERO},
+        time::{Duration, DurationKind, DURATION_ZERO_NSEC, DURATION_ZERO_SEC},
     },
 };
 use dust_dds_derive::actor_interface;
@@ -101,7 +102,10 @@ impl DomainParticipantFactoryActor {
             },
             reliability: ReliabilityQosPolicy {
                 kind: ReliabilityQosPolicyKind::BestEffort,
-                max_blocking_time: DurationKind::Finite(DURATION_ZERO),
+                max_blocking_time: DurationKind::Finite(Duration::new(
+                    DURATION_ZERO_SEC,
+                    DURATION_ZERO_NSEC,
+                )),
             },
             ..Default::default()
         };
@@ -176,7 +180,10 @@ impl DomainParticipantFactoryActor {
             },
             reliability: ReliabilityQosPolicy {
                 kind: ReliabilityQosPolicyKind::BestEffort,
-                max_blocking_time: DurationKind::Finite(DURATION_ZERO),
+                max_blocking_time: DurationKind::Finite(Duration::new(
+                    DURATION_ZERO_SEC,
+                    DURATION_ZERO_NSEC,
+                )),
             },
             ..Default::default()
         };
@@ -659,12 +666,9 @@ fn create_builtin_stateless_reader(guid: Guid) -> RtpsReaderKind {
 }
 
 fn create_builtin_stateful_reader(guid: Guid) -> RtpsReaderKind {
-    const DEFAULT_HEARTBEAT_SUPPRESSION_DURATION: Duration = DURATION_ZERO;
-    const DEFAULT_HEARTBEAT_RESPONSE_DELAY: Duration = Duration::new(0, 500);
-
     let topic_kind = TopicKind::WithKey;
-    let heartbeat_response_delay = DEFAULT_HEARTBEAT_RESPONSE_DELAY;
-    let heartbeat_suppression_duration = DEFAULT_HEARTBEAT_SUPPRESSION_DURATION;
+    let heartbeat_response_delay = DURATION_ZERO;
+    let heartbeat_suppression_duration = DURATION_ZERO;
     let expects_inline_qos = false;
     let unicast_locator_list = &[];
     let multicast_locator_list = &[];
@@ -685,15 +689,16 @@ fn create_builtin_stateful_reader(guid: Guid) -> RtpsReaderKind {
 fn create_builtin_stateful_writer(guid: Guid) -> RtpsWriter {
     const DEFAULT_HEARTBEAT_PERIOD: Duration = Duration::new(2, 0);
     const DEFAULT_NACK_RESPONSE_DELAY: Duration = Duration::new(0, 200);
-    const DEFAULT_NACK_SUPPRESSION_DURATION: Duration = DURATION_ZERO;
+    const DEFAULT_NACK_SUPPRESSION_DURATION: Duration =
+        Duration::new(DURATION_ZERO_SEC, DURATION_ZERO_NSEC);
 
     let unicast_locator_list = &[];
     let multicast_locator_list = &[];
     let topic_kind = TopicKind::WithKey;
     let push_mode = true;
-    let heartbeat_period = DEFAULT_HEARTBEAT_PERIOD;
-    let nack_response_delay = DEFAULT_NACK_RESPONSE_DELAY;
-    let nack_suppression_duration = DEFAULT_NACK_SUPPRESSION_DURATION;
+    let heartbeat_period = DEFAULT_HEARTBEAT_PERIOD.into();
+    let nack_response_delay = DEFAULT_NACK_RESPONSE_DELAY.into();
+    let nack_suppression_duration = DEFAULT_NACK_SUPPRESSION_DURATION.into();
     let data_max_size_serialized = usize::MAX;
 
     RtpsWriter::new(
@@ -740,7 +745,10 @@ pub fn sedp_data_reader_qos() -> DataReaderQos {
         },
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::Reliable,
-            max_blocking_time: DurationKind::Finite(DURATION_ZERO),
+            max_blocking_time: DurationKind::Finite(Duration::new(
+                DURATION_ZERO_SEC,
+                DURATION_ZERO_NSEC,
+            )),
         },
         ..Default::default()
     }
@@ -756,7 +764,10 @@ pub fn sedp_data_writer_qos() -> DataWriterQos {
         },
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::Reliable,
-            max_blocking_time: DurationKind::Finite(DURATION_ZERO),
+            max_blocking_time: DurationKind::Finite(Duration::new(
+                DURATION_ZERO_SEC,
+                DURATION_ZERO_NSEC,
+            )),
         },
         ..Default::default()
     }

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -666,9 +666,13 @@ fn create_builtin_stateless_reader(guid: Guid) -> RtpsReaderKind {
 }
 
 fn create_builtin_stateful_reader(guid: Guid) -> RtpsReaderKind {
+    const DEFAULT_HEARTBEAT_SUPPRESSION_DURATION: Duration =
+        Duration::new(DURATION_ZERO_SEC, DURATION_ZERO_NSEC);
+    const DEFAULT_HEARTBEAT_RESPONSE_DELAY: Duration = Duration::new(0, 500);
+
     let topic_kind = TopicKind::WithKey;
-    let heartbeat_response_delay = DURATION_ZERO;
-    let heartbeat_suppression_duration = DURATION_ZERO;
+    let heartbeat_response_delay = DEFAULT_HEARTBEAT_SUPPRESSION_DURATION.into();
+    let heartbeat_suppression_duration = DEFAULT_HEARTBEAT_RESPONSE_DELAY.into();
     let expects_inline_qos = false;
     let unicast_locator_list = &[];
     let multicast_locator_list = &[];

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -12,14 +12,10 @@ use crate::{
     implementation::{
         data_representation_builtin_endpoints::discovered_reader_data::DiscoveredReaderData,
         rtps::{
-            endpoint::RtpsEndpoint,
-            group::RtpsGroup,
-            messages::overall_structure::{RtpsMessageHeader, RtpsMessageRead},
-            types::{
+            behavior_types::DURATION_ZERO, endpoint::RtpsEndpoint, group::RtpsGroup, messages::overall_structure::{RtpsMessageHeader, RtpsMessageRead}, types::{
                 EntityId, Guid, Locator, TopicKind, USER_DEFINED_WRITER_NO_KEY,
                 USER_DEFINED_WRITER_WITH_KEY,
-            },
-            writer::RtpsWriter,
+            }, writer::RtpsWriter
         },
         rtps_udp_psm::udp_transport::UdpTransportWrite,
         utils::actor::{Actor, ActorAddress},
@@ -30,7 +26,7 @@ use crate::{
         qos::{DataWriterQos, PublisherQos, QosKind},
         qos_policy::PartitionQosPolicy,
         status::StatusKind,
-        time::{Duration, Time, DURATION_ZERO},
+        time::{Duration, Time},
     },
 };
 
@@ -131,7 +127,7 @@ impl PublisherActor {
                 &default_multicast_locator_list,
             ),
             true,
-            Duration::new(0, 200_000_000),
+            Duration::new(0, 200_000_000).into(),
             DURATION_ZERO,
             DURATION_ZERO,
             data_max_size_serialized,

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -22,6 +22,7 @@ use crate::{
         data_representation_builtin_endpoints::discovered_writer_data::DiscoveredWriterData,
         rtps::{
             self,
+            behavior_types::DURATION_ZERO,
             endpoint::RtpsEndpoint,
             group::RtpsGroup,
             messages::overall_structure::{RtpsMessageHeader, RtpsMessageRead},
@@ -40,7 +41,6 @@ use crate::{
         qos::{DataReaderQos, QosKind, SubscriberQos},
         qos_policy::PartitionQosPolicy,
         status::StatusKind,
-        time::DURATION_ZERO,
     },
 };
 

--- a/dds/src/implementation/rtps/behavior_types.rs
+++ b/dds/src/implementation/rtps/behavior_types.rs
@@ -30,3 +30,6 @@ impl Duration {
         self.fraction
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InstanceHandle(pub [u8; 16]);

--- a/dds/src/implementation/rtps/behavior_types.rs
+++ b/dds/src/implementation/rtps/behavior_types.rs
@@ -1,0 +1,55 @@
+use super::types::{Long, UnsignedLong};
+
+///
+/// This files shall only contain the types as listed in the DDSI-RTPS Version 2.5
+/// Table 8.52 - Types definitions for the Behavior Module
+///
+
+/// Special constant value representing a zero duration
+pub const DURATION_ZERO: Duration = Duration {
+    seconds: 0,
+    fraction: 0,
+};
+
+#[derive(Clone, Copy)]
+pub struct Duration {
+    seconds: Long,
+    fraction: UnsignedLong,
+}
+
+impl Duration {
+    pub fn new(seconds: Long, fraction: UnsignedLong) -> Self {
+        Self { seconds, fraction }
+    }
+
+    pub fn seconds(&self) -> i32 {
+        self.seconds
+    }
+
+    pub fn fraction(&self) -> u32 {
+        self.fraction
+    }
+}
+
+impl From<Duration> for std::time::Duration {
+    fn from(value: Duration) -> Self {
+        let secs = value.seconds as u64;
+        let nanos = (value.fraction as f64 / 2f64.powf(32.0) * 1_000_000_000.0).round() as u32;
+        std::time::Duration::new(secs, nanos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rtps_duration_to_std_duration() {
+        let rtps_duration = Duration::new(13, 2u32.pow(31));
+
+        let std_duration = std::time::Duration::from(rtps_duration);
+
+        assert_eq!(std_duration.as_secs(), 13);
+        assert_eq!(std_duration.subsec_nanos(), 500_000_000);
+    }
+}

--- a/dds/src/implementation/rtps/behavior_types.rs
+++ b/dds/src/implementation/rtps/behavior_types.rs
@@ -30,26 +30,3 @@ impl Duration {
         self.fraction
     }
 }
-
-impl From<Duration> for std::time::Duration {
-    fn from(value: Duration) -> Self {
-        let secs = value.seconds as u64;
-        let nanos = (value.fraction as f64 / 2f64.powf(32.0) * 1_000_000_000.0).round() as u32;
-        std::time::Duration::new(secs, nanos)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rtps_duration_to_std_duration() {
-        let rtps_duration = Duration::new(13, 2u32.pow(31));
-
-        let std_duration = std::time::Duration::from(rtps_duration);
-
-        assert_eq!(std_duration.as_secs(), 13);
-        assert_eq!(std_duration.subsec_nanos(), 500_000_000);
-    }
-}

--- a/dds/src/implementation/rtps/message_receiver.rs
+++ b/dds/src/implementation/rtps/message_receiver.rs
@@ -1,9 +1,11 @@
-use crate::implementation::rtps::{
-    messages::overall_structure::{RtpsMessageRead, RtpsSubmessageReadKind},
+use super::{
+    messages::{
+        self,
+        overall_structure::{RtpsMessageRead, RtpsSubmessageReadKind},
+        types::TIME_INVALID,
+    },
     types::{GuidPrefix, Locator, ProtocolVersion, VendorId, GUIDPREFIX_UNKNOWN},
 };
-
-use super::messages::{self, types::TIME_INVALID};
 
 pub struct MessageReceiver {
     source_version: ProtocolVersion,

--- a/dds/src/implementation/rtps/messages/overall_structure.rs
+++ b/dds/src/implementation/rtps/messages/overall_structure.rs
@@ -1,22 +1,24 @@
-use super::types::{ProtocolId, SubmessageFlag, SubmessageKind};
-use crate::implementation::rtps::{
-    error::{RtpsError, RtpsErrorKind, RtpsResult},
-    messages::{
-        submessage_elements::ArcSlice,
-        submessages::{
-            ack_nack::AckNackSubmessage, data::DataSubmessage, data_frag::DataFragSubmessage,
-            gap::GapSubmessage, heartbeat::HeartbeatSubmessage,
-            heartbeat_frag::HeartbeatFragSubmessage, info_destination::InfoDestinationSubmessage,
-            info_reply::InfoReplySubmessage, info_source::InfoSourceSubmessage,
-            info_timestamp::InfoTimestampSubmessage, nack_frag::NackFragSubmessage,
-            pad::PadSubmessage,
+use super::{
+    super::{
+        error::{RtpsError, RtpsErrorKind, RtpsResult},
+        messages::{
+            submessage_elements::ArcSlice,
+            submessages::{
+                ack_nack::AckNackSubmessage, data::DataSubmessage, data_frag::DataFragSubmessage,
+                gap::GapSubmessage, heartbeat::HeartbeatSubmessage,
+                heartbeat_frag::HeartbeatFragSubmessage,
+                info_destination::InfoDestinationSubmessage, info_reply::InfoReplySubmessage,
+                info_source::InfoSourceSubmessage, info_timestamp::InfoTimestampSubmessage,
+                nack_frag::NackFragSubmessage, pad::PadSubmessage,
+            },
+            types::{
+                ACKNACK, DATA, DATA_FRAG, GAP, HEARTBEAT, HEARTBEAT_FRAG, INFO_DST, INFO_REPLY,
+                INFO_SRC, INFO_TS, NACK_FRAG, PAD,
+            },
         },
-        types::{
-            ACKNACK, DATA, DATA_FRAG, GAP, HEARTBEAT, HEARTBEAT_FRAG, INFO_DST, INFO_REPLY,
-            INFO_SRC, INFO_TS, NACK_FRAG, PAD,
-        },
+        types::{GuidPrefix, ProtocolVersion, VendorId},
     },
-    types::{GuidPrefix, ProtocolVersion, VendorId},
+    types::{ProtocolId, SubmessageFlag, SubmessageKind},
 };
 use std::{io::BufRead, sync::Arc};
 
@@ -148,10 +150,16 @@ impl RtpsMessageRead {
             if b"RTPS" == &[data[0], data[1], data[2], data[3]] {
                 Ok(Self { data })
             } else {
-                Err(RtpsError::new(RtpsErrorKind::InvalidData, "RTPS not in data"))
+                Err(RtpsError::new(
+                    RtpsErrorKind::InvalidData,
+                    "RTPS not in data",
+                ))
             }
         } else {
-            Err(RtpsError::new(RtpsErrorKind::NotEnoughData, "Rtps message header"))
+            Err(RtpsError::new(
+                RtpsErrorKind::NotEnoughData,
+                "Rtps message header",
+            ))
         }
     }
 

--- a/dds/src/implementation/rtps/messages/submessage_elements.rs
+++ b/dds/src/implementation/rtps/messages/submessage_elements.rs
@@ -1,14 +1,11 @@
 use super::{
-    overall_structure::{Endianness, TryReadFromBytes, WriteIntoBytes},
-    types::ParameterId,
-};
-use crate::implementation::{
-    data_representation_builtin_endpoints::parameter_id_values::PID_SENTINEL,
-    rtps::{
+    super::{
         error::{RtpsError, RtpsErrorKind, RtpsResult},
         messages::types::FragmentNumber,
         types::{Locator, SequenceNumber},
     },
+    overall_structure::{Endianness, TryReadFromBytes, WriteIntoBytes},
+    types::ParameterId,
 };
 use std::{
     ops::{Index, Range, RangeFrom, RangeTo},
@@ -18,6 +15,8 @@ use std::{
 /// This files shall only contain the types as listed in the DDS-RTPS Version 2.3
 /// 8.3.5 RTPS SubmessageElements
 ///
+
+const PID_SENTINEL: i16 = 0x0001;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SequenceNumberSet {

--- a/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
+++ b/dds/src/implementation/rtps/messages/submessages/ack_nack.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::RtpsResult,
     messages::{
         overall_structure::{

--- a/dds/src/implementation/rtps/messages/submessages/data.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::RtpsResult, messages::{
         overall_structure::{
             Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes,

--- a/dds/src/implementation/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/data_frag.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::{RtpsError, RtpsErrorKind, RtpsResult}, messages::{
         overall_structure::{
             Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes,

--- a/dds/src/implementation/rtps/messages/submessages/gap.rs
+++ b/dds/src/implementation/rtps/messages/submessages/gap.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::RtpsResult, messages::{
         overall_structure::{
             Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes,

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::RtpsResult,
     messages::{
         overall_structure::{

--- a/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/heartbeat_frag.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::RtpsResult,
     messages::{
         overall_structure::{

--- a/dds/src/implementation/rtps/messages/submessages/info_destination.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_destination.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::RtpsResult,
     messages::{
         overall_structure::{

--- a/dds/src/implementation/rtps/messages/submessages/info_reply.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_reply.rs
@@ -1,11 +1,13 @@
-use crate::implementation::rtps::error::RtpsResult;
-use crate::implementation::rtps::messages::overall_structure::Submessage;
-use crate::implementation::rtps::messages::{
-    overall_structure::{
-        SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes, WriteIntoBytes,
+use super::super::super::{
+    error::RtpsResult,
+    messages::{
+        overall_structure::{
+            Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes,
+            WriteIntoBytes,
+        },
+        submessage_elements::LocatorList,
+        types::{SubmessageFlag, SubmessageKind},
     },
-    submessage_elements::LocatorList,
-    types::{SubmessageFlag, SubmessageKind},
 };
 
 #[derive(Debug, PartialEq, Eq)]

--- a/dds/src/implementation/rtps/messages/submessages/info_source.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_source.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::RtpsResult,
     messages::{
         overall_structure::{

--- a/dds/src/implementation/rtps/messages/submessages/info_timestamp.rs
+++ b/dds/src/implementation/rtps/messages/submessages/info_timestamp.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::RtpsResult,
     messages::{
         overall_structure::{

--- a/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
+++ b/dds/src/implementation/rtps/messages/submessages/nack_frag.rs
@@ -1,13 +1,15 @@
-use crate::implementation::rtps::{
-        error::RtpsResult, messages::{
-            overall_structure::{
-                Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes,
-                WriteIntoBytes,
-            },
-            submessage_elements::FragmentNumberSet,
-            types::{Count, SubmessageKind},
-        }, types::{EntityId, SequenceNumber}
-    };
+use super::super::super::{
+    error::RtpsResult,
+    messages::{
+        overall_structure::{
+            Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes,
+            WriteIntoBytes,
+        },
+        submessage_elements::FragmentNumberSet,
+        types::{Count, SubmessageKind},
+    },
+    types::{EntityId, SequenceNumber},
+};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct NackFragSubmessage {

--- a/dds/src/implementation/rtps/messages/submessages/pad.rs
+++ b/dds/src/implementation/rtps/messages/submessages/pad.rs
@@ -1,4 +1,4 @@
-use crate::implementation::rtps::{
+use super::super::super::{
     error::RtpsResult,
     messages::{
         overall_structure::{

--- a/dds/src/implementation/rtps/messages/types.rs
+++ b/dds/src/implementation/rtps/messages/types.rs
@@ -1,8 +1,8 @@
 use super::{
-    super::error::RtpsResult,
+    super::{behavior_types::Duration, error::RtpsResult},
     overall_structure::{Endianness, TryReadFromBytes, WriteIntoBytes},
 };
-use crate::infrastructure::{self, time::Duration};
+use crate::infrastructure;
 use std::{io::Read, ops::Sub};
 
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.5
@@ -198,7 +198,7 @@ impl Sub<Time> for Time {
     type Output = Duration;
 
     fn sub(self, rhs: Time) -> Self::Output {
-        infrastructure::time::Time::from(self) - infrastructure::time::Time::from(rhs)
+        (infrastructure::time::Time::from(self) - infrastructure::time::Time::from(rhs)).into()
     }
 }
 

--- a/dds/src/implementation/rtps/messages/types.rs
+++ b/dds/src/implementation/rtps/messages/types.rs
@@ -1,8 +1,8 @@
-use super::overall_structure::{Endianness, TryReadFromBytes, WriteIntoBytes};
-use crate::{
-    implementation::rtps::error::RtpsResult,
-    infrastructure::{self, time::Duration},
+use super::{
+    super::error::RtpsResult,
+    overall_structure::{Endianness, TryReadFromBytes, WriteIntoBytes},
 };
+use crate::infrastructure::{self, time::Duration};
 use std::{io::Read, ops::Sub};
 
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.5

--- a/dds/src/implementation/rtps/messages/types.rs
+++ b/dds/src/implementation/rtps/messages/types.rs
@@ -1,9 +1,8 @@
 use super::{
-    super::{behavior_types::Duration, error::RtpsResult},
+    super::error::RtpsResult,
     overall_structure::{Endianness, TryReadFromBytes, WriteIntoBytes},
 };
-use crate::infrastructure;
-use std::{io::Read, ops::Sub};
+use std::io::Read;
 
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.5
 /// Table 8.13 - Types used to define RTPS messages
@@ -178,30 +177,6 @@ impl WriteIntoBytes for Time {
     }
 }
 
-impl From<infrastructure::time::Time> for Time {
-    fn from(value: infrastructure::time::Time) -> Self {
-        let seconds = value.sec() as u32;
-        let fraction = (value.nanosec() as f64 / 1_000_000_000.0 * 2f64.powf(32.0)).round() as u32;
-        Self { seconds, fraction }
-    }
-}
-
-impl From<Time> for infrastructure::time::Time {
-    fn from(value: Time) -> Self {
-        let sec = value.seconds as i32;
-        let nanosec = (value.fraction as f64 / 2f64.powf(32.0) * 1_000_000_000.0).round() as u32;
-        infrastructure::time::Time::new(sec, nanosec)
-    }
-}
-
-impl Sub<Time> for Time {
-    type Output = Duration;
-
-    fn sub(self, rhs: Time) -> Self::Output {
-        (infrastructure::time::Time::from(self) - infrastructure::time::Time::from(rhs)).into()
-    }
-}
-
 /// Count_t
 /// Type used to hold a count that is incremented monotonically, used to identify message duplicates.
 pub type Count = Long;
@@ -242,38 +217,3 @@ pub type UExtension4 = [Octet; 4];
 /// Type used to hold an undefined 8-byte value. It is intended to be used in future revisions of the specification.
 #[allow(dead_code)]
 pub type WExtension8 = [Octet; 8];
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn dds_time_to_rtps_time() {
-        let dds_time = infrastructure::time::Time::new(13, 500_000_000);
-
-        let rtps_time = Time::from(dds_time);
-
-        assert_eq!(rtps_time.seconds(), 13);
-        assert_eq!(rtps_time.fraction(), 2u32.pow(31));
-    }
-
-    #[test]
-    fn rtps_time_to_dds_time() {
-        let rtps_time = Time::new(13, 2u32.pow(31));
-
-        let dds_time = infrastructure::time::Time::from(rtps_time);
-
-        assert_eq!(dds_time.sec(), 13);
-        assert_eq!(dds_time.nanosec(), 500_000_000);
-    }
-
-    #[test]
-    fn dds_time_to_rtps_time_to_dds_time() {
-        let dds_time = infrastructure::time::Time::new(13, 200);
-
-        let rtps_time = Time::from(dds_time);
-        let dds_time_from_rtps_time = infrastructure::time::Time::from(rtps_time);
-
-        assert_eq!(dds_time, dds_time_from_rtps_time)
-    }
-}

--- a/dds/src/implementation/rtps/mod.rs
+++ b/dds/src/implementation/rtps/mod.rs
@@ -1,3 +1,4 @@
+pub mod behavior_types;
 pub mod discovery_types;
 pub mod endpoint;
 pub mod entity;

--- a/dds/src/implementation/rtps/reader.rs
+++ b/dds/src/implementation/rtps/reader.rs
@@ -1,12 +1,11 @@
 use super::{
+    behavior_types::Duration,
     endpoint::RtpsEndpoint,
     messages::overall_structure::RtpsMessageHeader,
     types::{Guid, Locator},
     writer_proxy::RtpsWriterProxy,
 };
-use crate::{
-    implementation::rtps_udp_psm::udp_transport::UdpTransportWrite, infrastructure::time::Duration,
-};
+use crate::implementation::rtps_udp_psm::udp_transport::UdpTransportWrite;
 use std::sync::Arc;
 
 pub struct RtpsReader {

--- a/dds/src/implementation/rtps/reader_history_cache.rs
+++ b/dds/src/implementation/rtps/reader_history_cache.rs
@@ -1,14 +1,13 @@
-use crate::{
-    infrastructure::instance::InstanceHandle,
-    subscription::sample_info::{InstanceStateKind, SampleStateKind, ViewStateKind},
-};
-
 use super::{
     messages::{
         self,
         submessage_elements::{Data, ParameterList},
     },
     types::{ChangeKind, Guid},
+};
+use crate::{
+    infrastructure::instance::InstanceHandle,
+    subscription::sample_info::{InstanceStateKind, SampleStateKind, ViewStateKind},
 };
 
 #[derive(Debug)]

--- a/dds/src/implementation/rtps/reader_history_cache.rs
+++ b/dds/src/implementation/rtps/reader_history_cache.rs
@@ -1,14 +1,12 @@
 use super::{
+    behavior_types::InstanceHandle,
     messages::{
         self,
         submessage_elements::{Data, ParameterList},
     },
     types::{ChangeKind, Guid},
 };
-use crate::{
-    infrastructure::instance::InstanceHandle,
-    subscription::sample_info::{InstanceStateKind, SampleStateKind, ViewStateKind},
-};
+use crate::subscription::sample_info::{InstanceStateKind, SampleStateKind, ViewStateKind};
 
 #[derive(Debug)]
 pub struct RtpsReaderCacheChange {

--- a/dds/src/implementation/rtps/reader_locator.rs
+++ b/dds/src/implementation/rtps/reader_locator.rs
@@ -1,6 +1,6 @@
 use super::{
-    writer_history_cache::WriterHistoryCache,
     types::{Locator, SequenceNumber},
+    writer_history_cache::WriterHistoryCache,
 };
 
 pub struct RtpsReaderLocator {

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -1,4 +1,5 @@
 use super::{
+    behavior_types::Duration,
     messages::{
         submessages::{heartbeat::HeartbeatSubmessage, heartbeat_frag::HeartbeatFragSubmessage},
         types::{Count, FragmentNumber},
@@ -6,7 +7,6 @@ use super::{
     types::{EntityId, Guid, Locator, ReliabilityKind, SequenceNumber},
     writer_history_cache::WriterHistoryCache,
 };
-use crate::infrastructure::time::Duration;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HeartbeatMachine {
@@ -23,9 +23,7 @@ impl HeartbeatMachine {
         }
     }
     pub fn is_time_for_heartbeat(&self, heartbeat_period: Duration) -> bool {
-        self.timer.elapsed()
-            >= std::time::Duration::from_secs(heartbeat_period.sec() as u64)
-                + std::time::Duration::from_nanos(heartbeat_period.nanosec() as u64)
+        self.timer.elapsed() >= heartbeat_period.into()
     }
     pub fn submessage(
         &mut self,

--- a/dds/src/implementation/rtps/reader_proxy.rs
+++ b/dds/src/implementation/rtps/reader_proxy.rs
@@ -1,5 +1,4 @@
 use super::{
-    behavior_types::Duration,
     messages::{
         submessages::{heartbeat::HeartbeatSubmessage, heartbeat_frag::HeartbeatFragSubmessage},
         types::{Count, FragmentNumber},
@@ -22,8 +21,8 @@ impl HeartbeatMachine {
             timer: std::time::Instant::now(),
         }
     }
-    pub fn is_time_for_heartbeat(&self, heartbeat_period: Duration) -> bool {
-        self.timer.elapsed() >= heartbeat_period.into()
+    pub fn is_time_for_heartbeat(&self, heartbeat_period: std::time::Duration) -> bool {
+        self.timer.elapsed() >= heartbeat_period
     }
     pub fn submessage(
         &mut self,

--- a/dds/src/implementation/rtps/types.rs
+++ b/dds/src/implementation/rtps/types.rs
@@ -13,7 +13,7 @@ use std::{io::Read, net::IpAddr};
 
 type Octet = u8;
 pub type Long = i32;
-type UnsignedLong = u32;
+pub type UnsignedLong = u32;
 
 impl WriteIntoBytes for Octet {
     fn write_into_bytes(&self, buf: &mut &mut [u8]) {

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -1,13 +1,10 @@
 use super::{
-    endpoint::RtpsEndpoint,
-    messages::{
+    behavior_types::Duration, endpoint::RtpsEndpoint, messages::{
         self,
         submessage_elements::{Data, ParameterList},
-    },
-    types::{ChangeKind, Guid, Locator, SequenceNumber},
-    writer_history_cache::RtpsWriterCacheChange,
+    }, types::{ChangeKind, Guid, Locator, SequenceNumber}, writer_history_cache::RtpsWriterCacheChange
 };
-use crate::infrastructure::{instance::InstanceHandle, time::Duration};
+use crate::infrastructure::instance::InstanceHandle;
 
 pub struct RtpsWriter {
     endpoint: RtpsEndpoint,

--- a/dds/src/implementation/rtps/writer.rs
+++ b/dds/src/implementation/rtps/writer.rs
@@ -1,10 +1,13 @@
 use super::{
-    behavior_types::Duration, endpoint::RtpsEndpoint, messages::{
+    behavior_types::{Duration, InstanceHandle},
+    endpoint::RtpsEndpoint,
+    messages::{
         self,
         submessage_elements::{Data, ParameterList},
-    }, types::{ChangeKind, Guid, Locator, SequenceNumber}, writer_history_cache::RtpsWriterCacheChange
+    },
+    types::{ChangeKind, Guid, Locator, SequenceNumber},
+    writer_history_cache::RtpsWriterCacheChange,
 };
-use crate::infrastructure::instance::InstanceHandle;
 
 pub struct RtpsWriter {
     endpoint: RtpsEndpoint,

--- a/dds/src/implementation/rtps/writer_history_cache.rs
+++ b/dds/src/implementation/rtps/writer_history_cache.rs
@@ -1,4 +1,5 @@
 use super::{
+    behavior_types::InstanceHandle,
     messages::{
         self,
         submessage_elements::{Data, ParameterList},
@@ -6,10 +7,7 @@ use super::{
     },
     types::{ChangeKind, EntityId, Guid, SequenceNumber},
 };
-use crate::infrastructure::{
-    instance::InstanceHandle,
-    qos_policy::{HistoryQosPolicy, HistoryQosPolicyKind},
-};
+use crate::infrastructure::qos_policy::{HistoryQosPolicy, HistoryQosPolicyKind};
 use std::collections::{HashMap, VecDeque};
 
 pub struct RtpsWriterCacheChange {
@@ -242,10 +240,10 @@ impl WriterHistoryCache {
 #[cfg(test)]
 mod tests {
     use tests::messages::types::TIME_INVALID;
-
-    use crate::{implementation::rtps::types::GUID_UNKNOWN, infrastructure::instance::HANDLE_NIL};
-
+    use crate::implementation::rtps::types::GUID_UNKNOWN;
     use super::*;
+
+    const HANDLE_NIL: InstanceHandle = InstanceHandle([0; 16]);
 
     #[test]
     fn remove_change() {
@@ -253,7 +251,7 @@ mod tests {
         let change = RtpsWriterCacheChange::new(
             ChangeKind::Alive,
             GUID_UNKNOWN,
-            HANDLE_NIL,
+            InstanceHandle([0; 16]),
             1,
             TIME_INVALID,
             vec![Data::new(vec![].into())],
@@ -275,7 +273,7 @@ mod tests {
         let change1 = RtpsWriterCacheChange::new(
             ChangeKind::Alive,
             GUID_UNKNOWN,
-            HANDLE_NIL,
+            InstanceHandle([0; 16]),
             1,
             TIME_INVALID,
             vec![Data::new(vec![].into())],

--- a/dds/src/implementation/rtps/writer_proxy.rs
+++ b/dds/src/implementation/rtps/writer_proxy.rs
@@ -1,7 +1,7 @@
 use super::{
     messages::{
         overall_structure::{RtpsMessageHeader, RtpsMessageWrite, Submessage},
-        submessage_elements::{Data, FragmentNumberSet, SequenceNumberSet},
+        submessage_elements::{ArcSlice, Data, FragmentNumberSet, SequenceNumberSet},
         submessages::{
             ack_nack::AckNackSubmessage, data::DataSubmessage, data_frag::DataFragSubmessage,
             info_destination::InfoDestinationSubmessage, nack_frag::NackFragSubmessage,
@@ -10,9 +10,7 @@ use super::{
     },
     types::{EntityId, Guid, Locator, SequenceNumber},
 };
-use crate::implementation::{
-    rtps::messages::submessage_elements::ArcSlice, rtps_udp_psm::udp_transport::UdpTransportWrite,
-};
+use crate::implementation::rtps_udp_psm::udp_transport::UdpTransportWrite;
 use std::{cmp::max, collections::HashMap};
 
 fn total_fragments_expected(data_frag_submessage: &DataFragSubmessage) -> u32 {


### PR DESCRIPTION
Remove dependency of the DDS types InstanceHandle and Duration/Time in the RTPS module. This is done by adding the Duration and InstanceHandle type as specified in the RTPS standard. 
This adds some type transforms, but I think they are not dramatic and the benefit of dependency tree weighs more. 
What is left afterwards is only: HistoryQosPolicy, HistoryQosPolicyKind, InstanceStateKind, SampleStateKind, ViewStateKind
