### PR TITLE
Performance optimization: Replace custom trait by FnOnce

### DIFF
--- a/dds/src/implementation/actor.rs
+++ b/dds/src/implementation/actor.rs
@@ -14,7 +14,7 @@ where
 }
 
 struct ReplyMail<A> {
-    handle: Box<dyn FnOnce(&mut A) -> () + Send>,
+    handle: Box<dyn FnOnce(&mut A) + Send>,
 }
 
 pub struct ReplyReceiver<M>


### PR DESCRIPTION
Replace custom trait by FnOnce to avoid having to call option .take() methods