### PR TITLE
Fix data frag

### DIFF
--- a/dds/src/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -192,8 +192,7 @@ mod tests {
             b'c', b'd', 0, 0x00, // string + padding (1 byte)
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL, length
         ];
-        let mut result = Vec::new();
-        data.serialize_data(&mut result).unwrap();
+        let result = data.serialize_data().unwrap();
         assert_eq!(result, expected);
     }
 

--- a/dds/src/data_representation_builtin_endpoints/discovered_topic_data.rs
+++ b/dds/src/data_representation_builtin_endpoints/discovered_topic_data.rs
@@ -95,8 +95,7 @@ mod tests {
             b'c', b'd', 0, 0x00, // DomainTag: string + padding (1 byte)
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL, length
         ];
-        let mut result = Vec::new();
-        data.serialize_data(&mut result).unwrap();
+        let result = data.serialize_data().unwrap();
         assert_eq!(result, expected);
     }
 

--- a/dds/src/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -193,8 +193,7 @@ mod tests {
             21, 22, 23, 0xc9, // u8[3], u8
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL, length
         ];
-        let mut result = Vec::new();
-        data.serialize_data(&mut result).unwrap();
+        let result = data.serialize_data().unwrap();
         assert_eq!(result, expected);
     }
 

--- a/dds/src/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -488,8 +488,7 @@ mod tests {
             11, 0x00, 0x00, 0x00, // Duration: fraction
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL
         ];
-        let mut result = Vec::new();
-        data.serialize_data(&mut result).unwrap();
+        let result = data.serialize_data().unwrap();
         assert_eq!(result, expected);
     }
 }

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -171,8 +171,7 @@ where
             .receive_reply()
             .await;
 
-        let mut serialized_data = Vec::new();
-        instance.serialize_data(&mut serialized_data)?;
+        let serialized_data = instance.serialize_data()?;
         let instance_handle = type_support.instance_handle_from_serialized_foo(&serialized_data)?;
 
         self.writer_address
@@ -241,8 +240,7 @@ where
                 }
             }?;
 
-            let mut serialized_foo = Vec::new();
-            instance.serialize_data(&mut serialized_foo)?;
+            let serialized_foo = instance.serialize_data()?;
             let instance_serialized_key = type_support
                 .get_serialized_key_from_serialized_foo(&serialized_foo)?
                 .into();
@@ -294,8 +292,7 @@ where
             .receive_reply()
             .await;
 
-        let mut serialized_foo = Vec::new();
-        instance.serialize_data(&mut serialized_foo)?;
+        let serialized_foo = instance.serialize_data()?;
         let instance_handle = type_support.instance_handle_from_serialized_foo(&serialized_foo)?;
 
         self.writer_address
@@ -330,8 +327,7 @@ where
             .receive_reply()
             .await;
 
-        let mut serialized_data = Vec::new();
-        data.serialize_data(&mut serialized_data)?;
+        let serialized_data = data.serialize_data()?;
         let key = type_support.instance_handle_from_serialized_foo(&serialized_data)?;
 
         let message_sender_actor = self
@@ -411,8 +407,7 @@ where
             .receive_reply()
             .await;
 
-        let mut serialized_foo = Vec::new();
-        data.serialize_data(&mut serialized_foo)?;
+        let serialized_foo = data.serialize_data()?;
         let key = type_support.get_serialized_key_from_serialized_foo(&serialized_foo)?;
         let message_sender_actor = self
             .participant_address()

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -111,10 +111,8 @@ impl FooTypeSupport {
 
         let get_serialized_key_from_serialized_foo =
             define_function_with_correct_lifetime(|serialized_foo| {
-                let mut writer = Vec::new();
                 let foo_key = Foo::get_key_from_serialized_data(serialized_foo)?;
-                serialize_rtps_classic_cdr_le(&foo_key, &mut writer)?;
-                Ok(writer)
+                serialize_rtps_classic_cdr_le(&foo_key)
             });
 
         let instance_handle_from_serialized_foo =
@@ -688,10 +686,7 @@ impl Mail for IgnoreSubscription {
     type Result = DdsResult<()>;
 }
 impl MailHandler<IgnoreSubscription> for DomainParticipantActor {
-    fn handle(
-        &mut self,
-        message: IgnoreSubscription,
-    ) -> <IgnoreSubscription as Mail>::Result {
+    fn handle(&mut self, message: IgnoreSubscription) -> <IgnoreSubscription as Mail>::Result {
         if self.enabled {
             self.ignored_subcriptions.insert(message.handle);
             Ok(())
@@ -919,10 +914,7 @@ impl Mail for SetDefaultTopicQos {
     type Result = DdsResult<()>;
 }
 impl MailHandler<SetDefaultTopicQos> for DomainParticipantActor {
-    fn handle(
-        &mut self,
-        message: SetDefaultTopicQos,
-    ) -> <SetDefaultTopicQos as Mail>::Result {
+    fn handle(&mut self, message: SetDefaultTopicQos) -> <SetDefaultTopicQos as Mail>::Result {
         let qos = match message.qos {
             QosKind::Default => TopicQos::default(),
             QosKind::Specific(q) => {
@@ -942,10 +934,7 @@ impl Mail for GetDefaultPublisherQos {
     type Result = PublisherQos;
 }
 impl MailHandler<GetDefaultPublisherQos> for DomainParticipantActor {
-    fn handle(
-        &mut self,
-        _: GetDefaultPublisherQos,
-    ) -> <GetDefaultPublisherQos as Mail>::Result {
+    fn handle(&mut self, _: GetDefaultPublisherQos) -> <GetDefaultPublisherQos as Mail>::Result {
         self.default_publisher_qos.clone()
     }
 }
@@ -955,10 +944,7 @@ impl Mail for GetDefaultSubscriberQos {
     type Result = SubscriberQos;
 }
 impl MailHandler<GetDefaultSubscriberQos> for DomainParticipantActor {
-    fn handle(
-        &mut self,
-        _: GetDefaultSubscriberQos,
-    ) -> <GetDefaultSubscriberQos as Mail>::Result {
+    fn handle(&mut self, _: GetDefaultSubscriberQos) -> <GetDefaultSubscriberQos as Mail>::Result {
         self.default_subscriber_qos.clone()
     }
 }
@@ -1731,10 +1717,7 @@ impl Mail for RemoveMatchedWriter {
     type Result = DdsResult<()>;
 }
 impl MailHandler<RemoveMatchedWriter> for DomainParticipantActor {
-    fn handle(
-        &mut self,
-        message: RemoveMatchedWriter,
-    ) -> <RemoveMatchedWriter as Mail>::Result {
+    fn handle(&mut self, message: RemoveMatchedWriter) -> <RemoveMatchedWriter as Mail>::Result {
         for subscriber in self.user_defined_subscriber_list.values() {
             let subscriber_address = subscriber.address();
             let participant_mask_listener = (self.listener.clone(), self.status_kind.clone());
@@ -1902,10 +1885,7 @@ impl Mail for RemoveMatchedReader {
     type Result = DdsResult<()>;
 }
 impl MailHandler<RemoveMatchedReader> for DomainParticipantActor {
-    fn handle(
-        &mut self,
-        message: RemoveMatchedReader,
-    ) -> <RemoveMatchedReader as Mail>::Result {
+    fn handle(&mut self, message: RemoveMatchedReader) -> <RemoveMatchedReader as Mail>::Result {
         for publisher in self.user_defined_publisher_list.values() {
             let publisher_address = publisher.address();
             let participant_mask_listener = (self.listener.clone(), self.status_kind.clone());

--- a/dds/src/rtps/messages/overall_structure.rs
+++ b/dds/src/rtps/messages/overall_structure.rs
@@ -601,7 +601,7 @@ mod tests {
                 Parameter::new(6, vec![10, 11, 12, 13].into()),
                 Parameter::new(7, vec![20, 21, 22, 23].into()),
             ]),
-            Data::empty(),
+            Data::default(),
         ));
 
         let expected_submessages = vec![expected_data_submessage];

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -352,7 +352,7 @@ impl SerializedDataFragment {
 impl Default for SerializedDataFragment {
     fn default() -> Self {
         Self {
-            data: Data::empty(),
+            data: Data::default(),
             range: 0..0,
         }
     }
@@ -395,10 +395,6 @@ impl Data {
 
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
-    }
-
-    pub fn empty() -> Self {
-        Self(Arc::new([]))
     }
 }
 

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -378,12 +378,6 @@ impl WriteIntoBytes for SerializedDataFragment {
         self.data.as_ref()[self.range.start..self.range.end]
             .as_ref()
             .write_into_bytes(buf);
-        match self.data.len() % 4 {
-            1 => [0_u8; 3].write_into_bytes(buf),
-            2 => [0_u8; 2].write_into_bytes(buf),
-            3 => [0_u8; 1].write_into_bytes(buf),
-            _ => (),
-        };
     }
 }
 
@@ -408,6 +402,12 @@ impl Data {
     }
 }
 
+impl Default for Data {
+    fn default() -> Self {
+        Self(Arc::new([]))
+    }
+}
+
 impl From<Vec<u8>> for Data {
     fn from(value: Vec<u8>) -> Self {
         Self(value.into_boxed_slice().into())
@@ -423,12 +423,6 @@ impl AsRef<[u8]> for Data {
 impl WriteIntoBytes for Data {
     fn write_into_bytes(&self, buf: &mut dyn Write) {
         self.0.as_ref().write_into_bytes(buf);
-        match self.0.len() % 4 {
-            1 => [0_u8; 3].write_into_bytes(buf),
-            2 => [0_u8; 2].write_into_bytes(buf),
-            3 => [0_u8; 1].write_into_bytes(buf),
-            _ => (),
-        };
     }
 }
 

--- a/dds/src/rtps/messages/submessages/data.rs
+++ b/dds/src/rtps/messages/submessages/data.rs
@@ -236,7 +236,7 @@ mod tests {
         let parameter_1 = Parameter::new(6, vec![10, 11, 12, 13].into());
         let parameter_2 = Parameter::new(7, vec![20, 21, 22, 23].into());
         let inline_qos = ParameterList::new(vec![parameter_1, parameter_2]);
-        let serialized_payload = Data::new(vec![].into());
+        let serialized_payload = Data::default();
 
         let submessage = DataSubmessage::new(
             inline_qos_flag,
@@ -276,41 +276,6 @@ mod tests {
         let writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);
         let writer_sn = 5;
         let inline_qos = ParameterList::empty();
-        let serialized_payload = Data::new(vec![1, 2, 3, 4].into());
-        let submessage = DataSubmessage::new(
-            inline_qos_flag,
-            data_flag,
-            key_flag,
-            non_standard_payload_flag,
-            reader_id,
-            writer_id,
-            writer_sn,
-            inline_qos,
-            serialized_payload,
-        );
-        #[rustfmt::skip]
-        assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
-                0x15, 0b_0000_0101, 24, 0, // Submessage header
-                0, 0, 16, 0, // extraFlags, octetsToInlineQos
-                1, 2, 3, 4, // readerId: value[4]
-                6, 7, 8, 9, // writerId: value[4]
-                0, 0, 0, 0, // writerSN: high
-                5, 0, 0, 0, // writerSN: low
-                1, 2, 3, 4, // serialized payload
-            ]
-        );
-    }
-
-    #[test]
-    fn serialize_no_inline_qos_with_serialized_payload_non_multiple_of_4() {
-        let inline_qos_flag = false;
-        let data_flag = true;
-        let key_flag = false;
-        let non_standard_payload_flag = false;
-        let reader_id = EntityId::new([1, 2, 3], USER_DEFINED_READER_NO_KEY);
-        let writer_id = EntityId::new([6, 7, 8], USER_DEFINED_READER_GROUP);
-        let writer_sn = 5;
-        let inline_qos = ParameterList::empty();
         let serialized_payload = Data::new(vec![1, 2, 3].into());
         let submessage = DataSubmessage::new(
             inline_qos_flag,
@@ -325,13 +290,13 @@ mod tests {
         );
         #[rustfmt::skip]
         assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
-                0x15, 0b_0000_0101, 24, 0, // Submessage header
+                0x15, 0b_0000_0101, 23, 0, // Submessage header
                 0, 0, 16, 0, // extraFlags, octetsToInlineQos
                 1, 2, 3, 4, // readerId: value[4]
                 6, 7, 8, 9, // writerId: value[4]
                 0, 0, 0, 0, // writerSN: high
                 5, 0, 0, 0, // writerSN: low
-                1, 2, 3, 0, // serialized payload
+                1, 2, 3, // serialized payload (Note: padding is not added by the submessage, it should have been added by the CDR data itself; hence 3 bytes only)
             ]
         );
     }

--- a/dds/src/rtps/messages/submessages/data.rs
+++ b/dds/src/rtps/messages/submessages/data.rs
@@ -70,7 +70,7 @@ impl DataSubmessage {
         let serialized_payload = if data_flag || key_flag {
             Data::new(data_starting_at_inline_qos.into())
         } else {
-            Data::empty()
+            Data::default()
         };
 
         Ok(Self {

--- a/dds/src/rtps/messages/submessages/data_frag.rs
+++ b/dds/src/rtps/messages/submessages/data_frag.rs
@@ -261,7 +261,7 @@ mod tests {
     #[test]
     fn serialize_with_inline_qos_with_serialized_payload() {
         let inline_qos = ParameterList::new(vec![Parameter::new(8, vec![71, 72, 73, 74].into())]);
-        let serialized_payload = SerializedDataFragment::from(&[1, 2, 3][..]);
+        let serialized_payload = SerializedDataFragment::from([1, 2, 3].as_slice());
         let submessage = DataFragSubmessage::new(
             true,
             false,
@@ -278,7 +278,7 @@ mod tests {
         );
         #[rustfmt::skip]
         assert_eq!(write_submessage_into_bytes_vec(&submessage), vec![
-                0x16_u8, 0b_0000_0011, 48, 0, // Submessage header
+                0x16_u8, 0b_0000_0011, 47, 0, // Submessage header
                 0, 0, 28, 0, // extraFlags | octetsToInlineQos
                 1, 2, 3, 4, // readerId
                 6, 7, 8, 9, // writerId
@@ -290,7 +290,7 @@ mod tests {
                 8, 0, 4, 0, // inlineQos: parameterId, length
                 71, 72, 73, 74, // inlineQos: value[length]
                 1, 0, 0, 0, // inlineQos: Sentinel
-                1, 2, 3, 0, // serializedPayload
+                1, 2, 3, // serializedPayload
             ]
         );
     }

--- a/dds/src/rtps/writer_history_cache.rs
+++ b/dds/src/rtps/writer_history_cache.rs
@@ -168,7 +168,7 @@ mod tests {
             InstanceHandle([0; 16]),
             1,
             TIME_INVALID,
-            Data::empty(),
+            Data::default(),
             ParameterList::empty(),
         );
         hc.add_change(change);
@@ -185,7 +185,7 @@ mod tests {
             InstanceHandle([0; 16]),
             1,
             TIME_INVALID,
-            Data::empty(),
+            Data::default(),
             ParameterList::empty(),
         );
         let change2 = RtpsWriterCacheChange::new(
@@ -194,7 +194,7 @@ mod tests {
             HANDLE_NIL,
             2,
             TIME_INVALID,
-            Data::empty(),
+            Data::default(),
             ParameterList::empty(),
         );
         hc.add_change(change1);
@@ -211,7 +211,7 @@ mod tests {
             HANDLE_NIL,
             1,
             TIME_INVALID,
-            Data::empty(),
+            Data::default(),
             ParameterList::empty(),
         );
         let change2 = RtpsWriterCacheChange::new(
@@ -220,7 +220,7 @@ mod tests {
             HANDLE_NIL,
             2,
             TIME_INVALID,
-            Data::empty(),
+            Data::default(),
             ParameterList::empty(),
         );
         hc.add_change(change1);

--- a/dds/tests/reliability_tests.rs
+++ b/dds/tests/reliability_tests.rs
@@ -133,10 +133,7 @@ fn writer_should_send_heartbeat_periodically() {
     );
     let dummy_reader_discovery =
         DiscoveredReaderData::new(reader_proxy, subscription_builtin_topic_data);
-    let mut serialized_dummy_reader_discovery_bytes = Vec::new();
-    dummy_reader_discovery
-        .serialize_data(&mut serialized_dummy_reader_discovery_bytes)
-        .unwrap();
+    let serialized_dummy_reader_discovery_bytes = dummy_reader_discovery.serialize_data().unwrap();
 
     let discovered_reader_data_submessage = DataSubmessage::new(
         false,
@@ -307,10 +304,7 @@ fn writer_should_not_send_heartbeat_after_acknack() {
     );
     let dummy_reader_discovery =
         DiscoveredReaderData::new(reader_proxy, subscription_builtin_topic_data);
-    let mut serialized_dummy_reader_discovery_bytes = Vec::new();
-    dummy_reader_discovery
-        .serialize_data(&mut serialized_dummy_reader_discovery_bytes)
-        .unwrap();
+    let serialized_dummy_reader_discovery_bytes = dummy_reader_discovery.serialize_data().unwrap();
 
     let discovered_reader_data_submessage = DataSubmessage::new(
         false,
@@ -502,10 +496,7 @@ fn writer_should_resend_data_after_acknack_request() {
     );
     let dummy_reader_discovery =
         DiscoveredReaderData::new(reader_proxy, subscription_builtin_topic_data);
-    let mut serialized_dummy_reader_discovery_bytes = Vec::new();
-    dummy_reader_discovery
-        .serialize_data(&mut serialized_dummy_reader_discovery_bytes)
-        .unwrap();
+    let serialized_dummy_reader_discovery_bytes = dummy_reader_discovery.serialize_data().unwrap();
 
     let discovered_reader_data_submessage = DataSubmessage::new(
         false,
@@ -706,10 +697,7 @@ fn volatile_writer_should_send_gap_submessage_after_discovery() {
     );
     let dummy_reader_discovery =
         DiscoveredReaderData::new(reader_proxy, subscription_builtin_topic_data);
-    let mut serialized_dummy_reader_discovery_bytes = Vec::new();
-    dummy_reader_discovery
-        .serialize_data(&mut serialized_dummy_reader_discovery_bytes)
-        .unwrap();
+    let serialized_dummy_reader_discovery_bytes = dummy_reader_discovery.serialize_data().unwrap();
 
     let discovered_reader_data_submessage = DataSubmessage::new(
         false,
@@ -884,9 +872,8 @@ fn transient_local_writer_should_send_data_submessage_after_discovery() {
     );
     let dummy_reader_discovery =
         DiscoveredReaderData::new(reader_proxy, subscription_builtin_topic_data);
-    let mut serialized_dummy_reader_discovery_bytes = Vec::new();
-    dummy_reader_discovery
-        .serialize_data(&mut serialized_dummy_reader_discovery_bytes)
+    let serialized_dummy_reader_discovery_bytes = dummy_reader_discovery
+        .serialize_data()
         .unwrap();
 
     let discovered_reader_data_submessage = DataSubmessage::new(

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1,5 +1,4 @@
 use dust_dds::{
-    configuration::DustDdsConfigurationBuilder,
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{
         error::DdsError,
@@ -45,15 +44,6 @@ struct LargeData {
 #[test]
 fn large_data_should_be_fragmented() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
-    let factory = DomainParticipantFactory::get_instance();
-    factory
-        .set_configuration(
-            DustDdsConfigurationBuilder::new()
-                .fragment_size(15)
-                .build()
-                .unwrap(),
-        )
-        .unwrap();
     let participant = DomainParticipantFactory::get_instance()
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .unwrap();
@@ -108,7 +98,7 @@ fn large_data_should_be_fragmented() {
 
     let even_data = LargeData {
         id: 1,
-        value: Vec::from_iter(1..31),
+        value: vec![8; 15000],
     };
 
     writer.write(&even_data, None).unwrap();
@@ -131,7 +121,7 @@ fn large_data_should_be_fragmented() {
 
     let odd_data = LargeData {
         id: 1,
-        value: Vec::from_iter(1..30),
+        value: vec![8; 15001],
     };
 
     writer.write(&odd_data, None).unwrap();

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -303,9 +303,8 @@ fn foo_with_specialized_type_support_should_read_and_write() {
     }
 
     impl DdsSerialize for DynamicType {
-        fn serialize_data(&self, mut writer: impl std::io::Write) -> DdsResult<()> {
-            writer.write_all(&self.value).unwrap();
-            Ok(())
+        fn serialize_data(&self) -> DdsResult<Vec<u8>> {
+            Ok(self.value.clone())
         }
     }
 

--- a/dds_derive/src/derive/dds_serialize_data.rs
+++ b/dds_derive/src/derive/dds_serialize_data.rs
@@ -53,22 +53,18 @@ pub fn expand_dds_serialize_data(input: &DeriveInput) -> Result<TokenStream> {
                 Format::CdrLe => quote! {
                     dust_dds::topic_definition::type_support::serialize_rtps_classic_cdr_le(
                         self,
-                        writer,
                 )},
                 Format::CdrBe => quote! {
                     dust_dds::topic_definition::type_support::serialize_rtps_classic_cdr_be(
                         self,
-                        writer,
                 )},
                 Format::PlCdrLe => quote! {
                     dust_dds::topic_definition::type_support::serialize_rtps_cdr_pl_le(
                         self,
-                        writer,
                 )},
                 Format::PlCdrBe => quote! {
                     dust_dds::topic_definition::type_support::serialize_rtps_cdr_pl_be(
                         self,
-                        writer,
                 )},
             };
 
@@ -77,7 +73,7 @@ pub fn expand_dds_serialize_data(input: &DeriveInput) -> Result<TokenStream> {
 
             Ok(quote! {
                 impl #impl_generics dust_dds::topic_definition::type_support::DdsSerialize for #ident #type_generics #where_clause {
-                    fn serialize_data(&self, writer: impl std::io::Write) -> dust_dds::infrastructure::error::DdsResult<()> {
+                    fn serialize_data(&self) -> dust_dds::infrastructure::error::DdsResult<Vec<u8>> {
                         #serialize_function
                     }
                 }

--- a/interoperability_tests/cyclone_dds/cyclone_dds_big_data_publisher.c
+++ b/interoperability_tests/cyclone_dds/cyclone_dds_big_data_publisher.c
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
 		DDS_FATAL("dds_waitset_wait: %s\n", dds_strretcode(-rc));
 	}
 
-	char data_bytes[15000];
+	char data_bytes[15001];
 	for (int i = 0; i<sizeof(data_bytes); i++) {
 		data_bytes[i] = i;
 	};


### PR DESCRIPTION
The data messages were not send correctly if padding was needed in the data submessage element. According to X-Types specification bits must be set in the CDR header representation options. Further the Serialized data fragment addded padding itself, which is actually not the job of the submessage element but rather the job of the Rtps Message itself. This lead to wrong data being sent in case of fragmentation. 
Tests were added to address this and the interoperability test with Cyclone DDS was adjusted to contain padding bits.