### PR TITLE
Add DataRepresentationQosPolicy

### DIFF
--- a/.github/workflows/python_docs.yml
+++ b/.github/workflows/python_docs.yml
@@ -2,7 +2,8 @@ name: python_docs
 
 on:
   workflow_dispatch:
-  pull_request:
+  release:
+    types: published
 
 
 permissions:

--- a/dds/src/data_representation_builtin_endpoints/parameter_id_values.rs
+++ b/dds/src/data_representation_builtin_endpoints/parameter_id_values.rs
@@ -58,6 +58,7 @@ pub const PID_DATA_MAX_SIZE_SERIALIZED: ParameterId = PID_TYPE_MAX_SIZE_SERIALIZ
 // Following PID is listed in "Table 9.19 – Deprecated ParameterId Values" but
 // also in "Table 9.14 - ParameterId mapping and default values"
 pub const PID_GROUP_ENTITYID: ParameterId = 0x0053;
+pub const PID_DATA_REPRESENTATION: ParameterId = 0x0073;
 
 #[allow(overflowing_literals)]
 pub const PID_TYPE_REPRESENTATION: ParameterId = 0x8010;

--- a/dds/src/dds/builtin_topics.rs
+++ b/dds/src/dds/builtin_topics.rs
@@ -2,21 +2,22 @@ use dust_dds_derive::DdsDeserialize;
 
 use crate::{
     data_representation_builtin_endpoints::parameter_id_values::{
-        PID_DEADLINE, PID_DESTINATION_ORDER, PID_DURABILITY, PID_ENDPOINT_GUID, PID_GROUP_DATA,
-        PID_HISTORY, PID_LATENCY_BUDGET, PID_LIFESPAN, PID_LIVELINESS, PID_OWNERSHIP,
-        PID_PARTICIPANT_GUID, PID_PARTITION, PID_PRESENTATION, PID_RELIABILITY,
-        PID_RESOURCE_LIMITS, PID_TIME_BASED_FILTER, PID_TOPIC_DATA, PID_TOPIC_NAME,
-        PID_TRANSPORT_PRIORITY, PID_TYPE_NAME, PID_TYPE_REPRESENTATION, PID_USER_DATA,
+        PID_DATA_REPRESENTATION, PID_DEADLINE, PID_DESTINATION_ORDER, PID_DURABILITY,
+        PID_ENDPOINT_GUID, PID_GROUP_DATA, PID_HISTORY, PID_LATENCY_BUDGET, PID_LIFESPAN,
+        PID_LIVELINESS, PID_OWNERSHIP, PID_PARTICIPANT_GUID, PID_PARTITION, PID_PRESENTATION,
+        PID_RELIABILITY, PID_RESOURCE_LIMITS, PID_TIME_BASED_FILTER, PID_TOPIC_DATA,
+        PID_TOPIC_NAME, PID_TRANSPORT_PRIORITY, PID_TYPE_NAME, PID_TYPE_REPRESENTATION,
+        PID_USER_DATA,
     },
     infrastructure::{
         qos::{DataReaderQos, DataWriterQos, PublisherQos, SubscriberQos, TopicQos},
         qos_policy::{
-            DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
-            HistoryQosPolicy, LatencyBudgetQosPolicy, LifespanQosPolicy, LivelinessQosPolicy,
-            OwnershipQosPolicy, PartitionQosPolicy, PresentationQosPolicy, ReliabilityQosPolicy,
-            ResourceLimitsQosPolicy, TimeBasedFilterQosPolicy, TopicDataQosPolicy,
-            TransportPriorityQosPolicy, UserDataQosPolicy,
-            DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS,
+            DataRepresentationQosPolicy, DeadlineQosPolicy, DestinationOrderQosPolicy,
+            DurabilityQosPolicy, GroupDataQosPolicy, HistoryQosPolicy, LatencyBudgetQosPolicy,
+            LifespanQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy, PartitionQosPolicy,
+            PresentationQosPolicy, ReliabilityQosPolicy, ResourceLimitsQosPolicy,
+            TimeBasedFilterQosPolicy, TopicDataQosPolicy, TransportPriorityQosPolicy,
+            UserDataQosPolicy, DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS,
             DEFAULT_RELIABILITY_QOS_POLICY_DATA_WRITER,
         },
     },
@@ -116,6 +117,8 @@ pub struct TopicBuiltinTopicData {
     ownership: OwnershipQosPolicy,
     #[parameter(id = PID_TOPIC_DATA, default=Default::default())]
     topic_data: TopicDataQosPolicy,
+    #[parameter(id = PID_DATA_REPRESENTATION, default=Default::default())]
+    representation: DataRepresentationQosPolicy,
 }
 
 impl TopicBuiltinTopicData {
@@ -141,6 +144,7 @@ impl TopicBuiltinTopicData {
             resource_limits: topic_qos.resource_limits,
             ownership: topic_qos.ownership,
             topic_data: topic_qos.topic_data,
+            representation: topic_qos.representation,
         }
     }
 
@@ -218,6 +222,11 @@ impl TopicBuiltinTopicData {
     pub fn topic_data(&self) -> &TopicDataQosPolicy {
         &self.topic_data
     }
+
+    /// Get the data representation QoS policy of the discovered topic.
+    pub fn representation(&self) -> &DataRepresentationQosPolicy {
+        &self.representation
+    }
 }
 
 impl DdsHasKey for TopicBuiltinTopicData {
@@ -267,6 +276,8 @@ pub struct PublicationBuiltinTopicData {
     group_data: GroupDataQosPolicy,
     #[parameter(id = PID_TYPE_REPRESENTATION, default=Default::default())]
     xml_type: String,
+    #[parameter(id = PID_DATA_REPRESENTATION, default=Default::default())]
+    representation: DataRepresentationQosPolicy,
 }
 
 impl PublicationBuiltinTopicData {
@@ -300,6 +311,7 @@ impl PublicationBuiltinTopicData {
             group_data: publisher_qos.group_data,
             topic_data,
             xml_type,
+            representation: data_writer_qos.representation,
         }
     }
 
@@ -393,6 +405,11 @@ impl PublicationBuiltinTopicData {
     pub fn xml_type(&self) -> &str {
         &self.xml_type
     }
+
+    /// Get the data representation QoS policy of the discovered writer.
+    pub fn representation(&self) -> &DataRepresentationQosPolicy {
+        &self.representation
+    }
 }
 
 impl DdsHasKey for PublicationBuiltinTopicData {
@@ -442,6 +459,8 @@ pub struct SubscriptionBuiltinTopicData {
     group_data: GroupDataQosPolicy,
     #[parameter(id = PID_TYPE_REPRESENTATION, default=Default::default())]
     xml_type: String,
+    #[parameter(id = PID_DATA_REPRESENTATION, default=Default::default())]
+    representation: DataRepresentationQosPolicy,
 }
 
 impl SubscriptionBuiltinTopicData {
@@ -476,6 +495,7 @@ impl SubscriptionBuiltinTopicData {
             group_data: subscriber_qos.group_data,
             topic_data,
             xml_type,
+            representation: data_reader_qos.representation,
         }
     }
 
@@ -568,6 +588,11 @@ impl SubscriptionBuiltinTopicData {
     /// Note: This is only available if matched with a DustDDS writer which transmits this information as part of the discovery.
     pub fn xml_type(&self) -> &str {
         &self.xml_type
+    }
+
+    /// Get the data representation QoS policy of the discovered reader.
+    pub fn representation(&self) -> &DataRepresentationQosPolicy {
+        &self.representation
     }
 }
 

--- a/dds/src/dds/infrastructure/qos.rs
+++ b/dds/src/dds/infrastructure/qos.rs
@@ -116,6 +116,11 @@ impl Default for DataWriterQos {
 
 impl DataWriterQos {
     pub(crate) fn is_consistent(&self) -> DdsResult<()> {
+        // On the writer there can be no more than one value on the representation
+        if self.representation.value.len() > 1 {
+            return Err(DdsError::InconsistentPolicy);
+        }
+
         // The setting of RESOURCE_LIMITS max_samples must be consistent with the max_samples_per_instance. For these two
         // values to be consistent they must verify that *max_samples >= max_samples_per_instanc
         if self.resource_limits.max_samples < self.resource_limits.max_samples_per_instance {

--- a/dds/src/dds/infrastructure/qos.rs
+++ b/dds/src/dds/infrastructure/qos.rs
@@ -5,13 +5,13 @@ use crate::infrastructure::{
 
 use super::{
     qos_policy::{
-        DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, EntityFactoryQosPolicy,
-        GroupDataQosPolicy, HistoryQosPolicy, HistoryQosPolicyKind, LatencyBudgetQosPolicy,
-        LifespanQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy, PartitionQosPolicy,
-        PresentationQosPolicy, ReaderDataLifecycleQosPolicy, ReliabilityQosPolicy,
-        ReliabilityQosPolicyKind, ResourceLimitsQosPolicy, TimeBasedFilterQosPolicy,
-        TopicDataQosPolicy, TransportPriorityQosPolicy, UserDataQosPolicy,
-        WriterDataLifecycleQosPolicy,
+        DataRepresentationQosPolicy, DeadlineQosPolicy, DestinationOrderQosPolicy,
+        DurabilityQosPolicy, EntityFactoryQosPolicy, GroupDataQosPolicy, HistoryQosPolicy,
+        HistoryQosPolicyKind, LatencyBudgetQosPolicy, LifespanQosPolicy, LivelinessQosPolicy,
+        OwnershipQosPolicy, PartitionQosPolicy, PresentationQosPolicy,
+        ReaderDataLifecycleQosPolicy, ReliabilityQosPolicy, ReliabilityQosPolicyKind,
+        ResourceLimitsQosPolicy, TimeBasedFilterQosPolicy, TopicDataQosPolicy,
+        TransportPriorityQosPolicy, UserDataQosPolicy, WriterDataLifecycleQosPolicy,
     },
     time::DurationKind,
 };
@@ -83,6 +83,8 @@ pub struct DataWriterQos {
     pub ownership: OwnershipQosPolicy,
     /// Value of the writer data lifecycle QoS policy.
     pub writer_data_lifecycle: WriterDataLifecycleQosPolicy,
+    /// Value of the data representation QoS policy.
+    pub representation: DataRepresentationQosPolicy,
 }
 
 impl Default for DataWriterQos {
@@ -107,6 +109,7 @@ impl Default for DataWriterQos {
             lifespan: LifespanQosPolicy::default(),
             transport_priority: TransportPriorityQosPolicy::default(),
             writer_data_lifecycle: WriterDataLifecycleQosPolicy::default(),
+            representation: DataRepresentationQosPolicy::default(),
         }
     }
 }
@@ -199,6 +202,8 @@ pub struct DataReaderQos {
     pub time_based_filter: TimeBasedFilterQosPolicy,
     /// Value of the reader data lifecycle QoS policy.
     pub reader_data_lifecycle: ReaderDataLifecycleQosPolicy,
+    /// Value of the data representation QoS policy.
+    pub representation: DataRepresentationQosPolicy,
 }
 
 impl Default for DataReaderQos {
@@ -222,6 +227,7 @@ impl Default for DataReaderQos {
             ownership: OwnershipQosPolicy::default(),
             time_based_filter: TimeBasedFilterQosPolicy::default(),
             reader_data_lifecycle: ReaderDataLifecycleQosPolicy::default(),
+            representation: DataRepresentationQosPolicy::default(),
         }
     }
 }
@@ -297,6 +303,8 @@ pub struct TopicQos {
     pub lifespan: LifespanQosPolicy,
     /// Value of the ownership QoS policy.
     pub ownership: OwnershipQosPolicy,
+    /// Value of the data representation QoS policy.
+    pub representation: DataRepresentationQosPolicy,
 }
 
 impl Default for TopicQos {
@@ -320,6 +328,7 @@ impl Default for TopicQos {
             transport_priority: TransportPriorityQosPolicy::default(),
             lifespan: LifespanQosPolicy::default(),
             ownership: OwnershipQosPolicy::default(),
+            representation: DataRepresentationQosPolicy::default(),
         }
     }
 }

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -1216,6 +1216,7 @@ type DataRepresentationIdSeq = Vec<DataRepresentationId>;
 
 /// This policy is a DDS-XTypes extension and represents the standard data Representations available.
 /// [`DataWriter`](crate::publication::data_writer::DataWriter) and [`DataReader`](crate::subscription::data_reader::DataReader) must be able to negotiate which data representation(s) to use.
+#[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
 pub struct DataRepresentationQosPolicy {
     /// List of data representation values
     pub value: DataRepresentationIdSeq,

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -138,6 +138,7 @@ const TOPICDATA_QOS_POLICY_NAME: &str = "TopicData";
 const TRANSPORTPRIORITY_QOS_POLICY_NAME: &str = "TransportPriority";
 const GROUPDATA_QOS_POLICY_NAME: &str = "GroupData";
 const LIFESPAN_QOS_POLICY_NAME: &str = "Lifespan";
+const DATA_REPRESENTATION_QOS_POLICY_NAME: &str = "DataRepresentation";
 
 /// QosPolicy Id representing an invalid QoS policy
 pub const INVALID_QOS_POLICY_ID: QosPolicyId = 0;
@@ -183,6 +184,8 @@ pub const TRANSPORTPRIORITY_QOS_POLICY_ID: QosPolicyId = 20;
 pub const LIFESPAN_QOS_POLICY_ID: QosPolicyId = 21;
 /// Id for the DurabilityServiceQosPolicy
 pub const DURABILITYSERVICE_QOS_POLICY_ID: QosPolicyId = 22;
+/// Id for the DataRepresentationQosPolicy
+pub const DATA_REPRESENTATION_QOS_POLICY_ID: QosPolicyId = 23;
 
 /// This policy allows the application to attach additional information to the created Entity objects such that when
 /// a remote application discovers their existence it can access that information and use it for its own purposes.
@@ -1197,6 +1200,36 @@ impl Default for ReaderDataLifecycleQosPolicy {
             autopurge_nowriter_samples_delay: DurationKind::Infinite,
             autopurge_disposed_samples_delay: DurationKind::Infinite,
         }
+    }
+}
+
+/*******  DDS X-TYPES Extension **********/
+
+type DataRepresentationId = u16;
+/// XCDR data representation
+pub const XCDR_DATA_REPRESENTATION: DataRepresentationId = 0;
+/// XML data representation
+pub const XML_DATA_REPRESENTATION: DataRepresentationId = 1;
+/// XCDR2 data representation
+pub const XCDR2_DATA_REPRESENTATION: DataRepresentationId = 2;
+type DataRepresentationIdSeq = Vec<DataRepresentationId>;
+
+/// This policy is a DDS-XTypes extension and represents the standard data Representations available.
+/// [`DataWriter`](crate::publication::data_writer::DataWriter) and [`DataReader`](crate::subscription::data_reader::DataReader) must be able to negotiate which data representation(s) to use.
+pub struct DataRepresentationQosPolicy {
+    /// List of data representation values
+    pub value: DataRepresentationIdSeq,
+}
+
+impl QosPolicy for DataRepresentationQosPolicy {
+    fn name(&self) -> &str {
+        DATA_REPRESENTATION_QOS_POLICY_NAME
+    }
+}
+
+impl Default for DataRepresentationQosPolicy {
+    fn default() -> Self {
+        Self { value: Vec::new() }
     }
 }
 

--- a/dds/src/dds/infrastructure/qos_policy.rs
+++ b/dds/src/dds/infrastructure/qos_policy.rs
@@ -1216,7 +1216,7 @@ type DataRepresentationIdSeq = Vec<DataRepresentationId>;
 
 /// This policy is a DDS-XTypes extension and represents the standard data Representations available.
 /// [`DataWriter`](crate::publication::data_writer::DataWriter) and [`DataReader`](crate::subscription::data_reader::DataReader) must be able to negotiate which data representation(s) to use.
-#[derive(Debug, PartialEq, Eq, Clone, CdrSerialize, CdrDeserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Default, CdrSerialize, CdrDeserialize)]
 pub struct DataRepresentationQosPolicy {
     /// List of data representation values
     pub value: DataRepresentationIdSeq,
@@ -1225,12 +1225,6 @@ pub struct DataRepresentationQosPolicy {
 impl QosPolicy for DataRepresentationQosPolicy {
     fn name(&self) -> &str {
         DATA_REPRESENTATION_QOS_POLICY_NAME
-    }
-}
-
-impl Default for DataRepresentationQosPolicy {
-    fn default() -> Self {
-        Self { value: Vec::new() }
     }
 }
 

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -900,7 +900,7 @@ impl DataReaderActor {
         let writer_offered_representation = writer_info
             .representation()
             .value
-            .get(0)
+            .first()
             .unwrap_or(&XCDR_DATA_REPRESENTATION);
         if !self
             .qos

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -38,9 +38,11 @@ use crate::{
         qos::{DataReaderQos, SubscriberQos},
         qos_policy::{
             DestinationOrderQosPolicyKind, DurabilityQosPolicyKind, HistoryQosPolicyKind,
-            QosPolicyId, ReliabilityQosPolicyKind, TopicDataQosPolicy, DEADLINE_QOS_POLICY_ID,
+            QosPolicyId, ReliabilityQosPolicyKind, TopicDataQosPolicy,
+            DATA_REPRESENTATION_QOS_POLICY_ID, DEADLINE_QOS_POLICY_ID,
             DESTINATIONORDER_QOS_POLICY_ID, DURABILITY_QOS_POLICY_ID, LATENCYBUDGET_QOS_POLICY_ID,
             LIVELINESS_QOS_POLICY_ID, PRESENTATION_QOS_POLICY_ID, RELIABILITY_QOS_POLICY_ID,
+            XCDR_DATA_REPRESENTATION,
         },
         status::{
             LivelinessChangedStatus, QosPolicyCount, RequestedDeadlineMissedStatus,
@@ -893,6 +895,25 @@ impl DataReaderActor {
         }
         if &self.qos.destination_order > writer_info.destination_order() {
             incompatible_qos_policy_list.push(DESTINATIONORDER_QOS_POLICY_ID);
+        }
+
+        let writer_offered_representation = writer_info
+            .representation()
+            .value
+            .get(0)
+            .unwrap_or(&XCDR_DATA_REPRESENTATION);
+        if !self
+            .qos
+            .representation
+            .value
+            .contains(writer_offered_representation)
+        {
+            // Empty list is interpreted as containing XCDR_DATA_REPRESENTATION
+            if !(writer_offered_representation == &XCDR_DATA_REPRESENTATION
+                && self.qos.representation.value.is_empty())
+            {
+                incompatible_qos_policy_list.push(DATA_REPRESENTATION_QOS_POLICY_ID)
+            }
         }
 
         incompatible_qos_policy_list

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -1523,18 +1523,16 @@ fn get_discovered_reader_incompatible_qos_policy_list(
     let writer_offered_representation = writer_qos
         .representation
         .value
-        .get(0)
+        .first()
         .unwrap_or(&XCDR_DATA_REPRESENTATION);
-    if !discovered_reader_data
+    if !(discovered_reader_data
         .representation()
         .value
         .contains(writer_offered_representation)
-    {
-        if !(writer_offered_representation == &XCDR_DATA_REPRESENTATION
+        || writer_offered_representation == &XCDR_DATA_REPRESENTATION
             && discovered_reader_data.representation().value.is_empty())
-        {
-            incompatible_qos_policy_list.push(DATA_REPRESENTATION_QOS_POLICY_ID);
-        }
+    {
+        incompatible_qos_policy_list.push(DATA_REPRESENTATION_QOS_POLICY_ID);
     }
 
     incompatible_qos_policy_list

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -28,9 +28,10 @@ use crate::{
         qos::{DataWriterQos, PublisherQos},
         qos_policy::{
             DurabilityQosPolicyKind, HistoryQosPolicyKind, QosPolicyId, ReliabilityQosPolicyKind,
-            TopicDataQosPolicy, DEADLINE_QOS_POLICY_ID, DESTINATIONORDER_QOS_POLICY_ID,
-            DURABILITY_QOS_POLICY_ID, INVALID_QOS_POLICY_ID, LATENCYBUDGET_QOS_POLICY_ID,
-            LIVELINESS_QOS_POLICY_ID, PRESENTATION_QOS_POLICY_ID, RELIABILITY_QOS_POLICY_ID,
+            TopicDataQosPolicy, DATA_REPRESENTATION_QOS_POLICY_ID, DEADLINE_QOS_POLICY_ID,
+            DESTINATIONORDER_QOS_POLICY_ID, DURABILITY_QOS_POLICY_ID, INVALID_QOS_POLICY_ID,
+            LATENCYBUDGET_QOS_POLICY_ID, LIVELINESS_QOS_POLICY_ID, PRESENTATION_QOS_POLICY_ID,
+            RELIABILITY_QOS_POLICY_ID, XCDR_DATA_REPRESENTATION,
         },
         status::{
             OfferedIncompatibleQosStatus, PublicationMatchedStatus, QosPolicyCount, StatusKind,
@@ -1518,6 +1519,24 @@ fn get_discovered_reader_incompatible_qos_policy_list(
     if &writer_qos.destination_order < discovered_reader_data.destination_order() {
         incompatible_qos_policy_list.push(DESTINATIONORDER_QOS_POLICY_ID);
     }
+
+    let writer_offered_representation = writer_qos
+        .representation
+        .value
+        .get(0)
+        .unwrap_or(&XCDR_DATA_REPRESENTATION);
+    if !discovered_reader_data
+        .representation()
+        .value
+        .contains(writer_offered_representation)
+    {
+        if !(writer_offered_representation == &XCDR_DATA_REPRESENTATION
+            && discovered_reader_data.representation().value.is_empty())
+        {
+            incompatible_qos_policy_list.push(DATA_REPRESENTATION_QOS_POLICY_ID);
+        }
+    }
+
     incompatible_qos_policy_list
 }
 

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -417,6 +417,7 @@ impl DomainParticipantActor {
                     transport_priority: discovered_topic_data.transport_priority().clone(),
                     lifespan: discovered_topic_data.lifespan().clone(),
                     ownership: discovered_topic_data.ownership().clone(),
+                    representation: discovered_topic_data.representation().clone(),
                 };
                 let type_name = discovered_topic_data.get_type_name().to_owned();
                 let (topic_address, status_condition_address) = self.create_user_defined_topic(
@@ -1818,6 +1819,11 @@ impl MailHandler<AddMatchedWriter> for DomainParticipantActor {
                             .dds_publication_data()
                             .ownership()
                             .clone(),
+                        representation: message
+                            .discovered_writer_data
+                            .dds_publication_data()
+                            .representation()
+                            .clone(),
                     },
                 );
                 self.discovered_topic_list
@@ -1990,6 +1996,11 @@ impl MailHandler<AddMatchedReader> for DomainParticipantActor {
                             .discovered_reader_data
                             .subscription_builtin_topic_data()
                             .ownership()
+                            .clone(),
+                        representation: message
+                            .discovered_reader_data
+                            .subscription_builtin_topic_data()
+                            .representation()
                             .clone(),
                     },
                 );

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -4,7 +4,10 @@ use dust_dds::{
     domain::domain_participant_factory::DomainParticipantFactory,
     infrastructure::{
         qos::{DataReaderQos, DataWriterQos, PublisherQos, QosKind, SubscriberQos},
-        qos_policy::{PartitionQosPolicy, UserDataQosPolicy},
+        qos_policy::{
+            DataRepresentationQosPolicy, PartitionQosPolicy, UserDataQosPolicy,
+            XCDR2_DATA_REPRESENTATION, XCDR_DATA_REPRESENTATION,
+        },
         status::{StatusKind, NO_STATUS},
         time::Duration,
         wait_set::{Condition, WaitSet},
@@ -772,6 +775,96 @@ fn discovered_participant_removed_after_deletion() {
             panic!("Discovered participant not removed before timeout")
         }
     }
+}
+
+#[test]
+fn writer_offering_xcdr1_should_not_match_reader_requesting_xcdr2() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let dp = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = dp
+        .create_topic::<UserType>("topic_name", "UserType", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let publisher = dp
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        representation: DataRepresentationQosPolicy {
+            value: vec![XCDR_DATA_REPRESENTATION],
+        },
+        ..Default::default()
+    };
+    let data_writer = publisher
+        .create_datawriter::<UserType>(&topic, QosKind::Specific(writer_qos), None, NO_STATUS)
+        .unwrap();
+    let subscriber = dp
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        representation: DataRepresentationQosPolicy {
+            value: vec![XCDR2_DATA_REPRESENTATION],
+        },
+        ..Default::default()
+    };
+    let _data_reader = subscriber
+        .create_datareader::<UserType>(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
+        .unwrap();
+    let cond = data_writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::OfferedIncompatibleQos])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+}
+
+#[test]
+fn reader_requesting_xcdr2_should_not_match_writer_offering_xcdr1() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let dp = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = dp
+        .create_topic::<UserType>("topic_name", "UserType", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let publisher = dp
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        representation: DataRepresentationQosPolicy {
+            value: vec![XCDR_DATA_REPRESENTATION],
+        },
+        ..Default::default()
+    };
+    let _data_writer = publisher
+        .create_datawriter::<UserType>(&topic, QosKind::Specific(writer_qos), None, NO_STATUS)
+        .unwrap();
+    let subscriber = dp
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        representation: DataRepresentationQosPolicy {
+            value: vec![XCDR2_DATA_REPRESENTATION],
+        },
+        ..Default::default()
+    };
+    let data_reader = subscriber
+        .create_datareader::<UserType>(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
+        .unwrap();
+    let cond = data_reader.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::RequestedIncompatibleQos])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Add DataRepresentationQosPolicy to the Data Reader, Data Writer and Topic Qos and make use of it for the discovery process. For now this QoS has no effect on the actual data transmitted on the wire.