### PR TITLE
Add lifetime support for foo type in listeners

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",
@@ -16,7 +16,7 @@ keywords = ["dds", "rtps", "middleware", "network", "udp"]
 categories = ["api-bindings", "network-programming"]
 
 [dependencies]
-dust_dds_derive = { version = "0.9", path = "../dds_derive" }
+dust_dds_derive = { version = "0.10", path = "../dds_derive" }
 
 md5 = "0.7.0" # Chose this crate over other possibilities since it doesn't have any other dependencies
 

--- a/dds/benches/benchmark.rs
+++ b/dds/benches/benchmark.rs
@@ -106,7 +106,7 @@ fn best_effort_write_and_receive(c: &mut Criterion) {
     struct Listener {
         sender: std::sync::mpsc::SyncSender<()>,
     }
-    impl DataReaderListener for Listener {
+    impl DataReaderListener<'_> for Listener {
         type Foo = KeyedData;
         fn on_data_available(&mut self, the_reader: DataReader<KeyedData>) {
             the_reader
@@ -187,7 +187,7 @@ fn best_effort_write_and_receive_frag(c: &mut Criterion) {
     struct Listener {
         sender: std::sync::mpsc::SyncSender<()>,
     }
-    impl DataReaderListener for Listener {
+    impl DataReaderListener<'_> for Listener {
         type Foo = LargeKeyedData;
         fn on_data_available(&mut self, the_reader: DataReader<LargeKeyedData>) {
             the_reader

--- a/dds/examples/best_effort_subscriber.rs
+++ b/dds/examples/best_effort_subscriber.rs
@@ -26,7 +26,7 @@ struct Listener {
     sender: SyncSender<()>,
 }
 
-impl DataReaderListener for Listener {
+impl DataReaderListener<'_> for Listener {
     type Foo = BestEffortExampleType;
     fn on_data_available(&mut self, the_reader: DataReader<BestEffortExampleType>) {
         if let Ok(samples) =

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -460,7 +460,7 @@ where
     #[tracing::instrument(skip(self, a_listener))]
     pub fn set_listener(
         &self,
-        a_listener: Option<Box<dyn DataWriterListener<Foo = Foo> + Send + 'a>>,
+        a_listener: Option<Box<dyn DataWriterListener<'a, Foo = Foo> + Send + 'a>>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.writer_async.runtime_handle().block_on(

--- a/dds/src/dds/publication/data_writer_listener.rs
+++ b/dds/src/dds/publication/data_writer_listener.rs
@@ -45,7 +45,7 @@ pub trait DataWriterListener<'a>: 'static {
     }
 }
 
-impl<'a, Foo> DataWriterListenerAsync for Box<dyn DataWriterListener<'_, Foo = Foo> + Send + 'a>
+impl<'a, Foo> DataWriterListenerAsync<'_> for Box<dyn DataWriterListener<'_, Foo = Foo> + Send + 'a>
 where
     Self: 'static,
 {

--- a/dds/src/dds/publication/data_writer_listener.rs
+++ b/dds/src/dds/publication/data_writer_listener.rs
@@ -11,7 +11,7 @@ use crate::{
 use super::data_writer::DataWriter;
 
 /// This trait represents a listener object which can be associated with the [`DataWriter`] entity.
-pub trait DataWriterListener: 'static {
+pub trait DataWriterListener<'a>: 'static {
     /// Type of the DataWriter with which this Listener will be associated.
     type Foo;
 
@@ -45,7 +45,7 @@ pub trait DataWriterListener: 'static {
     }
 }
 
-impl<'a, Foo> DataWriterListenerAsync for Box<dyn DataWriterListener<Foo = Foo> + Send + 'a>
+impl<'a, Foo> DataWriterListenerAsync for Box<dyn DataWriterListener<'_, Foo = Foo> + Send + 'a>
 where
     Self: 'static,
 {

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -58,7 +58,7 @@ impl Publisher {
         &self,
         a_topic: &Topic,
         qos: QosKind<DataWriterQos>,
-        a_listener: Option<Box<dyn DataWriterListener<Foo = Foo> + Send + 'a>>,
+        a_listener: Option<Box<dyn DataWriterListener<'a, Foo = Foo> + Send + 'a>>,
         mask: &[StatusKind],
     ) -> DdsResult<DataWriter<Foo>>
     where

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -559,7 +559,7 @@ where
     #[tracing::instrument(skip(self, a_listener))]
     pub fn set_listener(
         &self,
-        a_listener: Option<Box<dyn DataReaderListener<Foo = Foo> + Send + 'a>>,
+        a_listener: Option<Box<dyn DataReaderListener<'a, Foo = Foo> + Send + 'a>>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.reader_async.runtime_handle().block_on(

--- a/dds/src/dds/subscription/data_reader_listener.rs
+++ b/dds/src/dds/subscription/data_reader_listener.rs
@@ -11,7 +11,7 @@ use crate::{
 use super::data_reader::DataReader;
 
 /// This trait represents a listener object which can be associated with the [`DataReader`] entity.
-pub trait DataReaderListener: 'static {
+pub trait DataReaderListener<'a>: 'static {
     /// Type of the DataReader with which this Listener will be associated.
     type Foo;
 
@@ -61,7 +61,7 @@ pub trait DataReaderListener: 'static {
     fn on_sample_lost(&mut self, _the_reader: DataReader<Self::Foo>, _status: SampleLostStatus) {}
 }
 
-impl<'a, Foo> DataReaderListenerAsync for Box<dyn DataReaderListener<Foo = Foo> + Send + 'a>
+impl<'a, Foo> DataReaderListenerAsync for Box<dyn DataReaderListener<'_, Foo = Foo> + Send + 'a>
 where
     Self: 'static,
 {

--- a/dds/src/dds/subscription/data_reader_listener.rs
+++ b/dds/src/dds/subscription/data_reader_listener.rs
@@ -61,7 +61,7 @@ pub trait DataReaderListener<'a>: 'static {
     fn on_sample_lost(&mut self, _the_reader: DataReader<Self::Foo>, _status: SampleLostStatus) {}
 }
 
-impl<'a, Foo> DataReaderListenerAsync for Box<dyn DataReaderListener<'_, Foo = Foo> + Send + 'a>
+impl<'a, Foo> DataReaderListenerAsync<'_> for Box<dyn DataReaderListener<'_, Foo = Foo> + Send + 'a>
 where
     Self: 'static,
 {

--- a/dds/src/dds/subscription/subscriber.rs
+++ b/dds/src/dds/subscription/subscriber.rs
@@ -60,7 +60,7 @@ impl Subscriber {
         &self,
         a_topic: &Topic,
         qos: QosKind<DataReaderQos>,
-        a_listener: Option<Box<dyn DataReaderListener<Foo = Foo> + Send + 'a>>,
+        a_listener: Option<Box<dyn DataReaderListener<'a, Foo = Foo> + Send + 'a>>,
         mask: &[StatusKind],
     ) -> DdsResult<DataReader<Foo>>
     where

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -559,7 +559,7 @@ where
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,
-        a_listener: Option<Box<dyn DataReaderListenerAsync<Foo = Foo> + Send + 'a>>,
+        a_listener: Option<Box<dyn DataReaderListenerAsync<'a, Foo = Foo> + Send + 'a>>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.reader_address

--- a/dds/src/dds_async/data_reader_listener.rs
+++ b/dds/src/dds_async/data_reader_listener.rs
@@ -8,7 +8,7 @@ use crate::infrastructure::status::{
 use super::data_reader::DataReaderAsync;
 
 /// This trait represents a listener object which can be associated with the [`DataReaderAsync`] entity.
-pub trait DataReaderListenerAsync
+pub trait DataReaderListenerAsync<'a>
 where
     Self: 'static,
 {

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -635,7 +635,7 @@ where
     #[tracing::instrument(skip(self, a_listener))]
     pub async fn set_listener(
         &self,
-        a_listener: Option<Box<dyn DataWriterListenerAsync<Foo = Foo> + Send + 'a>>,
+        a_listener: Option<Box<dyn DataWriterListenerAsync<'a, Foo = Foo> + Send + 'a>>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
         self.writer_address

--- a/dds/src/dds_async/data_writer_listener.rs
+++ b/dds/src/dds_async/data_writer_listener.rs
@@ -8,7 +8,7 @@ use crate::infrastructure::status::{
 use super::data_writer::DataWriterAsync;
 
 /// This trait represents a listener object which can be associated with the [`DataWriterAsync`] entity.
-pub trait DataWriterListenerAsync
+pub trait DataWriterListenerAsync<'a>
 where
     Self: 'static,
 {

--- a/dds/src/dds_async/publisher.rs
+++ b/dds/src/dds_async/publisher.rs
@@ -113,7 +113,7 @@ impl PublisherAsync {
         &'a self,
         a_topic: &'a TopicAsync,
         qos: QosKind<DataWriterQos>,
-        a_listener: Option<Box<dyn DataWriterListenerAsync<Foo = Foo> + Send + 'b>>,
+        a_listener: Option<Box<dyn DataWriterListenerAsync<'b, Foo = Foo> + Send + 'b>>,
         mask: &'a [StatusKind],
     ) -> DdsResult<DataWriterAsync<Foo>>
     where

--- a/dds/src/dds_async/subscriber.rs
+++ b/dds/src/dds_async/subscriber.rs
@@ -112,7 +112,7 @@ impl SubscriberAsync {
         &'a self,
         a_topic: &'a TopicAsync,
         qos: QosKind<DataReaderQos>,
-        a_listener: Option<Box<(dyn DataReaderListenerAsync<Foo = Foo> + Send + 'b)>>,
+        a_listener: Option<Box<(dyn DataReaderListenerAsync<'b, Foo = Foo> + Send + 'b)>>,
         mask: &'a [StatusKind],
     ) -> DdsResult<DataReaderAsync<Foo>>
     where

--- a/dds/src/implementation/actors/any_data_reader_listener.rs
+++ b/dds/src/implementation/actors/any_data_reader_listener.rs
@@ -35,7 +35,7 @@ pub trait AnyDataReaderListener {
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
 }
 
-impl<'a, Foo> AnyDataReaderListener for Box<dyn DataReaderListenerAsync<Foo = Foo> + Send + 'a>
+impl<'a, Foo> AnyDataReaderListener for Box<dyn DataReaderListenerAsync<'a, Foo = Foo> + Send + 'a>
 where
     Foo: 'a,
 {

--- a/dds/src/implementation/actors/any_data_writer_listener.rs
+++ b/dds/src/implementation/actors/any_data_writer_listener.rs
@@ -27,7 +27,7 @@ pub trait AnyDataWriterListener {
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
 }
 
-impl<'a, Foo> AnyDataWriterListener for Box<dyn DataWriterListenerAsync<Foo = Foo> + Send + 'a>
+impl<'a, Foo> AnyDataWriterListener for Box<dyn DataWriterListenerAsync<'a, Foo = Foo> + Send + 'a>
 where
     Foo: 'a,
 {

--- a/dds/tests/listeners.rs
+++ b/dds/tests/listeners.rs
@@ -587,7 +587,7 @@ fn on_data_available_listener() {
         sender: std::sync::mpsc::SyncSender<()>,
     }
 
-    impl DataReaderListener for DataAvailableListener {
+    impl DataReaderListener<'_> for DataAvailableListener {
         type Foo = MyData;
         fn on_data_available(&mut self, _the_reader: DataReader<MyData>) {
             self.sender.send(()).unwrap();
@@ -752,7 +752,7 @@ fn data_available_listener_not_called_when_data_on_readers_listener() {
         sender: std::sync::mpsc::SyncSender<()>,
     }
 
-    impl DataReaderListener for DataAvailableListener {
+    impl DataReaderListener<'_> for DataAvailableListener {
         type Foo = MyData;
         fn on_data_available(&mut self, _the_reader: DataReader<MyData>) {
             self.sender.send(()).unwrap();
@@ -839,7 +839,7 @@ fn participant_deadline_missed_listener() {
         sender: std::sync::mpsc::SyncSender<RequestedDeadlineMissedStatus>,
     }
 
-    impl DataReaderListener for DeadlineMissedListener {
+    impl DataReaderListener<'_> for DeadlineMissedListener {
         type Foo = MyData;
         fn on_requested_deadline_missed(
             &mut self,
@@ -929,7 +929,7 @@ fn participant_sample_rejected_listener() {
         sender: std::sync::mpsc::SyncSender<SampleRejectedStatus>,
     }
 
-    impl DataReaderListener for SampleRejectedListener {
+    impl DataReaderListener<'_> for SampleRejectedListener {
         type Foo = MyData;
         fn on_sample_rejected(
             &mut self,
@@ -1039,7 +1039,7 @@ fn participant_subscription_matched_listener() {
         sender: std::sync::mpsc::SyncSender<SubscriptionMatchedStatus>,
     }
 
-    impl DataReaderListener for SubscriptionMatchedListener {
+    impl DataReaderListener<'_> for SubscriptionMatchedListener {
         type Foo = MyData;
         fn on_subscription_matched(
             &mut self,
@@ -1125,7 +1125,7 @@ fn participant_requested_incompatible_qos_listener() {
         sender: std::sync::mpsc::SyncSender<RequestedIncompatibleQosStatus>,
     }
 
-    impl DataReaderListener for RequestedIncompatibleQosListener {
+    impl DataReaderListener<'_> for RequestedIncompatibleQosListener {
         type Foo = MyData;
         fn on_requested_incompatible_qos(
             &mut self,
@@ -1740,7 +1740,7 @@ fn data_writer_publication_matched_listener() {
         sender: std::sync::mpsc::SyncSender<PublicationMatchedStatus>,
     }
 
-    impl DataWriterListener for PublicationMatchedListener {
+    impl DataWriterListener<'_> for PublicationMatchedListener {
         type Foo = MyData;
         fn on_publication_matched(
             &mut self,
@@ -1827,7 +1827,7 @@ fn data_writer_offered_incompatible_qos_listener() {
         sender: std::sync::mpsc::SyncSender<OfferedIncompatibleQosStatus>,
     }
 
-    impl DataWriterListener for OfferedIncompatibleQosListener {
+    impl DataWriterListener<'_> for OfferedIncompatibleQosListener {
         type Foo = MyData;
 
         fn on_offered_incompatible_qos(
@@ -1924,10 +1924,10 @@ fn non_sync_listener_should_be_accepted() {
     impl PublisherListener for NonSyncListener {}
     impl SubscriberListener for NonSyncListener {}
     impl TopicListener for NonSyncListener {}
-    impl DataWriterListener for NonSyncListener {
+    impl DataWriterListener<'_> for NonSyncListener {
         type Foo = MyData;
     }
-    impl DataReaderListener for NonSyncListener {
+    impl DataReaderListener<'_> for NonSyncListener {
         type Foo = MyData;
     }
 

--- a/dds_derive/Cargo.toml
+++ b/dds_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_derive"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds_gen/Cargo.toml
+++ b/dds_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_gen"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",


### PR DESCRIPTION
It was not possible to use a user data type (Foo) that contains borrowed fields for Foo-listeners. To achieve this a lifetime is added to the listener traits (including the async versions). That is an API change, hence the version is increased