### PR TITLE
Replace Tokio by own minimal executor

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -24,12 +24,10 @@ socket2 = "0.5"
 network-interface = "1.1.1"
 
 fnmatch-regex = "0.2.0"
-
-tokio = { version = "1", features = ["rt-multi-thread"] }
 tracing = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["rt", "macros"] }
 criterion = { version = "0.3", features = ["html_reports"] }
 tracing-subscriber = "0.3"
 

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -25,7 +25,7 @@ network-interface = "1.1.1"
 
 fnmatch-regex = "0.2.0"
 
-tokio = { version = "1", features = ["rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/dds/examples/tokio_runtime.rs
+++ b/dds/examples/tokio_runtime.rs
@@ -23,7 +23,7 @@ struct UserData {
 async fn main() {
     let domain_id = 100;
 
-    let participant_factory = DomainParticipantFactoryAsync::new(tokio::runtime::Handle::current());
+    let participant_factory = DomainParticipantFactoryAsync::new();
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .await

--- a/dds/examples/tokio_runtime.rs
+++ b/dds/examples/tokio_runtime.rs
@@ -19,7 +19,7 @@ struct UserData {
     value: Vec<u8>,
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     let domain_id = 100;
 

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -6,6 +6,7 @@ use crate::{
         publisher_listener::PublisherListenerAsync, subscriber_listener::SubscriberListenerAsync,
         topic_listener::TopicListenerAsync,
     },
+    implementation::runtime::executor::block_on,
     infrastructure::{
         condition::StatusCondition,
         error::DdsResult,
@@ -75,14 +76,12 @@ impl DomainParticipant {
         a_listener: Option<Box<dyn PublisherListener + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<Publisher> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.create_publisher(
-                qos,
-                a_listener.map::<Box<dyn PublisherListenerAsync + Send>, _>(|b| Box::new(b)),
-                mask,
-            ))
-            .map(Publisher::new)
+        block_on(self.participant_async.create_publisher(
+            qos,
+            a_listener.map::<Box<dyn PublisherListenerAsync + Send>, _>(|b| Box::new(b)),
+            mask,
+        ))
+        .map(Publisher::new)
     }
 
     /// This operation deletes an existing [`Publisher`].
@@ -94,7 +93,7 @@ impl DomainParticipant {
     /// a PreconditionNotMet error.
     #[tracing::instrument(skip(self, a_publisher))]
     pub fn delete_publisher(&self, a_publisher: &Publisher) -> DdsResult<()> {
-        self.participant_async.runtime_handle().block_on(
+        block_on(
             self.participant_async
                 .delete_publisher(a_publisher.publisher_async()),
         )
@@ -115,14 +114,12 @@ impl DomainParticipant {
         a_listener: Option<Box<dyn SubscriberListener + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<Subscriber> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.create_subscriber(
-                qos,
-                a_listener.map::<Box<dyn SubscriberListenerAsync + Send>, _>(|b| Box::new(b)),
-                mask,
-            ))
-            .map(Subscriber::new)
+        block_on(self.participant_async.create_subscriber(
+            qos,
+            a_listener.map::<Box<dyn SubscriberListenerAsync + Send>, _>(|b| Box::new(b)),
+            mask,
+        ))
+        .map(Subscriber::new)
     }
 
     /// This operation deletes an existing [`Subscriber`].
@@ -133,7 +130,7 @@ impl DomainParticipant {
     /// [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError).
     #[tracing::instrument(skip(self, a_subscriber))]
     pub fn delete_subscriber(&self, a_subscriber: &Subscriber) -> DdsResult<()> {
-        self.participant_async.runtime_handle().block_on(
+        block_on(
             self.participant_async
                 .delete_subscriber(a_subscriber.subscriber_async()),
         )
@@ -158,16 +155,14 @@ impl DomainParticipant {
     where
         Foo: DdsKey + DdsHasKey + DdsTypeXml,
     {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.create_topic::<Foo>(
-                topic_name,
-                type_name,
-                qos,
-                a_listener.map::<Box<dyn TopicListenerAsync + Send>, _>(|b| Box::new(b)),
-                mask,
-            ))
-            .map(Topic::new)
+        block_on(self.participant_async.create_topic::<Foo>(
+            topic_name,
+            type_name,
+            qos,
+            a_listener.map::<Box<dyn TopicListenerAsync + Send>, _>(|b| Box::new(b)),
+            mask,
+        ))
+        .map(Topic::new)
     }
 
     #[doc(hidden)]
@@ -181,17 +176,15 @@ impl DomainParticipant {
         mask: &[StatusKind],
         dynamic_type_representation: Box<dyn DynamicTypeInterface + Send + Sync>,
     ) -> DdsResult<Topic> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.create_dynamic_topic(
-                topic_name,
-                type_name,
-                qos,
-                a_listener.map::<Box<dyn TopicListenerAsync + Send>, _>(|b| Box::new(b)),
-                mask,
-                dynamic_type_representation,
-            ))
-            .map(Topic::new)
+        block_on(self.participant_async.create_dynamic_topic(
+            topic_name,
+            type_name,
+            qos,
+            a_listener.map::<Box<dyn TopicListenerAsync + Send>, _>(|b| Box::new(b)),
+            mask,
+            dynamic_type_representation,
+        ))
+        .map(Topic::new)
     }
 
     /// This operation deletes a [`Topic`].
@@ -202,9 +195,7 @@ impl DomainParticipant {
     /// called on a different [`DomainParticipant`], the operation will have no effect and it will return [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError).
     #[tracing::instrument(skip(self, a_topic))]
     pub fn delete_topic(&self, a_topic: &Topic) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.delete_topic(a_topic.topic_async()))
+        block_on(self.participant_async.delete_topic(a_topic.topic_async()))
     }
 
     /// This operation gives access to an existing (or ready to exist) enabled [`Topic`], based on its name. The operation takes
@@ -223,13 +214,11 @@ impl DomainParticipant {
     where
         Foo: DdsKey + DdsHasKey + DdsTypeXml,
     {
-        self.participant_async
-            .runtime_handle()
-            .block_on(
-                self.participant_async
-                    .find_topic::<Foo>(topic_name, timeout),
-            )
-            .map(Topic::new)
+        block_on(
+            self.participant_async
+                .find_topic::<Foo>(topic_name, timeout),
+        )
+        .map(Topic::new)
     }
 
     /// This operation gives access to an existing locally-created [`Topic`], based on its name and type. The
@@ -244,11 +233,7 @@ impl DomainParticipant {
     /// If the operation fails to locate a [`Topic`], the operation succeeds and a [`None`] value is returned.
     #[tracing::instrument(skip(self))]
     pub fn lookup_topicdescription(&self, topic_name: &str) -> DdsResult<Option<Topic>> {
-        Ok(self
-            .participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.lookup_topicdescription(topic_name))?
-            .map(Topic::new))
+        Ok(block_on(self.participant_async.lookup_topicdescription(topic_name))?.map(Topic::new))
     }
 
     /// This operation allows access to the built-in [`Subscriber`]. Each [`DomainParticipant`] contains several built-in [`Topic`] objects as
@@ -273,9 +258,7 @@ impl DomainParticipant {
     /// The [`DomainParticipant::ignore_participant()`] operation is not reversible.
     #[tracing::instrument(skip(self))]
     pub fn ignore_participant(&self, handle: InstanceHandle) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.ignore_participant(handle))
+        block_on(self.participant_async.ignore_participant(handle))
     }
 
     /// This operation allows an application to instruct the Service to locally ignore a remote topic. This means it will locally ignore any
@@ -287,9 +270,7 @@ impl DomainParticipant {
     /// The [`DomainParticipant::ignore_topic()`] operation is not reversible.
     #[tracing::instrument(skip(self))]
     pub fn ignore_topic(&self, handle: InstanceHandle) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.ignore_topic(handle))
+        block_on(self.participant_async.ignore_topic(handle))
     }
 
     /// This operation allows an application to instruct the Service to locally ignore a remote publication; a publication is defined by
@@ -299,9 +280,7 @@ impl DomainParticipant {
     /// The [`DomainParticipant::ignore_publication()`] operation is not reversible.
     #[tracing::instrument(skip(self))]
     pub fn ignore_publication(&self, handle: InstanceHandle) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.ignore_publication(handle))
+        block_on(self.participant_async.ignore_publication(handle))
     }
 
     /// This operation allows an application to instruct the Service to locally ignore a remote subscription; a subscription is defined by
@@ -312,9 +291,7 @@ impl DomainParticipant {
     /// The [`DomainParticipant::ignore_subscription()`] operation is not reversible.
     #[tracing::instrument(skip(self))]
     pub fn ignore_subscription(&self, handle: InstanceHandle) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.ignore_subscription(handle))
+        block_on(self.participant_async.ignore_subscription(handle))
     }
 
     /// This operation retrieves the [`DomainId`] used to create the DomainParticipant. The [`DomainId`] identifies the DDS domain to
@@ -336,9 +313,7 @@ impl DomainParticipant {
     /// contained entities.
     #[tracing::instrument(skip(self))]
     pub fn delete_contained_entities(&self) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.delete_contained_entities())
+        block_on(self.participant_async.delete_contained_entities())
     }
 
     /// This operation manually asserts the liveliness of the [`DomainParticipant`]. This is used in combination
@@ -350,9 +325,7 @@ impl DomainParticipant {
     /// [`DomainParticipant`]. Consequently the use of this operation is only needed if the application is not writing data regularly.
     #[tracing::instrument(skip(self))]
     pub fn assert_liveliness(&self) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.assert_liveliness())
+        block_on(self.participant_async.assert_liveliness())
     }
 
     /// This operation sets a default value of the Publisher QoS policies which will be used for newly created [`Publisher`] entities in the
@@ -363,9 +336,7 @@ impl DomainParticipant {
     /// reset back to the initial values the factory would use, that is the values the default values of [`PublisherQos`].
     #[tracing::instrument(skip(self))]
     pub fn set_default_publisher_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.set_default_publisher_qos(qos))
+        block_on(self.participant_async.set_default_publisher_qos(qos))
     }
 
     /// This operation retrieves the default value of the Publisher QoS, that is, the QoS policies which will be used for newly created
@@ -374,9 +345,7 @@ impl DomainParticipant {
     /// [`DomainParticipant::set_default_publisher_qos()`], or else, if the call was never made, the default values of the [`PublisherQos`].
     #[tracing::instrument(skip(self))]
     pub fn get_default_publisher_qos(&self) -> DdsResult<PublisherQos> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_default_publisher_qos())
+        block_on(self.participant_async.get_default_publisher_qos())
     }
 
     /// This operation sets a default value of the Subscriber QoS policies that will be used for newly created [`Subscriber`] entities in the
@@ -387,9 +356,7 @@ impl DomainParticipant {
     /// reset back to the initial values the factory would use, that is the default values of [`SubscriberQos`].
     #[tracing::instrument(skip(self))]
     pub fn set_default_subscriber_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.set_default_subscriber_qos(qos))
+        block_on(self.participant_async.set_default_subscriber_qos(qos))
     }
 
     /// This operation retrieves the default value of the Subscriber QoS, that is, the QoS policies which will be used for newly created
@@ -398,9 +365,7 @@ impl DomainParticipant {
     /// [`DomainParticipant::set_default_subscriber_qos()`], or else, if the call was never made, the default values of [`SubscriberQos`].
     #[tracing::instrument(skip(self))]
     pub fn get_default_subscriber_qos(&self) -> DdsResult<SubscriberQos> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_default_subscriber_qos())
+        block_on(self.participant_async.get_default_subscriber_qos())
     }
 
     /// This operation sets a default value of the Topic QoS policies which will be used for newly created [`Topic`] entities in the case
@@ -411,9 +376,7 @@ impl DomainParticipant {
     /// back to the initial values the factory would use, that is the default values of [`TopicQos`].
     #[tracing::instrument(skip(self))]
     pub fn set_default_topic_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.set_default_topic_qos(qos))
+        block_on(self.participant_async.set_default_topic_qos(qos))
     }
 
     /// This operation retrieves the default value of the Topic QoS, that is, the QoS policies that will be used for newly created [`Topic`]
@@ -422,18 +385,14 @@ impl DomainParticipant {
     /// [`DomainParticipant::set_default_topic_qos()`], or else, if the call was never made, the default values of [`TopicQos`]
     #[tracing::instrument(skip(self))]
     pub fn get_default_topic_qos(&self) -> DdsResult<TopicQos> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_default_topic_qos())
+        block_on(self.participant_async.get_default_topic_qos())
     }
 
     /// This operation retrieves the list of DomainParticipants that have been discovered in the domain and that the application has not
     /// indicated should be “ignored” by means of the [`DomainParticipant::ignore_participant()`] operation.
     #[tracing::instrument(skip(self))]
     pub fn get_discovered_participants(&self) -> DdsResult<Vec<InstanceHandle>> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_discovered_participants())
+        block_on(self.participant_async.get_discovered_participants())
     }
 
     /// This operation retrieves information on a [`DomainParticipant`] that has been discovered on the network. The participant must
@@ -447,7 +406,7 @@ impl DomainParticipant {
         &self,
         participant_handle: InstanceHandle,
     ) -> DdsResult<ParticipantBuiltinTopicData> {
-        self.participant_async.runtime_handle().block_on(
+        block_on(
             self.participant_async
                 .get_discovered_participant_data(participant_handle),
         )
@@ -457,9 +416,7 @@ impl DomainParticipant {
     /// should be “ignored” by means of the [`DomainParticipant::ignore_topic()`] operation.
     #[tracing::instrument(skip(self))]
     pub fn get_discovered_topics(&self) -> DdsResult<Vec<InstanceHandle>> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_discovered_topics())
+        block_on(self.participant_async.get_discovered_topics())
     }
 
     /// This operation retrieves information on a Topic that has been discovered on the network. The topic must have been created by
@@ -473,7 +430,7 @@ impl DomainParticipant {
         &self,
         topic_handle: InstanceHandle,
     ) -> DdsResult<TopicBuiltinTopicData> {
-        self.participant_async.runtime_handle().block_on(
+        block_on(
             self.participant_async
                 .get_discovered_topic_data(topic_handle),
         )
@@ -487,18 +444,14 @@ impl DomainParticipant {
     /// `get_instance_handle`.
     #[tracing::instrument(skip(self))]
     pub fn contains_entity(&self, a_handle: InstanceHandle) -> DdsResult<bool> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.contains_entity(a_handle))
+        block_on(self.participant_async.contains_entity(a_handle))
     }
 
     /// This operation returns the current value of the time that the service uses to time-stamp data-writes and to set the reception timestamp
     /// for the data-updates it receives.
     #[tracing::instrument(skip(self))]
     pub fn get_current_time(&self) -> DdsResult<Time> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_current_time())
+        block_on(self.participant_async.get_current_time())
     }
 }
 
@@ -518,17 +471,13 @@ impl DomainParticipant {
     /// modified to match the current default for the Entity’s factory.
     #[tracing::instrument(skip(self))]
     pub fn set_qos(&self, qos: QosKind<DomainParticipantQos>) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.set_qos(qos))
+        block_on(self.participant_async.set_qos(qos))
     }
 
     /// This operation allows access to the existing set of [`DomainParticipantQos`] policies.
     #[tracing::instrument(skip(self))]
     pub fn get_qos(&self) -> DdsResult<DomainParticipantQos> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_qos())
+        block_on(self.participant_async.get_qos())
     }
 
     /// This operation installs a Listener on the Entity. The listener will only be invoked on the changes of communication status
@@ -543,15 +492,10 @@ impl DomainParticipant {
         a_listener: Option<Box<dyn DomainParticipantListener + Send + 'static>>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(
-                self.participant_async.set_listener(
-                    a_listener
-                        .map::<Box<dyn DomainParticipantListenerAsync + Send>, _>(|b| Box::new(b)),
-                    mask,
-                ),
-            )
+        block_on(self.participant_async.set_listener(
+            a_listener.map::<Box<dyn DomainParticipantListenerAsync + Send>, _>(|b| Box::new(b)),
+            mask,
+        ))
     }
 
     /// This operation allows access to the [`StatusCondition`] associated with the Entity. The returned
@@ -570,9 +514,7 @@ impl DomainParticipant {
     /// and does not include statuses that apply to contained entities.
     #[tracing::instrument(skip(self))]
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_status_changes())
+        block_on(self.participant_async.get_status_changes())
     }
 
     /// This operation enables the Entity. Entity objects can be created either enabled or disabled. This is controlled by the value of
@@ -597,16 +539,12 @@ impl DomainParticipant {
     /// enabled are “inactive”, that is, the operation [`StatusCondition::get_trigger_value()`] will always return `false`.
     #[tracing::instrument(skip(self))]
     pub fn enable(&self) -> DdsResult<()> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.enable())
+        block_on(self.participant_async.enable())
     }
 
     /// This operation returns the [`InstanceHandle`] that represents the Entity.
     #[tracing::instrument(skip(self))]
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        self.participant_async
-            .runtime_handle()
-            .block_on(self.participant_async.get_instance_handle())
+        block_on(self.participant_async.get_instance_handle())
     }
 }

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -6,6 +6,7 @@ use crate::{
         domain_participant_listener::DomainParticipantListenerAsync,
     },
     domain::domain_participant_listener::DomainParticipantListener,
+    implementation::runtime::executor::block_on,
     infrastructure::{
         error::DdsResult,
         qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
@@ -24,13 +25,6 @@ pub type DomainId = i32;
 /// [`DomainParticipantFactory::get_instance`] operation.
 pub struct DomainParticipantFactory {
     participant_factory_async: DomainParticipantFactoryAsync,
-    runtime: tokio::runtime::Runtime,
-}
-
-impl DomainParticipantFactory {
-    pub(crate) fn runtime(&self) -> &tokio::runtime::Runtime {
-        &self.runtime
-    }
 }
 
 impl DomainParticipantFactory {
@@ -49,17 +43,13 @@ impl DomainParticipantFactory {
         a_listener: Option<Box<dyn DomainParticipantListener + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<DomainParticipant> {
-        self.runtime
-            .block_on(
-                self.participant_factory_async.create_participant(
-                    domain_id,
-                    qos,
-                    a_listener
-                        .map::<Box<dyn DomainParticipantListenerAsync + Send>, _>(|b| Box::new(b)),
-                    mask,
-                ),
-            )
-            .map(DomainParticipant::new)
+        block_on(self.participant_factory_async.create_participant(
+            domain_id,
+            qos,
+            a_listener.map::<Box<dyn DomainParticipantListenerAsync + Send>, _>(|b| Box::new(b)),
+            mask,
+        ))
+        .map(DomainParticipant::new)
     }
 
     /// This operation deletes an existing [`DomainParticipant`]. This operation can only be invoked if all domain entities belonging to
@@ -67,7 +57,7 @@ impl DomainParticipantFactory {
     /// participant has been previously deleted this operation returns the error [`DdsError::AlreadyDeleted`](crate::infrastructure::error::DdsError::AlreadyDeleted).
     #[tracing::instrument(skip(self, participant))]
     pub fn delete_participant(&self, participant: &DomainParticipant) -> DdsResult<()> {
-        self.runtime.block_on(
+        block_on(
             self.participant_factory_async
                 .delete_participant(participant.participant_async()),
         )
@@ -78,18 +68,8 @@ impl DomainParticipantFactory {
     #[tracing::instrument]
     pub fn get_instance() -> &'static Self {
         static PARTICIPANT_FACTORY: OnceLock<DomainParticipantFactory> = OnceLock::new();
-        PARTICIPANT_FACTORY.get_or_init(|| {
-            let runtime = tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .thread_stack_size(4 * 1024 * 1024)
-                .build()
-                .expect("Failed to create Tokio runtime");
-            Self {
-                participant_factory_async: DomainParticipantFactoryAsync::new(
-                    runtime.handle().clone(),
-                ),
-                runtime,
-            }
+        PARTICIPANT_FACTORY.get_or_init(|| Self {
+            participant_factory_async: DomainParticipantFactoryAsync::new(),
         })
     }
 
@@ -99,10 +79,10 @@ impl DomainParticipantFactory {
     /// specified which one.
     #[tracing::instrument(skip(self))]
     pub fn lookup_participant(&self, domain_id: DomainId) -> DdsResult<Option<DomainParticipant>> {
-        Ok(self
-            .runtime
-            .block_on(self.participant_factory_async.lookup_participant(domain_id))?
-            .map(DomainParticipant::new))
+        Ok(
+            block_on(self.participant_factory_async.lookup_participant(domain_id))?
+                .map(DomainParticipant::new),
+        )
     }
 
     /// This operation sets a default value of the [`DomainParticipantQos`] policies which will be used for newly created
@@ -111,7 +91,7 @@ impl DomainParticipantFactory {
     /// return a [`DdsError::InconsistentPolicy`](crate::infrastructure::error::DdsError::InconsistentPolicy).
     #[tracing::instrument(skip(self))]
     pub fn set_default_participant_qos(&self, qos: QosKind<DomainParticipantQos>) -> DdsResult<()> {
-        self.runtime.block_on(
+        block_on(
             self.participant_factory_async
                 .set_default_participant_qos(qos),
         )
@@ -124,8 +104,7 @@ impl DomainParticipantFactory {
     /// [`DomainParticipantFactory::set_default_participant_qos`], or else, if the call was never made, the default value of [`DomainParticipantQos`].
     #[tracing::instrument(skip(self))]
     pub fn get_default_participant_qos(&self) -> DdsResult<DomainParticipantQos> {
-        self.runtime
-            .block_on(self.participant_factory_async.get_default_participant_qos())
+        block_on(self.participant_factory_async.get_default_participant_qos())
     }
 
     /// This operation sets the value of the [`DomainParticipantFactoryQos`] policies. These policies control the behavior of the object
@@ -135,22 +114,20 @@ impl DomainParticipantFactory {
     /// return a [`DdsError::InconsistentPolicy`](crate::infrastructure::error::DdsError::InconsistentPolicy).
     #[tracing::instrument(skip(self))]
     pub fn set_qos(&self, qos: QosKind<DomainParticipantFactoryQos>) -> DdsResult<()> {
-        self.runtime
-            .block_on(self.participant_factory_async.set_qos(qos))
+        block_on(self.participant_factory_async.set_qos(qos))
     }
 
     /// This operation returns the value of the [`DomainParticipantFactoryQos`] policies.
     #[tracing::instrument(skip(self))]
     pub fn get_qos(&self) -> DdsResult<DomainParticipantFactoryQos> {
-        self.runtime
-            .block_on(self.participant_factory_async.get_qos())
+        block_on(self.participant_factory_async.get_qos())
     }
 }
 
 impl DomainParticipantFactory {
     /// Set the configuration of the [`DomainParticipantFactory`] singleton
     pub fn set_configuration(&self, configuration: DustDdsConfiguration) -> DdsResult<()> {
-        self.runtime.block_on(
+        block_on(
             self.participant_factory_async
                 .set_configuration(configuration),
         )
@@ -158,7 +135,6 @@ impl DomainParticipantFactory {
 
     /// Get the current configuration of the [`DomainParticipantFactory`] singleton
     pub fn get_configuration(&self) -> DdsResult<DustDdsConfiguration> {
-        self.runtime
-            .block_on(self.participant_factory_async.get_configuration())
+        block_on(self.participant_factory_async.get_configuration())
     }
 }

--- a/dds/src/dds/domain/domain_participant_listener.rs
+++ b/dds/src/dds/domain/domain_participant_listener.rs
@@ -106,14 +106,12 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
         the_topic: TopicAsync,
         status: InconsistentTopicStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_inconsistent_topic(
-                self.as_mut(),
-                Topic::new(the_topic),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_inconsistent_topic(
+            self.as_mut(),
+            Topic::new(the_topic),
+            status,
+        );
+        Box::pin(std::future::ready(()))
     }
 
     fn on_liveliness_lost<'a, 'b>(
@@ -124,10 +122,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_liveliness_lost(self.as_mut(), the_writer, status)
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_liveliness_lost(self.as_mut(), the_writer, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_offered_deadline_missed<'a, 'b>(
@@ -138,10 +134,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_offered_deadline_missed(self.as_mut(), the_writer, status)
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_offered_deadline_missed(self.as_mut(), the_writer, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_offered_incompatible_qos<'a, 'b>(
@@ -152,14 +146,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_offered_incompatible_qos(
-                self.as_mut(),
-                the_writer,
-                status,
-            )
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_offered_incompatible_qos(self.as_mut(), the_writer, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_sample_lost<'a, 'b>(
@@ -170,10 +158,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_sample_lost(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_sample_lost(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_data_available<'a, 'b>(
@@ -183,10 +169,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_data_available(self.as_mut(), the_reader)
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_data_available(self.as_mut(), the_reader);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_sample_rejected<'a, 'b>(
@@ -197,10 +181,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_sample_rejected(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_sample_rejected(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_liveliness_changed<'a, 'b>(
@@ -211,10 +193,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_liveliness_changed(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_liveliness_changed(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_requested_deadline_missed<'a, 'b>(
@@ -225,14 +205,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_requested_deadline_missed(
-                self.as_mut(),
-                the_reader,
-                status,
-            )
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_requested_deadline_missed(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_requested_incompatible_qos<'a, 'b>(
@@ -243,14 +217,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_requested_incompatible_qos(
-                self.as_mut(),
-                the_reader,
-                status,
-            )
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_requested_incompatible_qos(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_publication_matched<'a, 'b>(
@@ -261,10 +229,8 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_publication_matched(self.as_mut(), the_writer, status)
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_publication_matched(self.as_mut(), the_writer, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_subscription_matched<'a, 'b>(
@@ -275,9 +241,7 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            DomainParticipantListener::on_subscription_matched(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        DomainParticipantListener::on_subscription_matched(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds/infrastructure/condition.rs
+++ b/dds/src/dds/infrastructure/condition.rs
@@ -1,4 +1,7 @@
-use crate::{dds_async::condition::StatusConditionAsync, infrastructure::error::DdsResult};
+use crate::{
+    dds_async::condition::StatusConditionAsync, implementation::runtime::executor::block_on,
+    infrastructure::error::DdsResult,
+};
 
 use super::status::StatusKind;
 
@@ -25,9 +28,7 @@ impl StatusCondition {
     /// [`StatusCondition`]. This operation returns the statuses that were explicitly set on the last call to [`StatusCondition::set_enabled_statuses`] or, if
     /// it was never called, the default list of enabled statuses which includes all the statuses.
     pub fn get_enabled_statuses(&self) -> DdsResult<Vec<StatusKind>> {
-        self.condition_async
-            .runtime_handle()
-            .block_on(self.condition_async.get_enabled_statuses())
+        block_on(self.condition_async.get_enabled_statuses())
     }
 
     /// This operation defines the list of communication statuses that are taken into account to determine the *trigger_value* of the
@@ -36,17 +37,13 @@ impl StatusCondition {
     /// attached conditions. Therefore, any [`WaitSet`](crate::infrastructure::wait_set::WaitSet) to which the [`StatusCondition`] is attached is potentially affected by this operation.
     /// If this function is not invoked, the default list of enabled statuses includes all the statuses.
     pub fn set_enabled_statuses(&self, mask: &[StatusKind]) -> DdsResult<()> {
-        self.condition_async
-            .runtime_handle()
-            .block_on(self.condition_async.set_enabled_statuses(mask))
+        block_on(self.condition_async.set_enabled_statuses(mask))
     }
 
     /// This operation returns the Entity associated with the [`StatusCondition`]. Note that there is exactly one Entity associated with
     /// each [`StatusCondition`].
     pub fn get_entity(&self) {
-        self.condition_async
-            .runtime_handle()
-            .block_on(self.condition_async.get_entity())
+        block_on(self.condition_async.get_entity())
     }
 }
 
@@ -54,8 +51,6 @@ impl StatusCondition {
 impl StatusCondition {
     /// This operation retrieves the *trigger_value* of the [`StatusCondition`].
     pub fn get_trigger_value(&self) -> DdsResult<bool> {
-        self.condition_async
-            .runtime_handle()
-            .block_on(self.condition_async.get_trigger_value())
+        block_on(self.condition_async.get_trigger_value())
     }
 }

--- a/dds/src/dds/infrastructure/wait_set.rs
+++ b/dds/src/dds/infrastructure/wait_set.rs
@@ -1,6 +1,6 @@
 use crate::{
     dds_async::wait_set::{ConditionAsync, WaitSetAsync},
-    domain::domain_participant_factory::DomainParticipantFactory,
+    implementation::runtime::executor::block_on,
     infrastructure::{error::DdsResult, time::Duration},
 };
 
@@ -48,9 +48,7 @@ impl WaitSet {
     /// [`WaitSet`] that already has a thread blocking on it, the operation will return immediately with the value [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError::PreconditionNotMet).
     #[tracing::instrument(skip(self))]
     pub fn wait(&self, timeout: Duration) -> DdsResult<Vec<Condition>> {
-        Ok(DomainParticipantFactory::get_instance()
-            .runtime()
-            .block_on(self.waitset_async.wait(timeout))?
+        Ok(block_on(self.waitset_async.wait(timeout))?
             .into_iter()
             .map(|c| match c {
                 ConditionAsync::StatusCondition(sc) => {
@@ -67,14 +65,9 @@ impl WaitSet {
     #[tracing::instrument(skip(self, cond))]
     pub fn attach_condition(&mut self, cond: Condition) -> DdsResult<()> {
         match cond {
-            Condition::StatusCondition(sc) => {
-                DomainParticipantFactory::get_instance().runtime().block_on(
-                    self.waitset_async
-                        .attach_condition(ConditionAsync::StatusCondition(
-                            sc.condition_async().clone(),
-                        )),
-                )
-            }
+            Condition::StatusCondition(sc) => block_on(self.waitset_async.attach_condition(
+                ConditionAsync::StatusCondition(sc.condition_async().clone()),
+            )),
         }
     }
 
@@ -88,9 +81,7 @@ impl WaitSet {
     /// This operation retrieves the list of attached conditions.
     #[tracing::instrument(skip(self))]
     pub fn get_conditions(&self) -> DdsResult<Vec<Condition>> {
-        Ok(DomainParticipantFactory::get_instance()
-            .runtime()
-            .block_on(self.waitset_async.get_conditions())?
+        Ok(block_on(self.waitset_async.get_conditions())?
             .into_iter()
             .map(|c| match c {
                 ConditionAsync::StatusCondition(sc) => {

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -1,6 +1,7 @@
 use crate::{
     builtin_topics::SubscriptionBuiltinTopicData,
     dds_async::{data_writer::DataWriterAsync, data_writer_listener::DataWriterListenerAsync},
+    implementation::runtime::executor::block_on,
     infrastructure::{
         condition::StatusCondition,
         error::DdsResult,
@@ -60,9 +61,7 @@ where
     /// and specify no [`InstanceHandle`] to indicate that the *key* should be examined to identify the instance.
     #[tracing::instrument(skip(self, instance))]
     pub fn register_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.register_instance(instance))
+        block_on(self.writer_async.register_instance(instance))
     }
 
     /// This operation performs the same function and return the same values as [`DataWriter::register_instance`] and can be used instead of
@@ -75,7 +74,7 @@ where
         instance: &Foo,
         timestamp: Time,
     ) -> DdsResult<Option<InstanceHandle>> {
-        self.writer_async.runtime_handle().block_on(
+        block_on(
             self.writer_async
                 .register_instance_w_timestamp(instance, timestamp),
         )
@@ -115,9 +114,7 @@ where
         instance: &Foo,
         handle: Option<InstanceHandle>,
     ) -> DdsResult<()> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.unregister_instance(instance, handle))
+        block_on(self.writer_async.unregister_instance(instance, handle))
     }
 
     /// This operation performs the same function and returns the same values as [`DataWriter::unregister_instance`] and can
@@ -132,7 +129,7 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        self.writer_async.runtime_handle().block_on(
+        block_on(
             self.writer_async
                 .unregister_instance_w_timestamp(instance, handle, timestamp),
         )
@@ -144,9 +141,7 @@ where
     /// correspond to an existing data object known to the [`DataWriter`].
     #[tracing::instrument(skip(self, key_holder))]
     pub fn get_key_value(&self, key_holder: &mut Foo, handle: InstanceHandle) -> DdsResult<()> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.get_key_value(key_holder, handle))
+        block_on(self.writer_async.get_key_value(key_holder, handle))
     }
 
     /// This operation takes as a parameter an instance and returns an [`InstanceHandle`] that can be used in subsequent operations
@@ -156,9 +151,7 @@ where
     /// reason the Service is unable to provide an [`InstanceHandle`], the operation will return [`None`].
     #[tracing::instrument(skip(self, instance))]
     pub fn lookup_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.lookup_instance(instance))
+        block_on(self.writer_async.lookup_instance(instance))
     }
 
     /// This operation modifies the value of a data instance. When this operation is used, the Service will automatically supply the
@@ -195,9 +188,7 @@ where
     /// chance of freeing the necessary resources. For example, if the only way to gain the necessary resources would be for the user to unregister an instance.
     #[tracing::instrument(skip(self, data))]
     pub fn write(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.write(data, handle))
+        block_on(self.writer_async.write(data, handle))
     }
 
     /// This operation performs the same function and returns the same values as [`DataWriter::write`] and can
@@ -212,9 +203,7 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.write_w_timestamp(data, handle, timestamp))
+        block_on(self.writer_async.write_w_timestamp(data, handle, timestamp))
     }
 
     /// This operation requests the middleware to delete the data (the actual deletion is postponed until there is no more use for that
@@ -231,9 +220,7 @@ where
     /// [`DdsError::OutOfResources`](crate::infrastructure::error::DdsError) under the same circumstances described for [`DataWriter::write`].
     #[tracing::instrument(skip(self, data))]
     pub fn dispose(&self, data: &Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.dispose(data, handle))
+        block_on(self.writer_async.dispose(data, handle))
     }
 
     /// This operation performs the same function and returns the same values as [`DataWriter::dispose`] and can
@@ -248,7 +235,7 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        self.writer_async.runtime_handle().block_on(
+        block_on(
             self.writer_async
                 .dispose_w_timestamp(data, handle, timestamp),
         )
@@ -266,41 +253,31 @@ impl<Foo> DataWriter<Foo> {
     /// Otherwise the operation will return immediately with [`Ok`].
     #[tracing::instrument(skip(self))]
     pub fn wait_for_acknowledgments(&self, max_wait: Duration) -> DdsResult<()> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.wait_for_acknowledgments(max_wait))
+        block_on(self.writer_async.wait_for_acknowledgments(max_wait))
     }
 
     /// This operation allows access to the [`LivelinessLostStatus`].
     #[tracing::instrument(skip(self))]
     pub fn get_liveliness_lost_status(&self) -> DdsResult<LivelinessLostStatus> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.get_liveliness_lost_status())
+        block_on(self.writer_async.get_liveliness_lost_status())
     }
 
     /// This operation allows access to the [`OfferedDeadlineMissedStatus`].
     #[tracing::instrument(skip(self))]
     pub fn get_offered_deadline_missed_status(&self) -> DdsResult<OfferedDeadlineMissedStatus> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.get_offered_deadline_missed_status())
+        block_on(self.writer_async.get_offered_deadline_missed_status())
     }
 
     /// This operation allows access to the [`OfferedIncompatibleQosStatus`].
     #[tracing::instrument(skip(self))]
     pub fn get_offered_incompatible_qos_status(&self) -> DdsResult<OfferedIncompatibleQosStatus> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.get_offered_incompatible_qos_status())
+        block_on(self.writer_async.get_offered_incompatible_qos_status())
     }
 
     /// This operation allows access to the [`PublicationMatchedStatus`].
     #[tracing::instrument(skip(self))]
     pub fn get_publication_matched_status(&self) -> DdsResult<PublicationMatchedStatus> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.get_publication_matched_status())
+        block_on(self.writer_async.get_publication_matched_status())
     }
 
     /// This operation returns the [`Topic`] associated with the [`DataWriter`]. This is the same [`Topic`] that was used to create the [`DataWriter`].
@@ -325,9 +302,7 @@ impl<Foo> DataWriter<Foo> {
     /// if the application is not writing data regularly.
     #[tracing::instrument(skip(self))]
     pub fn assert_liveliness(&self) -> DdsResult<()> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.assert_liveliness())
+        block_on(self.writer_async.assert_liveliness())
     }
 
     /// This operation retrieves information on a subscription that is currently “associated” with the [`DataWriter`]; that is, a subscription
@@ -341,7 +316,7 @@ impl<Foo> DataWriter<Foo> {
         &self,
         subscription_handle: InstanceHandle,
     ) -> DdsResult<SubscriptionBuiltinTopicData> {
-        self.writer_async.runtime_handle().block_on(
+        block_on(
             self.writer_async
                 .get_matched_subscription_data(subscription_handle),
         )
@@ -355,9 +330,7 @@ impl<Foo> DataWriter<Foo> {
     /// [`SampleInfo::instance_handle`](crate::subscription::sample_info::SampleInfo) field when reading the “DCPSSubscriptions” builtin topic.
     #[tracing::instrument(skip(self))]
     pub fn get_matched_subscriptions(&self) -> DdsResult<Vec<InstanceHandle>> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.get_matched_subscriptions())
+        block_on(self.writer_async.get_matched_subscriptions())
     }
 }
 
@@ -377,17 +350,13 @@ impl<Foo> DataWriter<Foo> {
     /// modified to match the current default for the Entity’s factory.
     #[tracing::instrument(skip(self))]
     pub fn set_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.set_qos(qos))
+        block_on(self.writer_async.set_qos(qos))
     }
 
     /// This operation allows access to the existing set of [`DataWriterQos`] policies.
     #[tracing::instrument(skip(self))]
     pub fn get_qos(&self) -> DdsResult<DataWriterQos> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.get_qos())
+        block_on(self.writer_async.get_qos())
     }
 
     /// This operation allows access to the [`StatusCondition`] associated with the Entity. The returned
@@ -406,9 +375,7 @@ impl<Foo> DataWriter<Foo> {
     /// and does not include statuses that apply to contained entities.
     #[tracing::instrument(skip(self))]
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.get_status_changes())
+        block_on(self.writer_async.get_status_changes())
     }
 
     /// This operation enables the Entity. Entity objects can be created either enabled or disabled. This is controlled by the value of
@@ -433,17 +400,13 @@ impl<Foo> DataWriter<Foo> {
     /// enabled are “inactive,” that is, the operation [`StatusCondition::get_trigger_value()`] will always return `false`.
     #[tracing::instrument(skip(self))]
     pub fn enable(&self) -> DdsResult<()> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.enable())
+        block_on(self.writer_async.enable())
     }
 
     /// This operation returns the [`InstanceHandle`] that represents the Entity.
     #[tracing::instrument(skip(self))]
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        self.writer_async
-            .runtime_handle()
-            .block_on(self.writer_async.get_instance_handle())
+        block_on(self.writer_async.get_instance_handle())
     }
 }
 
@@ -463,7 +426,7 @@ where
         a_listener: Option<Box<dyn DataWriterListener<'a, Foo = Foo> + Send + 'a>>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        self.writer_async.runtime_handle().block_on(
+        block_on(
             self.writer_async.set_listener(
                 a_listener
                     .map::<Box<dyn DataWriterListenerAsync<Foo = Foo> + Send>, _>(|b| Box::new(b)),

--- a/dds/src/dds/publication/data_writer_listener.rs
+++ b/dds/src/dds/publication/data_writer_listener.rs
@@ -56,14 +56,8 @@ where
         the_writer: DataWriterAsync<Self::Foo>,
         status: LivelinessLostStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataWriterListener::on_liveliness_lost(
-                self.as_mut(),
-                DataWriter::new(the_writer),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DataWriterListener::on_liveliness_lost(self.as_mut(), DataWriter::new(the_writer), status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_offered_deadline_missed(
@@ -71,14 +65,12 @@ where
         the_writer: DataWriterAsync<Self::Foo>,
         status: OfferedDeadlineMissedStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataWriterListener::on_offered_deadline_missed(
-                self.as_mut(),
-                DataWriter::new(the_writer),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DataWriterListener::on_offered_deadline_missed(
+            self.as_mut(),
+            DataWriter::new(the_writer),
+            status,
+        );
+        Box::pin(std::future::ready(()))
     }
 
     fn on_offered_incompatible_qos(
@@ -86,14 +78,12 @@ where
         the_writer: DataWriterAsync<Self::Foo>,
         status: OfferedIncompatibleQosStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataWriterListener::on_offered_incompatible_qos(
-                self.as_mut(),
-                DataWriter::new(the_writer),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DataWriterListener::on_offered_incompatible_qos(
+            self.as_mut(),
+            DataWriter::new(the_writer),
+            status,
+        );
+        Box::pin(std::future::ready(()))
     }
 
     fn on_publication_matched(
@@ -101,13 +91,11 @@ where
         the_writer: DataWriterAsync<Self::Foo>,
         status: PublicationMatchedStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataWriterListener::on_publication_matched(
-                self.as_mut(),
-                DataWriter::new(the_writer),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DataWriterListener::on_publication_matched(
+            self.as_mut(),
+            DataWriter::new(the_writer),
+            status,
+        );
+        Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds/publication/publisher.rs
+++ b/dds/src/dds/publication/publisher.rs
@@ -4,6 +4,7 @@ use crate::{
         publisher_listener::PublisherListenerAsync,
     },
     domain::domain_participant::DomainParticipant,
+    implementation::runtime::executor::block_on,
     infrastructure::{
         condition::StatusCondition,
         error::DdsResult,
@@ -64,19 +65,16 @@ impl Publisher {
     where
         Foo: 'a,
     {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(
-                self.publisher_async.create_datawriter::<Foo>(
-                    a_topic.topic_async(),
-                    qos,
-                    a_listener.map::<Box<dyn DataWriterListenerAsync<Foo = Foo> + Send>, _>(|b| {
-                        Box::new(b)
-                    }),
-                    mask,
-                ),
-            )
-            .map(DataWriter::new)
+        block_on(
+            self.publisher_async.create_datawriter::<Foo>(
+                a_topic.topic_async(),
+                qos,
+                a_listener
+                    .map::<Box<dyn DataWriterListenerAsync<Foo = Foo> + Send>, _>(|b| Box::new(b)),
+                mask,
+            ),
+        )
+        .map(DataWriter::new)
     }
 
     /// This operation deletes a [`DataWriter`] that belongs to the [`Publisher`]. This operation must be called on the
@@ -87,7 +85,7 @@ impl Publisher {
     /// [`DataWriter`].
     #[tracing::instrument(skip(self, a_datawriter))]
     pub fn delete_datawriter<Foo>(&self, a_datawriter: &DataWriter<Foo>) -> DdsResult<()> {
-        self.publisher_async.runtime_handle().block_on(
+        block_on(
             self.publisher_async
                 .delete_datawriter::<Foo>(a_datawriter.writer_async()),
         )
@@ -99,11 +97,10 @@ impl Publisher {
     /// specified which one.
     #[tracing::instrument(skip(self))]
     pub fn lookup_datawriter<Foo>(&self, topic_name: &str) -> DdsResult<Option<DataWriter<Foo>>> {
-        Ok(self
-            .publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.lookup_datawriter::<Foo>(topic_name))?
-            .map(DataWriter::new))
+        Ok(
+            block_on(self.publisher_async.lookup_datawriter::<Foo>(topic_name))?
+                .map(DataWriter::new),
+        )
     }
 
     /// This operation indicates to the Service that the application is about to make multiple modifications using [`DataWriter`] objects
@@ -114,9 +111,7 @@ impl Publisher {
     /// be published will be discarded.
     #[tracing::instrument(skip(self))]
     pub fn suspend_publications(&self) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.suspend_publications())
+        block_on(self.publisher_async.suspend_publications())
     }
 
     /// This operation indicates to the Service that the application has completed the multiple changes initiated by the previous
@@ -126,9 +121,7 @@ impl Publisher {
     /// the operation will return [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError).
     #[tracing::instrument(skip(self))]
     pub fn resume_publications(&self) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.resume_publications())
+        block_on(self.publisher_async.resume_publications())
     }
 
     /// This operation requests that the application will begin a *coherent set* of modifications using [`DataWriter`] objects attached to
@@ -149,18 +142,14 @@ impl Publisher {
     /// otherwise, it may e.g., erroneously interpret that the aircraft is on a collision course).
     #[tracing::instrument(skip(self))]
     pub fn begin_coherent_changes(&self) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.begin_coherent_changes())
+        block_on(self.publisher_async.begin_coherent_changes())
     }
 
     /// This operation terminates the *coherent set* initiated by the matching call to [`Publisher::begin_coherent_changes`]. If there is no matching
     /// call to [`Publisher::begin_coherent_changes`], the operation will return [`DdsError::PreconditionNotMet`](crate::infrastructure::error::DdsError).
     #[tracing::instrument(skip(self))]
     pub fn end_coherent_changes(&self) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.end_coherent_changes())
+        block_on(self.publisher_async.end_coherent_changes())
     }
 
     /// This operation blocks the calling thread until either all data written by the reliable [`DataWriter`] entities is acknowledged by all
@@ -170,9 +159,7 @@ impl Publisher {
     /// indicates that `max_wait` elapsed before all the data was acknowledged.
     #[tracing::instrument(skip(self))]
     pub fn wait_for_acknowledgments(&self, max_wait: Duration) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.wait_for_acknowledgments(max_wait))
+        block_on(self.publisher_async.wait_for_acknowledgments(max_wait))
     }
 
     /// This operation returns the [`DomainParticipant`] to which the [`Publisher`] belongs.
@@ -189,9 +176,7 @@ impl Publisher {
     /// contained [`DataWriter`] objects
     #[tracing::instrument(skip(self))]
     pub fn delete_contained_entities(&self) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.delete_contained_entities())
+        block_on(self.publisher_async.delete_contained_entities())
     }
 
     /// This operation sets the default value of the [`DataWriterQos`] which will be used for newly created [`DataWriter`] entities in
@@ -202,9 +187,7 @@ impl Publisher {
     /// reset back to the initial values the factory would use, that is the default value of [`DataWriterQos`].
     #[tracing::instrument(skip(self))]
     pub fn set_default_datawriter_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.set_default_datawriter_qos(qos))
+        block_on(self.publisher_async.set_default_datawriter_qos(qos))
     }
 
     /// This operation retrieves the default factory value of the [`DataWriterQos`], that is, the qos policies which will be used for newly created
@@ -213,9 +196,7 @@ impl Publisher {
     /// [`Publisher::set_default_datawriter_qos`], or else, if the call was never made, the default values of [`DataWriterQos`].
     #[tracing::instrument(skip(self))]
     pub fn get_default_datawriter_qos(&self) -> DdsResult<DataWriterQos> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.get_default_datawriter_qos())
+        block_on(self.publisher_async.get_default_datawriter_qos())
     }
 
     /// This operation copies the policies in the `a_topic_qos` to the corresponding policies in the `a_datawriter_qos`.
@@ -250,17 +231,13 @@ impl Publisher {
     /// modified to match the current default for the Entity’s factory.
     #[tracing::instrument(skip(self))]
     pub fn set_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.set_qos(qos))
+        block_on(self.publisher_async.set_qos(qos))
     }
 
     /// This operation allows access to the existing set of [`PublisherQos`] policies.
     #[tracing::instrument(skip(self))]
     pub fn get_qos(&self) -> DdsResult<PublisherQos> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.get_qos())
+        block_on(self.publisher_async.get_qos())
     }
 
     /// This operation installs a Listener on the Entity. The listener will only be invoked on the changes of communication status
@@ -275,12 +252,10 @@ impl Publisher {
         a_listener: Option<Box<dyn PublisherListener + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.set_listener(
-                a_listener.map::<Box<dyn PublisherListenerAsync + Send>, _>(|b| Box::new(b)),
-                mask,
-            ))
+        block_on(self.publisher_async.set_listener(
+            a_listener.map::<Box<dyn PublisherListenerAsync + Send>, _>(|b| Box::new(b)),
+            mask,
+        ))
     }
 
     /// This operation allows access to the [`StatusCondition`] associated with the Entity. The returned
@@ -299,9 +274,7 @@ impl Publisher {
     /// and does not include statuses that apply to contained entities.
     #[tracing::instrument(skip(self))]
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.get_status_changes())
+        block_on(self.publisher_async.get_status_changes())
     }
 
     /// This operation enables the Entity. Entity objects can be created either enabled or disabled. This is controlled by the value of
@@ -326,16 +299,12 @@ impl Publisher {
     /// enabled are “inactive”, that is, the operation [`StatusCondition::get_trigger_value()`] will always return `false`.
     #[tracing::instrument(skip(self))]
     pub fn enable(&self) -> DdsResult<()> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.enable())
+        block_on(self.publisher_async.enable())
     }
 
     /// This operation returns the [`InstanceHandle`] that represents the Entity.
     #[tracing::instrument(skip(self))]
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        self.publisher_async
-            .runtime_handle()
-            .block_on(self.publisher_async.get_instance_handle())
+        block_on(self.publisher_async.get_instance_handle())
     }
 }

--- a/dds/src/dds/publication/publisher_listener.rs
+++ b/dds/src/dds/publication/publisher_listener.rs
@@ -54,10 +54,8 @@ impl PublisherListenerAsync for Box<dyn PublisherListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            PublisherListener::on_liveliness_lost(self.as_mut(), the_writer, status)
-        });
-        Box::pin(async {})
+        PublisherListener::on_liveliness_lost(self.as_mut(), the_writer, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_offered_deadline_missed<'a, 'b>(
@@ -68,10 +66,8 @@ impl PublisherListenerAsync for Box<dyn PublisherListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            PublisherListener::on_offered_deadline_missed(self.as_mut(), the_writer, status)
-        });
-        Box::pin(async {})
+        PublisherListener::on_offered_deadline_missed(self.as_mut(), the_writer, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_offered_incompatible_qos<'a, 'b>(
@@ -82,10 +78,8 @@ impl PublisherListenerAsync for Box<dyn PublisherListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            PublisherListener::on_offered_incompatible_qos(self.as_mut(), the_writer, status)
-        });
-        Box::pin(async {})
+        PublisherListener::on_offered_incompatible_qos(self.as_mut(), the_writer, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_publication_matched<'a, 'b>(
@@ -96,9 +90,7 @@ impl PublisherListenerAsync for Box<dyn PublisherListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            PublisherListener::on_publication_matched(self.as_mut(), the_writer, status)
-        });
-        Box::pin(async {})
+        PublisherListener::on_publication_matched(self.as_mut(), the_writer, status);
+        Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -1,6 +1,7 @@
 use crate::{
     builtin_topics::PublicationBuiltinTopicData,
     dds_async::{data_reader::DataReaderAsync, data_reader_listener::DataReaderListenerAsync},
+    implementation::runtime::executor::block_on,
     infrastructure::{
         condition::StatusCondition,
         error::{DdsError, DdsResult},
@@ -140,14 +141,10 @@ impl<Foo> DataReader<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.read(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-            ))
+        block_on(
+            self.reader_async
+                .read(max_samples, sample_states, view_states, instance_states),
+        )
     }
 
     /// This operation accesses a collection of [`Sample`] from the [`DataReader`]. This operation uses the same
@@ -161,14 +158,10 @@ impl<Foo> DataReader<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.take(
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-            ))
+        block_on(
+            self.reader_async
+                .take(max_samples, sample_states, view_states, instance_states),
+        )
     }
 
     /// This operation reads the next, non-previously accessed [`Sample`] value from the [`DataReader`].
@@ -180,9 +173,7 @@ impl<Foo> DataReader<Foo> {
     /// sequences and specify states.
     #[tracing::instrument(skip(self))]
     pub fn read_next_sample(&self) -> DdsResult<Sample<Foo>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.read_next_sample())
+        block_on(self.reader_async.read_next_sample())
     }
 
     /// This operation takes the next, non-previously accessed [`Sample`] value from the [`DataReader`].
@@ -194,9 +185,7 @@ impl<Foo> DataReader<Foo> {
     /// sequences and specify states.
     #[tracing::instrument(skip(self))]
     pub fn take_next_sample(&self) -> DdsResult<Sample<Foo>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.take_next_sample())
+        block_on(self.reader_async.take_next_sample())
     }
 
     /// This operation accesses a collection of [`Sample`] from the [`DataReader`]. The
@@ -216,15 +205,13 @@ impl<Foo> DataReader<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.read_instance(
-                max_samples,
-                a_handle,
-                sample_states,
-                view_states,
-                instance_states,
-            ))
+        block_on(self.reader_async.read_instance(
+            max_samples,
+            a_handle,
+            sample_states,
+            view_states,
+            instance_states,
+        ))
     }
 
     /// This operation accesses a collection of [`Sample`] from the [`DataReader`]. The
@@ -244,15 +231,13 @@ impl<Foo> DataReader<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.take_instance(
-                max_samples,
-                a_handle,
-                sample_states,
-                view_states,
-                instance_states,
-            ))
+        block_on(self.reader_async.take_instance(
+            max_samples,
+            a_handle,
+            sample_states,
+            view_states,
+            instance_states,
+        ))
     }
 
     /// This operation accesses a collection of [`Sample`] from the [`DataReader`] where all the samples belong to a single instance.
@@ -287,15 +272,13 @@ impl<Foo> DataReader<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.read_next_instance(
-                max_samples,
-                previous_handle,
-                sample_states,
-                view_states,
-                instance_states,
-            ))
+        block_on(self.reader_async.read_next_instance(
+            max_samples,
+            previous_handle,
+            sample_states,
+            view_states,
+            instance_states,
+        ))
     }
 
     /// This operation accesses a collection of [`Sample`] values from the [`DataReader`] and removes them from the [`DataReader`].
@@ -310,15 +293,13 @@ impl<Foo> DataReader<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.take_next_instance(
-                max_samples,
-                previous_handle,
-                sample_states,
-                view_states,
-                instance_states,
-            ))
+        block_on(self.reader_async.take_next_instance(
+            max_samples,
+            previous_handle,
+            sample_states,
+            view_states,
+            instance_states,
+        ))
     }
 
     /// This operation can be used to retrieve the instance key that corresponds to an `handle`.
@@ -327,9 +308,7 @@ impl<Foo> DataReader<Foo> {
     /// if the [`InstanceHandle`] `handle` does not correspond to an existing data object known to the [`DataReader`].
     #[tracing::instrument(skip(self, key_holder))]
     pub fn get_key_value(&self, key_holder: &mut Foo, handle: InstanceHandle) -> DdsResult<()> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_key_value(key_holder, handle))
+        block_on(self.reader_async.get_key_value(key_holder, handle))
     }
 
     /// This operation takes as a parameter an instance and returns an [`InstanceHandle`] handle
@@ -340,9 +319,7 @@ impl<Foo> DataReader<Foo> {
     /// an instance handle, the operation will succeed and return [`None`].
     #[tracing::instrument(skip(self, instance))]
     pub fn lookup_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.lookup_instance(instance))
+        block_on(self.reader_async.lookup_instance(instance))
     }
 }
 
@@ -350,17 +327,13 @@ impl<Foo> DataReader<Foo> {
     /// This operation allows access to the [`LivelinessChangedStatus`].
     #[tracing::instrument(skip(self))]
     pub fn get_liveliness_changed_status(&self) -> DdsResult<LivelinessChangedStatus> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_liveliness_changed_status())
+        block_on(self.reader_async.get_liveliness_changed_status())
     }
 
     /// This operation allows access to the [`RequestedDeadlineMissedStatus`].
     #[tracing::instrument(skip(self))]
     pub fn get_requested_deadline_missed_status(&self) -> DdsResult<RequestedDeadlineMissedStatus> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_requested_deadline_missed_status())
+        block_on(self.reader_async.get_requested_deadline_missed_status())
     }
 
     /// This operation allows access to the [`RequestedIncompatibleQosStatus`].
@@ -368,33 +341,25 @@ impl<Foo> DataReader<Foo> {
     pub fn get_requested_incompatible_qos_status(
         &self,
     ) -> DdsResult<RequestedIncompatibleQosStatus> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_requested_incompatible_qos_status())
+        block_on(self.reader_async.get_requested_incompatible_qos_status())
     }
 
     /// This operation allows access to the [`SampleLostStatus`].
     #[tracing::instrument(skip(self))]
     pub fn get_sample_lost_status(&self) -> DdsResult<SampleLostStatus> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_sample_lost_status())
+        block_on(self.reader_async.get_sample_lost_status())
     }
 
     /// This operation allows access to the [`SampleRejectedStatus`].
     #[tracing::instrument(skip(self))]
     pub fn get_sample_rejected_status(&self) -> DdsResult<SampleRejectedStatus> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_sample_rejected_status())
+        block_on(self.reader_async.get_sample_rejected_status())
     }
 
     /// This operation allows access to the [`SubscriptionMatchedStatus`].
     #[tracing::instrument(skip(self))]
     pub fn get_subscription_matched_status(&self) -> DdsResult<SubscriptionMatchedStatus> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_subscription_matched_status())
+        block_on(self.reader_async.get_subscription_matched_status())
     }
 
     /// This operation returns the [`Topic`] associated with the [`DataReader`]. This is the same [`Topic`]
@@ -424,9 +389,7 @@ impl<Foo> DataReader<Foo> {
     /// data is received.
     #[tracing::instrument(skip(self))]
     pub fn wait_for_historical_data(&self, max_wait: Duration) -> DdsResult<()> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.wait_for_historical_data(max_wait))
+        block_on(self.reader_async.wait_for_historical_data(max_wait))
     }
 
     /// This operation retrieves information on a publication that is currently “associated” with the [`DataReader`];
@@ -441,7 +404,7 @@ impl<Foo> DataReader<Foo> {
         &self,
         publication_handle: InstanceHandle,
     ) -> DdsResult<PublicationBuiltinTopicData> {
-        self.reader_async.runtime_handle().block_on(
+        block_on(
             self.reader_async
                 .get_matched_publication_data(publication_handle),
         )
@@ -455,9 +418,7 @@ impl<Foo> DataReader<Foo> {
     /// [`SampleInfo::instance_handle`](crate::subscription::sample_info::SampleInfo) when reading the “DCPSPublications” builtin topic.
     #[tracing::instrument(skip(self))]
     pub fn get_matched_publications(&self) -> DdsResult<Vec<InstanceHandle>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_matched_publications())
+        block_on(self.reader_async.get_matched_publications())
     }
 }
 
@@ -476,17 +437,13 @@ impl<Foo> DataReader<Foo> {
     /// modified to match the current default for the Entity’s factory.
     #[tracing::instrument(skip(self))]
     pub fn set_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.set_qos(qos))
+        block_on(self.reader_async.set_qos(qos))
     }
 
     /// This operation allows access to the existing set of [`DataReaderQos`] policies.
     #[tracing::instrument(skip(self))]
     pub fn get_qos(&self) -> DdsResult<DataReaderQos> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_qos())
+        block_on(self.reader_async.get_qos())
     }
 
     /// This operation allows access to the [`StatusCondition`] associated with the Entity. The returned
@@ -505,9 +462,7 @@ impl<Foo> DataReader<Foo> {
     /// and does not include statuses that apply to contained entities.
     #[tracing::instrument(skip(self))]
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_status_changes())
+        block_on(self.reader_async.get_status_changes())
     }
 
     /// This operation enables the Entity. Entity objects can be created either enabled or disabled. This is controlled by the value of
@@ -532,17 +487,13 @@ impl<Foo> DataReader<Foo> {
     /// enabled are “inactive,” that is, the operation [`StatusCondition::get_trigger_value()`] will always return `false`.
     #[tracing::instrument(skip(self))]
     pub fn enable(&self) -> DdsResult<()> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.enable())
+        block_on(self.reader_async.enable())
     }
 
     /// This operation returns the [`InstanceHandle`] that represents the Entity.
     #[tracing::instrument(skip(self))]
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        self.reader_async
-            .runtime_handle()
-            .block_on(self.reader_async.get_instance_handle())
+        block_on(self.reader_async.get_instance_handle())
     }
 }
 
@@ -562,7 +513,7 @@ where
         a_listener: Option<Box<dyn DataReaderListener<'a, Foo = Foo> + Send + 'a>>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        self.reader_async.runtime_handle().block_on(
+        block_on(
             self.reader_async.set_listener(
                 a_listener
                     .map::<Box<dyn DataReaderListenerAsync<Foo = Foo> + Send>, _>(|b| Box::new(b)),

--- a/dds/src/dds/subscription/data_reader_listener.rs
+++ b/dds/src/dds/subscription/data_reader_listener.rs
@@ -71,10 +71,8 @@ where
         &mut self,
         the_reader: DataReaderAsync<Self::Foo>,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataReaderListener::on_data_available(self.as_mut(), DataReader::new(the_reader))
-        });
-        Box::pin(async {})
+        DataReaderListener::on_data_available(self.as_mut(), DataReader::new(the_reader));
+        Box::pin(std::future::ready(()))
     }
 
     fn on_sample_rejected(
@@ -82,14 +80,8 @@ where
         the_reader: DataReaderAsync<Self::Foo>,
         status: SampleRejectedStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataReaderListener::on_sample_rejected(
-                self.as_mut(),
-                DataReader::new(the_reader),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DataReaderListener::on_sample_rejected(self.as_mut(), DataReader::new(the_reader), status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_liveliness_changed(
@@ -97,14 +89,12 @@ where
         the_reader: DataReaderAsync<Self::Foo>,
         status: LivelinessChangedStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataReaderListener::on_liveliness_changed(
-                self.as_mut(),
-                DataReader::new(the_reader),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DataReaderListener::on_liveliness_changed(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
+        Box::pin(std::future::ready(()))
     }
 
     fn on_requested_deadline_missed(
@@ -112,14 +102,12 @@ where
         the_reader: DataReaderAsync<Self::Foo>,
         status: RequestedDeadlineMissedStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataReaderListener::on_requested_deadline_missed(
-                self.as_mut(),
-                DataReader::new(the_reader),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DataReaderListener::on_requested_deadline_missed(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
+        Box::pin(std::future::ready(()))
     }
 
     fn on_requested_incompatible_qos(
@@ -127,14 +115,12 @@ where
         the_reader: DataReaderAsync<Self::Foo>,
         status: RequestedIncompatibleQosStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataReaderListener::on_requested_incompatible_qos(
-                self.as_mut(),
-                DataReader::new(the_reader),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DataReaderListener::on_requested_incompatible_qos(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
+        Box::pin(std::future::ready(()))
     }
 
     fn on_subscription_matched(
@@ -142,14 +128,12 @@ where
         the_reader: DataReaderAsync<Self::Foo>,
         status: SubscriptionMatchedStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataReaderListener::on_subscription_matched(
-                self.as_mut(),
-                DataReader::new(the_reader),
-                status,
-            )
-        });
-        Box::pin(async {})
+        DataReaderListener::on_subscription_matched(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
+        Box::pin(std::future::ready(()))
     }
 
     fn on_sample_lost(
@@ -157,9 +141,7 @@ where
         the_reader: DataReaderAsync<Self::Foo>,
         status: SampleLostStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            DataReaderListener::on_sample_lost(self.as_mut(), DataReader::new(the_reader), status)
-        });
-        Box::pin(async {})
+        DataReaderListener::on_sample_lost(self.as_mut(), DataReader::new(the_reader), status);
+        Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds/subscription/subscriber_listener.rs
+++ b/dds/src/dds/subscription/subscriber_listener.rs
@@ -67,10 +67,8 @@ impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
         &mut self,
         the_subscriber: SubscriberAsync,
     ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        tokio::task::block_in_place(|| {
-            SubscriberListener::on_data_on_readers(self.as_mut(), Subscriber::new(the_subscriber))
-        });
-        Box::pin(async {})
+        SubscriberListener::on_data_on_readers(self.as_mut(), Subscriber::new(the_subscriber));
+        Box::pin(std::future::ready(()))
     }
 
     fn on_data_available<'a, 'b>(
@@ -80,10 +78,8 @@ impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            SubscriberListener::on_data_available(self.as_mut(), the_reader)
-        });
-        Box::pin(async {})
+        SubscriberListener::on_data_available(self.as_mut(), the_reader);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_sample_rejected<'a, 'b>(
@@ -94,10 +90,8 @@ impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            SubscriberListener::on_sample_rejected(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        SubscriberListener::on_sample_rejected(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_liveliness_changed<'a, 'b>(
@@ -108,10 +102,8 @@ impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            SubscriberListener::on_liveliness_changed(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        SubscriberListener::on_liveliness_changed(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_requested_deadline_missed<'a, 'b>(
@@ -122,10 +114,8 @@ impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            SubscriberListener::on_requested_deadline_missed(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        SubscriberListener::on_requested_deadline_missed(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_requested_incompatible_qos<'a, 'b>(
@@ -136,10 +126,8 @@ impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            SubscriberListener::on_requested_incompatible_qos(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        SubscriberListener::on_requested_incompatible_qos(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_subscription_matched<'a, 'b>(
@@ -150,10 +138,8 @@ impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            SubscriberListener::on_subscription_matched(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        SubscriberListener::on_subscription_matched(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 
     fn on_sample_lost<'a, 'b>(
@@ -164,9 +150,7 @@ impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
     where
         'a: 'b,
     {
-        tokio::task::block_in_place(|| {
-            SubscriberListener::on_sample_lost(self.as_mut(), the_reader, status)
-        });
-        Box::pin(async {})
+        SubscriberListener::on_sample_lost(self.as_mut(), the_reader, status);
+        Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds/topic_definition/topic.rs
+++ b/dds/src/dds/topic_definition/topic.rs
@@ -1,6 +1,7 @@
 use crate::{
     dds_async::topic::TopicAsync,
     domain::domain_participant::DomainParticipant,
+    implementation::runtime::executor::block_on,
     infrastructure::{
         condition::StatusCondition,
         error::DdsResult,
@@ -33,9 +34,7 @@ impl Topic {
     /// This method allows the application to retrieve the [`InconsistentTopicStatus`] of the [`Topic`].
     #[tracing::instrument(skip(self))]
     pub fn get_inconsistent_topic_status(&self) -> DdsResult<InconsistentTopicStatus> {
-        self.topic_async
-            .runtime_handle()
-            .block_on(self.topic_async.get_inconsistent_topic_status())
+        block_on(self.topic_async.get_inconsistent_topic_status())
     }
 }
 
@@ -76,17 +75,13 @@ impl Topic {
     /// modified to match the current default for the Entity’s factory.
     #[tracing::instrument(skip(self))]
     pub fn set_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
-        self.topic_async
-            .runtime_handle()
-            .block_on(self.topic_async.set_qos(qos))
+        block_on(self.topic_async.set_qos(qos))
     }
 
     /// This operation allows access to the existing set of [`TopicQos`] policies.
     #[tracing::instrument(skip(self))]
     pub fn get_qos(&self) -> DdsResult<TopicQos> {
-        self.topic_async
-            .runtime_handle()
-            .block_on(self.topic_async.get_qos())
+        block_on(self.topic_async.get_qos())
     }
 
     /// This operation allows access to the [`StatusCondition`] associated with the Entity. The returned
@@ -105,9 +100,7 @@ impl Topic {
     /// and does not include statuses that apply to contained entities.
     #[tracing::instrument(skip(self))]
     pub fn get_status_changes(&self) -> DdsResult<Vec<StatusKind>> {
-        self.topic_async
-            .runtime_handle()
-            .block_on(self.topic_async.get_status_changes())
+        block_on(self.topic_async.get_status_changes())
     }
 
     /// This operation enables the Entity. Entity objects can be created either enabled or disabled. This is controlled by the value of
@@ -132,17 +125,13 @@ impl Topic {
     /// enabled are “inactive,” that is, the operation [`StatusCondition::get_trigger_value()`] will always return `false`.
     #[tracing::instrument(skip(self))]
     pub fn enable(&self) -> DdsResult<()> {
-        self.topic_async
-            .runtime_handle()
-            .block_on(self.topic_async.enable())
+        block_on(self.topic_async.enable())
     }
 
     /// This operation returns the [`InstanceHandle`] that represents the Entity.
     #[tracing::instrument(skip(self))]
     pub fn get_instance_handle(&self) -> DdsResult<InstanceHandle> {
-        self.topic_async
-            .runtime_handle()
-            .block_on(self.topic_async.get_instance_handle())
+        block_on(self.topic_async.get_instance_handle())
     }
 
     /// This operation installs a Listener on the Entity. The listener will only be invoked on the changes of communication status
@@ -157,14 +146,12 @@ impl Topic {
         a_listener: Option<Box<dyn TopicListener + Send>>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        self.topic_async
-            .runtime_handle()
-            .block_on(self.topic_async.set_listener(
-                match a_listener {
-                    Some(l) => Some(Box::new(l)),
-                    None => None,
-                },
-                mask,
-            ))
+        block_on(self.topic_async.set_listener(
+            match a_listener {
+                Some(l) => Some(Box::new(l)),
+                None => None,
+            },
+            mask,
+        ))
     }
 }

--- a/dds/src/dds/topic_definition/topic_listener.rs
+++ b/dds/src/dds/topic_definition/topic_listener.rs
@@ -18,9 +18,7 @@ impl TopicListenerAsync for Box<dyn TopicListener + Send> {
         the_topic: TopicAsync,
         status: InconsistentTopicStatus,
     ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
-        tokio::task::block_in_place(|| {
-            TopicListener::on_inconsistent_topic(self.as_mut(), Topic::new(the_topic), status)
-        });
-        Box::pin(async {})
+        TopicListener::on_inconsistent_topic(self.as_mut(), Topic::new(the_topic), status);
+        Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -2,7 +2,7 @@ use crate::{
     implementation::{
         actor::ActorAddress,
         actors::status_condition_actor::{self, StatusConditionActor},
-        runtime::timer::TimerHandle,
+        runtime::{executor::ExecutorHandle, timer::TimerHandle},
     },
     infrastructure::{error::DdsResult, status::StatusKind},
 };
@@ -11,19 +11,19 @@ use crate::{
 #[derive(Clone)]
 pub struct StatusConditionAsync {
     address: ActorAddress<StatusConditionActor>,
-    runtime_handle: tokio::runtime::Handle,
+    _executor_handle: ExecutorHandle,
     timer_handle: TimerHandle,
 }
 
 impl StatusConditionAsync {
     pub(crate) fn new(
         address: ActorAddress<StatusConditionActor>,
-        runtime_handle: tokio::runtime::Handle,
+        executor_handle: ExecutorHandle,
         timer_handle: TimerHandle,
     ) -> Self {
         Self {
             address,
-            runtime_handle,
+            _executor_handle: executor_handle,
             timer_handle,
         }
     }
@@ -32,8 +32,9 @@ impl StatusConditionAsync {
         &self.address
     }
 
-    pub(crate) fn runtime_handle(&self) -> &tokio::runtime::Handle {
-        &self.runtime_handle
+    #[allow(dead_code)]
+    pub(crate) fn executor_handle(&self) -> &ExecutorHandle {
+        &self._executor_handle
     }
 
     pub(crate) fn timer_handle(&self) -> &TimerHandle {

--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -2,6 +2,7 @@ use crate::{
     implementation::{
         actor::ActorAddress,
         actors::status_condition_actor::{self, StatusConditionActor},
+        runtime::timer::TimerHandle,
     },
     infrastructure::{error::DdsResult, status::StatusKind},
 };
@@ -11,16 +12,19 @@ use crate::{
 pub struct StatusConditionAsync {
     address: ActorAddress<StatusConditionActor>,
     runtime_handle: tokio::runtime::Handle,
+    timer_handle: TimerHandle,
 }
 
 impl StatusConditionAsync {
     pub(crate) fn new(
         address: ActorAddress<StatusConditionActor>,
         runtime_handle: tokio::runtime::Handle,
+        timer_handle: TimerHandle,
     ) -> Self {
         Self {
             address,
             runtime_handle,
+            timer_handle,
         }
     }
 
@@ -30,6 +34,10 @@ impl StatusConditionAsync {
 
     pub(crate) fn runtime_handle(&self) -> &tokio::runtime::Handle {
         &self.runtime_handle
+    }
+
+    pub(crate) fn timer_handle(&self) -> &TimerHandle {
+        &self.timer_handle
     }
 }
 

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -76,10 +76,6 @@ impl<Foo> DataReaderAsync<Foo> {
         &self.reader_address
     }
 
-    pub(crate) fn runtime_handle(&self) -> &tokio::runtime::Handle {
-        self.subscriber.runtime_handle()
-    }
-
     async fn announce_reader(&self) -> DdsResult<()> {
         let builtin_publisher = self
             .get_subscriber()
@@ -517,7 +513,7 @@ impl<Foo> DataReaderAsync<Foo> {
     pub fn get_statuscondition(&self) -> StatusConditionAsync {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
-            self.runtime_handle().clone(),
+            self.subscriber.get_participant().executor_handle().clone(),
             self.subscriber.get_participant().timer_handle().clone(),
         )
     }
@@ -574,7 +570,6 @@ where
                 listener: a_listener
                     .map::<Box<dyn AnyDataReaderListener + Send>, _>(|b| Box::new(b)),
                 status_kind: mask.to_vec(),
-                runtime_handle: self.runtime_handle().clone(),
             })?
             .receive_reply()
             .await

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -518,6 +518,7 @@ impl<Foo> DataReaderAsync<Foo> {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
             self.runtime_handle().clone(),
+            self.subscriber.get_participant().timer_handle().clone(),
         )
     }
 

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -260,6 +260,7 @@ where
                     message_sender_actor,
                     now,
                     data_writer_address: self.writer_address.clone(),
+                    executor_handle: self.publisher.get_participant().executor_handle().clone(),
                     timer_handle: self.publisher.get_participant().timer_handle().clone(),
                 })?
                 .receive_reply()
@@ -346,6 +347,7 @@ where
                 message_sender_actor,
                 now,
                 data_writer_address: self.writer_address.clone(),
+                executor_handle: self.publisher.get_participant().executor_handle().clone(),
                 timer_handle: self.publisher.get_participant().timer_handle().clone(),
             })?
             .receive_reply()
@@ -425,6 +427,7 @@ where
                 message_sender_actor,
                 now,
                 data_writer_address: self.writer_address.clone(),
+                executor_handle: self.publisher.get_participant().executor_handle().clone(),
                 timer_handle: self.publisher.get_participant().timer_handle().clone(),
             })?
             .receive_reply()

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -584,6 +584,7 @@ impl<Foo> DataWriterAsync<Foo> {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
             self.runtime_handle().clone(),
+            self.publisher.get_participant().timer_handle().clone(),
         )
     }
 
@@ -612,6 +613,7 @@ impl<Foo> DataWriterAsync<Foo> {
                     data_writer_address: writer.clone(),
                     message_sender_actor,
                     runtime_handle: self.runtime_handle().clone(),
+                    timer_handle: self.publisher.get_participant().timer_handle().clone(),
                 })?
                 .receive_reply()
                 .await;

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -79,10 +79,6 @@ impl<Foo> DataWriterAsync<Foo> {
         self.publisher.publisher_address()
     }
 
-    pub(crate) fn runtime_handle(&self) -> &tokio::runtime::Handle {
-        self.publisher.runtime_handle()
-    }
-
     pub(crate) fn writer_address(&self) -> &ActorAddress<DataWriterActor> {
         &self.writer_address
     }
@@ -583,7 +579,7 @@ impl<Foo> DataWriterAsync<Foo> {
     pub fn get_statuscondition(&self) -> StatusConditionAsync {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
-            self.runtime_handle().clone(),
+            self.publisher.get_participant().executor_handle().clone(),
             self.publisher.get_participant().timer_handle().clone(),
         )
     }
@@ -612,7 +608,7 @@ impl<Foo> DataWriterAsync<Foo> {
                 .send_actor_mail(data_writer_actor::Enable {
                     data_writer_address: writer.clone(),
                     message_sender_actor,
-                    runtime_handle: self.runtime_handle().clone(),
+                    executor_handle: self.publisher.get_participant().executor_handle().clone(),
                     timer_handle: self.publisher.get_participant().timer_handle().clone(),
                 })?
                 .receive_reply()
@@ -649,7 +645,6 @@ where
                 listener: a_listener
                     .map::<Box<dyn AnyDataWriterListener + Send>, _>(|b| Box::new(b)),
                 status_kind: mask.to_vec(),
-                runtime_handle: self.runtime_handle().clone(),
             })?
             .receive_reply()
             .await

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -762,6 +762,7 @@ impl DomainParticipantAsync {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
             self.runtime_handle.clone(),
+            self.timer_handle.clone(),
         )
     }
 
@@ -832,6 +833,7 @@ impl DomainParticipantAsync {
                         data_writer_address: builtin_writer.clone(),
                         message_sender_actor,
                         runtime_handle: self.runtime_handle.clone(),
+                        timer_handle: self.timer_handle.clone(),
                     })?
                     .receive_reply()
                     .await;

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -79,6 +79,10 @@ impl DomainParticipantFactoryAsync {
             .send_actor_mail(subscriber_actor::GetStatuscondition)?
             .receive_reply()
             .await;
+        let timer_handle = participant_address
+            .send_actor_mail(domain_participant_actor::GetTimerHandle)?
+            .receive_reply()
+            .await;
         let domain_participant = DomainParticipantAsync::new(
             participant_address.clone(),
             status_condition,
@@ -86,6 +90,7 @@ impl DomainParticipantFactoryAsync {
             builtin_subscriber_status_condition_address,
             domain_id,
             self.runtime_handle.clone(),
+            timer_handle,
         );
 
         if self
@@ -164,6 +169,10 @@ impl DomainParticipantFactoryAsync {
                     .send_actor_mail(subscriber_actor::GetStatuscondition)?
                     .receive_reply()
                     .await;
+                let timer_handle = dp
+                    .send_actor_mail(domain_participant_actor::GetTimerHandle)?
+                    .receive_reply()
+                    .await;
                 return Ok(Some(DomainParticipantAsync::new(
                     dp,
                     status_condition,
@@ -171,6 +180,7 @@ impl DomainParticipantFactoryAsync {
                     builtin_subscriber_status_condition_address,
                     domain_id,
                     self.runtime_handle.clone(),
+                    timer_handle,
                 )));
             }
         }

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -34,6 +34,12 @@ pub struct DomainParticipantFactoryAsync {
     domain_participant_factory_actor: Actor<DomainParticipantFactoryActor>,
 }
 
+impl Default for DomainParticipantFactoryAsync {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DomainParticipantFactoryAsync {
     /// Create a new [`DomainParticipantFactoryAsync`].
     /// All the tasks of Dust DDS will be spawned on the runtime which is given as an argument.

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -11,6 +11,7 @@ use crate::{
             domain_participant_factory_actor::{self, DomainParticipantFactoryActor},
             subscriber_actor,
         },
+        runtime::executor::Executor,
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -29,20 +30,21 @@ use super::{
 /// a constructor by passing a handle to a [`Tokio`](https://crates.io/crates/tokio) runtime. This allows the factory
 /// to spin tasks on an existing runtime which can be shared with other things outside Dust DDS.
 pub struct DomainParticipantFactoryAsync {
+    _executor: Executor,
     domain_participant_factory_actor: Actor<DomainParticipantFactoryActor>,
-    runtime_handle: tokio::runtime::Handle,
 }
 
 impl DomainParticipantFactoryAsync {
     /// Create a new [`DomainParticipantFactoryAsync`].
     /// All the tasks of Dust DDS will be spawned on the runtime which is given as an argument.
-    pub fn new(runtime_handle: tokio::runtime::Handle) -> Self {
+    pub fn new() -> Self {
+        let executor = Executor::new();
         let domain_participant_factory_actor =
-            Actor::spawn(DomainParticipantFactoryActor::new(), &runtime_handle);
+            Actor::spawn(DomainParticipantFactoryActor::new(), &executor.handle());
 
         Self {
+            _executor: executor,
             domain_participant_factory_actor,
-            runtime_handle,
         }
     }
 
@@ -55,7 +57,6 @@ impl DomainParticipantFactoryAsync {
         mask: &[StatusKind],
     ) -> DdsResult<DomainParticipantAsync> {
         let status_kind = mask.to_vec();
-        let runtime_handle = self.runtime_handle.clone();
         let participant_address = self
             .domain_participant_factory_actor
             .send_actor_mail(domain_participant_factory_actor::CreateParticipant {
@@ -63,7 +64,6 @@ impl DomainParticipantFactoryAsync {
                 qos,
                 listener: a_listener,
                 status_kind,
-                runtime_handle,
             })
             .receive_reply()
             .await?;
@@ -83,13 +83,17 @@ impl DomainParticipantFactoryAsync {
             .send_actor_mail(domain_participant_actor::GetTimerHandle)?
             .receive_reply()
             .await;
+        let executor_handle = participant_address
+            .send_actor_mail(domain_participant_actor::GetExecutorHandle)?
+            .receive_reply()
+            .await;
         let domain_participant = DomainParticipantAsync::new(
             participant_address.clone(),
             status_condition,
             builtin_subscriber,
             builtin_subscriber_status_condition_address,
             domain_id,
-            self.runtime_handle.clone(),
+            executor_handle,
             timer_handle,
         );
 
@@ -173,13 +177,17 @@ impl DomainParticipantFactoryAsync {
                     .send_actor_mail(domain_participant_actor::GetTimerHandle)?
                     .receive_reply()
                     .await;
+                let executor_handle = dp
+                    .send_actor_mail(domain_participant_actor::GetExecutorHandle)?
+                    .receive_reply()
+                    .await;
                 return Ok(Some(DomainParticipantAsync::new(
                     dp,
                     status_condition,
                     builtin_subscriber,
                     builtin_subscriber_status_condition_address,
                     domain_id,
-                    self.runtime_handle.clone(),
+                    executor_handle,
                     timer_handle,
                 )));
             }

--- a/dds/src/dds_async/publisher.rs
+++ b/dds/src/dds_async/publisher.rs
@@ -55,10 +55,6 @@ impl PublisherAsync {
         &self.publisher_address
     }
 
-    pub(crate) fn runtime_handle(&self) -> &tokio::runtime::Handle {
-        self.participant.runtime_handle()
-    }
-
     async fn announce_deleted_data_writer(
         &self,
         writer: &Actor<DataWriterActor>,
@@ -160,7 +156,7 @@ impl PublisherAsync {
                 mask: mask.to_vec(),
                 default_unicast_locator_list,
                 default_multicast_locator_list,
-                runtime_handle: self.participant.runtime_handle().clone(),
+                executor_handle: self.participant.executor_handle().clone(),
             })?
             .receive_reply()
             .await?;
@@ -426,7 +422,6 @@ impl PublisherAsync {
             .send_actor_mail(publisher_actor::SetListener {
                 listener: a_listener,
                 status_kind: mask.to_vec(),
-                runtime_handle: self.participant.runtime_handle().clone(),
             })?
             .receive_reply()
             .await
@@ -437,7 +432,7 @@ impl PublisherAsync {
     pub fn get_statuscondition(&self) -> StatusConditionAsync {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
-            self.participant.runtime_handle().clone(),
+            self.participant.executor_handle().clone(),
             self.participant.timer_handle().clone(),
         )
     }

--- a/dds/src/dds_async/publisher.rs
+++ b/dds/src/dds_async/publisher.rs
@@ -438,6 +438,7 @@ impl PublisherAsync {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
             self.participant.runtime_handle().clone(),
+            self.participant.timer_handle().clone(),
         )
     }
 

--- a/dds/src/dds_async/subscriber.rs
+++ b/dds/src/dds_async/subscriber.rs
@@ -54,10 +54,6 @@ impl SubscriberAsync {
         &self.subscriber_address
     }
 
-    pub(crate) fn runtime_handle(&self) -> &tokio::runtime::Handle {
-        self.participant.runtime_handle()
-    }
-
     async fn announce_deleted_data_reader(
         &self,
         reader: &Actor<DataReaderActor>,
@@ -156,7 +152,7 @@ impl SubscriberAsync {
                 mask: mask.to_vec(),
                 default_unicast_locator_list,
                 default_multicast_locator_list,
-                runtime_handle: self.runtime_handle().clone(),
+                executor_handle: self.participant.executor_handle().clone(),
             })?
             .receive_reply()
             .await?;
@@ -388,7 +384,6 @@ impl SubscriberAsync {
             .send_actor_mail(subscriber_actor::SetListener {
                 listener: a_listener,
                 status_kind: mask.to_vec(),
-                runtime_handle: self.runtime_handle().clone(),
             })?
             .receive_reply()
             .await
@@ -399,7 +394,7 @@ impl SubscriberAsync {
     pub fn get_statuscondition(&self) -> StatusConditionAsync {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
-            self.runtime_handle().clone(),
+            self.participant.executor_handle().clone(),
             self.participant.timer_handle().clone(),
         )
     }

--- a/dds/src/dds_async/subscriber.rs
+++ b/dds/src/dds_async/subscriber.rs
@@ -400,6 +400,7 @@ impl SubscriberAsync {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
             self.runtime_handle().clone(),
+            self.participant.timer_handle().clone(),
         )
     }
 

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -58,10 +58,6 @@ impl TopicAsync {
         self.participant.participant_address()
     }
 
-    pub(crate) fn runtime_handle(&self) -> &tokio::runtime::Handle {
-        self.participant.runtime_handle()
-    }
-
     async fn announce_topic(&self) -> DdsResult<()> {
         let builtin_publisher = self.get_participant().get_builtin_publisher().await?;
         if let Some(sedp_topics_announcer) = builtin_publisher
@@ -158,7 +154,7 @@ impl TopicAsync {
     pub fn get_statuscondition(&self) -> StatusConditionAsync {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
-            self.runtime_handle().clone(),
+            self.participant.executor_handle().clone(),
             self.participant.timer_handle().clone(),
         )
     }

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -159,6 +159,7 @@ impl TopicAsync {
         StatusConditionAsync::new(
             self.status_condition_address.clone(),
             self.runtime_handle().clone(),
+            self.participant.timer_handle().clone(),
         )
     }
 

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -2038,7 +2038,6 @@ pub struct AddMatchedWriter {
         Option<MpscSender<ParticipantListenerMessage>>,
         Vec<StatusKind>,
     ),
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for AddMatchedWriter {
     type Result = DdsResult<()>;
@@ -2169,7 +2168,6 @@ pub struct RemoveMatchedWriter {
         Option<MpscSender<ParticipantListenerMessage>>,
         Vec<StatusKind>,
     ),
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for RemoveMatchedWriter {
     type Result = DdsResult<()>;

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1259,6 +1259,7 @@ impl DataReaderActor {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add_change(
         &mut self,
         change: ReaderCacheChange,
@@ -1572,6 +1573,7 @@ impl DataReaderActor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn start_deadline_missed_task(
         &mut self,
         change_instance_handle: InstanceHandle,

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -26,7 +26,7 @@ use crate::{
             cdr_deserializer::ClassicCdrDeserializer, endianness::CdrEndianness,
         },
         runtime::{
-            executor::{block_on, AbortHandle, ExecutorHandle},
+            executor::{block_on, ExecutorHandle, TaskHandle},
             mpsc::{mpsc_channel, MpscSender},
             timer::TimerHandle,
         },
@@ -381,7 +381,7 @@ pub struct DataReaderActor {
     data_reader_listener_thread: Option<DataReaderListenerThread>,
     status_kind: Vec<StatusKind>,
     instances: HashMap<InstanceHandle, InstanceState>,
-    instance_deadline_missed_task: HashMap<InstanceHandle, AbortHandle>,
+    instance_deadline_missed_task: HashMap<InstanceHandle, TaskHandle>,
 }
 
 impl DataReaderActor {
@@ -1711,7 +1711,7 @@ impl DataReaderActor {
             });
 
             self.instance_deadline_missed_task
-                .insert(change_instance_handle, deadline_missed_task.abort_handle());
+                .insert(change_instance_handle, deadline_missed_task);
         }
         Ok(())
     }

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -1192,7 +1192,6 @@ pub struct AddMatchedReader {
         Vec<StatusKind>,
     ),
     pub message_sender_actor: ActorAddress<MessageSenderActor>,
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for AddMatchedReader {
     type Result = DdsResult<()>;
@@ -1366,7 +1365,6 @@ pub struct RemoveMatchedReader {
         Option<MpscSender<ParticipantListenerMessage>>,
         Vec<StatusKind>,
     ),
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for RemoveMatchedReader {
     type Result = DdsResult<()>;

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -328,6 +328,7 @@ impl DataWriterActor {
         message_sender_actor: ActorAddress<MessageSenderActor>,
         now: Time,
         writer_address: ActorAddress<DataWriterActor>,
+        executor_handle: ExecutorHandle,
         timer_handle: TimerHandle,
     ) {
         let seq_num = change.sequence_number();
@@ -338,7 +339,7 @@ impl DataWriterActor {
             if change_lifespan > Duration::new(0, 0) {
                 self.writer_cache.add_change(change);
 
-                tokio::spawn(async move {
+                executor_handle.spawn(async move {
                     timer_handle.sleep(change_lifespan.into()).await;
 
                     writer_address
@@ -899,6 +900,7 @@ pub struct UnregisterInstanceWTimestamp {
     pub message_sender_actor: ActorAddress<MessageSenderActor>,
     pub now: Time,
     pub data_writer_address: ActorAddress<DataWriterActor>,
+    pub executor_handle: ExecutorHandle,
     pub timer_handle: TimerHandle,
 }
 impl Mail for UnregisterInstanceWTimestamp {
@@ -944,6 +946,7 @@ impl MailHandler<UnregisterInstanceWTimestamp> for DataWriterActor {
             message.message_sender_actor,
             message.now,
             message.data_writer_address,
+            message.executor_handle,
             message.timer_handle,
         );
         Ok(())
@@ -982,6 +985,7 @@ pub struct DisposeWTimestamp {
     pub message_sender_actor: ActorAddress<MessageSenderActor>,
     pub now: Time,
     pub data_writer_address: ActorAddress<DataWriterActor>,
+    pub executor_handle: ExecutorHandle,
     pub timer_handle: TimerHandle,
 }
 impl Mail for DisposeWTimestamp {
@@ -1015,6 +1019,7 @@ impl MailHandler<DisposeWTimestamp> for DataWriterActor {
             message.message_sender_actor,
             message.now,
             message.data_writer_address,
+            message.executor_handle,
             message.timer_handle,
         );
 
@@ -1126,6 +1131,7 @@ pub struct WriteWTimestamp {
     pub message_sender_actor: ActorAddress<MessageSenderActor>,
     pub now: Time,
     pub data_writer_address: ActorAddress<DataWriterActor>,
+    pub executor_handle: ExecutorHandle,
     pub timer_handle: TimerHandle,
 }
 impl Mail for WriteWTimestamp {
@@ -1152,6 +1158,7 @@ impl MailHandler<WriteWTimestamp> for DataWriterActor {
             message.message_sender_actor,
             message.now,
             message.data_writer_address,
+            message.executor_handle,
             message.timer_handle,
         );
 

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -1580,7 +1580,6 @@ impl MailHandler<SetMetatrafficMulticastLocatorList> for DomainParticipantActor 
 pub struct AddDiscoveredParticipant {
     pub discovered_participant_data: SpdpDiscoveredParticipantData,
     pub participant: DomainParticipantAsync,
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for AddDiscoveredParticipant {
     type Result = DdsResult<()>;
@@ -1686,7 +1685,6 @@ impl MailHandler<RemoveDiscoveredParticipant> for DomainParticipantActor {
 pub struct AddMatchedWriter {
     pub discovered_writer_data: DiscoveredWriterData,
     pub participant: DomainParticipantAsync,
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for AddMatchedWriter {
     type Result = DdsResult<()>;
@@ -1861,7 +1859,6 @@ impl MailHandler<RemoveMatchedWriter> for DomainParticipantActor {
 pub struct AddMatchedReader {
     pub discovered_reader_data: DiscoveredReaderData,
     pub participant: DomainParticipantAsync,
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for AddMatchedReader {
     type Result = DdsResult<()>;
@@ -2513,7 +2510,6 @@ async fn process_spdp_participant_discovery(participant: &DomainParticipantAsync
                                 .send_actor_mail(AddDiscoveredParticipant {
                                     discovered_participant_data,
                                     participant: participant.clone(),
-                                    executor_handle: participant.executor_handle().clone(),
                                 })?
                                 .receive_reply()
                                 .await?;
@@ -2562,7 +2558,6 @@ async fn process_sedp_publications_discovery(
                                 AddMatchedWriter {
                                     discovered_writer_data,
                                     participant: participant.clone(),
-                                    executor_handle: participant.executor_handle().clone(),
                                 },
                             )?;
                         }
@@ -2617,7 +2612,6 @@ async fn process_sedp_subscriptions_discovery(
                                 AddMatchedReader {
                                     discovered_reader_data,
                                     participant: participant.clone(),
-                                    executor_handle: participant.executor_handle().clone(),
                                 },
                             )?;
                         }

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -1267,6 +1267,7 @@ impl MailHandler<ProcessMetatrafficRtpsMessage> for DomainParticipantActor {
                             participant: message.participant.clone(),
                             participant_mask_listener,
                             handle: message.handle.clone(),
+                            timer_handle: self.timer_driver.handle(),
                         },
                     );
                 }
@@ -1287,6 +1288,7 @@ impl MailHandler<ProcessMetatrafficRtpsMessage> for DomainParticipantActor {
                             participant: message.participant.clone(),
                             participant_mask_listener,
                             handle: message.handle.clone(),
+                            timer_handle: self.timer_driver.handle(),
                         },
                     );
                 }
@@ -1380,6 +1382,7 @@ impl MailHandler<ProcessUserDefinedRtpsMessage> for DomainParticipantActor {
                                 participant: message.participant.clone(),
                                 participant_mask_listener,
                                 handle: message.handle.clone(),
+                                timer_handle: self.timer_driver.handle(),
                             },
                         );
                     }
@@ -1403,6 +1406,7 @@ impl MailHandler<ProcessUserDefinedRtpsMessage> for DomainParticipantActor {
                                 participant: message.participant.clone(),
                                 participant_mask_listener,
                                 handle: message.handle.clone(),
+                                timer_handle: self.timer_driver.handle(),
                             },
                         );
                     }

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -1631,32 +1631,26 @@ impl MailHandler<AddDiscoveredParticipant> for DomainParticipantActor {
             self.add_matched_publications_detector(
                 &message.discovered_participant_data,
                 message.participant.clone(),
-                message.executor_handle.clone(),
             )?;
             self.add_matched_publications_announcer(
                 &message.discovered_participant_data,
                 message.participant.clone(),
-                message.executor_handle.clone(),
             )?;
             self.add_matched_subscriptions_detector(
                 &message.discovered_participant_data,
                 message.participant.clone(),
-                message.executor_handle.clone(),
             )?;
             self.add_matched_subscriptions_announcer(
                 &message.discovered_participant_data,
                 message.participant.clone(),
-                message.executor_handle.clone(),
             )?;
             self.add_matched_topics_detector(
                 &message.discovered_participant_data,
                 message.participant.clone(),
-                message.executor_handle.clone(),
             )?;
             self.add_matched_topics_announcer(
                 &message.discovered_participant_data,
                 message.participant.clone(),
-                message.executor_handle.clone(),
             )?;
 
             self.discovered_participant_list.insert(
@@ -1754,7 +1748,6 @@ impl MailHandler<AddMatchedWriter> for DomainParticipantActor {
                         subscriber_address,
                         participant: message.participant.clone(),
                         participant_mask_listener,
-                        executor_handle: message.executor_handle.clone(),
                     });
                 }
 
@@ -1840,7 +1833,6 @@ impl MailHandler<AddMatchedWriter> for DomainParticipantActor {
 pub struct RemoveMatchedWriter {
     pub discovered_writer_handle: InstanceHandle,
     pub participant: DomainParticipantAsync,
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for RemoveMatchedWriter {
     type Result = DdsResult<()>;
@@ -1860,7 +1852,6 @@ impl MailHandler<RemoveMatchedWriter> for DomainParticipantActor {
                 subscriber_address,
                 participant: message.participant.clone(),
                 participant_mask_listener,
-                executor_handle: message.executor_handle.clone(),
             });
         }
         Ok(())
@@ -1935,7 +1926,6 @@ impl MailHandler<AddMatchedReader> for DomainParticipantActor {
                         participant: message.participant.clone(),
                         participant_mask_listener,
                         message_sender_actor: self.message_sender_actor.address(),
-                        executor_handle: message.executor_handle.clone(),
                     });
                 }
 
@@ -2017,7 +2007,6 @@ impl MailHandler<AddMatchedReader> for DomainParticipantActor {
 pub struct RemoveMatchedReader {
     pub discovered_reader_handle: InstanceHandle,
     pub participant: DomainParticipantAsync,
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for RemoveMatchedReader {
     type Result = DdsResult<()>;
@@ -2037,7 +2026,6 @@ impl MailHandler<RemoveMatchedReader> for DomainParticipantActor {
                 publisher_address,
                 participant: message.participant.clone(),
                 participant_mask_listener,
-                executor_handle: message.executor_handle.clone(),
             });
         }
         Ok(())
@@ -2102,7 +2090,6 @@ impl DomainParticipantActor {
         &self,
         discovered_participant_data: &SpdpDiscoveredParticipantData,
         participant: DomainParticipantAsync,
-        executor_handle: ExecutorHandle,
     ) -> DdsResult<()> {
         if discovered_participant_data
             .participant_proxy()
@@ -2165,7 +2152,6 @@ impl DomainParticipantActor {
                     participant,
                     participant_mask_listener,
                     message_sender_actor: self.message_sender_actor.address(),
-                    executor_handle,
                 });
         }
         Ok(())
@@ -2175,7 +2161,6 @@ impl DomainParticipantActor {
         &self,
         discovered_participant_data: &SpdpDiscoveredParticipantData,
         participant: DomainParticipantAsync,
-        executor_handle: ExecutorHandle,
     ) -> DdsResult<()> {
         if discovered_participant_data
             .participant_proxy()
@@ -2231,7 +2216,6 @@ impl DomainParticipantActor {
                             .map(|l| l.sender().clone()),
                         self.status_kind.clone(),
                     ),
-                    executor_handle,
                 });
         }
         Ok(())
@@ -2241,7 +2225,6 @@ impl DomainParticipantActor {
         &self,
         discovered_participant_data: &SpdpDiscoveredParticipantData,
         participant: DomainParticipantAsync,
-        executor_handle: ExecutorHandle,
     ) -> DdsResult<()> {
         if discovered_participant_data
             .participant_proxy()
@@ -2297,7 +2280,6 @@ impl DomainParticipantActor {
                         self.status_kind.clone(),
                     ),
                     message_sender_actor: self.message_sender_actor.address(),
-                    executor_handle,
                 });
         }
         Ok(())
@@ -2307,7 +2289,6 @@ impl DomainParticipantActor {
         &self,
         discovered_participant_data: &SpdpDiscoveredParticipantData,
         participant: DomainParticipantAsync,
-        executor_handle: ExecutorHandle,
     ) -> DdsResult<()> {
         if discovered_participant_data
             .participant_proxy()
@@ -2363,7 +2344,6 @@ impl DomainParticipantActor {
                             .map(|l| l.sender().clone()),
                         self.status_kind.clone(),
                     ),
-                    executor_handle,
                 });
         }
 
@@ -2374,7 +2354,6 @@ impl DomainParticipantActor {
         &self,
         discovered_participant_data: &SpdpDiscoveredParticipantData,
         participant: DomainParticipantAsync,
-        executor_handle: ExecutorHandle,
     ) -> DdsResult<()> {
         if discovered_participant_data
             .participant_proxy()
@@ -2430,7 +2409,6 @@ impl DomainParticipantActor {
                         self.status_kind.clone(),
                     ),
                     message_sender_actor: self.message_sender_actor.address(),
-                    executor_handle,
                 });
         }
         Ok(())
@@ -2440,7 +2418,6 @@ impl DomainParticipantActor {
         &self,
         discovered_participant_data: &SpdpDiscoveredParticipantData,
         participant: DomainParticipantAsync,
-        executor_handle: ExecutorHandle,
     ) -> DdsResult<()> {
         if discovered_participant_data
             .participant_proxy()
@@ -2496,7 +2473,6 @@ impl DomainParticipantActor {
                             .map(|l| l.sender().clone()),
                         self.status_kind.clone(),
                     ),
-                    executor_handle,
                 });
         }
         Ok(())
@@ -2603,7 +2579,6 @@ async fn process_sedp_publications_discovery(
                                     .sample_info()
                                     .instance_handle,
                                 participant: participant.clone(),
-                                executor_handle: participant.executor_handle().clone(),
                             })?;
                     }
                     InstanceStateKind::NotAliveNoWriters => {
@@ -2659,7 +2634,6 @@ async fn process_sedp_subscriptions_discovery(
                                     .sample_info()
                                     .instance_handle,
                                 participant: participant.clone(),
-                                executor_handle: participant.executor_handle().clone(),
                             })?;
                     }
                     InstanceStateKind::NotAliveNoWriters => {

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -589,10 +589,8 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
 
         // Start the regular participant announcement task
         let participant_clone = participant.clone();
-        let participant_announcement_interval = self
-            .configuration
-            .participant_announcement_interval()
-            .clone();
+        let participant_announcement_interval =
+            self.configuration.participant_announcement_interval();
 
         executor_handle.spawn(async move {
             loop {

--- a/dds/src/implementation/actors/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_factory_actor.rs
@@ -22,6 +22,7 @@ use crate::{
     implementation::{
         actor::{Actor, ActorAddress, Mail, MailHandler},
         actors::domain_participant_actor::DomainParticipantActor,
+        runtime::timer::TimerDriver,
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -525,6 +526,9 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
             DEFAULT_MULTICAST_LOCATOR_ADDRESS,
         )];
         rtps_participant.set_metatraffic_multicast_locator_list(metatraffic_multicast_locator_list);
+
+        let timer_driver = TimerDriver::new();
+        let timer_handle = timer_driver.handle();
         //****** Spawn the participant actor and tasks **********//
         let (
             domain_participant,
@@ -544,6 +548,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
             builtin_data_reader_list,
             message_sender_actor,
             &message.runtime_handle,
+            timer_driver,
         );
         let participant_actor = Actor::spawn(domain_participant, &message.runtime_handle);
         let participant = DomainParticipantAsync::new(
@@ -553,6 +558,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
             builtin_subscriber_status_condition_address,
             message.domain_id,
             message.runtime_handle.clone(),
+            timer_handle,
         );
 
         let participant_address_clone = participant_actor.address();

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -489,7 +489,6 @@ pub struct AddMatchedReader {
         Vec<StatusKind>,
     ),
     pub message_sender_actor: ActorAddress<MessageSenderActor>,
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for AddMatchedReader {
     type Result = DdsResult<()>;
@@ -525,7 +524,6 @@ impl MailHandler<AddMatchedReader> for PublisherActor {
                     publisher_mask_listener,
                     participant_mask_listener: message.participant_mask_listener.clone(),
                     message_sender_actor: message.message_sender_actor.clone(),
-                    executor_handle: message.executor_handle.clone(),
                 });
             }
         }
@@ -541,7 +539,6 @@ pub struct RemoveMatchedReader {
         Option<MpscSender<ParticipantListenerMessage>>,
         Vec<StatusKind>,
     ),
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for RemoveMatchedReader {
     type Result = DdsResult<()>;
@@ -566,7 +563,6 @@ impl MailHandler<RemoveMatchedReader> for PublisherActor {
                 ),
                 publisher_mask_listener,
                 participant_mask_listener: message.participant_mask_listener.clone(),
-                executor_handle: message.executor_handle.clone(),
             });
         }
         Ok(())

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -12,7 +12,7 @@ use crate::{
     implementation::{
         actor::{Actor, ActorAddress, Mail, MailHandler},
         runtime::{
-            executor::block_on,
+            executor::{block_on, ExecutorHandle},
             mpsc::{mpsc_channel, MpscSender},
         },
     },
@@ -121,7 +121,7 @@ impl PublisherActor {
         listener: Option<Box<dyn PublisherListenerAsync + Send>>,
         status_kind: Vec<StatusKind>,
         data_writer_list: Vec<DataWriterActor>,
-        handle: &tokio::runtime::Handle,
+        handle: &ExecutorHandle,
     ) -> Self {
         let data_writer_list = data_writer_list
             .into_iter()
@@ -213,7 +213,7 @@ pub struct CreateDatawriter {
     pub mask: Vec<StatusKind>,
     pub default_unicast_locator_list: Vec<Locator>,
     pub default_multicast_locator_list: Vec<Locator>,
-    pub runtime_handle: tokio::runtime::Handle,
+    pub executor_handle: ExecutorHandle,
 }
 impl Mail for CreateDatawriter {
     type Result = DdsResult<ActorAddress<DataWriterActor>>;
@@ -264,9 +264,9 @@ impl MailHandler<CreateDatawriter> for PublisherActor {
             message.a_listener,
             message.mask,
             qos,
-            &message.runtime_handle,
+            &message.executor_handle,
         );
-        let data_writer_actor = Actor::spawn(data_writer, &message.runtime_handle);
+        let data_writer_actor = Actor::spawn(data_writer, &message.executor_handle);
         let data_writer_address = data_writer_actor.address();
         self.data_writer_list
             .insert(InstanceHandle::new(guid.into()), data_writer_actor);
@@ -489,7 +489,7 @@ pub struct AddMatchedReader {
         Vec<StatusKind>,
     ),
     pub message_sender_actor: ActorAddress<MessageSenderActor>,
-    pub handle: tokio::runtime::Handle,
+    pub executor_handle: ExecutorHandle,
 }
 impl Mail for AddMatchedReader {
     type Result = DdsResult<()>;
@@ -525,7 +525,7 @@ impl MailHandler<AddMatchedReader> for PublisherActor {
                     publisher_mask_listener,
                     participant_mask_listener: message.participant_mask_listener.clone(),
                     message_sender_actor: message.message_sender_actor.clone(),
-                    handle: message.handle.clone(),
+                    executor_handle: message.executor_handle.clone(),
                 });
             }
         }
@@ -541,7 +541,7 @@ pub struct RemoveMatchedReader {
         Option<MpscSender<ParticipantListenerMessage>>,
         Vec<StatusKind>,
     ),
-    pub handle: tokio::runtime::Handle,
+    pub executor_handle: ExecutorHandle,
 }
 impl Mail for RemoveMatchedReader {
     type Result = DdsResult<()>;
@@ -566,7 +566,7 @@ impl MailHandler<RemoveMatchedReader> for PublisherActor {
                 ),
                 publisher_mask_listener,
                 participant_mask_listener: message.participant_mask_listener.clone(),
-                handle: message.handle.clone(),
+                executor_handle: message.executor_handle.clone(),
             });
         }
         Ok(())
@@ -586,7 +586,6 @@ impl MailHandler<GetStatuscondition> for PublisherActor {
 pub struct SetListener {
     pub listener: Option<Box<dyn PublisherListenerAsync + Send>>,
     pub status_kind: Vec<StatusKind>,
-    pub runtime_handle: tokio::runtime::Handle,
 }
 impl Mail for SetListener {
     type Result = DdsResult<()>;

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -22,6 +22,7 @@ use crate::{
         runtime::{
             executor::block_on,
             mpsc::{mpsc_channel, MpscSender},
+            timer::TimerHandle,
         },
     },
     infrastructure::{
@@ -491,6 +492,7 @@ pub struct ProcessDataSubmessage {
         Vec<StatusKind>,
     ),
     pub handle: tokio::runtime::Handle,
+    pub timer_handle: TimerHandle,
 }
 impl Mail for ProcessDataSubmessage {
     type Result = ();
@@ -521,6 +523,7 @@ impl MailHandler<ProcessDataSubmessage> for SubscriberActor {
                 subscriber_mask_listener,
                 participant_mask_listener: message.participant_mask_listener.clone(),
                 handle: message.handle.clone(),
+                timer_handle: message.timer_handle.clone(),
             });
         }
     }
@@ -538,6 +541,7 @@ pub struct ProcessDataFragSubmessage {
         Vec<StatusKind>,
     ),
     pub handle: tokio::runtime::Handle,
+    pub timer_handle: TimerHandle,
 }
 impl Mail for ProcessDataFragSubmessage {
     type Result = ();
@@ -568,6 +572,7 @@ impl MailHandler<ProcessDataFragSubmessage> for SubscriberActor {
                 subscriber_mask_listener,
                 participant_mask_listener: message.participant_mask_listener.clone(),
                 handle: message.handle.clone(),
+                timer_handle: message.timer_handle.clone(),
             });
         }
     }

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -650,7 +650,6 @@ pub struct AddMatchedWriter {
         Option<MpscSender<ParticipantListenerMessage>>,
         Vec<StatusKind>,
     ),
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for AddMatchedWriter {
     type Result = DdsResult<()>;
@@ -685,7 +684,6 @@ impl MailHandler<AddMatchedWriter> for SubscriberActor {
                     subscriber_qos,
                     subscriber_mask_listener,
                     participant_mask_listener: message.participant_mask_listener.clone(),
-                    executor_handle: message.executor_handle.clone(),
                 });
             }
         }
@@ -701,7 +699,6 @@ pub struct RemoveMatchedWriter {
         Option<MpscSender<ParticipantListenerMessage>>,
         Vec<StatusKind>,
     ),
-    pub executor_handle: ExecutorHandle,
 }
 impl Mail for RemoveMatchedWriter {
     type Result = DdsResult<()>;
@@ -726,7 +723,6 @@ impl MailHandler<RemoveMatchedWriter> for SubscriberActor {
                 ),
                 subscriber_mask_listener,
                 participant_mask_listener: message.participant_mask_listener.clone(),
-                executor_handle: message.executor_handle.clone(),
             });
         }
 

--- a/dds/src/implementation/actors/topic_actor.rs
+++ b/dds/src/implementation/actors/topic_actor.rs
@@ -7,7 +7,7 @@ use crate::{
     implementation::{
         actor::{Actor, ActorAddress, Mail, MailHandler},
         runtime::{
-            executor::block_on,
+            executor::{block_on, ExecutorHandle},
             mpsc::{mpsc_channel, MpscSender},
         },
     },
@@ -95,7 +95,7 @@ impl TopicActor {
         topic_name: &str,
         listener: Option<Box<dyn TopicListenerAsync + Send>>,
         type_support: Arc<dyn DynamicTypeInterface + Send + Sync>,
-        handle: &tokio::runtime::Handle,
+        handle: &ExecutorHandle,
     ) -> (Self, ActorAddress<StatusConditionActor>) {
         let status_condition = Actor::spawn(StatusConditionActor::default(), handle);
         let status_condition_address = status_condition.address();

--- a/dds/src/implementation/actors/topic_actor.rs
+++ b/dds/src/implementation/actors/topic_actor.rs
@@ -39,7 +39,7 @@ impl InconsistentTopicStatus {
 pub enum TopicListenerOperation {}
 
 pub struct TopicListenerMessage {
-    pub listener_operation: TopicListenerOperation,
+    pub _listener_operation: TopicListenerOperation,
 }
 
 struct TopicListenerThread {

--- a/dds/src/implementation/runtime/executor.rs
+++ b/dds/src/implementation/runtime/executor.rs
@@ -1,9 +1,12 @@
 use std::{
     future::Future,
-    pin::pin,
-    sync::Arc,
+    pin::{pin, Pin},
+    sync::{
+        mpsc::{channel, Sender},
+        Arc, Mutex,
+    },
     task::{Context, Poll, Wake, Waker},
-    thread::{self, Thread},
+    thread::{self, JoinHandle, Thread},
 };
 
 pub fn block_on<T>(f: impl Future<Output = T>) -> T {
@@ -20,6 +23,70 @@ pub fn block_on<T>(f: impl Future<Output = T>) -> T {
         match pinned_fut.as_mut().poll(&mut cx) {
             Poll::Ready(t) => return t,
             Poll::Pending => thread::park(),
+        }
+    }
+}
+
+pub struct Task {
+    future: Mutex<Pin<Box<dyn Future<Output = ()> + Send>>>,
+    task_sender: Sender<Arc<Task>>,
+}
+
+impl Wake for Task {
+    fn wake(self: Arc<Self>) {
+        self.task_sender.send(self.clone()).unwrap();
+    }
+}
+
+pub struct ExecutorHandle {
+    task_sender: Sender<Arc<Task>>,
+    thread_handle: Thread,
+}
+
+impl ExecutorHandle {
+    pub fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) {
+        let future = Box::pin(f);
+        self.task_sender
+            .send(Arc::new(Task {
+                future: Mutex::new(future),
+                task_sender: self.task_sender.clone(),
+            }))
+            .unwrap();
+        self.thread_handle.unpark();
+    }
+}
+
+pub struct Executor {
+    task_sender: Sender<Arc<Task>>,
+    executor_thread_handle: JoinHandle<()>,
+}
+
+impl Executor {
+    pub fn new() -> Self {
+        let (task_sender, task_receiver) = channel::<Arc<Task>>();
+        let executor_thread_handle = std::thread::spawn(move || {
+            while let Ok(task) = task_receiver.recv() {
+                let waker = Waker::from(task.clone());
+                let mut cx = Context::from_waker(&waker);
+                let _ = task
+                    .future
+                    .try_lock()
+                    .expect("Only ever locked here")
+                    .as_mut()
+                    .poll(&mut cx);
+            }
+        });
+
+        Self {
+            task_sender,
+            executor_thread_handle,
+        }
+    }
+
+    pub fn handle(&self) -> ExecutorHandle {
+        ExecutorHandle {
+            task_sender: self.task_sender.clone(),
+            thread_handle: self.executor_thread_handle.thread().clone(),
         }
     }
 }

--- a/dds/src/implementation/runtime/mod.rs
+++ b/dds/src/implementation/runtime/mod.rs
@@ -1,3 +1,4 @@
 pub mod executor;
 pub mod mpsc;
 pub mod oneshot;
+pub mod timer;

--- a/dds/src/implementation/runtime/mpsc.rs
+++ b/dds/src/implementation/runtime/mpsc.rs
@@ -8,7 +8,7 @@ use std::{
 
 pub fn mpsc_channel<T>() -> (MpscSender<T>, MpscReceiver<T>) {
     let inner = Arc::new(Mutex::new(MpscInner {
-        data: VecDeque::new(),
+        data: VecDeque::with_capacity(64),
         waker: None,
         is_closed: false,
     }));

--- a/dds/src/implementation/runtime/mpsc.rs
+++ b/dds/src/implementation/runtime/mpsc.rs
@@ -10,7 +10,6 @@ pub fn mpsc_channel<T>() -> (MpscSender<T>, MpscReceiver<T>) {
     let inner = Arc::new(Mutex::new(MpscInner {
         data: VecDeque::new(),
         waker: None,
-        sender_count: 1,
         is_closed: false,
     }));
     (
@@ -24,7 +23,6 @@ pub fn mpsc_channel<T>() -> (MpscSender<T>, MpscReceiver<T>) {
 struct MpscInner<T> {
     data: VecDeque<T>,
     waker: Option<Waker>,
-    sender_count: usize,
     is_closed: bool,
 }
 
@@ -42,7 +40,6 @@ impl<T> std::fmt::Debug for MpscInner<T> {
         f.debug_struct("MpscInner")
             .field("data_length", &self.data.len())
             .field("waker", &self.waker)
-            .field("sender_count", &self.sender_count)
             .finish()
     }
 }
@@ -58,24 +55,8 @@ pub struct MpscSender<T> {
 
 impl<T> Clone for MpscSender<T> {
     fn clone(&self) -> Self {
-        let mut inner_lock = self.inner.lock().expect("Mutex shouldn't be poisoned");
-        inner_lock.sender_count += 1;
         Self {
             inner: self.inner.clone(),
-        }
-    }
-}
-
-impl<T> Drop for MpscSender<T> {
-    fn drop(&mut self) {
-        let mut inner_lock = self.inner.lock().expect("Mutex shouldn't be poisoned");
-        inner_lock.sender_count -= 1;
-        // When the sender is dropped wake the waiting task
-        // so that it can finish knowing it won't get any message
-        if inner_lock.sender_count == 0 {
-            if let Some(w) = inner_lock.waker.take() {
-                w.wake()
-            }
         }
     }
 }

--- a/dds/src/implementation/runtime/oneshot.rs
+++ b/dds/src/implementation/runtime/oneshot.rs
@@ -44,7 +44,7 @@ impl<T> OneshotSender<T> {
             }
         }
 
-        // Don't run the destructure since the channel is already woken up with a value
+        // Don't run the drop since the channel is already woken up with a value
         std::mem::forget(self)
     }
 }

--- a/dds/src/implementation/runtime/timer.rs
+++ b/dds/src/implementation/runtime/timer.rs
@@ -24,9 +24,7 @@ impl Eq for TimerWake {}
 
 impl PartialOrd for TimerWake {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        // Reverse order compared to usual implementation
-        // since the binary heap is a max tree
-        other.deadline.partial_cmp(&self.deadline)
+        Some(self.cmp(other))
     }
 }
 
@@ -120,10 +118,7 @@ impl TimerHeap {
 
     #[inline(always)]
     fn is_next_timer_elapsed(&self) -> bool {
-        match self.heap.peek() {
-            Some(t) if t.deadline < Instant::now() => true,
-            _ => false,
-        }
+        matches!(self.heap.peek(), Some(t) if t.deadline < Instant::now())
     }
 
     #[inline(always)]
@@ -169,7 +164,7 @@ impl TimerHandle {
             if let Poll::Ready(t) = pin!(&mut future).poll(cx) {
                 return Poll::Ready(Ok(t));
             }
-            if let Poll::Ready(_) = pin!(&mut timeout).poll(cx) {
+            if pin!(&mut timeout).poll(cx).is_ready() {
                 return Poll::Ready(Err(TimeoutError::Timeout));
             }
 

--- a/dds/src/implementation/runtime/timer.rs
+++ b/dds/src/implementation/runtime/timer.rs
@@ -1,0 +1,231 @@
+use std::{
+    collections::BinaryHeap,
+    future::{poll_fn, Future},
+    pin::{pin, Pin},
+    sync::{mpsc::RecvTimeoutError, Arc, Mutex},
+    task::{Context, Poll, Waker},
+    thread::JoinHandle,
+    time::{Duration, Instant},
+};
+
+pub struct TimerWake {
+    id: usize,
+    deadline: Instant,
+    waker: Waker,
+}
+
+impl PartialEq for TimerWake {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.deadline == other.deadline
+    }
+}
+
+impl Eq for TimerWake {}
+
+impl PartialOrd for TimerWake {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        // Reverse order compared to usual implementation
+        // since the binary heap is a max tree
+        other.deadline.partial_cmp(&self.deadline)
+    }
+}
+
+impl Ord for TimerWake {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Reverse order compared to usual implementation
+        // since the binary heap is a max tree
+        other.deadline.cmp(&self.deadline)
+    }
+}
+
+pub struct Sleep {
+    id: usize,
+    deadline: Option<Instant>,
+    duration: Duration,
+    periodic_task_sender: std::sync::mpsc::Sender<TimerWake>,
+}
+
+impl Sleep {
+    pub fn is_elapsed(&self) -> bool {
+        if let Some(d) = self.deadline {
+            Instant::now() > d
+        } else {
+            false
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.deadline = Some(Instant::now() + self.duration);
+    }
+}
+
+impl Future for Sleep {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        if this.is_elapsed() {
+            Poll::Ready(())
+        } else {
+            if this.deadline.is_none() {
+                // First time being polled starts the sleep count
+                this.reset();
+            }
+            let deadline = this
+                .deadline
+                .expect("Must have deadline set after check above");
+            let timer_wake = TimerWake {
+                id: this.id,
+                deadline,
+                waker: cx.waker().clone(),
+            };
+            this.periodic_task_sender
+                .send(timer_wake)
+                .expect("Shouldn't fail to send");
+            Poll::Pending
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum TimeoutError {
+    Timeout,
+}
+
+struct TimerHeap {
+    heap: BinaryHeap<TimerWake>,
+}
+
+impl TimerHeap {
+    fn new() -> Self {
+        Self {
+            heap: BinaryHeap::with_capacity(10),
+        }
+    }
+
+    #[inline(always)]
+    fn push(&mut self, item: TimerWake) {
+        self.heap.push(item)
+    }
+
+    #[inline(always)]
+    fn duration_until_next_timer(&self) -> Option<Duration> {
+        if let Some(t) = self.heap.peek() {
+            let d = t.deadline.duration_since(Instant::now());
+            Some(d)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    fn is_next_timer_elapsed(&self) -> bool {
+        match self.heap.peek() {
+            Some(t) if t.deadline < Instant::now() => true,
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    fn notify_next_timer(&mut self) {
+        if let Some(t) = self.heap.pop() {
+            debug_assert!(t.deadline < Instant::now());
+            t.waker.wake();
+        }
+    }
+}
+
+struct HandleInner {
+    sleep_task_id: usize,
+    periodic_task_sender: std::sync::mpsc::Sender<TimerWake>,
+}
+
+#[derive(Clone)]
+pub struct TimerHandle {
+    inner: Arc<Mutex<HandleInner>>,
+}
+
+impl TimerHandle {
+    pub fn sleep(&self, duration: Duration) -> Sleep {
+        let mut inner_lock = self.inner.lock().expect("Mutex should not be poisoned");
+        let id = inner_lock.sleep_task_id;
+        inner_lock.sleep_task_id += 1;
+        Sleep {
+            id,
+            deadline: None,
+            duration,
+            periodic_task_sender: inner_lock.periodic_task_sender.clone(),
+        }
+    }
+
+    pub fn timeout<T>(
+        &self,
+        duration: Duration,
+        mut future: Pin<Box<dyn Future<Output = T> + Send>>,
+    ) -> impl Future<Output = Result<T, TimeoutError>> {
+        let mut timeout = self.sleep(duration);
+
+        poll_fn(move |cx| {
+            if let Poll::Ready(t) = pin!(&mut future).poll(cx) {
+                return Poll::Ready(Ok(t));
+            }
+            if let Poll::Ready(_) = pin!(&mut timeout).poll(cx) {
+                return Poll::Ready(Err(TimeoutError::Timeout));
+            }
+
+            Poll::Pending
+        })
+    }
+}
+
+pub struct TimerDriver {
+    inner: Arc<Mutex<HandleInner>>,
+    _timer_thread_join_handle: JoinHandle<()>,
+}
+
+impl TimerDriver {
+    pub fn new() -> Self {
+        let (periodic_task_sender, periodic_task_receiver) =
+            std::sync::mpsc::channel::<TimerWake>();
+        let timer_thread_join_handle = std::thread::spawn(move || {
+            let mut timer_heap = TimerHeap::new();
+            loop {
+                // Check if there are any elapsed tasks and wake them
+                while timer_heap.is_next_timer_elapsed() {
+                    timer_heap.notify_next_timer();
+                }
+
+                // Wait for a new timer wake to come. Sleep forever
+                // if there are no timer tasks on the queue otherwise
+                // sleep until the next deadline so that the tasks can be
+                // notified at the correct time
+                let new_timer = match timer_heap.duration_until_next_timer() {
+                    Some(d) => periodic_task_receiver.recv_timeout(d),
+                    None => periodic_task_receiver
+                        .recv()
+                        .map_err(|_| RecvTimeoutError::Disconnected),
+                };
+
+                match new_timer {
+                    Ok(t) => timer_heap.push(t),
+                    Err(RecvTimeoutError::Timeout) => (),
+                    Err(RecvTimeoutError::Disconnected) => break,
+                }
+            }
+        });
+        let inner = Arc::new(Mutex::new(HandleInner {
+            sleep_task_id: 0,
+            periodic_task_sender,
+        }));
+        Self {
+            inner,
+            _timer_thread_join_handle: timer_thread_join_handle,
+        }
+    }
+
+    pub fn handle(&self) -> TimerHandle {
+        TimerHandle {
+            inner: self.inner.clone(),
+        }
+    }
+}

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -262,7 +262,7 @@ impl Parameter {
                     "Available data for parameter less than length",
                 ));
             }
-            let value: Arc<[u8]> = Arc::from(&data[0..length as usize]);
+            let value: Arc<[u8]> = Arc::from(data[0..length as usize].to_vec().into_boxed_slice());
             if length as usize > value.len() {
                 return Err(RtpsError::new(
                     RtpsErrorKind::InvalidData,
@@ -367,7 +367,7 @@ impl AsRef<[u8]> for SerializedDataFragment {
 impl From<&[u8]> for SerializedDataFragment {
     fn from(value: &[u8]) -> Self {
         Self {
-            data: Data::new(Arc::from(value)),
+            data: Data::new(Arc::from(value.to_vec().into_boxed_slice())),
             range: 0..value.len(),
         }
     }

--- a/dds/src/rtps/messages/submessage_elements.rs
+++ b/dds/src/rtps/messages/submessage_elements.rs
@@ -262,7 +262,7 @@ impl Parameter {
                     "Available data for parameter less than length",
                 ));
             }
-            let value: Arc<[u8]> = Arc::from(data[0..length as usize].to_vec().into_boxed_slice());
+            let value: Arc<[u8]> = Arc::from(&data[0..length as usize]);
             if length as usize > value.len() {
                 return Err(RtpsError::new(
                     RtpsErrorKind::InvalidData,
@@ -367,7 +367,7 @@ impl AsRef<[u8]> for SerializedDataFragment {
 impl From<&[u8]> for SerializedDataFragment {
     fn from(value: &[u8]) -> Self {
         Self {
-            data: Data::new(Arc::from(value.to_vec().into_boxed_slice())),
+            data: Data::new(Arc::from(value)),
             range: 0..value.len(),
         }
     }

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -112,7 +112,7 @@ impl RtpsWriterProxy {
                     writer_id,
                     writer_sn,
                     inline_qos,
-                    Data::new(Arc::from(data.to_vec().into_boxed_slice())),
+                    Data::new(Arc::from(data)),
                 ))
             } else {
                 None

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -112,7 +112,7 @@ impl RtpsWriterProxy {
                     writer_id,
                     writer_sn,
                     inline_qos,
-                    Data::new(Arc::from(data)),
+                    Data::new(Arc::from(data.to_vec().into_boxed_slice())),
                 ))
             } else {
                 None

--- a/dds/tests/tokio_runtime.rs
+++ b/dds/tests/tokio_runtime.rs
@@ -27,7 +27,7 @@ struct UserData {
 async fn dust_dds_should_run_inside_tokio_runtime() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
-    let participant_factory = DomainParticipantFactoryAsync::new(tokio::runtime::Handle::current());
+    let participant_factory = DomainParticipantFactoryAsync::new();
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .await

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -171,7 +171,7 @@ async fn async_foo_with_lifetime_with_listener_should_compile() {
     }
 
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
-    let participant_factory = DomainParticipantFactoryAsync::new(tokio::runtime::Handle::current());
+    let participant_factory = DomainParticipantFactoryAsync::new();
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
         .await


### PR DESCRIPTION
Replace Tokio runtime by a custom minimal executor to avoid the overhead introduced by the Tokio runtime and decrease compilation time.