### PR TITLE
Performance optimization: Replace actor channel by unbounded channel

### DIFF
--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -39,8 +39,7 @@ impl StatusConditionAsync {
     pub async fn get_enabled_statuses(&self) -> DdsResult<Vec<StatusKind>> {
         Ok(self
             .address
-            .send_actor_mail(status_condition_actor::GetEnabledStatuses)
-            .await?
+            .send_actor_mail(status_condition_actor::GetEnabledStatuses)?
             .receive_reply()
             .await)
     }
@@ -51,8 +50,7 @@ impl StatusConditionAsync {
         self.address
             .send_actor_mail(status_condition_actor::SetEnabledStatuses {
                 mask: mask.to_vec(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await;
         Ok(())
@@ -71,8 +69,7 @@ impl StatusConditionAsync {
     pub async fn get_trigger_value(&self) -> DdsResult<bool> {
         Ok(self
             .address
-            .send_actor_mail(status_condition_actor::GetTriggerValue)
-            .await?
+            .send_actor_mail(status_condition_actor::GetTriggerValue)?
             .receive_reply()
             .await)
     }

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -91,20 +91,17 @@ impl<Foo> DataReaderAsync<Foo> {
         {
             let subscriber_qos = self
                 .subscriber_address()
-                .send_actor_mail(subscriber_actor::GetQos)
-                .await?
+                .send_actor_mail(subscriber_actor::GetQos)?
                 .receive_reply()
                 .await;
             let default_unicast_locator_list = self
                 .participant_address()
-                .send_actor_mail(domain_participant_actor::GetDefaultUnicastLocatorList)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetDefaultUnicastLocatorList)?
                 .receive_reply()
                 .await;
             let default_multicast_locator_list = self
                 .participant_address()
-                .send_actor_mail(domain_participant_actor::GetDefaultMulticastLocatorList)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetDefaultMulticastLocatorList)?
                 .receive_reply()
                 .await;
             let discovered_reader_data = self
@@ -113,8 +110,7 @@ impl<Foo> DataReaderAsync<Foo> {
                     subscriber_qos,
                     default_unicast_locator_list,
                     default_multicast_locator_list,
-                })
-                .await?
+                })?
                 .receive_reply()
                 .await?;
 
@@ -156,8 +152,7 @@ impl<Foo> DataReaderAsync<Foo> {
                 view_states: view_states.to_vec(),
                 instance_states: instance_states.to_vec(),
                 specific_instance_handle: None,
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
 
@@ -184,8 +179,7 @@ impl<Foo> DataReaderAsync<Foo> {
                 view_states: view_states.to_vec(),
                 instance_states: instance_states.to_vec(),
                 specific_instance_handle: None,
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
 
@@ -206,8 +200,7 @@ impl<Foo> DataReaderAsync<Foo> {
                 view_states: ANY_VIEW_STATE.to_vec(),
                 instance_states: ANY_INSTANCE_STATE.to_vec(),
                 specific_instance_handle: None,
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
         let (data, sample_info) = samples.pop().expect("Would return NoData if empty");
@@ -225,8 +218,7 @@ impl<Foo> DataReaderAsync<Foo> {
                 view_states: ANY_VIEW_STATE.to_vec(),
                 instance_states: ANY_INSTANCE_STATE.to_vec(),
                 specific_instance_handle: None,
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
         let (data, sample_info) = samples.pop().expect("Would return NoData if empty");
@@ -251,8 +243,7 @@ impl<Foo> DataReaderAsync<Foo> {
                 view_states: view_states.to_vec(),
                 instance_states: instance_states.to_vec(),
                 specific_instance_handle: Some(a_handle),
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
         Ok(samples
@@ -279,8 +270,7 @@ impl<Foo> DataReaderAsync<Foo> {
                 view_states: view_states.to_vec(),
                 instance_states: instance_states.to_vec(),
                 specific_instance_handle: Some(a_handle),
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
 
@@ -308,8 +298,7 @@ impl<Foo> DataReaderAsync<Foo> {
                 sample_states: sample_states.to_vec(),
                 view_states: view_states.to_vec(),
                 instance_states: instance_states.to_vec(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
         Ok(samples
@@ -336,8 +325,7 @@ impl<Foo> DataReaderAsync<Foo> {
                 sample_states: sample_states.to_vec(),
                 view_states: view_states.to_vec(),
                 instance_states: instance_states.to_vec(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
         Ok(samples
@@ -403,8 +391,7 @@ impl<Foo> DataReaderAsync<Foo> {
     pub async fn get_subscription_matched_status(&self) -> DdsResult<SubscriptionMatchedStatus> {
         Ok(self
             .reader_address
-            .send_actor_mail(data_reader_actor::GetSubscriptionMatchedStatus)
-            .await?
+            .send_actor_mail(data_reader_actor::GetSubscriptionMatchedStatus)?
             .receive_reply()
             .await)
     }
@@ -428,8 +415,7 @@ impl<Foo> DataReaderAsync<Foo> {
             loop {
                 if self
                     .reader_address
-                    .send_actor_mail(data_reader_actor::IsHistoricalDataReceived)
-                    .await?
+                    .send_actor_mail(data_reader_actor::IsHistoricalDataReceived)?
                     .receive_reply()
                     .await?
                 {
@@ -448,8 +434,7 @@ impl<Foo> DataReaderAsync<Foo> {
         publication_handle: InstanceHandle,
     ) -> DdsResult<PublicationBuiltinTopicData> {
         self.reader_address
-            .send_actor_mail(data_reader_actor::GetMatchedPublicationData { publication_handle })
-            .await?
+            .send_actor_mail(data_reader_actor::GetMatchedPublicationData { publication_handle })?
             .receive_reply()
             .await
     }
@@ -459,8 +444,7 @@ impl<Foo> DataReaderAsync<Foo> {
     pub async fn get_matched_publications(&self) -> DdsResult<Vec<InstanceHandle>> {
         Ok(self
             .reader_address
-            .send_actor_mail(data_reader_actor::GetMatchedPublications)
-            .await?
+            .send_actor_mail(data_reader_actor::GetMatchedPublications)?
             .receive_reply()
             .await)
     }
@@ -472,8 +456,7 @@ impl<Foo> DataReaderAsync<Foo> {
         let qos = match qos {
             QosKind::Default => {
                 self.subscriber_address()
-                    .send_actor_mail(subscriber_actor::GetDefaultDatareaderQos)
-                    .await?
+                    .send_actor_mail(subscriber_actor::GetDefaultDatareaderQos)?
                     .receive_reply()
                     .await
             }
@@ -481,14 +464,12 @@ impl<Foo> DataReaderAsync<Foo> {
         };
 
         self.reader_address
-            .send_actor_mail(data_reader_actor::SetQos { qos })
-            .await?
+            .send_actor_mail(data_reader_actor::SetQos { qos })?
             .receive_reply()
             .await?;
         if self
             .reader_address
-            .send_actor_mail(data_reader_actor::IsEnabled)
-            .await?
+            .send_actor_mail(data_reader_actor::IsEnabled)?
             .receive_reply()
             .await
         {
@@ -503,8 +484,7 @@ impl<Foo> DataReaderAsync<Foo> {
     pub async fn get_qos(&self) -> DdsResult<DataReaderQos> {
         Ok(self
             .reader_address
-            .send_actor_mail(data_reader_actor::GetQos)
-            .await?
+            .send_actor_mail(data_reader_actor::GetQos)?
             .receive_reply()
             .await)
     }
@@ -529,14 +509,12 @@ impl<Foo> DataReaderAsync<Foo> {
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
             .reader_address
-            .send_actor_mail(data_reader_actor::IsEnabled)
-            .await?
+            .send_actor_mail(data_reader_actor::IsEnabled)?
             .receive_reply()
             .await
         {
             self.reader_address
-                .send_actor_mail(data_reader_actor::Enable)
-                .await?
+                .send_actor_mail(data_reader_actor::Enable)?
                 .receive_reply()
                 .await;
 
@@ -550,8 +528,7 @@ impl<Foo> DataReaderAsync<Foo> {
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         Ok(self
             .reader_address
-            .send_actor_mail(data_reader_actor::GetInstanceHandle)
-            .await?
+            .send_actor_mail(data_reader_actor::GetInstanceHandle)?
             .receive_reply()
             .await)
     }
@@ -574,8 +551,7 @@ where
                     .map::<Box<dyn AnyDataReaderListener + Send>, _>(|b| Box::new(b)),
                 status_kind: mask.to_vec(),
                 runtime_handle: self.runtime_handle().clone(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await;
         Ok(())

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -100,14 +100,12 @@ impl<Foo> DataWriterAsync<Foo> {
             let publisher_qos = self.get_publisher().get_qos().await?;
             let default_unicast_locator_list = self
                 .participant_address()
-                .send_actor_mail(domain_participant_actor::GetDefaultUnicastLocatorList)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetDefaultUnicastLocatorList)?
                 .receive_reply()
                 .await;
             let default_multicast_locator_list = self
                 .participant_address()
-                .send_actor_mail(domain_participant_actor::GetDefaultMulticastLocatorList)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetDefaultMulticastLocatorList)?
                 .receive_reply()
                 .await;
             let discovered_writer_data = self
@@ -116,8 +114,7 @@ impl<Foo> DataWriterAsync<Foo> {
                     publisher_qos,
                     default_unicast_locator_list,
                     default_multicast_locator_list,
-                })
-                .await?
+                })?
                 .receive_reply()
                 .await?;
             sedp_publications_announcer
@@ -137,8 +134,7 @@ where
     pub async fn register_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
         let timestamp = self
             .participant_address()
-            .send_actor_mail(domain_participant_actor::GetCurrentTime)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetCurrentTime)?
             .receive_reply()
             .await;
         self.register_instance_w_timestamp(instance, timestamp)
@@ -164,8 +160,7 @@ where
     ) -> DdsResult<()> {
         let timestamp = self
             .participant_address()
-            .send_actor_mail(domain_participant_actor::GetCurrentTime)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetCurrentTime)?
             .receive_reply()
             .await;
         self.unregister_instance_w_timestamp(instance, handle, timestamp)
@@ -183,8 +178,7 @@ where
         let type_support = self
             .topic
             .topic_address()
-            .send_actor_mail(topic_actor::GetTypeSupport)
-            .await?
+            .send_actor_mail(topic_actor::GetTypeSupport)?
             .receive_reply()
             .await;
         let has_key = type_support.has_key();
@@ -220,14 +214,12 @@ where
                 type_support.get_serialized_key_from_serialized_foo(&serialized_foo)?;
             let message_sender_actor = self
                 .participant_address()
-                .send_actor_mail(domain_participant_actor::GetMessageSender)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetMessageSender)?
                 .receive_reply()
                 .await;
             let now = self
                 .participant_address()
-                .send_actor_mail(domain_participant_actor::GetCurrentTime)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetCurrentTime)?
                 .receive_reply()
                 .await;
 
@@ -239,8 +231,7 @@ where
                     message_sender_actor,
                     now,
                     data_writer_address: self.writer_address.clone(),
-                })
-                .await?
+                })?
                 .receive_reply()
                 .await
         } else {
@@ -264,8 +255,7 @@ where
         let type_support = self
             .topic
             .topic_address()
-            .send_actor_mail(topic_actor::GetTypeSupport)
-            .await?
+            .send_actor_mail(topic_actor::GetTypeSupport)?
             .receive_reply()
             .await;
 
@@ -274,8 +264,7 @@ where
         let instance_handle = type_support.instance_handle_from_serialized_foo(&serialized_foo)?;
 
         self.writer_address
-            .send_actor_mail(data_writer_actor::LookupInstance { instance_handle })
-            .await?
+            .send_actor_mail(data_writer_actor::LookupInstance { instance_handle })?
             .receive_reply()
             .await
     }
@@ -285,8 +274,7 @@ where
     pub async fn write(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
         let timestamp = self
             .participant_address()
-            .send_actor_mail(domain_participant_actor::GetCurrentTime)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetCurrentTime)?
             .receive_reply()
             .await;
         self.write_w_timestamp(data, handle, timestamp).await
@@ -303,8 +291,7 @@ where
         let type_support = self
             .topic
             .topic_address()
-            .send_actor_mail(topic_actor::GetTypeSupport)
-            .await?
+            .send_actor_mail(topic_actor::GetTypeSupport)?
             .receive_reply()
             .await;
 
@@ -314,14 +301,12 @@ where
 
         let message_sender_actor = self
             .participant_address()
-            .send_actor_mail(domain_participant_actor::GetMessageSender)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetMessageSender)?
             .receive_reply()
             .await;
         let now = self
             .participant_address()
-            .send_actor_mail(domain_participant_actor::GetCurrentTime)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetCurrentTime)?
             .receive_reply()
             .await;
         self.writer_address
@@ -333,8 +318,7 @@ where
                 message_sender_actor,
                 now,
                 data_writer_address: self.writer_address.clone(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
 
@@ -346,8 +330,7 @@ where
     pub async fn dispose(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
         let timestamp = self
             .participant_address()
-            .send_actor_mail(domain_participant_actor::GetCurrentTime)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetCurrentTime)?
             .receive_reply()
             .await;
         self.dispose_w_timestamp(data, handle, timestamp).await
@@ -389,8 +372,7 @@ where
         let type_support = self
             .topic
             .topic_address()
-            .send_actor_mail(topic_actor::GetTypeSupport)
-            .await?
+            .send_actor_mail(topic_actor::GetTypeSupport)?
             .receive_reply()
             .await;
 
@@ -399,14 +381,12 @@ where
         let key = type_support.get_serialized_key_from_serialized_foo(&serialized_foo)?;
         let message_sender_actor = self
             .participant_address()
-            .send_actor_mail(domain_participant_actor::GetMessageSender)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetMessageSender)?
             .receive_reply()
             .await;
         let now = self
             .participant_address()
-            .send_actor_mail(domain_participant_actor::GetCurrentTime)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetCurrentTime)?
             .receive_reply()
             .await;
         self.writer_address
@@ -417,8 +397,7 @@ where
                 message_sender_actor,
                 now,
                 data_writer_address: self.writer_address.clone(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await
     }
@@ -432,8 +411,7 @@ impl<Foo> DataWriterAsync<Foo> {
             loop {
                 if self
                     .writer_address
-                    .send_actor_mail(data_writer_actor::AreAllChangesAcknowledge)
-                    .await?
+                    .send_actor_mail(data_writer_actor::AreAllChangesAcknowledge)?
                     .receive_reply()
                     .await
                 {
@@ -472,8 +450,7 @@ impl<Foo> DataWriterAsync<Foo> {
     pub async fn get_publication_matched_status(&self) -> DdsResult<PublicationMatchedStatus> {
         Ok(self
             .writer_address
-            .send_actor_mail(data_writer_actor::GetPublicationMatchedStatus)
-            .await?
+            .send_actor_mail(data_writer_actor::GetPublicationMatchedStatus)?
             .receive_reply()
             .await)
     }
@@ -505,8 +482,7 @@ impl<Foo> DataWriterAsync<Foo> {
         self.writer_address
             .send_actor_mail(data_writer_actor::GetMatchedSubscriptionData {
                 handle: subscription_handle,
-            })
-            .await?
+            })?
             .receive_reply()
             .await
             .ok_or(DdsError::BadParameter)
@@ -517,8 +493,7 @@ impl<Foo> DataWriterAsync<Foo> {
     pub async fn get_matched_subscriptions(&self) -> DdsResult<Vec<InstanceHandle>> {
         Ok(self
             .writer_address
-            .send_actor_mail(data_writer_actor::GetMatchedSubscriptions)
-            .await?
+            .send_actor_mail(data_writer_actor::GetMatchedSubscriptions)?
             .receive_reply()
             .await)
     }
@@ -531,8 +506,7 @@ impl<Foo> DataWriterAsync<Foo> {
         let qos = match qos {
             QosKind::Default => {
                 self.publisher_address()
-                    .send_actor_mail(publisher_actor::GetDefaultDatawriterQos)
-                    .await?
+                    .send_actor_mail(publisher_actor::GetDefaultDatawriterQos)?
                     .receive_reply()
                     .await
             }
@@ -540,14 +514,12 @@ impl<Foo> DataWriterAsync<Foo> {
         };
 
         self.writer_address
-            .send_actor_mail(data_writer_actor::SetQos { qos })
-            .await?
+            .send_actor_mail(data_writer_actor::SetQos { qos })?
             .receive_reply()
             .await?;
         if self
             .writer_address
-            .send_actor_mail(data_writer_actor::IsEnabled)
-            .await?
+            .send_actor_mail(data_writer_actor::IsEnabled)?
             .receive_reply()
             .await
         {
@@ -562,8 +534,7 @@ impl<Foo> DataWriterAsync<Foo> {
     pub async fn get_qos(&self) -> DdsResult<DataWriterQos> {
         Ok(self
             .writer_address
-            .send_actor_mail(data_writer_actor::GetQos)
-            .await?
+            .send_actor_mail(data_writer_actor::GetQos)?
             .receive_reply()
             .await)
     }
@@ -588,15 +559,13 @@ impl<Foo> DataWriterAsync<Foo> {
     pub async fn enable(&self) -> DdsResult<()> {
         let writer = self.writer_address();
         if !writer
-            .send_actor_mail(data_writer_actor::IsEnabled)
-            .await?
+            .send_actor_mail(data_writer_actor::IsEnabled)?
             .receive_reply()
             .await
         {
             let message_sender_actor = self
                 .participant_address()
-                .send_actor_mail(domain_participant_actor::GetMessageSender)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetMessageSender)?
                 .receive_reply()
                 .await;
             writer
@@ -604,8 +573,7 @@ impl<Foo> DataWriterAsync<Foo> {
                     data_writer_address: writer.clone(),
                     message_sender_actor,
                     runtime_handle: self.runtime_handle().clone(),
-                })
-                .await?
+                })?
                 .receive_reply()
                 .await;
 
@@ -619,8 +587,7 @@ impl<Foo> DataWriterAsync<Foo> {
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         Ok(self
             .writer_address
-            .send_actor_mail(data_writer_actor::GetInstanceHandle)
-            .await?
+            .send_actor_mail(data_writer_actor::GetInstanceHandle)?
             .receive_reply()
             .await)
     }
@@ -642,8 +609,7 @@ where
                     .map::<Box<dyn AnyDataWriterListener + Send>, _>(|b| Box::new(b)),
                 status_kind: mask.to_vec(),
                 runtime_handle: self.runtime_handle().clone(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await;
         Ok(())

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -75,8 +75,7 @@ impl DomainParticipantAsync {
     pub(crate) async fn announce_participant(&self) -> DdsResult<()> {
         if self
             .participant_address
-            .send_actor_mail(domain_participant_actor::IsEnabled)
-            .await?
+            .send_actor_mail(domain_participant_actor::IsEnabled)?
             .receive_reply()
             .await
         {
@@ -88,8 +87,7 @@ impl DomainParticipantAsync {
             {
                 let data = self
                     .participant_address
-                    .send_actor_mail(domain_participant_actor::AsSpdpDiscoveredParticipantData)
-                    .await?
+                    .send_actor_mail(domain_participant_actor::AsSpdpDiscoveredParticipantData)?
                     .receive_reply()
                     .await;
                 spdp_participant_writer.write(&data, None).await?;
@@ -105,7 +103,6 @@ impl DomainParticipantAsync {
         {
             let data = topic
                 .send_actor_mail(topic_actor::AsDiscoveredTopicData)
-                .await
                 .receive_reply()
                 .await;
             sedp_topics_announcer.dispose(&data, None).await?;
@@ -131,21 +128,18 @@ impl DomainParticipantAsync {
                 a_listener,
                 mask: mask.to_vec(),
                 runtime_handle: self.runtime_handle.clone(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await;
         let publisher = PublisherAsync::new(publisher_address, status_condition, self.clone());
         if self
             .participant_address
-            .send_actor_mail(domain_participant_actor::IsEnabled)
-            .await?
+            .send_actor_mail(domain_participant_actor::IsEnabled)?
             .receive_reply()
             .await
             && self
                 .participant_address
-                .send_actor_mail(domain_participant_actor::GetQos)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetQos)?
                 .receive_reply()
                 .await
                 .entity_factory
@@ -163,8 +157,7 @@ impl DomainParticipantAsync {
         self.participant_address
             .send_actor_mail(domain_participant_actor::DeleteUserDefinedPublisher {
                 handle: a_publisher.get_instance_handle().await?,
-            })
-            .await?
+            })?
             .receive_reply()
             .await
     }
@@ -184,8 +177,7 @@ impl DomainParticipantAsync {
                 a_listener,
                 mask: mask.to_vec(),
                 runtime_handle: self.runtime_handle.clone(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await;
 
@@ -197,14 +189,12 @@ impl DomainParticipantAsync {
 
         if self
             .participant_address
-            .send_actor_mail(domain_participant_actor::IsEnabled)
-            .await?
+            .send_actor_mail(domain_participant_actor::IsEnabled)?
             .receive_reply()
             .await
             && self
                 .participant_address
-                .send_actor_mail(domain_participant_actor::GetQos)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetQos)?
                 .receive_reply()
                 .await
                 .entity_factory
@@ -222,8 +212,7 @@ impl DomainParticipantAsync {
         self.participant_address
             .send_actor_mail(domain_participant_actor::DeleteUserDefinedSubscriber {
                 handle: a_subscriber.get_instance_handle().await?,
-            })
-            .await?
+            })?
             .receive_reply()
             .await
     }
@@ -268,8 +257,7 @@ impl DomainParticipantAsync {
                 mask: mask.to_vec(),
                 type_support: dynamic_type_representation.into(),
                 runtime_handle: self.runtime_handle.clone(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
         let topic = TopicAsync::new(
@@ -281,14 +269,12 @@ impl DomainParticipantAsync {
         );
         if self
             .participant_address
-            .send_actor_mail(domain_participant_actor::IsEnabled)
-            .await?
+            .send_actor_mail(domain_participant_actor::IsEnabled)?
             .receive_reply()
             .await
             && self
                 .participant_address
-                .send_actor_mail(domain_participant_actor::GetQos)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetQos)?
                 .receive_reply()
                 .await
                 .entity_factory
@@ -309,8 +295,7 @@ impl DomainParticipantAsync {
             self.participant_address
                 .send_actor_mail(domain_participant_actor::DeleteUserDefinedTopic {
                     topic_name: a_topic.get_name(),
-                })
-                .await?
+                })?
                 .receive_reply()
                 .await
         }
@@ -334,8 +319,7 @@ impl DomainParticipantAsync {
                         topic_name: topic_name.to_owned(),
                         type_support: Arc::new(FooTypeSupport::new::<Foo>()),
                         runtime_handle: self.runtime_handle.clone(),
-                    })
-                    .await?
+                    })?
                     .receive_reply()
                     .await?
                 {
@@ -360,8 +344,7 @@ impl DomainParticipantAsync {
             .participant_address
             .send_actor_mail(domain_participant_actor::LookupTopicdescription {
                 topic_name: topic_name.to_owned(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await?
         {
@@ -391,8 +374,7 @@ impl DomainParticipantAsync {
     #[tracing::instrument(skip(self))]
     pub async fn ignore_participant(&self, handle: InstanceHandle) -> DdsResult<()> {
         self.participant_address
-            .send_actor_mail(domain_participant_actor::IgnoreParticipant { handle })
-            .await?
+            .send_actor_mail(domain_participant_actor::IgnoreParticipant { handle })?
             .receive_reply()
             .await
     }
@@ -407,8 +389,7 @@ impl DomainParticipantAsync {
     #[tracing::instrument(skip(self))]
     pub async fn ignore_publication(&self, handle: InstanceHandle) -> DdsResult<()> {
         self.participant_address
-            .send_actor_mail(domain_participant_actor::IgnorePublication { handle })
-            .await?
+            .send_actor_mail(domain_participant_actor::IgnorePublication { handle })?
             .receive_reply()
             .await
     }
@@ -417,8 +398,7 @@ impl DomainParticipantAsync {
     #[tracing::instrument(skip(self))]
     pub async fn ignore_subscription(&self, handle: InstanceHandle) -> DdsResult<()> {
         self.participant_address
-            .send_actor_mail(domain_participant_actor::IgnoreSubscription { handle })
-            .await?
+            .send_actor_mail(domain_participant_actor::IgnoreSubscription { handle })?
             .receive_reply()
             .await
     }
@@ -434,8 +414,7 @@ impl DomainParticipantAsync {
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
         for deleted_publisher in self
             .participant_address
-            .send_actor_mail(domain_participant_actor::DrainPublisherList)
-            .await?
+            .send_actor_mail(domain_participant_actor::DrainPublisherList)?
             .receive_reply()
             .await
         {
@@ -443,7 +422,6 @@ impl DomainParticipantAsync {
                 deleted_publisher.address(),
                 deleted_publisher
                     .send_actor_mail(publisher_actor::GetStatuscondition)
-                    .await
                     .receive_reply()
                     .await,
                 self.clone(),
@@ -454,8 +432,7 @@ impl DomainParticipantAsync {
 
         for deleted_subscriber in self
             .participant_address
-            .send_actor_mail(domain_participant_actor::DrainSubscriberList)
-            .await?
+            .send_actor_mail(domain_participant_actor::DrainSubscriberList)?
             .receive_reply()
             .await
         {
@@ -463,7 +440,6 @@ impl DomainParticipantAsync {
                 deleted_subscriber.address(),
                 deleted_subscriber
                     .send_actor_mail(subscriber_actor::GetStatuscondition)
-                    .await
                     .receive_reply()
                     .await,
                 self.clone(),
@@ -474,8 +450,7 @@ impl DomainParticipantAsync {
 
         for deleted_topic in self
             .participant_address
-            .send_actor_mail(domain_participant_actor::DrainTopicList)
-            .await?
+            .send_actor_mail(domain_participant_actor::DrainTopicList)?
             .receive_reply()
             .await
         {
@@ -495,8 +470,7 @@ impl DomainParticipantAsync {
     #[tracing::instrument(skip(self))]
     pub async fn set_default_publisher_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
         self.participant_address
-            .send_actor_mail(domain_participant_actor::SetDefaultPublisherQos { qos })
-            .await?
+            .send_actor_mail(domain_participant_actor::SetDefaultPublisherQos { qos })?
             .receive_reply()
             .await
     }
@@ -506,8 +480,7 @@ impl DomainParticipantAsync {
     pub async fn get_default_publisher_qos(&self) -> DdsResult<PublisherQos> {
         Ok(self
             .participant_address
-            .send_actor_mail(domain_participant_actor::GetDefaultPublisherQos)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetDefaultPublisherQos)?
             .receive_reply()
             .await)
     }
@@ -516,8 +489,7 @@ impl DomainParticipantAsync {
     #[tracing::instrument(skip(self))]
     pub async fn set_default_subscriber_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
         self.participant_address
-            .send_actor_mail(domain_participant_actor::SetDefaultSubscriberQos { qos })
-            .await?
+            .send_actor_mail(domain_participant_actor::SetDefaultSubscriberQos { qos })?
             .receive_reply()
             .await
     }
@@ -527,8 +499,7 @@ impl DomainParticipantAsync {
     pub async fn get_default_subscriber_qos(&self) -> DdsResult<SubscriberQos> {
         Ok(self
             .participant_address
-            .send_actor_mail(domain_participant_actor::GetDefaultSubscriberQos)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetDefaultSubscriberQos)?
             .receive_reply()
             .await)
     }
@@ -537,8 +508,7 @@ impl DomainParticipantAsync {
     #[tracing::instrument(skip(self))]
     pub async fn set_default_topic_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
         self.participant_address
-            .send_actor_mail(domain_participant_actor::SetDefaultTopicQos { qos })
-            .await?
+            .send_actor_mail(domain_participant_actor::SetDefaultTopicQos { qos })?
             .receive_reply()
             .await
     }
@@ -548,8 +518,7 @@ impl DomainParticipantAsync {
     pub async fn get_default_topic_qos(&self) -> DdsResult<TopicQos> {
         Ok(self
             .participant_address
-            .send_actor_mail(domain_participant_actor::GetDefaultTopicQos)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetDefaultTopicQos)?
             .receive_reply()
             .await)
     }
@@ -559,8 +528,7 @@ impl DomainParticipantAsync {
     pub async fn get_discovered_participants(&self) -> DdsResult<Vec<InstanceHandle>> {
         Ok(self
             .participant_address
-            .send_actor_mail(domain_participant_actor::GetDiscoveredParticipants)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetDiscoveredParticipants)?
             .receive_reply()
             .await)
     }
@@ -574,8 +542,7 @@ impl DomainParticipantAsync {
         self.participant_address
             .send_actor_mail(domain_participant_actor::GetDiscoveredParticipantData {
                 participant_handle,
-            })
-            .await?
+            })?
             .receive_reply()
             .await
     }
@@ -585,8 +552,7 @@ impl DomainParticipantAsync {
     pub async fn get_discovered_topics(&self) -> DdsResult<Vec<InstanceHandle>> {
         Ok(self
             .participant_address
-            .send_actor_mail(domain_participant_actor::GetDiscoveredTopics)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetDiscoveredTopics)?
             .receive_reply()
             .await)
     }
@@ -598,8 +564,7 @@ impl DomainParticipantAsync {
         topic_handle: InstanceHandle,
     ) -> DdsResult<TopicBuiltinTopicData> {
         self.participant_address
-            .send_actor_mail(domain_participant_actor::GetDiscoveredTopicData { topic_handle })
-            .await?
+            .send_actor_mail(domain_participant_actor::GetDiscoveredTopicData { topic_handle })?
             .receive_reply()
             .await
     }
@@ -615,8 +580,7 @@ impl DomainParticipantAsync {
     pub async fn get_current_time(&self) -> DdsResult<Time> {
         Ok(self
             .participant_address
-            .send_actor_mail(domain_participant_actor::GetCurrentTime)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetCurrentTime)?
             .receive_reply()
             .await)
     }
@@ -632,8 +596,7 @@ impl DomainParticipantAsync {
         };
 
         self.participant_address
-            .send_actor_mail(domain_participant_actor::SetQos { qos })
-            .await?
+            .send_actor_mail(domain_participant_actor::SetQos { qos })?
             .receive_reply()
             .await?;
         self.announce_participant().await
@@ -644,8 +607,7 @@ impl DomainParticipantAsync {
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantQos> {
         Ok(self
             .participant_address
-            .send_actor_mail(domain_participant_actor::GetQos)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetQos)?
             .receive_reply()
             .await)
     }
@@ -662,8 +624,7 @@ impl DomainParticipantAsync {
                 listener: a_listener,
                 status_kind: mask.to_vec(),
                 runtime_handle: self.runtime_handle.clone(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await;
         Ok(())
@@ -690,8 +651,7 @@ impl DomainParticipantAsync {
         self.participant_address
             .send_actor_mail(domain_participant_actor::Enable {
                 runtime_handle: self.runtime_handle.clone(),
-            })
-            .await?
+            })?
             .receive_reply()
             .await?;
 
@@ -705,8 +665,7 @@ impl DomainParticipantAsync {
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         Ok(self
             .participant_address
-            .send_actor_mail(domain_participant_actor::GetInstanceHandle)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetInstanceHandle)?
             .receive_reply()
             .await)
     }
@@ -716,13 +675,11 @@ impl DomainParticipantAsync {
     pub(crate) async fn get_builtin_publisher(&self) -> DdsResult<PublisherAsync> {
         let publisher_address = self
             .participant_address
-            .send_actor_mail(domain_participant_actor::GetBuiltinPublisher)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetBuiltinPublisher)?
             .receive_reply()
             .await;
         let publisher_status_condition = publisher_address
-            .send_actor_mail(publisher_actor::GetStatuscondition)
-            .await?
+            .send_actor_mail(publisher_actor::GetStatuscondition)?
             .receive_reply()
             .await;
         Ok(PublisherAsync::new(

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     domain::domain_participant_factory::DomainId,
     implementation::{
-        actor::{Actor, DEFAULT_ACTOR_BUFFER_SIZE},
+        actor::Actor,
         actors::{
             domain_participant_actor,
             domain_participant_factory_actor::{self, DomainParticipantFactoryActor},
@@ -37,11 +37,8 @@ impl DomainParticipantFactoryAsync {
     /// Create a new [`DomainParticipantFactoryAsync`].
     /// All the tasks of Dust DDS will be spawned on the runtime which is given as an argument.
     pub fn new(runtime_handle: tokio::runtime::Handle) -> Self {
-        let domain_participant_factory_actor = Actor::spawn(
-            DomainParticipantFactoryActor::new(),
-            &runtime_handle,
-            DEFAULT_ACTOR_BUFFER_SIZE,
-        );
+        let domain_participant_factory_actor =
+            Actor::spawn(DomainParticipantFactoryActor::new(), &runtime_handle);
 
         Self {
             domain_participant_factory_actor,
@@ -68,22 +65,18 @@ impl DomainParticipantFactoryAsync {
                 status_kind,
                 runtime_handle,
             })
-            .await
             .receive_reply()
             .await?;
         let status_condition = participant_address
-            .send_actor_mail(domain_participant_actor::GetStatuscondition)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetStatuscondition)?
             .receive_reply()
             .await;
         let builtin_subscriber = participant_address
-            .send_actor_mail(domain_participant_actor::GetBuiltInSubscriber)
-            .await?
+            .send_actor_mail(domain_participant_actor::GetBuiltInSubscriber)?
             .receive_reply()
             .await;
         let builtin_subscriber_status_condition_address = builtin_subscriber
-            .send_actor_mail(subscriber_actor::GetStatuscondition)
-            .await?
+            .send_actor_mail(subscriber_actor::GetStatuscondition)?
             .receive_reply()
             .await;
         let domain_participant = DomainParticipantAsync::new(
@@ -113,7 +106,6 @@ impl DomainParticipantFactoryAsync {
         let deleted_participant = self
             .domain_participant_factory_actor
             .send_actor_mail(domain_participant_factory_actor::DeleteParticipant { handle })
-            .await
             .receive_reply()
             .await?;
         let builtin_publisher = participant.get_builtin_publisher().await?;
@@ -123,7 +115,6 @@ impl DomainParticipantFactoryAsync {
         {
             let data = deleted_participant
                 .send_actor_mail(domain_participant_actor::AsSpdpDiscoveredParticipantData)
-                .await
                 .receive_reply()
                 .await;
             spdp_participant_writer.dispose(&data, None).await?;
@@ -140,23 +131,19 @@ impl DomainParticipantFactoryAsync {
         if let Some(dp) = self
             .domain_participant_factory_actor
             .send_actor_mail(domain_participant_factory_actor::LookupParticipant { domain_id })
-            .await
             .receive_reply()
             .await?
         {
             let status_condition = dp
-                .send_actor_mail(domain_participant_actor::GetStatuscondition)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetStatuscondition)?
                 .receive_reply()
                 .await;
             let builtin_subscriber = dp
-                .send_actor_mail(domain_participant_actor::GetBuiltInSubscriber)
-                .await?
+                .send_actor_mail(domain_participant_actor::GetBuiltInSubscriber)?
                 .receive_reply()
                 .await;
             let builtin_subscriber_status_condition_address = builtin_subscriber
-                .send_actor_mail(subscriber_actor::GetStatuscondition)
-                .await?
+                .send_actor_mail(subscriber_actor::GetStatuscondition)?
                 .receive_reply()
                 .await;
             Ok(Some(DomainParticipantAsync::new(
@@ -179,7 +166,6 @@ impl DomainParticipantFactoryAsync {
     ) -> DdsResult<()> {
         self.domain_participant_factory_actor
             .send_actor_mail(domain_participant_factory_actor::SetDefaultParticipantQos { qos })
-            .await
             .receive_reply()
             .await
     }
@@ -189,7 +175,6 @@ impl DomainParticipantFactoryAsync {
         Ok(self
             .domain_participant_factory_actor
             .send_actor_mail(domain_participant_factory_actor::GetDefaultParticipantQos)
-            .await
             .receive_reply()
             .await)
     }
@@ -198,7 +183,6 @@ impl DomainParticipantFactoryAsync {
     pub async fn set_qos(&self, qos: QosKind<DomainParticipantFactoryQos>) -> DdsResult<()> {
         self.domain_participant_factory_actor
             .send_actor_mail(domain_participant_factory_actor::SetQos { qos })
-            .await
             .receive_reply()
             .await
     }
@@ -208,7 +192,6 @@ impl DomainParticipantFactoryAsync {
         Ok(self
             .domain_participant_factory_actor
             .send_actor_mail(domain_participant_factory_actor::GetQos)
-            .await
             .receive_reply()
             .await)
     }
@@ -217,7 +200,6 @@ impl DomainParticipantFactoryAsync {
     pub async fn set_configuration(&self, configuration: DustDdsConfiguration) -> DdsResult<()> {
         self.domain_participant_factory_actor
             .send_actor_mail(domain_participant_factory_actor::SetConfiguration { configuration })
-            .await
             .receive_reply()
             .await;
         Ok(())
@@ -228,7 +210,6 @@ impl DomainParticipantFactoryAsync {
         Ok(self
             .domain_participant_factory_actor
             .send_actor_mail(domain_participant_factory_actor::GetConfiguration)
-            .await
             .receive_reply()
             .await)
     }

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -70,8 +70,7 @@ impl TopicAsync {
         {
             let discovered_topic_data = self
                 .topic_address
-                .send_actor_mail(topic_actor::AsDiscoveredTopicData)
-                .await?
+                .send_actor_mail(topic_actor::AsDiscoveredTopicData)?
                 .receive_reply()
                 .await;
             sedp_topics_announcer
@@ -88,8 +87,7 @@ impl TopicAsync {
     pub async fn get_inconsistent_topic_status(&self) -> DdsResult<InconsistentTopicStatus> {
         Ok(self
             .topic_address
-            .send_actor_mail(topic_actor::GetInconsistentTopicStatus)
-            .await?
+            .send_actor_mail(topic_actor::GetInconsistentTopicStatus)?
             .receive_reply()
             .await)
     }
@@ -122,8 +120,7 @@ impl TopicAsync {
         let qos = match qos {
             QosKind::Default => {
                 self.participant_address()
-                    .send_actor_mail(domain_participant_actor::GetDefaultTopicQos)
-                    .await?
+                    .send_actor_mail(domain_participant_actor::GetDefaultTopicQos)?
                     .receive_reply()
                     .await
             }
@@ -131,15 +128,13 @@ impl TopicAsync {
         };
 
         self.topic_address
-            .send_actor_mail(topic_actor::SetQos { qos })
-            .await?
+            .send_actor_mail(topic_actor::SetQos { qos })?
             .receive_reply()
             .await?;
 
         if self
             .topic_address
-            .send_actor_mail(topic_actor::IsEnabled)
-            .await?
+            .send_actor_mail(topic_actor::IsEnabled)?
             .receive_reply()
             .await
         {
@@ -153,8 +148,7 @@ impl TopicAsync {
     pub async fn get_qos(&self) -> DdsResult<TopicQos> {
         Ok(self
             .topic_address
-            .send_actor_mail(topic_actor::GetQos)
-            .await?
+            .send_actor_mail(topic_actor::GetQos)?
             .receive_reply()
             .await)
     }
@@ -179,14 +173,12 @@ impl TopicAsync {
     pub async fn enable(&self) -> DdsResult<()> {
         if !self
             .topic_address
-            .send_actor_mail(topic_actor::IsEnabled)
-            .await?
+            .send_actor_mail(topic_actor::IsEnabled)?
             .receive_reply()
             .await
         {
             self.topic_address
-                .send_actor_mail(topic_actor::Enable)
-                .await?
+                .send_actor_mail(topic_actor::Enable)?
                 .receive_reply()
                 .await;
             self.announce_topic().await?;
@@ -200,8 +192,7 @@ impl TopicAsync {
     pub async fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
         Ok(self
             .topic_address
-            .send_actor_mail(topic_actor::GetInstanceHandle)
-            .await?
+            .send_actor_mail(topic_actor::GetInstanceHandle)?
             .receive_reply()
             .await)
     }

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -287,7 +287,6 @@ impl RtpsWriterProxy {
                     submessages,
                     destination_locator_list: self.unicast_locator_list().to_vec(),
                 })
-                .await
                 .ok();
         }
     }


### PR DESCRIPTION
Replace actor channel by unbounded channel to remove the await on the message sending. This makes the code simpler and more performant. For our system this is not problematic since most operations require waiting for a reply so there is little chance that actor buffers will be growing unboundedly.