### PR TITLE
Refactor: Set participant locator lists after construction

### DIFF
--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -1231,6 +1231,25 @@ impl DomainParticipantActor {
     fn get_message_sender(&self) -> Actor<MessageSenderActor> {
         self.message_sender_actor.clone()
     }
+
+    pub fn set_default_unicast_locator_list(&mut self, list: Vec<Locator>) {
+        self.rtps_participant.set_default_unicast_locator_list(list)
+    }
+
+    pub fn set_default_multicast_locator_list(&mut self, list: Vec<Locator>) {
+        self.rtps_participant
+            .set_default_multicast_locator_list(list)
+    }
+
+    pub fn set_metatraffic_unicast_locator_list(&mut self, list: Vec<Locator>) {
+        self.rtps_participant
+            .set_metatraffic_unicast_locator_list(list)
+    }
+
+    pub fn set_metatraffic_multicast_locator_list(&mut self, list: Vec<Locator>) {
+        self.rtps_participant
+            .set_metatraffic_multicast_locator_list(list)
+    }
 }
 
 impl DomainParticipantActor {

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -373,8 +373,8 @@ impl DomainParticipantFactoryActor {
             runtime_handle.clone(),
         );
 
+        // Start the regular participant announcement task
         let participant_address_clone = participant_actor.address();
-
         let mut interval =
             tokio::time::interval(self.configuration.participant_announcement_interval());
         runtime_handle.spawn(async move {

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -230,7 +230,7 @@ impl DomainParticipantFactoryActor {
             handle,
         );
 
-        let spdp_discovery_locator_list = vec![Locator::new(
+        let spdp_discovery_locator_list = [Locator::new(
             LOCATOR_KIND_UDP_V4,
             port_builtin_multicast(domain_id) as u32,
             DEFAULT_MULTICAST_LOCATOR_ADDRESS,

--- a/dds/src/rtps/participant.rs
+++ b/dds/src/rtps/participant.rs
@@ -50,15 +50,31 @@ impl RtpsParticipant {
         self.default_unicast_locator_list.as_slice()
     }
 
+    pub fn set_default_unicast_locator_list(&mut self, list: Vec<Locator>) {
+        self.default_unicast_locator_list = list;
+    }
+
     pub fn default_multicast_locator_list(&self) -> &[Locator] {
         self.default_multicast_locator_list.as_slice()
+    }
+
+    pub fn set_default_multicast_locator_list(&mut self, list: Vec<Locator>) {
+        self.default_multicast_locator_list = list;
     }
 
     pub fn metatraffic_unicast_locator_list(&self) -> &[Locator] {
         self.metatraffic_unicast_locator_list.as_ref()
     }
 
+    pub fn set_metatraffic_unicast_locator_list(&mut self, list: Vec<Locator>) {
+        self.metatraffic_unicast_locator_list = list;
+    }
+
     pub fn metatraffic_multicast_locator_list(&self) -> &[Locator] {
         self.metatraffic_multicast_locator_list.as_ref()
+    }
+
+    pub fn set_metatraffic_multicast_locator_list(&mut self, list: Vec<Locator>) {
+        self.metatraffic_multicast_locator_list = list;
     }
 }


### PR DESCRIPTION
This is an internal refactor which add the possibility of setting locator list after the construction of the domain participant. This allows opening the sockets later which simplifies the code flow. It also opens the option for the future of having dynamic network configuration.