### PR TITLE
Performance optimization: Use Cursor for serializing RTPS messages

### DIFF
--- a/dds/src/rtps/messages/overall_structure.rs
+++ b/dds/src/rtps/messages/overall_structure.rs
@@ -247,7 +247,7 @@ impl RtpsMessageRead {
 }
 
 #[allow(dead_code)] // Only used as convenience in tests
-pub fn write_into_bytes_vec<'a>(value: impl WriteIntoBytes) -> Vec<u8> {
+pub fn write_into_bytes_vec(value: impl WriteIntoBytes) -> Vec<u8> {
     let mut buf = [0u8; BUFFER_SIZE];
     let mut cursor = Cursor::new(buf.as_mut_slice());
     value.write_into_bytes(&mut cursor);
@@ -256,7 +256,7 @@ pub fn write_into_bytes_vec<'a>(value: impl WriteIntoBytes) -> Vec<u8> {
 }
 
 #[allow(dead_code)] // Only used as convenience in tests
-pub fn write_submessage_into_bytes_vec<'a>(value: &(dyn Submessage + Send)) -> Vec<u8> {
+pub fn write_submessage_into_bytes_vec(value: &(dyn Submessage + Send)) -> Vec<u8> {
     let buf = Vec::new();
     let mut cursor = Cursor::new(buf);
     value.write_submessage_into_bytes(&mut cursor);
@@ -276,7 +276,6 @@ impl RtpsMessageWrite {
         for submessage in submessages {
             submessage.write_submessage_into_bytes(&mut cursor);
         }
-        let len = cursor.position() as usize;
         Self {
             data: Arc::from(cursor.into_inner().into_boxed_slice()),
         }

--- a/dds/src/rtps/messages/overall_structure.rs
+++ b/dds/src/rtps/messages/overall_structure.rs
@@ -25,8 +25,6 @@ use std::{
     sync::Arc,
 };
 
-const BUFFER_SIZE: usize = 65000;
-
 pub enum Endianness {
     BigEndian,
     LittleEndian,

--- a/dds/src/rtps/messages/overall_structure.rs
+++ b/dds/src/rtps/messages/overall_structure.rs
@@ -20,7 +20,10 @@ use super::{
     },
     types::{ProtocolId, SubmessageFlag, SubmessageKind},
 };
-use std::{io::{BufRead, Cursor}, sync::Arc};
+use std::{
+    io::{BufRead, Cursor, Write},
+    sync::Arc,
+};
 
 const BUFFER_SIZE: usize = 65000;
 
@@ -43,16 +46,16 @@ pub trait TryReadFromBytes: Sized {
 }
 
 pub trait WriteIntoBytes {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>);
+    fn write_into_bytes(&self, buf: &mut dyn Write);
 }
 
 pub trait Submessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]);
-    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>);
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut dyn Write);
+    fn write_submessage_elements_into_bytes(&self, buf: &mut dyn Write);
 }
 
-impl<T: ?Sized + Send + Submessage> WriteIntoBytes for T {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+impl dyn Submessage + Send + '_ {
+    fn write_submessage_into_bytes(&self, buf: &mut Cursor<Vec<u8>>) {
         let header_position: u64 = buf.position();
         let elements_position = header_position + 4;
         buf.set_position(elements_position);
@@ -60,7 +63,7 @@ impl<T: ?Sized + Send + Submessage> WriteIntoBytes for T {
         let pos = buf.position();
         buf.set_position(header_position);
         let len = pos - elements_position;
-        self.write_submessage_header_into_bytes(len as u16, &mut buf.get_mut()[header_position as usize ..]);
+        self.write_submessage_header_into_bytes(len as u16, buf);
         buf.set_position(pos);
     }
 }
@@ -244,12 +247,20 @@ impl RtpsMessageRead {
 }
 
 #[allow(dead_code)] // Only used as convenience in tests
-pub fn write_into_bytes_vec<T: WriteIntoBytes>(value: T) -> Vec<u8> {
+pub fn write_into_bytes_vec<'a>(value: impl WriteIntoBytes) -> Vec<u8> {
     let mut buf = [0u8; BUFFER_SIZE];
     let mut cursor = Cursor::new(buf.as_mut_slice());
     value.write_into_bytes(&mut cursor);
     let len = cursor.position() as usize;
     Vec::from(&buf[..len])
+}
+
+#[allow(dead_code)] // Only used as convenience in tests
+pub fn write_submessage_into_bytes_vec<'a>(value: &(dyn Submessage + Send)) -> Vec<u8> {
+    let buf = Vec::new();
+    let mut cursor = Cursor::new(buf);
+    value.write_submessage_into_bytes(&mut cursor);
+    cursor.into_inner()
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -259,15 +270,15 @@ pub struct RtpsMessageWrite {
 
 impl RtpsMessageWrite {
     pub fn new(header: &RtpsMessageHeader, submessages: &[Box<dyn Submessage + Send>]) -> Self {
-        let mut buffer = [0; BUFFER_SIZE];
-        let mut cursor = Cursor::new(buffer.as_mut_slice());
+        let buffer = Vec::new();
+        let mut cursor = Cursor::new(buffer);
         header.write_into_bytes(&mut cursor);
         for submessage in submessages {
-            submessage.write_into_bytes(&mut cursor);
+            submessage.write_submessage_into_bytes(&mut cursor);
         }
         let len = cursor.position() as usize;
         Self {
-            data: Arc::from(&buffer[..len]),
+            data: Arc::from(cursor.into_inner().into_boxed_slice()),
         }
     }
 
@@ -321,7 +332,7 @@ impl RtpsMessageHeader {
 }
 
 impl WriteIntoBytes for RtpsMessageHeader {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         ProtocolId::PROTOCOL_RTPS.write_into_bytes(buf);
         self.version.write_into_bytes(buf);
         self.vendor_id.write_into_bytes(buf);
@@ -359,7 +370,7 @@ impl SubmessageHeaderWrite {
 }
 
 impl WriteIntoBytes for SubmessageHeaderWrite {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         self.submessage_id.write_into_bytes(buf);
         self.flags_octet.write_into_bytes(buf);
         self.submessage_length.write_into_bytes(buf);

--- a/dds/src/rtps/messages/overall_structure.rs
+++ b/dds/src/rtps/messages/overall_structure.rs
@@ -248,17 +248,14 @@ impl RtpsMessageRead {
 
 #[allow(dead_code)] // Only used as convenience in tests
 pub fn write_into_bytes_vec(value: impl WriteIntoBytes) -> Vec<u8> {
-    let mut buf = [0u8; BUFFER_SIZE];
-    let mut cursor = Cursor::new(buf.as_mut_slice());
+    let mut cursor = Cursor::new(Vec::new());
     value.write_into_bytes(&mut cursor);
-    let len = cursor.position() as usize;
-    Vec::from(&buf[..len])
+    cursor.into_inner()
 }
 
 #[allow(dead_code)] // Only used as convenience in tests
 pub fn write_submessage_into_bytes_vec(value: &(dyn Submessage + Send)) -> Vec<u8> {
-    let buf = Vec::new();
-    let mut cursor = Cursor::new(buf);
+    let mut cursor = Cursor::new(Vec::new());
     value.write_submessage_into_bytes(&mut cursor);
     cursor.into_inner()
 }

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -8,7 +8,7 @@ use super::{
     types::ParameterId,
 };
 use std::{
-    io::Cursor,
+    io::{Cursor, Write},
     ops::{Index, Range, RangeFrom, RangeTo},
     sync::Arc,
 };
@@ -104,7 +104,7 @@ impl TryReadFromBytes for SequenceNumberSet {
 }
 
 impl WriteIntoBytes for SequenceNumberSet {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         let number_of_bitmap_elements = ((self.num_bits + 31) / 32) as usize; //In standard referred to as "M"
 
         self.base.write_into_bytes(buf);
@@ -150,7 +150,7 @@ impl FragmentNumberSet {
 }
 
 impl WriteIntoBytes for FragmentNumberSet {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         let mut bitmap = [0; 8];
         let mut num_bits = 0;
         for fragment_number in &self.set {
@@ -198,7 +198,7 @@ impl TryReadFromBytes for LocatorList {
 }
 
 impl WriteIntoBytes for LocatorList {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         let num_locators = self.value().len() as u32;
         num_locators.write_into_bytes(buf);
         for locator in self.value().iter() {
@@ -309,7 +309,7 @@ impl ParameterList {
 }
 
 impl WriteIntoBytes for Parameter {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         let padding = match self.value().len() % 4 {
             1 => &[0_u8; 3][..],
             2 => &[0_u8; 2][..],
@@ -325,7 +325,7 @@ impl WriteIntoBytes for Parameter {
 }
 
 impl WriteIntoBytes for ParameterList {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         for parameter in self.parameter().iter() {
             parameter.write_into_bytes(buf);
         }
@@ -469,7 +469,7 @@ impl AsRef<[u8]> for Data {
 }
 
 impl WriteIntoBytes for Data {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         self.0.as_ref().write_into_bytes(buf);
         match self.0.len() % 4 {
             1 => [0_u8; 3].write_into_bytes(buf),

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -8,7 +8,7 @@ use super::{
     types::ParameterId,
 };
 use std::{
-    io::{Cursor, Write},
+    io::Write,
     ops::{Index, Range, RangeFrom, RangeTo},
     sync::Arc,
 };

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -8,6 +8,7 @@ use super::{
     types::ParameterId,
 };
 use std::{
+    io::Cursor,
     ops::{Index, Range, RangeFrom, RangeTo},
     sync::Arc,
 };
@@ -103,7 +104,7 @@ impl TryReadFromBytes for SequenceNumberSet {
 }
 
 impl WriteIntoBytes for SequenceNumberSet {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         let number_of_bitmap_elements = ((self.num_bits + 31) / 32) as usize; //In standard referred to as "M"
 
         self.base.write_into_bytes(buf);
@@ -149,7 +150,7 @@ impl FragmentNumberSet {
 }
 
 impl WriteIntoBytes for FragmentNumberSet {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         let mut bitmap = [0; 8];
         let mut num_bits = 0;
         for fragment_number in &self.set {
@@ -197,7 +198,7 @@ impl TryReadFromBytes for LocatorList {
 }
 
 impl WriteIntoBytes for LocatorList {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         let num_locators = self.value().len() as u32;
         num_locators.write_into_bytes(buf);
         for locator in self.value().iter() {
@@ -308,7 +309,7 @@ impl ParameterList {
 }
 
 impl WriteIntoBytes for Parameter {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         let padding = match self.value().len() % 4 {
             1 => &[0_u8; 3][..],
             2 => &[0_u8; 2][..],
@@ -324,7 +325,7 @@ impl WriteIntoBytes for Parameter {
 }
 
 impl WriteIntoBytes for ParameterList {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         for parameter in self.parameter().iter() {
             parameter.write_into_bytes(buf);
         }
@@ -468,7 +469,7 @@ impl AsRef<[u8]> for Data {
 }
 
 impl WriteIntoBytes for Data {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.0.as_ref().write_into_bytes(buf);
         match self.0.len() % 4 {
             1 => [0_u8; 3].write_into_bytes(buf),

--- a/dds/src/rtps/messages/submessages/ack_nack.rs
+++ b/dds/src/rtps/messages/submessages/ack_nack.rs
@@ -10,6 +10,7 @@ use super::super::super::{
     },
     types::EntityId,
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct AckNackSubmessage {
@@ -75,20 +76,20 @@ impl AckNackSubmessage {
 }
 
 impl Submessage for AckNackSubmessage {
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
         self.reader_sn_state.write_into_bytes(buf);
         self.count.write_into_bytes(buf);
     }
 
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::ACKNACK,
             &[self.final_flag],
             octets_to_next_header,
         )
-        .write_into_bytes(&mut buf);
+        .write_into_bytes(&mut Cursor::new(buf));
     }
 }
 

--- a/dds/src/rtps/messages/submessages/ack_nack.rs
+++ b/dds/src/rtps/messages/submessages/ack_nack.rs
@@ -10,7 +10,7 @@ use super::super::super::{
     },
     types::EntityId,
 };
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct AckNackSubmessage {
@@ -76,20 +76,20 @@ impl AckNackSubmessage {
 }
 
 impl Submessage for AckNackSubmessage {
-    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut dyn Write) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
         self.reader_sn_state.write_into_bytes(buf);
         self.count.write_into_bytes(buf);
     }
 
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut dyn Write) {
         SubmessageHeaderWrite::new(
             SubmessageKind::ACKNACK,
             &[self.final_flag],
             octets_to_next_header,
         )
-        .write_into_bytes(&mut Cursor::new(buf));
+        .write_into_bytes(buf);
     }
 }
 
@@ -97,7 +97,7 @@ impl Submessage for AckNackSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::write_into_bytes_vec,
+        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 
@@ -114,7 +114,7 @@ mod tests {
             14,
         );
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x06_u8, 0b_0000_0001, 24, 0, // Submessage header
                 1, 2, 3, 4, // readerId: value[4]
                 6, 7, 8, 9, // writerId: value[4]

--- a/dds/src/rtps/messages/submessages/ack_nack.rs
+++ b/dds/src/rtps/messages/submessages/ack_nack.rs
@@ -10,7 +10,7 @@ use super::super::super::{
     },
     types::EntityId,
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct AckNackSubmessage {
@@ -97,7 +97,7 @@ impl Submessage for AckNackSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
+        messages::overall_structure::write_submessage_into_bytes_vec,
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 
@@ -139,8 +139,7 @@ mod tests {
             2, 0, 0, 0, // count
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage =
-            AckNackSubmessage::try_from_bytes(&submessage_header, data.as_ref()).unwrap();
+        let submessage = AckNackSubmessage::try_from_bytes(&submessage_header, data).unwrap();
         let expected_final_flag = false;
         let expected_reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
         let expected_writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);

--- a/dds/src/rtps/messages/submessages/data.rs
+++ b/dds/src/rtps/messages/submessages/data.rs
@@ -11,7 +11,7 @@ use super::super::super::{
     types::{EntityId, SequenceNumber},
 };
 use crate::rtps::error::{RtpsError, RtpsErrorKind};
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct DataSubmessage {
@@ -149,7 +149,7 @@ impl DataSubmessage {
 }
 
 impl Submessage for DataSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut dyn Write) {
         SubmessageHeaderWrite::new(
             SubmessageKind::DATA,
             &[
@@ -160,10 +160,10 @@ impl Submessage for DataSubmessage {
             ],
             octets_to_next_header,
         )
-        .write_into_bytes(&mut Cursor::new(buf))
+        .write_into_bytes(buf)
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut dyn Write) {
         const EXTRA_FLAGS: u16 = 0;
         const OCTETS_TO_INLINE_QOS: u16 = 16;
         EXTRA_FLAGS.write_into_bytes(buf);
@@ -184,7 +184,10 @@ impl Submessage for DataSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::{overall_structure::write_into_bytes_vec, submessage_elements::Parameter},
+        messages::{
+            overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
+            submessage_elements::Parameter,
+        },
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 
@@ -211,7 +214,7 @@ mod tests {
             serialized_payload,
         );
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x15_u8, 0b_0000_0001, 20, 0, // Submessage header
                 0, 0, 16, 0, // extraFlags, octetsToInlineQos
                 1, 2, 3, 4, // readerId: value[4]
@@ -248,7 +251,7 @@ mod tests {
             serialized_payload,
         );
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x15, 0b_0000_0011, 40, 0, // Submessage header
                 0, 0, 16, 0, // extraFlags, octetsToInlineQos
                 1, 2, 3, 4, // readerId: value[4]
@@ -287,7 +290,7 @@ mod tests {
             serialized_payload,
         );
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x15, 0b_0000_0101, 24, 0, // Submessage header
                 0, 0, 16, 0, // extraFlags, octetsToInlineQos
                 1, 2, 3, 4, // readerId: value[4]
@@ -322,7 +325,7 @@ mod tests {
             serialized_payload,
         );
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x15, 0b_0000_0101, 24, 0, // Submessage header
                 0, 0, 16, 0, // extraFlags, octetsToInlineQos
                 1, 2, 3, 4, // readerId: value[4]

--- a/dds/src/rtps/messages/submessages/data.rs
+++ b/dds/src/rtps/messages/submessages/data.rs
@@ -1,5 +1,3 @@
-use crate::rtps::error::{RtpsError, RtpsErrorKind};
-
 use super::super::super::{
     error::RtpsResult,
     messages::{
@@ -12,6 +10,8 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
+use crate::rtps::error::{RtpsError, RtpsErrorKind};
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct DataSubmessage {
@@ -149,7 +149,7 @@ impl DataSubmessage {
 }
 
 impl Submessage for DataSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::DATA,
             &[
@@ -160,10 +160,10 @@ impl Submessage for DataSubmessage {
             ],
             octets_to_next_header,
         )
-        .write_into_bytes(&mut buf)
+        .write_into_bytes(&mut Cursor::new(buf))
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         const EXTRA_FLAGS: u16 = 0;
         const OCTETS_TO_INLINE_QOS: u16 = 16;
         EXTRA_FLAGS.write_into_bytes(buf);

--- a/dds/src/rtps/messages/submessages/data.rs
+++ b/dds/src/rtps/messages/submessages/data.rs
@@ -11,7 +11,7 @@ use super::super::super::{
     types::{EntityId, SequenceNumber},
 };
 use crate::rtps::error::{RtpsError, RtpsErrorKind};
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct DataSubmessage {
@@ -185,8 +185,7 @@ mod tests {
     use super::*;
     use crate::rtps::{
         messages::{
-            overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
-            submessage_elements::Parameter,
+            overall_structure::write_submessage_into_bytes_vec, submessage_elements::Parameter,
         },
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };

--- a/dds/src/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/rtps/messages/submessages/data_frag.rs
@@ -10,6 +10,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DataFragSubmessage {
@@ -183,7 +184,7 @@ impl DataFragSubmessage {
 }
 
 impl Submessage for DataFragSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::DATA_FRAG,
             &[
@@ -193,10 +194,10 @@ impl Submessage for DataFragSubmessage {
             ],
             octets_to_next_header,
         )
-        .write_into_bytes(&mut buf)
+        .write_into_bytes(&mut Cursor::new(buf))
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         const EXTRA_FLAGS: u16 = 0;
         const OCTETS_TO_INLINE_QOS: u16 = 28;
         EXTRA_FLAGS.write_into_bytes(buf);

--- a/dds/src/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/rtps/messages/submessages/data_frag.rs
@@ -10,7 +10,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct DataFragSubmessage {
@@ -221,8 +221,7 @@ mod tests {
     use super::*;
     use crate::rtps::{
         messages::{
-            overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
-            submessage_elements::Parameter,
+            overall_structure::write_submessage_into_bytes_vec, submessage_elements::Parameter,
         },
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };

--- a/dds/src/rtps/messages/submessages/gap.rs
+++ b/dds/src/rtps/messages/submessages/gap.rs
@@ -10,6 +10,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct GapSubmessage {
@@ -67,12 +68,12 @@ impl GapSubmessage {
 }
 
 impl Submessage for GapSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::GAP, &[], octets_to_next_header)
-            .write_into_bytes(&mut buf);
+        .write_into_bytes(&mut Cursor::new(buf))
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
         self.gap_start.write_into_bytes(buf);

--- a/dds/src/rtps/messages/submessages/gap.rs
+++ b/dds/src/rtps/messages/submessages/gap.rs
@@ -10,7 +10,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct GapSubmessage {
@@ -84,7 +84,7 @@ impl Submessage for GapSubmessage {
 #[cfg(test)]
 mod tests {
     use crate::rtps::{
-        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
+        messages::overall_structure::write_submessage_into_bytes_vec,
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 
@@ -128,7 +128,7 @@ mod tests {
             0, 0, 0, 0, // gapList: SequenceNumberSet: numBits (ULong)
         ][..];
         let submessage_header = SubmessageHeaderRead::try_read_from_bytes(&mut data).unwrap();
-        let submessage = GapSubmessage::try_from_bytes(&&submessage_header, data.as_ref()).unwrap();
+        let submessage = GapSubmessage::try_from_bytes(&submessage_header, data).unwrap();
         assert_eq!(expected_reader_id, submessage._reader_id());
         assert_eq!(expected_writer_id, submessage.writer_id());
         assert_eq!(expected_gap_start, submessage.gap_start());

--- a/dds/src/rtps/messages/submessages/gap.rs
+++ b/dds/src/rtps/messages/submessages/gap.rs
@@ -10,7 +10,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct GapSubmessage {
@@ -68,12 +68,12 @@ impl GapSubmessage {
 }
 
 impl Submessage for GapSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut dyn Write) {
         SubmessageHeaderWrite::new(SubmessageKind::GAP, &[], octets_to_next_header)
-        .write_into_bytes(&mut Cursor::new(buf))
+            .write_into_bytes(buf)
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut dyn Write) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
         self.gap_start.write_into_bytes(buf);
@@ -84,7 +84,7 @@ impl Submessage for GapSubmessage {
 #[cfg(test)]
 mod tests {
     use crate::rtps::{
-        messages::overall_structure::write_into_bytes_vec,
+        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 
@@ -96,7 +96,7 @@ mod tests {
         let gap_list = SequenceNumberSet::new(10, []);
         let submessage = GapSubmessage::new(reader_id, writer_id, gap_start, gap_list);
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x08_u8, 0b_0000_0001, 28, 0, // Submessage header
                 1, 2, 3, 4, // readerId: value[4]
                 6, 7, 8, 9, // writerId: value[4]

--- a/dds/src/rtps/messages/submessages/heartbeat.rs
+++ b/dds/src/rtps/messages/submessages/heartbeat.rs
@@ -9,6 +9,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HeartbeatSubmessage {
@@ -90,16 +91,16 @@ impl HeartbeatSubmessage {
 }
 
 impl Submessage for HeartbeatSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::HEARTBEAT,
             &[self.final_flag, self.liveliness_flag],
             octets_to_next_header,
         )
-        .write_into_bytes(&mut buf);
+        .write_into_bytes(&mut Cursor::new(buf));
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
         self.first_sn.write_into_bytes(buf);

--- a/dds/src/rtps/messages/submessages/heartbeat.rs
+++ b/dds/src/rtps/messages/submessages/heartbeat.rs
@@ -9,7 +9,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HeartbeatSubmessage {
@@ -113,7 +113,7 @@ impl Submessage for HeartbeatSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
+        messages::overall_structure::write_submessage_into_bytes_vec,
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 

--- a/dds/src/rtps/messages/submessages/heartbeat_frag.rs
+++ b/dds/src/rtps/messages/submessages/heartbeat_frag.rs
@@ -9,6 +9,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HeartbeatFragSubmessage {
@@ -74,12 +75,12 @@ impl HeartbeatFragSubmessage {
 }
 
 impl Submessage for HeartbeatFragSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::HEARTBEAT_FRAG, &[], octets_to_next_header)
-            .write_into_bytes(&mut buf);
+            .write_into_bytes(&mut Cursor::new(buf));
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
         self.writer_sn.write_into_bytes(buf);

--- a/dds/src/rtps/messages/submessages/heartbeat_frag.rs
+++ b/dds/src/rtps/messages/submessages/heartbeat_frag.rs
@@ -9,7 +9,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HeartbeatFragSubmessage {
@@ -93,7 +93,7 @@ impl Submessage for HeartbeatFragSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
+        messages::overall_structure::write_submessage_into_bytes_vec,
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 

--- a/dds/src/rtps/messages/submessages/heartbeat_frag.rs
+++ b/dds/src/rtps/messages/submessages/heartbeat_frag.rs
@@ -9,7 +9,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct HeartbeatFragSubmessage {
@@ -75,12 +75,12 @@ impl HeartbeatFragSubmessage {
 }
 
 impl Submessage for HeartbeatFragSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut dyn Write) {
         SubmessageHeaderWrite::new(SubmessageKind::HEARTBEAT_FRAG, &[], octets_to_next_header)
-            .write_into_bytes(&mut Cursor::new(buf));
+            .write_into_bytes(buf);
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut dyn Write) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
         self.writer_sn.write_into_bytes(buf);
@@ -93,7 +93,7 @@ impl Submessage for HeartbeatFragSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::write_into_bytes_vec,
+        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 
@@ -107,7 +107,7 @@ mod tests {
             2,
         );
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x13_u8, 0b_0000_0001, 24, 0, // Submessage header
                 1, 2, 3, 4, // readerId: value[4]
                 6, 7, 8, 9, // writerId: value[4]

--- a/dds/src/rtps/messages/submessages/info_destination.rs
+++ b/dds/src/rtps/messages/submessages/info_destination.rs
@@ -9,7 +9,7 @@ use super::super::super::{
     },
     types::GuidPrefix,
 };
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoDestinationSubmessage {
@@ -41,12 +41,12 @@ impl InfoDestinationSubmessage {
 }
 
 impl Submessage for InfoDestinationSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut dyn Write) {
         SubmessageHeaderWrite::new(SubmessageKind::INFO_DST, &[], octets_to_next_header)
-            .write_into_bytes(&mut Cursor::new(buf));
+            .write_into_bytes(buf);
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut dyn Write) {
         self.guid_prefix.write_into_bytes(buf);
     }
 }
@@ -55,7 +55,8 @@ impl Submessage for InfoDestinationSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::write_into_bytes_vec, types::GUIDPREFIX_UNKNOWN,
+        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
+        types::GUIDPREFIX_UNKNOWN,
     };
 
     #[test]
@@ -63,7 +64,7 @@ mod tests {
         let guid_prefix = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         let submessage = InfoDestinationSubmessage::new(guid_prefix);
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
               0x0e, 0b_0000_0001, 12, 0, // Submessage header
                 1, 2, 3, 4, //guid_prefix
                 5, 6, 7, 8, //guid_prefix

--- a/dds/src/rtps/messages/submessages/info_destination.rs
+++ b/dds/src/rtps/messages/submessages/info_destination.rs
@@ -9,6 +9,7 @@ use super::super::super::{
     },
     types::GuidPrefix,
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoDestinationSubmessage {
@@ -40,12 +41,12 @@ impl InfoDestinationSubmessage {
 }
 
 impl Submessage for InfoDestinationSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::INFO_DST, &[], octets_to_next_header)
-            .write_into_bytes(&mut buf);
+            .write_into_bytes(&mut Cursor::new(buf));
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.guid_prefix.write_into_bytes(buf);
     }
 }

--- a/dds/src/rtps/messages/submessages/info_destination.rs
+++ b/dds/src/rtps/messages/submessages/info_destination.rs
@@ -9,7 +9,7 @@ use super::super::super::{
     },
     types::GuidPrefix,
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoDestinationSubmessage {
@@ -55,8 +55,7 @@ impl Submessage for InfoDestinationSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
-        types::GUIDPREFIX_UNKNOWN,
+        messages::overall_structure::write_submessage_into_bytes_vec, types::GUIDPREFIX_UNKNOWN,
     };
 
     #[test]

--- a/dds/src/rtps/messages/submessages/info_reply.rs
+++ b/dds/src/rtps/messages/submessages/info_reply.rs
@@ -9,7 +9,7 @@ use super::super::super::{
         types::{SubmessageFlag, SubmessageKind},
     },
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoReplySubmessage {
@@ -83,8 +83,7 @@ impl InfoReplySubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
-        types::Locator,
+        messages::overall_structure::write_submessage_into_bytes_vec, types::Locator,
     };
 
     #[test]

--- a/dds/src/rtps/messages/submessages/info_reply.rs
+++ b/dds/src/rtps/messages/submessages/info_reply.rs
@@ -9,6 +9,7 @@ use super::super::super::{
         types::{SubmessageFlag, SubmessageKind},
     },
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoReplySubmessage {
@@ -51,12 +52,12 @@ impl InfoReplySubmessage {
 }
 
 impl Submessage for InfoReplySubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::INFO_REPLY, &[], octets_to_next_header)
-            .write_into_bytes(&mut buf);
+            .write_into_bytes(&mut Cursor::new(buf));
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.unicast_locator_list.write_into_bytes(buf);
         if self.multicast_flag {
             self.multicast_locator_list.write_into_bytes(buf);

--- a/dds/src/rtps/messages/submessages/info_source.rs
+++ b/dds/src/rtps/messages/submessages/info_source.rs
@@ -9,7 +9,7 @@ use super::super::super::{
     },
     types::{GuidPrefix, Long, ProtocolVersion, VendorId},
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoSourceSubmessage {
@@ -77,7 +77,7 @@ impl Submessage for InfoSourceSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
+        messages::overall_structure::write_submessage_into_bytes_vec,
         types::{GUIDPREFIX_UNKNOWN, PROTOCOLVERSION_1_0, VENDOR_ID_UNKNOWN},
     };
 

--- a/dds/src/rtps/messages/submessages/info_source.rs
+++ b/dds/src/rtps/messages/submessages/info_source.rs
@@ -9,6 +9,7 @@ use super::super::super::{
     },
     types::{GuidPrefix, Long, ProtocolVersion, VendorId},
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoSourceSubmessage {
@@ -59,12 +60,12 @@ impl InfoSourceSubmessage {
 }
 
 impl Submessage for InfoSourceSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::INFO_SRC, &[], octets_to_next_header)
-            .write_into_bytes(&mut buf);
+            .write_into_bytes(&mut Cursor::new(buf));
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         0_u32.write_into_bytes(buf);
         self.protocol_version.write_into_bytes(buf);
         self.vendor_id.write_into_bytes(buf);

--- a/dds/src/rtps/messages/submessages/info_timestamp.rs
+++ b/dds/src/rtps/messages/submessages/info_timestamp.rs
@@ -7,6 +7,7 @@ use super::super::super::{
         types::{SubmessageFlag, SubmessageKind, Time, TIME_INVALID},
     },
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoTimestampSubmessage {
@@ -50,16 +51,16 @@ impl InfoTimestampSubmessage {
 }
 
 impl Submessage for InfoTimestampSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(
             SubmessageKind::INFO_TS,
             &[self.invalidate_flag],
             octets_to_next_header,
         )
-        .write_into_bytes(&mut buf);
+        .write_into_bytes(&mut Cursor::new(buf));
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         if !self.invalidate_flag {
             self.timestamp.write_into_bytes(buf);
         }

--- a/dds/src/rtps/messages/submessages/info_timestamp.rs
+++ b/dds/src/rtps/messages/submessages/info_timestamp.rs
@@ -7,7 +7,7 @@ use super::super::super::{
         types::{SubmessageFlag, SubmessageKind, Time, TIME_INVALID},
     },
 };
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoTimestampSubmessage {
@@ -51,16 +51,16 @@ impl InfoTimestampSubmessage {
 }
 
 impl Submessage for InfoTimestampSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut dyn Write) {
         SubmessageHeaderWrite::new(
             SubmessageKind::INFO_TS,
             &[self.invalidate_flag],
             octets_to_next_header,
         )
-        .write_into_bytes(&mut Cursor::new(buf));
+        .write_into_bytes(buf);
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut dyn Write) {
         if !self.invalidate_flag {
             self.timestamp.write_into_bytes(buf);
         }
@@ -70,13 +70,15 @@ impl Submessage for InfoTimestampSubmessage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rtps::messages::overall_structure::write_into_bytes_vec;
+    use crate::rtps::messages::overall_structure::{
+        write_into_bytes_vec, write_submessage_into_bytes_vec,
+    };
 
     #[test]
     fn serialize_info_timestamp_valid_time() {
         let submessage = InfoTimestampSubmessage::new(false, Time::new(4, 0));
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x09_u8, 0b_0000_0001, 8, 0, // Submessage header
                 4, 0, 0, 0, // Time
                 0, 0, 0, 0, // Time
@@ -88,7 +90,7 @@ mod tests {
     fn serialize_info_timestamp_invalid_time() {
         let submessage = InfoTimestampSubmessage::new(true, TIME_INVALID);
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x09_u8, 0b_0000_0011, 0, 0, // Submessage header
             ]
         );

--- a/dds/src/rtps/messages/submessages/info_timestamp.rs
+++ b/dds/src/rtps/messages/submessages/info_timestamp.rs
@@ -7,7 +7,7 @@ use super::super::super::{
         types::{SubmessageFlag, SubmessageKind, Time, TIME_INVALID},
     },
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct InfoTimestampSubmessage {
@@ -70,9 +70,7 @@ impl Submessage for InfoTimestampSubmessage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rtps::messages::overall_structure::{
-        write_into_bytes_vec, write_submessage_into_bytes_vec,
-    };
+    use crate::rtps::messages::overall_structure::write_submessage_into_bytes_vec;
 
     #[test]
     fn serialize_info_timestamp_valid_time() {

--- a/dds/src/rtps/messages/submessages/nack_frag.rs
+++ b/dds/src/rtps/messages/submessages/nack_frag.rs
@@ -10,7 +10,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct NackFragSubmessage {
@@ -94,7 +94,7 @@ impl Submessage for NackFragSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
+        messages::overall_structure::write_submessage_into_bytes_vec,
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 

--- a/dds/src/rtps/messages/submessages/nack_frag.rs
+++ b/dds/src/rtps/messages/submessages/nack_frag.rs
@@ -10,7 +10,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct NackFragSubmessage {
@@ -76,12 +76,12 @@ impl NackFragSubmessage {
 }
 
 impl Submessage for NackFragSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut dyn Write) {
         SubmessageHeaderWrite::new(SubmessageKind::NACK_FRAG, &[], octets_to_next_header)
-            .write_into_bytes(&mut Cursor::new(buf));
+            .write_into_bytes(buf);
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut dyn Write) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
         self.writer_sn.write_into_bytes(buf);
@@ -94,7 +94,7 @@ impl Submessage for NackFragSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::{
-        messages::overall_structure::write_into_bytes_vec,
+        messages::overall_structure::{write_into_bytes_vec, write_submessage_into_bytes_vec},
         types::{USER_DEFINED_READER_GROUP, USER_DEFINED_READER_NO_KEY},
     };
 
@@ -108,7 +108,7 @@ mod tests {
             6,
         );
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x12_u8, 0b_0000_0001, 28, 0, // Submessage header
                 1, 2, 3, 4, // readerId: value[4]
                 6, 7, 8, 9, // writerId: value[4]

--- a/dds/src/rtps/messages/submessages/nack_frag.rs
+++ b/dds/src/rtps/messages/submessages/nack_frag.rs
@@ -10,6 +10,7 @@ use super::super::super::{
     },
     types::{EntityId, SequenceNumber},
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct NackFragSubmessage {
@@ -75,12 +76,12 @@ impl NackFragSubmessage {
 }
 
 impl Submessage for NackFragSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::NACK_FRAG, &[], octets_to_next_header)
-            .write_into_bytes(&mut buf);
+            .write_into_bytes(&mut Cursor::new(buf));
     }
 
-    fn write_submessage_elements_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_submessage_elements_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.reader_id.write_into_bytes(buf);
         self.writer_id.write_into_bytes(buf);
         self.writer_sn.write_into_bytes(buf);

--- a/dds/src/rtps/messages/submessages/pad.rs
+++ b/dds/src/rtps/messages/submessages/pad.rs
@@ -7,7 +7,7 @@ use super::super::super::{
         types::SubmessageKind,
     },
 };
-use std::io::{Cursor, Write};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PadSubmessage {}
@@ -46,7 +46,7 @@ impl Submessage for PadSubmessage {
 mod tests {
     use super::*;
     use crate::rtps::messages::overall_structure::{
-        write_into_bytes_vec, write_submessage_into_bytes_vec, SubmessageHeaderRead,
+        write_submessage_into_bytes_vec, SubmessageHeaderRead,
     };
 
     #[test]

--- a/dds/src/rtps/messages/submessages/pad.rs
+++ b/dds/src/rtps/messages/submessages/pad.rs
@@ -7,6 +7,7 @@ use super::super::super::{
         types::SubmessageKind,
     },
 };
+use std::io::Cursor;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PadSubmessage {}
@@ -33,12 +34,12 @@ impl Default for PadSubmessage {
 }
 
 impl Submessage for PadSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, mut buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
         SubmessageHeaderWrite::new(SubmessageKind::PAD, &[], octets_to_next_header)
-            .write_into_bytes(&mut buf);
+            .write_into_bytes(&mut Cursor::new(buf));
     }
 
-    fn write_submessage_elements_into_bytes(&self, _buf: &mut &mut [u8]) {}
+    fn write_submessage_elements_into_bytes(&self, _buf: &mut Cursor<&mut [u8]>) {}
 }
 
 #[cfg(test)]

--- a/dds/src/rtps/messages/submessages/pad.rs
+++ b/dds/src/rtps/messages/submessages/pad.rs
@@ -7,7 +7,7 @@ use super::super::super::{
         types::SubmessageKind,
     },
 };
-use std::io::Cursor;
+use std::io::{Cursor, Write};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PadSubmessage {}
@@ -34,24 +34,26 @@ impl Default for PadSubmessage {
 }
 
 impl Submessage for PadSubmessage {
-    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut [u8]) {
+    fn write_submessage_header_into_bytes(&self, octets_to_next_header: u16, buf: &mut dyn Write) {
         SubmessageHeaderWrite::new(SubmessageKind::PAD, &[], octets_to_next_header)
-            .write_into_bytes(&mut Cursor::new(buf));
+            .write_into_bytes(buf);
     }
 
-    fn write_submessage_elements_into_bytes(&self, _buf: &mut Cursor<&mut [u8]>) {}
+    fn write_submessage_elements_into_bytes(&self, _buf: &mut dyn Write) {}
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rtps::messages::overall_structure::{write_into_bytes_vec, SubmessageHeaderRead};
+    use crate::rtps::messages::overall_structure::{
+        write_into_bytes_vec, write_submessage_into_bytes_vec, SubmessageHeaderRead,
+    };
 
     #[test]
     fn serialize_pad() {
         let submessage = PadSubmessage::new();
         #[rustfmt::skip]
-        assert_eq!(write_into_bytes_vec(submessage), vec![
+        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
                 0x01, 0b_0000_0001, 0, 0, // Submessage header
             ]
         );

--- a/dds/src/rtps/messages/types.rs
+++ b/dds/src/rtps/messages/types.rs
@@ -2,7 +2,7 @@ use super::{
     super::error::RtpsResult,
     overall_structure::{Endianness, TryReadFromBytes, WriteIntoBytes},
 };
-use std::io::{Cursor, Read, Write};
+use std::io::{Read, Write};
 
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.5
 /// Table 8.13 - Types used to define RTPS messages

--- a/dds/src/rtps/messages/types.rs
+++ b/dds/src/rtps/messages/types.rs
@@ -2,7 +2,7 @@ use super::{
     super::error::RtpsResult,
     overall_structure::{Endianness, TryReadFromBytes, WriteIntoBytes},
 };
-use std::io::Read;
+use std::io::{Cursor, Read};
 
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.5
 /// Table 8.13 - Types used to define RTPS messages
@@ -67,7 +67,7 @@ pub enum ProtocolId {
 }
 
 impl WriteIntoBytes for ProtocolId {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         b"RTPS".write_into_bytes(buf);
     }
 }
@@ -113,7 +113,7 @@ pub const NACK_FRAG: u8 = 0x12;
 pub const HEARTBEAT_FRAG: u8 = 0x13;
 
 impl WriteIntoBytes for SubmessageKind {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         let data = match self {
             SubmessageKind::DATA => DATA,
             SubmessageKind::GAP => GAP,
@@ -171,7 +171,7 @@ pub const TIME_INVALID: Time = Time::new(0xffffffff, 0xffffffff);
 pub const TIME_INFINITE: Time = Time::new(0xffffffff, 0xfffffffe);
 
 impl WriteIntoBytes for Time {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.seconds.write_into_bytes(buf);
         self.fraction.write_into_bytes(buf);
     }

--- a/dds/src/rtps/messages/types.rs
+++ b/dds/src/rtps/messages/types.rs
@@ -2,7 +2,7 @@ use super::{
     super::error::RtpsResult,
     overall_structure::{Endianness, TryReadFromBytes, WriteIntoBytes},
 };
-use std::io::{Cursor, Read};
+use std::io::{Cursor, Read, Write};
 
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.5
 /// Table 8.13 - Types used to define RTPS messages
@@ -67,7 +67,7 @@ pub enum ProtocolId {
 }
 
 impl WriteIntoBytes for ProtocolId {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         b"RTPS".write_into_bytes(buf);
     }
 }
@@ -113,7 +113,7 @@ pub const NACK_FRAG: u8 = 0x12;
 pub const HEARTBEAT_FRAG: u8 = 0x13;
 
 impl WriteIntoBytes for SubmessageKind {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         let data = match self {
             SubmessageKind::DATA => DATA,
             SubmessageKind::GAP => GAP,
@@ -171,7 +171,7 @@ pub const TIME_INVALID: Time = Time::new(0xffffffff, 0xffffffff);
 pub const TIME_INFINITE: Time = Time::new(0xffffffff, 0xfffffffe);
 
 impl WriteIntoBytes for Time {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         self.seconds.write_into_bytes(buf);
         self.fraction.write_into_bytes(buf);
     }

--- a/dds/src/rtps/types.rs
+++ b/dds/src/rtps/types.rs
@@ -5,7 +5,7 @@ use super::{
 use crate::serialized_payload::cdr::{deserialize::CdrDeserialize, serialize::CdrSerialize};
 use network_interface::Addr;
 use std::{
-    io::{Cursor, Read, Write},
+    io::{Read, Write},
     net::IpAddr,
 };
 

--- a/dds/src/rtps/types.rs
+++ b/dds/src/rtps/types.rs
@@ -19,43 +19,43 @@ pub type Long = i32;
 pub type UnsignedLong = u32;
 
 impl WriteIntoBytes for Octet {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(&[*self]).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for Long {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self.to_le_bytes().as_slice()).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for UnsignedLong {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self.to_le_bytes().as_slice()).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for u16 {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self.to_le_bytes().as_slice()).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for i16 {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self.to_le_bytes().as_slice()).expect("buffer big enough");
     }
 }
 
 impl<const N: usize> WriteIntoBytes for [Octet; N] {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for &[u8] {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self).expect("buffer big enough");
     }
 }
@@ -190,7 +190,7 @@ pub const ENTITYID_UNKNOWN: EntityId = EntityId::new([0; 3], USER_DEFINED_UNKNOW
 pub const ENTITYID_PARTICIPANT: EntityId = EntityId::new([0, 0, 0x01], BUILT_IN_PARTICIPANT);
 
 impl WriteIntoBytes for EntityId {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         self.entity_key().write_into_bytes(buf);
         self.entity_kind().write_into_bytes(buf);
     }
@@ -234,7 +234,7 @@ impl TryReadFromBytes for SequenceNumber {
 }
 
 impl WriteIntoBytes for SequenceNumber {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         let high = (*self >> 32) as Long;
         let low = *self as UnsignedLong;
         high.write_into_bytes(buf);
@@ -254,7 +254,7 @@ pub struct Locator {
 }
 
 impl WriteIntoBytes for Locator {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         self.kind.write_into_bytes(buf);
         self.port.write_into_bytes(buf);
         self.address.write_into_bytes(buf);
@@ -402,7 +402,7 @@ impl TryReadFromBytes for ProtocolVersion {
 }
 
 impl WriteIntoBytes for ProtocolVersion {
-    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
         self.bytes.write_into_bytes(buf);
     }
 }

--- a/dds/src/rtps/types.rs
+++ b/dds/src/rtps/types.rs
@@ -4,7 +4,10 @@ use super::{
 };
 use crate::serialized_payload::cdr::{deserialize::CdrDeserialize, serialize::CdrSerialize};
 use network_interface::Addr;
-use std::{io::Read, net::IpAddr};
+use std::{
+    io::{Cursor, Read, Write},
+    net::IpAddr,
+};
 
 ///
 /// This files shall only contain the types as listed in the DDSI-RTPS Version 2.5
@@ -16,58 +19,44 @@ pub type Long = i32;
 pub type UnsignedLong = u32;
 
 impl WriteIntoBytes for Octet {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
-        let (a, b) = std::mem::take(buf).split_at_mut(1);
-        a[0] = *self;
-        *buf = b;
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+        buf.write_all(&[*self]).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for Long {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
-        let (a, b) = std::mem::take(buf).split_at_mut(4);
-        a.copy_from_slice(self.to_le_bytes().as_slice());
-        *buf = b;
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+        buf.write_all(self.to_le_bytes().as_slice()).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for UnsignedLong {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
-        let (a, b) = std::mem::take(buf).split_at_mut(4);
-        a.copy_from_slice(self.to_le_bytes().as_slice());
-        *buf = b;
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+        buf.write_all(self.to_le_bytes().as_slice()).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for u16 {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
-        let (a, b) = std::mem::take(buf).split_at_mut(2);
-        a.copy_from_slice(self.to_le_bytes().as_slice());
-        *buf = b;
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+        buf.write_all(self.to_le_bytes().as_slice()).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for i16 {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
-        let (a, b) = std::mem::take(buf).split_at_mut(2);
-        a.copy_from_slice(self.to_le_bytes().as_slice());
-        *buf = b;
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+        buf.write_all(self.to_le_bytes().as_slice()).expect("buffer big enough");
     }
 }
 
 impl<const N: usize> WriteIntoBytes for [Octet; N] {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
-        let (a, b) = std::mem::take(buf).split_at_mut(N);
-        a.copy_from_slice(self);
-        *buf = b;
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+        buf.write_all(self).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for &[u8] {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
-        let (a, b) = std::mem::take(buf).split_at_mut(self.len());
-        a.copy_from_slice(self);
-        *buf = b;
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
+        buf.write_all(self).expect("buffer big enough");
     }
 }
 
@@ -201,7 +190,7 @@ pub const ENTITYID_UNKNOWN: EntityId = EntityId::new([0; 3], USER_DEFINED_UNKNOW
 pub const ENTITYID_PARTICIPANT: EntityId = EntityId::new([0, 0, 0x01], BUILT_IN_PARTICIPANT);
 
 impl WriteIntoBytes for EntityId {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.entity_key().write_into_bytes(buf);
         self.entity_kind().write_into_bytes(buf);
     }
@@ -245,7 +234,7 @@ impl TryReadFromBytes for SequenceNumber {
 }
 
 impl WriteIntoBytes for SequenceNumber {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         let high = (*self >> 32) as Long;
         let low = *self as UnsignedLong;
         high.write_into_bytes(buf);
@@ -265,7 +254,7 @@ pub struct Locator {
 }
 
 impl WriteIntoBytes for Locator {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.kind.write_into_bytes(buf);
         self.port.write_into_bytes(buf);
         self.address.write_into_bytes(buf);
@@ -413,7 +402,7 @@ impl TryReadFromBytes for ProtocolVersion {
 }
 
 impl WriteIntoBytes for ProtocolVersion {
-    fn write_into_bytes(&self, buf: &mut &mut [u8]) {
+    fn write_into_bytes(&self, buf: &mut Cursor<&mut [u8]>) {
         self.bytes.write_into_bytes(buf);
     }
 }


### PR DESCRIPTION
Serialize the RTPS Message into a Vec instead of a stack allocated array. This avoids having to initialize the whole array and saves a re-allocation when moving the contents into an Arc.