### PR TITLE
Performance optimization: Data frag optimization

### DIFF
--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -243,8 +243,10 @@ where
 
             let mut serialized_foo = Vec::new();
             instance.serialize_data(&mut serialized_foo)?;
-            let instance_serialized_key =
-                type_support.get_serialized_key_from_serialized_foo(&serialized_foo)?;
+            let instance_serialized_key = type_support
+                .get_serialized_key_from_serialized_foo(&serialized_foo)?
+                .into();
+
             let message_sender_actor = self
                 .participant_address()
                 .send_actor_mail(domain_participant_actor::GetMessageSender)?
@@ -344,7 +346,7 @@ where
             .await;
         self.writer_address
             .send_actor_mail(data_writer_actor::WriteWTimestamp {
-                serialized_data,
+                serialized_data: serialized_data.into(),
                 instance_handle: key,
                 _handle: handle,
                 timestamp,
@@ -424,7 +426,7 @@ where
             .await;
         self.writer_address
             .send_actor_mail(data_writer_actor::DisposeWTimestamp {
-                instance_serialized_key: key,
+                instance_serialized_key: key.into(),
                 handle: instance_handle,
                 timestamp,
                 message_sender_actor,

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -893,7 +893,7 @@ impl MailHandler<UnregisterInstanceWTimestamp> for DataWriterActor {
             STATUS_INFO_UNREGISTERED.serialize(&mut serializer).unwrap();
         }
         let pid_status_info = Parameter::new(PID_STATUS_INFO, Arc::from(serialized_status_info));
-        let pid_key_hash = Parameter::new(PID_KEY_HASH, Arc::from(message.handle.as_ref().clone()));
+        let pid_key_hash = Parameter::new(PID_KEY_HASH, Arc::from(*message.handle.as_ref()));
         let inline_qos = ParameterList::new(vec![pid_status_info, pid_key_hash]);
 
         let change: RtpsWriterCacheChange = self.rtps_writer.new_change(
@@ -962,7 +962,7 @@ impl MailHandler<DisposeWTimestamp> for DataWriterActor {
         STATUS_INFO_DISPOSED.serialize(&mut serializer).unwrap();
 
         let pid_status_info = Parameter::new(PID_STATUS_INFO, Arc::from(serialized_status_info));
-        let pid_key_hash = Parameter::new(PID_KEY_HASH, Arc::from(message.handle.as_ref().clone()));
+        let pid_key_hash = Parameter::new(PID_KEY_HASH, Arc::from(*message.handle.as_ref()));
         let inline_qos = ParameterList::new(vec![pid_status_info, pid_key_hash]);
 
         let change: RtpsWriterCacheChange = self.rtps_writer.new_change(
@@ -1098,7 +1098,7 @@ impl MailHandler<WriteWTimestamp> for DataWriterActor {
             .register_instance_w_timestamp(message.instance_handle, message.timestamp)?
             .unwrap_or(HANDLE_NIL);
 
-        let pid_key_hash = Parameter::new(PID_KEY_HASH, Arc::from(handle.as_ref().clone()));
+        let pid_key_hash = Parameter::new(PID_KEY_HASH, Arc::from(*handle.as_ref()));
         let parameter_list = ParameterList::new(vec![pid_key_hash]);
         let change = self.rtps_writer.new_change(
             ChangeKind::Alive,

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -338,9 +338,6 @@ impl WriteIntoBytes for ParameterList {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct SerializedData;
-
-#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SerializedDataFragment {
     data: Data,
     range: Range<usize>,

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use std::{
     io::{BufRead, Write},
+    ops::Range,
     sync::Arc,
 };
 ///
@@ -337,6 +338,59 @@ impl WriteIntoBytes for ParameterList {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SerializedData;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SerializedDataFragment {
+    data: Data,
+    range: Range<usize>,
+}
+
+impl SerializedDataFragment {
+    pub fn new(data: Data, range: Range<usize>) -> Self {
+        Self { data, range }
+    }
+}
+
+impl Default for SerializedDataFragment {
+    fn default() -> Self {
+        Self {
+            data: Data::empty(),
+            range: 0..0,
+        }
+    }
+}
+
+impl AsRef<[u8]> for SerializedDataFragment {
+    fn as_ref(&self) -> &[u8] {
+        &self.data.as_ref()[self.range.start..self.range.end]
+    }
+}
+
+impl From<&[u8]> for SerializedDataFragment {
+    fn from(value: &[u8]) -> Self {
+        Self {
+            data: Data::new(Arc::from(value)),
+            range: 0..value.len(),
+        }
+    }
+}
+
+impl WriteIntoBytes for SerializedDataFragment {
+    fn write_into_bytes(&self, buf: &mut dyn Write) {
+        self.data.as_ref()[self.range.start..self.range.end]
+            .as_ref()
+            .write_into_bytes(buf);
+        match self.data.len() % 4 {
+            1 => [0_u8; 3].write_into_bytes(buf),
+            2 => [0_u8; 2].write_into_bytes(buf),
+            3 => [0_u8; 1].write_into_bytes(buf),
+            _ => (),
+        };
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Data(Arc<[u8]>);
 
 impl Data {
@@ -354,6 +408,12 @@ impl Data {
 
     pub fn empty() -> Self {
         Self(Arc::new([]))
+    }
+}
+
+impl From<Vec<u8>> for Data {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value.into_boxed_slice().into())
     }
 }
 

--- a/dds/src/rtps/writer.rs
+++ b/dds/src/rtps/writer.rs
@@ -59,14 +59,14 @@ impl RtpsWriter {
         self.heartbeat_period
     }
 
-    pub fn _data_max_size_serialized(&self) -> usize {
+    pub fn data_max_size_serialized(&self) -> usize {
         self.data_max_size_serialized
     }
 
     pub fn new_change(
         &mut self,
         kind: ChangeKind,
-        data: Vec<u8>,
+        data: Data,
         inline_qos: ParameterList,
         handle: InstanceHandle,
         timestamp: messages::types::Time,
@@ -78,9 +78,7 @@ impl RtpsWriter {
             handle,
             self.last_change_sequence_number,
             timestamp,
-            data.chunks(self.data_max_size_serialized)
-                .map(|c| Data::new(c.to_vec().into()))
-                .collect(),
+            data,
             inline_qos,
         )
     }

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -100,7 +100,7 @@ impl RtpsWriterProxy {
                 let inline_qos = frag_seq_num_list[0].inline_qos().clone();
                 let mut data = Vec::new();
                 for frag in frag_seq_num_list {
-                    data.append(&mut frag.serialized_payload().as_ref().to_vec());
+                    data.extend_from_slice(frag.serialized_payload().as_ref());
                 }
 
                 Some(DataSubmessage::new(


### PR DESCRIPTION
This PR remove the copying of the data when creating fragmented messages. Instead the fragments are created only when the DataFragSubmessage is generated. This PR also includes the sending of the PID_KEY_HASH parameter to reduce the number of calculations of the InstanceHandle on the reader.