### PR TITLE
Replace tokio sockets by udp sockets

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -26,7 +26,6 @@ network-interface = "1.1.1"
 fnmatch-regex = "0.2.0"
 
 tokio = { version = "1", features = [
-	"net",
 	"rt-multi-thread",
 	"sync",
 	"time",

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -2108,7 +2108,8 @@ impl MailHandler<AddMatchedWriter> for DataReaderActor {
                     }
                     _ => (),
                 }
-            } else if self.incompatible_writer_list.insert(instance_handle) {
+            } else if !self.incompatible_writer_list.contains(&instance_handle) {
+                self.incompatible_writer_list.insert(instance_handle);
                 self.on_requested_incompatible_qos(
                     incompatible_qos_policy_list,
                     &message.data_reader_address,

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -1291,21 +1291,16 @@ impl MailHandler<AddMatchedReader> for DataWriterActor {
                 }
 
                 self.send_message(message.message_sender_actor);
-            } else {
-                if !self.incompatible_subscriptions.contains(&instance_handle) {
-                    self.incompatible_subscriptions
-                        .add_offered_incompatible_qos(
-                            instance_handle,
-                            incompatible_qos_policy_list,
-                        );
-                    self.on_offered_incompatible_qos(
-                        message.data_writer_address,
-                        message.publisher,
-                        message.publisher_mask_listener,
-                        message.participant_mask_listener,
-                        &message.handle,
-                    )?;
-                }
+            } else if !self.incompatible_subscriptions.contains(&instance_handle) {
+                self.incompatible_subscriptions
+                    .add_offered_incompatible_qos(instance_handle, incompatible_qos_policy_list);
+                self.on_offered_incompatible_qos(
+                    message.data_writer_address,
+                    message.publisher,
+                    message.publisher_mask_listener,
+                    message.participant_mask_listener,
+                    &message.handle,
+                )?;
             }
         }
         Ok(())

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -197,6 +197,10 @@ impl IncompatibleSubscriptions {
 
         status
     }
+
+    fn contains(&self, handle: &InstanceHandle) -> bool {
+        self.incompatible_subscription_list.contains(handle)
+    }
 }
 
 pub struct DataWriterActor {
@@ -1288,15 +1292,20 @@ impl MailHandler<AddMatchedReader> for DataWriterActor {
 
                 self.send_message(message.message_sender_actor);
             } else {
-                self.incompatible_subscriptions
-                    .add_offered_incompatible_qos(instance_handle, incompatible_qos_policy_list);
-                self.on_offered_incompatible_qos(
-                    message.data_writer_address,
-                    message.publisher,
-                    message.publisher_mask_listener,
-                    message.participant_mask_listener,
-                    &message.handle,
-                )?;
+                if !self.incompatible_subscriptions.contains(&instance_handle) {
+                    self.incompatible_subscriptions
+                        .add_offered_incompatible_qos(
+                            instance_handle,
+                            incompatible_qos_policy_list,
+                        );
+                    self.on_offered_incompatible_qos(
+                        message.data_writer_address,
+                        message.publisher,
+                        message.publisher_mask_listener,
+                        message.participant_mask_listener,
+                        &message.handle,
+                    )?;
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Replace tokio sockets by udp sockets by creating std::thread to listen on the blocking socket. This allows us to remove the "net" feature of tokio