### PR TITLE
Performance optimization: Reuse memory for data reception

### DIFF
--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     rtps::{
         messages::{
-            submessage_elements::{ArcSlice, Parameter, ParameterList, SequenceNumberSet},
+            submessage_elements::{Parameter, ParameterList, SequenceNumberSet},
             submessages::{
                 ack_nack::AckNackSubmessage, gap::GapSubmessage,
                 info_destination::InfoDestinationSubmessage,
@@ -53,7 +53,10 @@ use crate::{
     serialized_payload::cdr::serialize::CdrSerialize,
     topic_definition::type_support::DdsKey,
 };
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use super::{
     any_data_writer_listener::AnyDataWriterListener,
@@ -913,7 +916,7 @@ impl MailHandler<UnregisterInstanceWTimestamp> for DataWriterActor {
 
         let inline_qos = ParameterList::new(vec![Parameter::new(
             PID_STATUS_INFO,
-            ArcSlice::from(serialized_status_info),
+            Arc::from(serialized_status_info),
         )]);
 
         let change: RtpsWriterCacheChange = self.rtps_writer.new_change(
@@ -984,7 +987,7 @@ impl MailHandler<DisposeWTimestamp> for DataWriterActor {
 
         let inline_qos = ParameterList::new(vec![Parameter::new(
             PID_STATUS_INFO,
-            ArcSlice::from(serialized_status_info),
+            Arc::from(serialized_status_info),
         )]);
 
         let change: RtpsWriterCacheChange = self.rtps_writer.new_change(

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -1336,7 +1336,7 @@ impl MailHandler<ProcessMetatrafficRtpsMessage> for DomainParticipantActor {
             "Received metatraffic RTPS message"
         );
         let reception_timestamp = self.get_current_time().into();
-        let mut message_receiver = MessageReceiver::new(&message.rtps_message);
+        let mut message_receiver = MessageReceiver::new(message.rtps_message);
         while let Some(submessage) = message_receiver.next() {
             match submessage {
                 RtpsSubmessageReadKind::Data(data_submessage) => {
@@ -1434,7 +1434,7 @@ impl MailHandler<ProcessUserDefinedRtpsMessage> for DomainParticipantActor {
         message: ProcessUserDefinedRtpsMessage,
     ) -> <ProcessUserDefinedRtpsMessage as Mail>::Result {
         let reception_timestamp = self.get_current_time().into();
-        let mut message_receiver = MessageReceiver::new(&message.rtps_message);
+        let mut message_receiver = MessageReceiver::new(message.rtps_message);
         while let Some(submessage) = message_receiver.next() {
             match submessage {
                 RtpsSubmessageReadKind::Data(data_submessage) => {

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -387,7 +387,7 @@ pub async fn read_message(
 ) -> DdsResult<RtpsMessageRead> {
     let (bytes, _) = socket.recv_from(buf).await?;
     if bytes > 0 {
-        Ok(RtpsMessageRead::try_from(buf.as_ref())?)
+        Ok(RtpsMessageRead::try_from(&buf[0..bytes])?)
     } else {
         Err(DdsError::NoData)
     }

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -74,6 +74,8 @@ use std::{
 };
 use tracing::{info, warn};
 
+const MAX_DATAGRAM_SIZE: usize = 65507;
+
 #[derive(Default)]
 pub struct DomainParticipantFactoryActor {
     domain_participant_list: HashMap<InstanceHandle, Actor<DomainParticipantActor>>,
@@ -541,7 +543,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         let participant_clone = participant.clone();
         let mut socket = tokio::net::UdpSocket::from_std(default_unicast_socket)?;
         message.runtime_handle.spawn(async move {
-            let mut buf = Box::new([0; 65507]);
+            let mut buf = Box::new([0; MAX_DATAGRAM_SIZE]);
             loop {
                 if let Ok(message) = read_message(&mut socket, buf.as_mut_slice()).await {
                     let r = participant_address_clone
@@ -582,7 +584,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
                 DdsError::Error("Failed to open metattrafic unicast socket".to_string())
             })?;
         message.runtime_handle.spawn(async move {
-            let mut buf = Box::new([0; 65507]);
+            let mut buf = Box::new([0; MAX_DATAGRAM_SIZE]);
             loop {
                 if let Ok(message) = read_message(&mut socket, buf.as_mut_slice()).await {
                     let r = process_metatraffic_rtps_message(
@@ -622,7 +624,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
             interface_address_list,
         )?;
         message.runtime_handle.spawn(async move {
-            let mut buf = Box::new([0; 65507]);
+            let mut buf = Box::new([0; MAX_DATAGRAM_SIZE]);
             loop {
                 if let Ok(message) = read_message(&mut socket, buf.as_mut_slice()).await {
                     let r = process_metatraffic_rtps_message(

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -386,9 +386,7 @@ pub async fn read_message(socket: &mut tokio::net::UdpSocket) -> DdsResult<RtpsM
     let (bytes, _) = socket.recv_from(&mut buf).await?;
     buf.truncate(bytes);
     if bytes > 0 {
-        Ok(RtpsMessageRead::try_from(Arc::from(
-            buf.into_boxed_slice(),
-        ))?)
+        Ok(RtpsMessageRead::try_from(buf.as_ref())?)
     } else {
         Err(DdsError::NoData)
     }

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -386,7 +386,9 @@ pub async fn read_message(socket: &mut tokio::net::UdpSocket) -> DdsResult<RtpsM
     let (bytes, _) = socket.recv_from(&mut buf).await?;
     buf.truncate(bytes);
     if bytes > 0 {
-        Ok(RtpsMessageRead::new(Arc::from(buf.into_boxed_slice()))?)
+        Ok(RtpsMessageRead::try_from(Arc::from(
+            buf.into_boxed_slice(),
+        ))?)
     } else {
         Err(DdsError::NoData)
     }

--- a/dds/src/rtps/message_receiver.rs
+++ b/dds/src/rtps/message_receiver.rs
@@ -59,11 +59,12 @@ impl Iterator for MessageReceiver {
 }
 
 impl MessageReceiver {
-    pub fn new(message: &RtpsMessageRead) -> Self {
+    pub fn new(message: RtpsMessageRead) -> Self {
+        let header = message.header();
         Self {
-            source_version: message.header().version(),
-            source_vendor_id: message.header().vendor_id(),
-            source_guid_prefix: message.header().guid_prefix(),
+            source_version: header.version(),
+            source_vendor_id: header.vendor_id(),
+            source_guid_prefix: header.guid_prefix(),
             dest_guid_prefix: GUIDPREFIX_UNKNOWN,
             _unicast_reply_locator_list: Vec::new(),
             _multicast_reply_locator_list: Vec::new(),

--- a/dds/src/rtps/messages/overall_structure.rs
+++ b/dds/src/rtps/messages/overall_structure.rs
@@ -181,48 +181,37 @@ impl TryFrom<&[u8]> for RtpsMessageRead {
                             break;
                         }
                         let submessage = match submessage_header.submessage_id() {
-                            ACKNACK => {
-                                AckNackSubmessage::try_from_bytes(&submessage_header, &mut v)
-                                    .map(RtpsSubmessageReadKind::AckNack)
-                            }
-                            DATA => DataSubmessage::try_from_bytes(&submessage_header, &mut v)
+                            ACKNACK => AckNackSubmessage::try_from_bytes(&submessage_header, v)
+                                .map(RtpsSubmessageReadKind::AckNack),
+                            DATA => DataSubmessage::try_from_bytes(&submessage_header, v)
                                 .map(RtpsSubmessageReadKind::Data),
-                            DATA_FRAG => {
-                                DataFragSubmessage::try_from_bytes(&submessage_header, &mut v)
-                                    .map(RtpsSubmessageReadKind::DataFrag)
-                            }
-                            GAP => GapSubmessage::try_from_bytes(&submessage_header, &mut v)
+                            DATA_FRAG => DataFragSubmessage::try_from_bytes(&submessage_header, v)
+                                .map(RtpsSubmessageReadKind::DataFrag),
+                            GAP => GapSubmessage::try_from_bytes(&submessage_header, v)
                                 .map(RtpsSubmessageReadKind::Gap),
-                            HEARTBEAT => {
-                                HeartbeatSubmessage::try_from_bytes(&submessage_header, &mut v)
-                                    .map(RtpsSubmessageReadKind::Heartbeat)
-                            }
+                            HEARTBEAT => HeartbeatSubmessage::try_from_bytes(&submessage_header, v)
+                                .map(RtpsSubmessageReadKind::Heartbeat),
                             HEARTBEAT_FRAG => {
-                                HeartbeatFragSubmessage::try_from_bytes(&submessage_header, &mut v)
+                                HeartbeatFragSubmessage::try_from_bytes(&submessage_header, v)
                                     .map(RtpsSubmessageReadKind::HeartbeatFrag)
                             }
-                            INFO_DST => InfoDestinationSubmessage::try_from_bytes(
-                                &submessage_header,
-                                &mut v,
-                            )
-                            .map(RtpsSubmessageReadKind::InfoDestination),
+                            INFO_DST => {
+                                InfoDestinationSubmessage::try_from_bytes(&submessage_header, v)
+                                    .map(RtpsSubmessageReadKind::InfoDestination)
+                            }
                             INFO_REPLY => {
-                                InfoReplySubmessage::try_from_bytes(&submessage_header, &mut v)
+                                InfoReplySubmessage::try_from_bytes(&submessage_header, v)
                                     .map(RtpsSubmessageReadKind::InfoReply)
                             }
-                            INFO_SRC => {
-                                InfoSourceSubmessage::try_from_bytes(&submessage_header, &mut v)
-                                    .map(RtpsSubmessageReadKind::InfoSource)
-                            }
+                            INFO_SRC => InfoSourceSubmessage::try_from_bytes(&submessage_header, v)
+                                .map(RtpsSubmessageReadKind::InfoSource),
                             INFO_TS => {
-                                InfoTimestampSubmessage::try_from_bytes(&submessage_header, &mut v)
+                                InfoTimestampSubmessage::try_from_bytes(&submessage_header, v)
                                     .map(RtpsSubmessageReadKind::InfoTimestamp)
                             }
-                            NACK_FRAG => {
-                                NackFragSubmessage::try_from_bytes(&submessage_header, &mut v)
-                                    .map(RtpsSubmessageReadKind::NackFrag)
-                            }
-                            PAD => PadSubmessage::try_from_bytes(&submessage_header, &mut v)
+                            NACK_FRAG => NackFragSubmessage::try_from_bytes(&submessage_header, v)
+                                .map(RtpsSubmessageReadKind::NackFrag),
+                            PAD => PadSubmessage::try_from_bytes(&submessage_header, v)
                                 .map(RtpsSubmessageReadKind::Pad),
                             _ => Err(RtpsError::new(
                                 RtpsErrorKind::InvalidData,

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -230,7 +230,7 @@ impl Parameter {
     }
 
     fn try_read_from_bytes(data: &mut &[u8], endianness: &Endianness) -> RtpsResult<Self> {
-        let mut slice = data.as_ref();
+        let mut slice = *data;
         let len = slice.len();
         if len < 4 {
             return Err(RtpsError::new(

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -256,6 +256,12 @@ impl Parameter {
         let value = if parameter_id == PID_SENTINEL {
             ArcSlice::empty()
         } else {
+            if data.len() < length as usize {
+                return Err(RtpsError::new(
+                    RtpsErrorKind::NotEnoughData,
+                    "Available data for parameter less than length",
+                ));
+            }
             let value = ArcSlice::from(&data[0..length as usize]);
             if length as usize > value.len() {
                 return Err(RtpsError::new(

--- a/dds/src/rtps/messages/submessages/ack_nack.rs
+++ b/dds/src/rtps/messages/submessages/ack_nack.rs
@@ -11,7 +11,7 @@ use super::super::super::{
     types::EntityId,
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct AckNackSubmessage {
     final_flag: SubmessageFlag,
     reader_id: EntityId,

--- a/dds/src/rtps/messages/submessages/data.rs
+++ b/dds/src/rtps/messages/submessages/data.rs
@@ -37,7 +37,7 @@ impl DataSubmessage {
                 "Submessage header length value bigger than actual data in the buffer",
             ));
         }
-        let mut slice = data.as_ref();
+        let mut slice = data;
         let endianness = submessage_header.endianness();
         let inline_qos_flag = submessage_header.flags()[1];
         let data_flag = submessage_header.flags()[2];

--- a/dds/src/rtps/messages/submessages/data.rs
+++ b/dds/src/rtps/messages/submessages/data.rs
@@ -7,7 +7,7 @@ use super::super::super::{
             Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes,
             WriteIntoBytes,
         },
-        submessage_elements::{ArcSlice, Data, ParameterList},
+        submessage_elements::{Data, ParameterList},
         types::{SubmessageFlag, SubmessageKind},
     },
     types::{EntityId, SequenceNumber},
@@ -27,9 +27,9 @@ pub struct DataSubmessage {
 }
 
 impl DataSubmessage {
-    pub fn try_from_arc_slice(
+    pub fn try_from_bytes(
         submessage_header: &SubmessageHeaderRead,
-        data: ArcSlice,
+        data: &[u8],
     ) -> RtpsResult<Self> {
         if submessage_header.submessage_length() as usize > data.len() {
             return Err(RtpsError::new(
@@ -57,9 +57,9 @@ impl DataSubmessage {
             ));
         }
         let mut data_starting_at_inline_qos =
-            data.sub_slice(octets_to_inline_qos..submessage_header.submessage_length() as usize)?;
+            &data[octets_to_inline_qos..submessage_header.submessage_length() as usize];
         let inline_qos = if inline_qos_flag {
-            ParameterList::try_read_from_arc_slice(
+            ParameterList::try_read_from_bytes(
                 &mut data_starting_at_inline_qos,
                 submessage_header.endianness(),
             )?
@@ -68,7 +68,7 @@ impl DataSubmessage {
         };
 
         let serialized_payload = if data_flag || key_flag {
-            Data::new(data_starting_at_inline_qos)
+            Data::new(data_starting_at_inline_qos.into())
         } else {
             Data::empty()
         };
@@ -355,8 +355,7 @@ mod tests {
             5, 0, 0, 0, // writerSN: low
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let data_submessage =
-            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+        let data_submessage = DataSubmessage::try_from_bytes(&submessage_header, data).unwrap();
 
         assert_eq!(inline_qos_flag, data_submessage._inline_qos_flag());
         assert_eq!(data_flag, data_submessage._data_flag());
@@ -385,8 +384,7 @@ mod tests {
             123, 123, 123 // Following data
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let data_submessage =
-            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+        let data_submessage = DataSubmessage::try_from_bytes(&submessage_header, data).unwrap();
         assert_eq!(&expected_inline_qos, data_submessage.inline_qos());
         assert_eq!(
             &expected_serialized_payload,
@@ -417,8 +415,7 @@ mod tests {
             1, 0, 1, 0, // inlineQos: Sentinel
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let data_submessage =
-            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+        let data_submessage = DataSubmessage::try_from_bytes(&submessage_header, data).unwrap();
         assert_eq!(&inline_qos, data_submessage.inline_qos());
         assert_eq!(&serialized_payload, data_submessage.serialized_payload());
     }
@@ -447,8 +444,7 @@ mod tests {
             1, 2, 3, 4, // SerializedPayload
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let data_submessage =
-            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+        let data_submessage = DataSubmessage::try_from_bytes(&submessage_header, data).unwrap();
 
         assert_eq!(&expected_inline_qos, data_submessage.inline_qos());
         assert_eq!(
@@ -479,8 +475,7 @@ mod tests {
             1, 0, 1, 0, // inlineQos: Sentinel
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let data_submessage =
-            DataSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+        let data_submessage = DataSubmessage::try_from_bytes(&submessage_header, data).unwrap();
 
         assert_eq!(&expected_inline_qos, data_submessage.inline_qos());
     }
@@ -498,7 +493,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         // Should not panic with this input
-        let _ = DataSubmessage::try_from_arc_slice(&submessage_header, data.into());
+        let _ = DataSubmessage::try_from_bytes(&submessage_header, data);
     }
 
     #[test]
@@ -516,7 +511,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         // Should not panic with this input
-        let _ = DataSubmessage::try_from_arc_slice(&submessage_header, data.into());
+        let _ = DataSubmessage::try_from_bytes(&submessage_header, data);
     }
 
     #[test]
@@ -528,6 +523,6 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         // Should not panic with this input
-        let _ = DataSubmessage::try_from_arc_slice(&submessage_header, data.into());
+        let _ = DataSubmessage::try_from_bytes(&submessage_header, data);
     }
 }

--- a/dds/src/rtps/messages/submessages/data.rs
+++ b/dds/src/rtps/messages/submessages/data.rs
@@ -13,7 +13,7 @@ use super::super::super::{
     types::{EntityId, SequenceNumber},
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DataSubmessage {
     inline_qos_flag: bool,
     data_flag: bool,

--- a/dds/src/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/rtps/messages/submessages/data_frag.rs
@@ -39,7 +39,7 @@ impl DataFragSubmessage {
             ));
         }
 
-        let mut slice = data.as_ref();
+        let mut slice = data;
         if data.len() >= 32 {
             let endianness = submessage_header.endianness();
             let inline_qos_flag = submessage_header.flags()[1];

--- a/dds/src/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/rtps/messages/submessages/data_frag.rs
@@ -5,7 +5,7 @@ use super::super::super::{
             Submessage, SubmessageHeaderRead, SubmessageHeaderWrite, TryReadFromBytes,
             WriteIntoBytes,
         },
-        submessage_elements::{ArcSlice, Data, ParameterList},
+        submessage_elements::{Data, ParameterList},
         types::{FragmentNumber, SubmessageFlag, SubmessageKind},
     },
     types::{EntityId, SequenceNumber},
@@ -28,9 +28,9 @@ pub struct DataFragSubmessage {
 }
 
 impl DataFragSubmessage {
-    pub fn try_from_arc_slice(
+    pub fn try_from_bytes(
         submessage_header: &SubmessageHeaderRead,
-        data: ArcSlice,
+        data: &[u8],
     ) -> RtpsResult<Self> {
         if submessage_header.submessage_length() as usize > data.len() {
             return Err(RtpsError::new(
@@ -305,9 +305,7 @@ mod tests {
             4, 0, 0, 0, // sampleSize
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage =
-            DataFragSubmessage::try_from_arc_slice(&submessage_header, ArcSlice::from(data))
-                .unwrap();
+        let submessage = DataFragSubmessage::try_from_bytes(&submessage_header, data).unwrap();
 
         let expected_inline_qos_flag = false;
         let expected_non_standard_payload_flag = false;
@@ -368,7 +366,7 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         let submessage =
-            DataFragSubmessage::try_from_arc_slice(&submessage_header, data.into()).unwrap();
+            DataFragSubmessage::try_from_bytes(&submessage_header, data.into()).unwrap();
 
         let expected_inline_qos_flag = true;
         let expected_non_standard_payload_flag = false;
@@ -419,6 +417,6 @@ mod tests {
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
         // Should not panic with this input
-        let _ = DataFragSubmessage::try_from_arc_slice(&submessage_header, data.into());
+        let _ = DataFragSubmessage::try_from_bytes(&submessage_header, data.into());
     }
 }

--- a/dds/src/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/rtps/messages/submessages/data_frag.rs
@@ -65,18 +65,15 @@ impl DataFragSubmessage {
                 ));
             }
 
-            let mut data_starting_at_inline_qos = data
-                .sub_slice(octets_to_inline_qos..submessage_header.submessage_length() as usize)?;
+            let mut data_starting_at_inline_qos =
+                &data[octets_to_inline_qos..submessage_header.submessage_length() as usize];
 
             let inline_qos = if inline_qos_flag {
-                ParameterList::try_read_from_arc_slice(
-                    &mut data_starting_at_inline_qos,
-                    endianness,
-                )?
+                ParameterList::try_read_from_bytes(&mut data_starting_at_inline_qos, endianness)?
             } else {
                 ParameterList::empty()
             };
-            let serialized_payload = Data::new(data_starting_at_inline_qos);
+            let serialized_payload = Data::new(data_starting_at_inline_qos.into());
 
             Ok(Self {
                 inline_qos_flag,

--- a/dds/src/rtps/messages/submessages/gap.rs
+++ b/dds/src/rtps/messages/submessages/gap.rs
@@ -11,7 +11,7 @@ use super::super::super::{
     types::{EntityId, SequenceNumber},
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct GapSubmessage {
     reader_id: EntityId,
     writer_id: EntityId,

--- a/dds/src/rtps/messages/submessages/heartbeat.rs
+++ b/dds/src/rtps/messages/submessages/heartbeat.rs
@@ -10,7 +10,7 @@ use super::super::super::{
     types::{EntityId, SequenceNumber},
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct HeartbeatSubmessage {
     final_flag: SubmessageFlag,
     liveliness_flag: SubmessageFlag,

--- a/dds/src/rtps/messages/submessages/heartbeat_frag.rs
+++ b/dds/src/rtps/messages/submessages/heartbeat_frag.rs
@@ -10,7 +10,7 @@ use super::super::super::{
     types::{EntityId, SequenceNumber},
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct HeartbeatFragSubmessage {
     reader_id: EntityId,
     writer_id: EntityId,

--- a/dds/src/rtps/messages/submessages/nack_frag.rs
+++ b/dds/src/rtps/messages/submessages/nack_frag.rs
@@ -11,7 +11,7 @@ use super::super::super::{
     types::{EntityId, SequenceNumber},
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct NackFragSubmessage {
     reader_id: EntityId,
     writer_id: EntityId,

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -1,7 +1,7 @@
 use super::{
     messages::{
         overall_structure::Submessage,
-        submessage_elements::{ArcSlice, Data, FragmentNumberSet, SequenceNumberSet},
+        submessage_elements::{Data, FragmentNumberSet, SequenceNumberSet},
         submessages::{
             ack_nack::AckNackSubmessage, data::DataSubmessage, data_frag::DataFragSubmessage,
             info_destination::InfoDestinationSubmessage, nack_frag::NackFragSubmessage,
@@ -14,7 +14,7 @@ use crate::implementation::{
     actor::ActorAddress,
     actors::message_sender_actor::{self, MessageSenderActor},
 };
-use std::{cmp::max, collections::HashMap};
+use std::{cmp::max, collections::HashMap, sync::Arc};
 
 fn total_fragments_expected(data_frag_submessage: &DataFragSubmessage) -> u32 {
     let data_size = data_frag_submessage.data_size();
@@ -112,7 +112,7 @@ impl RtpsWriterProxy {
                     writer_id,
                     writer_sn,
                     inline_qos,
-                    Data::new(ArcSlice::from(data)),
+                    Data::new(Arc::from(data)),
                 ))
             } else {
                 None

--- a/dds/tests/reliability_tests.rs
+++ b/dds/tests/reliability_tests.rs
@@ -200,7 +200,7 @@ fn writer_should_send_heartbeat_periodically() {
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
 
-    let received_data_heartbeat = RtpsMessageRead::new(Arc::from(buffer)).unwrap();
+    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
     assert!(received_data_heartbeat
         .submessages()
         .iter()
@@ -218,7 +218,7 @@ fn writer_should_send_heartbeat_periodically() {
         .set_read_timeout(Some(std::time::Duration::from_millis(300)))
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
-    let received_heartbeat = RtpsMessageRead::new(Arc::from(buffer)).unwrap();
+    let received_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
     assert!(received_heartbeat
         .submessages()
         .iter()
@@ -390,7 +390,7 @@ fn writer_should_not_send_heartbeat_after_acknack() {
         .default_unicast_locator_list()[0]
         .port();
 
-    let received_data_heartbeat = RtpsMessageRead::new(Arc::from(buffer))
+    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer))
         .unwrap()
         .submessages();
     let received_heartbeat = received_data_heartbeat
@@ -577,7 +577,7 @@ fn writer_should_resend_data_after_acknack_request() {
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
 
-    let received_data_heartbeat = RtpsMessageRead::new(Arc::from(buffer))
+    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer))
         .unwrap()
         .submessages();
     let received_heartbeat = received_data_heartbeat
@@ -611,7 +611,7 @@ fn writer_should_resend_data_after_acknack_request() {
         .set_read_timeout(Some(std::time::Duration::from_millis(300)))
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
-    let received_data_heartbeat = RtpsMessageRead::new(Arc::from(buffer)).unwrap();
+    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
     assert!(received_data_heartbeat
         .submessages()
         .iter()
@@ -775,7 +775,7 @@ fn volatile_writer_should_send_gap_submessage_after_discovery() {
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
 
-    let received_gap = RtpsMessageRead::new(Arc::from(buffer)).unwrap();
+    let received_gap = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
     assert!(received_gap
         .submessages()
         .iter()
@@ -788,7 +788,7 @@ fn volatile_writer_should_send_gap_submessage_after_discovery() {
         .set_read_timeout(Some(std::time::Duration::from_millis(300)))
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
-    let received_heartbeat = RtpsMessageRead::new(Arc::from(buffer)).unwrap();
+    let received_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
     assert!(received_heartbeat
         .submessages()
         .iter()
@@ -953,7 +953,7 @@ fn transient_local_writer_should_send_data_submessage_after_discovery() {
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
 
-    let received_data_heartbeat = RtpsMessageRead::new(Arc::from(buffer)).unwrap();
+    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
     assert!(received_data_heartbeat
         .submessages()
         .iter()
@@ -971,7 +971,7 @@ fn transient_local_writer_should_send_data_submessage_after_discovery() {
         .set_read_timeout(Some(std::time::Duration::from_millis(300)))
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
-    let received_heartbeat = RtpsMessageRead::new(Arc::from(buffer)).unwrap();
+    let received_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
     assert!(received_heartbeat
         .submessages()
         .iter()

--- a/dds/tests/reliability_tests.rs
+++ b/dds/tests/reliability_tests.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use dust_dds::{
     builtin_topics::{BuiltInTopicKey, SubscriptionBuiltinTopicData},
     data_representation_builtin_endpoints::{
@@ -200,14 +198,13 @@ fn writer_should_send_heartbeat_periodically() {
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
 
-    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
-    assert!(received_data_heartbeat
-        .submessages()
+    let received_data_heartbeat = RtpsMessageRead::try_from(buffer.as_slice()).unwrap();
+    let submessages = received_data_heartbeat.submessages();
+    assert!(submessages
         .iter()
         .find(|s| matches!(s, RtpsSubmessageReadKind::Data(_)))
         .is_some());
-    assert!(received_data_heartbeat
-        .submessages()
+    assert!(submessages
         .iter()
         .find(|s| matches!(s, RtpsSubmessageReadKind::Heartbeat(_)))
         .is_some());
@@ -218,7 +215,7 @@ fn writer_should_send_heartbeat_periodically() {
         .set_read_timeout(Some(std::time::Duration::from_millis(300)))
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
-    let received_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
+    let received_heartbeat = RtpsMessageRead::try_from(buffer.as_slice()).unwrap();
     assert!(received_heartbeat
         .submessages()
         .iter()
@@ -390,7 +387,7 @@ fn writer_should_not_send_heartbeat_after_acknack() {
         .default_unicast_locator_list()[0]
         .port();
 
-    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer))
+    let received_data_heartbeat = RtpsMessageRead::try_from(buffer.as_slice())
         .unwrap()
         .submessages();
     let received_heartbeat = received_data_heartbeat
@@ -577,7 +574,7 @@ fn writer_should_resend_data_after_acknack_request() {
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
 
-    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer))
+    let received_data_heartbeat = RtpsMessageRead::try_from(buffer.as_slice())
         .unwrap()
         .submessages();
     let received_heartbeat = received_data_heartbeat
@@ -611,14 +608,13 @@ fn writer_should_resend_data_after_acknack_request() {
         .set_read_timeout(Some(std::time::Duration::from_millis(300)))
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
-    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
-    assert!(received_data_heartbeat
-        .submessages()
+    let received_data_heartbeat = RtpsMessageRead::try_from(buffer.as_slice()).unwrap();
+    let submessages = received_data_heartbeat.submessages();
+    assert!(submessages
         .iter()
         .find(|s| matches!(s, RtpsSubmessageReadKind::Data(_)))
         .is_some());
-    assert!(received_data_heartbeat
-        .submessages()
+    assert!(submessages
         .iter()
         .find(|s| matches!(s, RtpsSubmessageReadKind::Heartbeat(_)))
         .is_some());
@@ -775,7 +771,7 @@ fn volatile_writer_should_send_gap_submessage_after_discovery() {
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
 
-    let received_gap = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
+    let received_gap = RtpsMessageRead::try_from(buffer.as_slice()).unwrap();
     assert!(received_gap
         .submessages()
         .iter()
@@ -788,7 +784,7 @@ fn volatile_writer_should_send_gap_submessage_after_discovery() {
         .set_read_timeout(Some(std::time::Duration::from_millis(300)))
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
-    let received_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
+    let received_heartbeat = RtpsMessageRead::try_from(buffer.as_slice()).unwrap();
     assert!(received_heartbeat
         .submessages()
         .iter()
@@ -953,14 +949,13 @@ fn transient_local_writer_should_send_data_submessage_after_discovery() {
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
 
-    let received_data_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
-    assert!(received_data_heartbeat
-        .submessages()
+    let received_data_heartbeat = RtpsMessageRead::try_from(buffer.as_slice()).unwrap();
+    let submessages = received_data_heartbeat.submessages();
+    assert!(submessages
         .iter()
         .find(|s| matches!(s, RtpsSubmessageReadKind::Data(_)))
         .is_some());
-    assert!(received_data_heartbeat
-        .submessages()
+    assert!(submessages
         .iter()
         .find(|s| matches!(s, RtpsSubmessageReadKind::Heartbeat(_)))
         .is_some());
@@ -971,9 +966,9 @@ fn transient_local_writer_should_send_data_submessage_after_discovery() {
         .set_read_timeout(Some(std::time::Duration::from_millis(300)))
         .unwrap();
     mock_reader_socket.recv(&mut buffer).unwrap();
-    let received_heartbeat = RtpsMessageRead::try_from(Arc::from(buffer)).unwrap();
-    assert!(received_heartbeat
-        .submessages()
+    let received_heartbeat = RtpsMessageRead::try_from(buffer.as_slice()).unwrap();
+    let submessages = received_heartbeat.submessages();
+    assert!(submessages
         .iter()
         .find(|s| matches!(s, RtpsSubmessageReadKind::Heartbeat(_)))
         .is_some());

--- a/fuzz/fuzz_targets/fuzz_data_frag_submessage.rs
+++ b/fuzz/fuzz_targets/fuzz_data_frag_submessage.rs
@@ -9,7 +9,7 @@ fuzz_target!(|data: &[u8]| -> Corpus {
     if data.len() > 4 {
         let mut data = data;
         let header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        DataFragSubmessage::try_from_arc_slice(&header, data.into()).ok();
+        DataFragSubmessage::try_from_bytes(&header, data).ok();
         Corpus::Keep
     } else {
         Corpus::Reject

--- a/fuzz/fuzz_targets/fuzz_data_submessage.rs
+++ b/fuzz/fuzz_targets/fuzz_data_submessage.rs
@@ -9,7 +9,7 @@ fuzz_target!(|data: &[u8]| -> Corpus {
     if data.len() > 4 {
         let mut data = data;
         let header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        DataSubmessage::try_from_arc_slice(&header, data.into()).ok();
+        DataSubmessage::try_from_bytes(&header, data.into()).ok();
         Corpus::Keep
     } else {
         Corpus::Reject


### PR DESCRIPTION
Replace the strategy of allocating a new buffer in an Arc on every reception by re-using the same Box slice for receiving all data and cloning the parts that are necessary (e.g. parameter list and cache changes).