### PR TITLE
Allow using Reader and Writer functionality on Listeners without Foo

### DIFF
--- a/bindings/python/src/domain/domain_participant_listener.rs
+++ b/bindings/python/src/domain/domain_participant_listener.rs
@@ -23,7 +23,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 {
     fn on_data_available(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
     ) {
         let args = ((),);
         Python::with_gil(|py| {
@@ -36,7 +36,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_sample_rejected(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::SampleRejectedStatus,
     ) {
         let args = ((), SampleRejectedStatus::from(status));
@@ -50,7 +50,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_liveliness_changed(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::LivelinessChangedStatus,
     ) {
         let args = ((), LivelinessChangedStatus::from(status));
@@ -64,7 +64,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_requested_deadline_missed(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::RequestedDeadlineMissedStatus,
     ) {
         let args = ((), RequestedDeadlineMissedStatus::from(status));
@@ -78,7 +78,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_requested_incompatible_qos(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::RequestedIncompatibleQosStatus,
     ) {
         let args = ((), RequestedIncompatibleQosStatus::from(status));
@@ -92,7 +92,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_subscription_matched(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::SubscriptionMatchedStatus,
     ) {
         let args = ((), SubscriptionMatchedStatus::from(status));
@@ -106,7 +106,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_sample_lost(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::SampleLostStatus,
     ) {
         let args = ((), SampleLostStatus::from(status));
@@ -137,7 +137,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_liveliness_lost(
         &mut self,
-        _the_writer: &dyn dust_dds::publication::data_writer::AnyDataWriter,
+        _the_writer: dust_dds::publication::data_writer::DataWriter<()>,
         status: dust_dds::infrastructure::status::LivelinessLostStatus,
     ) {
         let args = ((), LivelinessLostStatus::from(status));
@@ -151,7 +151,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_offered_deadline_missed(
         &mut self,
-        _the_writer: &dyn dust_dds::publication::data_writer::AnyDataWriter,
+        _the_writer: dust_dds::publication::data_writer::DataWriter<()>,
         status: dust_dds::infrastructure::status::OfferedDeadlineMissedStatus,
     ) {
         let args = ((), OfferedDeadlineMissedStatus::from(status));
@@ -165,7 +165,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_offered_incompatible_qos(
         &mut self,
-        _the_writer: &dyn dust_dds::publication::data_writer::AnyDataWriter,
+        _the_writer: dust_dds::publication::data_writer::DataWriter<()>,
         status: dust_dds::infrastructure::status::OfferedIncompatibleQosStatus,
     ) {
         let args = ((), OfferedIncompatibleQosStatus::from(status));
@@ -179,7 +179,7 @@ impl dust_dds::domain::domain_participant_listener::DomainParticipantListener
 
     fn on_publication_matched(
         &mut self,
-        _the_writer: &dyn dust_dds::publication::data_writer::AnyDataWriter,
+        _the_writer: dust_dds::publication::data_writer::DataWriter<()>,
         status: dust_dds::infrastructure::status::PublicationMatchedStatus,
     ) {
         let args = ((), PublicationMatchedStatus::from(status));

--- a/bindings/python/src/publication/publisher_listener.rs
+++ b/bindings/python/src/publication/publisher_listener.rs
@@ -16,7 +16,7 @@ impl From<Py<PyAny>> for PublisherListener {
 impl dust_dds::publication::publisher_listener::PublisherListener for PublisherListener {
     fn on_liveliness_lost(
         &mut self,
-        _the_writer: &dyn dust_dds::publication::data_writer::AnyDataWriter,
+        _the_writer: dust_dds::publication::data_writer::DataWriter<()>,
         status: dust_dds::infrastructure::status::LivelinessLostStatus,
     ) {
         let args = ((), LivelinessLostStatus::from(status));
@@ -30,7 +30,7 @@ impl dust_dds::publication::publisher_listener::PublisherListener for PublisherL
 
     fn on_offered_deadline_missed(
         &mut self,
-        _the_writer: &dyn dust_dds::publication::data_writer::AnyDataWriter,
+        _the_writer: dust_dds::publication::data_writer::DataWriter<()>,
         status: dust_dds::infrastructure::status::OfferedDeadlineMissedStatus,
     ) {
         let args = ((), OfferedDeadlineMissedStatus::from(status));
@@ -44,7 +44,7 @@ impl dust_dds::publication::publisher_listener::PublisherListener for PublisherL
 
     fn on_offered_incompatible_qos(
         &mut self,
-        _the_writer: &dyn dust_dds::publication::data_writer::AnyDataWriter,
+        _the_writer: dust_dds::publication::data_writer::DataWriter<()>,
         status: dust_dds::infrastructure::status::OfferedIncompatibleQosStatus,
     ) {
         let args = ((), OfferedIncompatibleQosStatus::from(status));
@@ -58,7 +58,7 @@ impl dust_dds::publication::publisher_listener::PublisherListener for PublisherL
 
     fn on_publication_matched(
         &mut self,
-        _the_writer: &dyn dust_dds::publication::data_writer::AnyDataWriter,
+        _the_writer: dust_dds::publication::data_writer::DataWriter<()>,
         status: dust_dds::infrastructure::status::PublicationMatchedStatus,
     ) {
         let args = ((), PublicationMatchedStatus::from(status));

--- a/bindings/python/src/subscription/subcriber_listener.rs
+++ b/bindings/python/src/subscription/subcriber_listener.rs
@@ -32,7 +32,7 @@ impl dust_dds::subscription::subscriber_listener::SubscriberListener for Subscri
 
     fn on_data_available(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
     ) {
         let args = ((),);
         Python::with_gil(|py| {
@@ -45,7 +45,7 @@ impl dust_dds::subscription::subscriber_listener::SubscriberListener for Subscri
 
     fn on_sample_rejected(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::SampleRejectedStatus,
     ) {
         let args = ((), SampleRejectedStatus::from(status));
@@ -59,7 +59,7 @@ impl dust_dds::subscription::subscriber_listener::SubscriberListener for Subscri
 
     fn on_liveliness_changed(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::LivelinessChangedStatus,
     ) {
         let args = ((), LivelinessChangedStatus::from(status));
@@ -73,7 +73,7 @@ impl dust_dds::subscription::subscriber_listener::SubscriberListener for Subscri
 
     fn on_requested_deadline_missed(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::RequestedDeadlineMissedStatus,
     ) {
         let args = ((), RequestedDeadlineMissedStatus::from(status));
@@ -87,7 +87,7 @@ impl dust_dds::subscription::subscriber_listener::SubscriberListener for Subscri
 
     fn on_requested_incompatible_qos(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::RequestedIncompatibleQosStatus,
     ) {
         let args = ((), RequestedIncompatibleQosStatus::from(status));
@@ -101,7 +101,7 @@ impl dust_dds::subscription::subscriber_listener::SubscriberListener for Subscri
 
     fn on_subscription_matched(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::SubscriptionMatchedStatus,
     ) {
         let args = ((), SubscriptionMatchedStatus::from(status));
@@ -115,7 +115,7 @@ impl dust_dds::subscription::subscriber_listener::SubscriberListener for Subscri
 
     fn on_sample_lost(
         &mut self,
-        _the_reader: &dyn dust_dds::subscription::data_reader::AnyDataReader,
+        _the_reader: dust_dds::subscription::data_reader::DataReader<()>,
         status: dust_dds::infrastructure::status::SampleLostStatus,
     ) {
         let args = ((), SampleLostStatus::from(status));

--- a/dds/src/dds/domain/domain_participant_listener.rs
+++ b/dds/src/dds/domain/domain_participant_listener.rs
@@ -1,7 +1,10 @@
 use std::{future::Future, pin::Pin};
 
 use crate::{
-    dds_async::{domain_participant_listener::DomainParticipantListenerAsync, topic::TopicAsync},
+    dds_async::{
+        data_reader::DataReaderAsync, domain_participant_listener::DomainParticipantListenerAsync,
+        topic::TopicAsync,
+    },
     infrastructure::status::{
         InconsistentTopicStatus, LivelinessChangedStatus, LivelinessLostStatus,
         OfferedDeadlineMissedStatus, OfferedIncompatibleQosStatus, PublicationMatchedStatus,
@@ -9,7 +12,7 @@ use crate::{
         SampleRejectedStatus, SubscriptionMatchedStatus,
     },
     publication::data_writer::AnyDataWriter,
-    subscription::data_reader::AnyDataReader,
+    subscription::data_reader::DataReader,
     topic_definition::topic::Topic,
 };
 
@@ -46,23 +49,18 @@ pub trait DomainParticipantListener {
     }
 
     /// Method that is called when any data reader in the domain participant reports a sample lost status.
-    fn on_sample_lost(&mut self, _the_reader: &dyn AnyDataReader, _status: SampleLostStatus) {}
+    fn on_sample_lost(&mut self, _the_reader: DataReader<()>, _status: SampleLostStatus) {}
 
     /// Method that is called when any data reader in the domain participant reports a data available status.
-    fn on_data_available(&mut self, _the_reader: &dyn AnyDataReader) {}
+    fn on_data_available(&mut self, _the_reader: DataReader<()>) {}
 
     /// Method that is called when any data reader in the domain participant reports a sample rejected status.
-    fn on_sample_rejected(
-        &mut self,
-        _the_reader: &dyn AnyDataReader,
-        _status: SampleRejectedStatus,
-    ) {
-    }
+    fn on_sample_rejected(&mut self, _the_reader: DataReader<()>, _status: SampleRejectedStatus) {}
 
     /// Method that is called when any data reader in the domain participant reports a liveliness changed status.
     fn on_liveliness_changed(
         &mut self,
-        _the_reader: &dyn AnyDataReader,
+        _the_reader: DataReader<()>,
         _status: LivelinessChangedStatus,
     ) {
     }
@@ -70,7 +68,7 @@ pub trait DomainParticipantListener {
     /// Method that is called when any data reader in the domain participant reports a requested deadline missed status.
     fn on_requested_deadline_missed(
         &mut self,
-        _the_reader: &dyn AnyDataReader,
+        _the_reader: DataReader<()>,
         _status: RequestedDeadlineMissedStatus,
     ) {
     }
@@ -78,7 +76,7 @@ pub trait DomainParticipantListener {
     /// Method that is called when any data reader in the domain participant reports a requested incompatible QoS status.
     fn on_requested_incompatible_qos(
         &mut self,
-        _the_reader: &dyn AnyDataReader,
+        _the_reader: DataReader<()>,
         _status: RequestedIncompatibleQosStatus,
     ) {
     }
@@ -94,7 +92,7 @@ pub trait DomainParticipantListener {
     /// Method that is called when any data reader in the domain participant reports a subscription matched status.
     fn on_subscription_matched(
         &mut self,
-        _the_reader: &dyn AnyDataReader,
+        _the_reader: DataReader<()>,
         _status: SubscriptionMatchedStatus,
     ) {
     }
@@ -150,74 +148,76 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
         Box::pin(std::future::ready(()))
     }
 
-    fn on_sample_lost<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_sample_lost(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: SampleLostStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        DomainParticipantListener::on_sample_lost(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        DomainParticipantListener::on_sample_lost(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_data_available<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        DomainParticipantListener::on_data_available(self.as_mut(), the_reader);
+    fn on_data_available(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        DomainParticipantListener::on_data_available(self.as_mut(), DataReader::new(the_reader));
         Box::pin(std::future::ready(()))
     }
 
-    fn on_sample_rejected<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_sample_rejected(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: SampleRejectedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        DomainParticipantListener::on_sample_rejected(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        DomainParticipantListener::on_sample_rejected(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_liveliness_changed<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_liveliness_changed(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: LivelinessChangedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        DomainParticipantListener::on_liveliness_changed(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        DomainParticipantListener::on_liveliness_changed(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_requested_deadline_missed<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_requested_deadline_missed(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: RequestedDeadlineMissedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        DomainParticipantListener::on_requested_deadline_missed(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        DomainParticipantListener::on_requested_deadline_missed(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_requested_incompatible_qos<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_requested_incompatible_qos(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: RequestedIncompatibleQosStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        DomainParticipantListener::on_requested_incompatible_qos(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        DomainParticipantListener::on_requested_incompatible_qos(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
@@ -233,15 +233,16 @@ impl DomainParticipantListenerAsync for Box<dyn DomainParticipantListener + Send
         Box::pin(std::future::ready(()))
     }
 
-    fn on_subscription_matched<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_subscription_matched(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: SubscriptionMatchedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        DomainParticipantListener::on_subscription_matched(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        DomainParticipantListener::on_subscription_matched(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -435,9 +435,3 @@ where
         )
     }
 }
-
-/// Trait representing a generic data writer. This trait is not meant to be implemented by the user and is used
-/// to represent a generic DataWriter (i.e. without Foo) type on the listeners.
-pub trait AnyDataWriter {}
-
-impl AnyDataWriter for () {}

--- a/dds/src/dds/publication/publisher_listener.rs
+++ b/dds/src/dds/publication/publisher_listener.rs
@@ -1,29 +1,24 @@
 use std::{future::Future, pin::Pin};
 
 use crate::{
-    dds_async::publisher_listener::PublisherListenerAsync,
+    dds_async::{data_writer::DataWriterAsync, publisher_listener::PublisherListenerAsync},
     infrastructure::status::{
         LivelinessLostStatus, OfferedDeadlineMissedStatus, OfferedIncompatibleQosStatus,
         PublicationMatchedStatus,
     },
 };
 
-use super::data_writer::AnyDataWriter;
+use super::data_writer::DataWriter;
 
 /// This trait represents a listener object which can be associated with the [`Publisher`](super::publisher::Publisher) entity.
 pub trait PublisherListener {
     /// Method that is called when any writer belonging to this publisher reports a liveliness lost status.
-    fn on_liveliness_lost(
-        &mut self,
-        _the_writer: &dyn AnyDataWriter,
-        _status: LivelinessLostStatus,
-    ) {
-    }
+    fn on_liveliness_lost(&mut self, _the_writer: DataWriter<()>, _status: LivelinessLostStatus) {}
 
     /// Method that is called when any writer belonging to this publisher reports an offered deadline missed status.
     fn on_offered_deadline_missed(
         &mut self,
-        _the_writer: &dyn AnyDataWriter,
+        _the_writer: DataWriter<()>,
         _status: OfferedDeadlineMissedStatus,
     ) {
     }
@@ -31,7 +26,7 @@ pub trait PublisherListener {
     /// Method that is called when any writer belonging to this publisher reports an offered incompatible qos status.
     fn on_offered_incompatible_qos(
         &mut self,
-        _the_writer: &dyn AnyDataWriter,
+        _the_writer: DataWriter<()>,
         _status: OfferedIncompatibleQosStatus,
     ) {
     }
@@ -39,58 +34,58 @@ pub trait PublisherListener {
     /// Method that is called when any writer belonging to this publisher reports a publication matched status.
     fn on_publication_matched(
         &mut self,
-        _the_writer: &dyn AnyDataWriter,
+        _the_writer: DataWriter<()>,
         _status: PublicationMatchedStatus,
     ) {
     }
 }
 
 impl PublisherListenerAsync for Box<dyn PublisherListener + Send> {
-    fn on_liveliness_lost<'a, 'b>(
-        &'a mut self,
-        the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_liveliness_lost(
+        &mut self,
+        the_writer: DataWriterAsync<()>,
         status: LivelinessLostStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        PublisherListener::on_liveliness_lost(self.as_mut(), the_writer, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        PublisherListener::on_liveliness_lost(self.as_mut(), DataWriter::new(the_writer), status);
         Box::pin(std::future::ready(()))
     }
 
-    fn on_offered_deadline_missed<'a, 'b>(
-        &'a mut self,
-        the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_offered_deadline_missed(
+        &mut self,
+        the_writer: DataWriterAsync<()>,
         status: OfferedDeadlineMissedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        PublisherListener::on_offered_deadline_missed(self.as_mut(), the_writer, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        PublisherListener::on_offered_deadline_missed(
+            self.as_mut(),
+            DataWriter::new(the_writer),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_offered_incompatible_qos<'a, 'b>(
-        &'a mut self,
-        the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_offered_incompatible_qos(
+        &mut self,
+        the_writer: DataWriterAsync<()>,
         status: OfferedIncompatibleQosStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        PublisherListener::on_offered_incompatible_qos(self.as_mut(), the_writer, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        PublisherListener::on_offered_incompatible_qos(
+            self.as_mut(),
+            DataWriter::new(the_writer),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_publication_matched<'a, 'b>(
-        &'a mut self,
-        the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_publication_matched(
+        &mut self,
+        the_writer: DataWriterAsync<()>,
         status: PublicationMatchedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        PublisherListener::on_publication_matched(self.as_mut(), the_writer, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        PublisherListener::on_publication_matched(
+            self.as_mut(),
+            DataWriter::new(the_writer),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds/subscription/data_reader.rs
+++ b/dds/src/dds/subscription/data_reader.rs
@@ -522,9 +522,3 @@ where
         )
     }
 }
-
-/// Trait representing a generic data reader. This trait is not meant to be implemented by the user and is used
-/// to represent a generic DataReader (i.e. without Foo) type on the listeners.
-pub trait AnyDataReader {}
-
-impl AnyDataReader for () {}

--- a/dds/src/dds/subscription/subscriber_listener.rs
+++ b/dds/src/dds/subscription/subscriber_listener.rs
@@ -1,14 +1,17 @@
 use std::{future::Future, pin::Pin};
 
 use crate::{
-    dds_async::{subscriber::SubscriberAsync, subscriber_listener::SubscriberListenerAsync},
+    dds_async::{
+        data_reader::DataReaderAsync, subscriber::SubscriberAsync,
+        subscriber_listener::SubscriberListenerAsync,
+    },
     infrastructure::status::{
         LivelinessChangedStatus, RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus,
         SampleLostStatus, SampleRejectedStatus, SubscriptionMatchedStatus,
     },
 };
 
-use super::{data_reader::AnyDataReader, subscriber::Subscriber};
+use super::{data_reader::DataReader, subscriber::Subscriber};
 
 /// This trait represents a listener object which can be associated with the [`Subscriber`](super::subscriber::Subscriber) entity.
 pub trait SubscriberListener {
@@ -16,20 +19,15 @@ pub trait SubscriberListener {
     fn on_data_on_readers(&mut self, _the_subscriber: Subscriber) {}
 
     /// Method that is called when any reader belonging to this subcriber reports new data available.
-    fn on_data_available(&mut self, _the_reader: &dyn AnyDataReader) {}
+    fn on_data_available(&mut self, _the_reader: DataReader<()>) {}
 
     /// Method that is called when any reader belonging to this subcriber reports a sample rejected status.
-    fn on_sample_rejected(
-        &mut self,
-        _the_reader: &dyn AnyDataReader,
-        _status: SampleRejectedStatus,
-    ) {
-    }
+    fn on_sample_rejected(&mut self, _the_reader: DataReader<()>, _status: SampleRejectedStatus) {}
 
     /// Method that is called when any reader belonging to this subcriber reports a liveliness changed status.
     fn on_liveliness_changed(
         &mut self,
-        _the_reader: &dyn AnyDataReader,
+        _the_reader: DataReader<()>,
         _status: LivelinessChangedStatus,
     ) {
     }
@@ -37,7 +35,7 @@ pub trait SubscriberListener {
     /// Method that is called when any reader belonging to this subcriber reports a requested deadline missed status.
     fn on_requested_deadline_missed(
         &mut self,
-        _the_reader: &dyn AnyDataReader,
+        _the_reader: DataReader<()>,
         _status: RequestedDeadlineMissedStatus,
     ) {
     }
@@ -45,7 +43,7 @@ pub trait SubscriberListener {
     /// Method that is called when any reader belonging to this subcriber reports a requested incompatible QoS status.
     fn on_requested_incompatible_qos(
         &mut self,
-        _the_reader: &dyn AnyDataReader,
+        _the_reader: DataReader<()>,
         _status: RequestedIncompatibleQosStatus,
     ) {
     }
@@ -53,13 +51,13 @@ pub trait SubscriberListener {
     /// Method that is called when any reader belonging to this subcriber reports a subscription matched status.
     fn on_subscription_matched(
         &mut self,
-        _the_reader: &dyn AnyDataReader,
+        _the_reader: DataReader<()>,
         _status: SubscriptionMatchedStatus,
     ) {
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a sample lost status.
-    fn on_sample_lost(&mut self, _the_reader: &dyn AnyDataReader, _status: SampleLostStatus) {}
+    fn on_sample_lost(&mut self, _the_reader: DataReader<()>, _status: SampleLostStatus) {}
 }
 
 impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
@@ -71,86 +69,81 @@ impl SubscriberListenerAsync for Box<dyn SubscriberListener + Send> {
         Box::pin(std::future::ready(()))
     }
 
-    fn on_data_available<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        SubscriberListener::on_data_available(self.as_mut(), the_reader);
+    fn on_data_available(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        SubscriberListener::on_data_available(self.as_mut(), DataReader::new(the_reader));
         Box::pin(std::future::ready(()))
     }
 
-    fn on_sample_rejected<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_sample_rejected(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: SampleRejectedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        SubscriberListener::on_sample_rejected(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        SubscriberListener::on_sample_rejected(self.as_mut(), DataReader::new(the_reader), status);
         Box::pin(std::future::ready(()))
     }
 
-    fn on_liveliness_changed<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_liveliness_changed(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: LivelinessChangedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        SubscriberListener::on_liveliness_changed(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        SubscriberListener::on_liveliness_changed(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_requested_deadline_missed<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_requested_deadline_missed(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: RequestedDeadlineMissedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        SubscriberListener::on_requested_deadline_missed(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        SubscriberListener::on_requested_deadline_missed(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_requested_incompatible_qos<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_requested_incompatible_qos(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: RequestedIncompatibleQosStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        SubscriberListener::on_requested_incompatible_qos(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        SubscriberListener::on_requested_incompatible_qos(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_subscription_matched<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_subscription_matched(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: SubscriptionMatchedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        SubscriberListener::on_subscription_matched(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        SubscriberListener::on_subscription_matched(
+            self.as_mut(),
+            DataReader::new(the_reader),
+            status,
+        );
         Box::pin(std::future::ready(()))
     }
 
-    fn on_sample_lost<'a, 'b>(
-        &'a mut self,
-        the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_sample_lost(
+        &mut self,
+        the_reader: DataReaderAsync<()>,
         status: SampleLostStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
-        SubscriberListener::on_sample_lost(self.as_mut(), the_reader, status);
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        SubscriberListener::on_sample_lost(self.as_mut(), DataReader::new(the_reader), status);
         Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds_async/domain_participant_listener.rs
+++ b/dds/src/dds_async/domain_participant_listener.rs
@@ -8,10 +8,9 @@ use crate::{
         SampleRejectedStatus, SubscriptionMatchedStatus,
     },
     publication::data_writer::AnyDataWriter,
-    subscription::data_reader::AnyDataReader,
 };
 
-use super::topic::TopicAsync;
+use super::{data_reader::DataReaderAsync, topic::TopicAsync};
 
 /// This trait represents a listener object which can be associated with the [`DomainParticipantAsync`] entity.
 pub trait DomainParticipantListenerAsync {
@@ -61,73 +60,55 @@ pub trait DomainParticipantListenerAsync {
     }
 
     /// Method that is called when any data reader in the domain participant reports a sample lost status.
-    fn on_sample_lost<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_sample_lost(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: SampleLostStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any data reader in the domain participant reports a data available status.
-    fn on_data_available<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    fn on_data_available(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any data reader in the domain participant reports a sample rejected status.
-    fn on_sample_rejected<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_sample_rejected(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: SampleRejectedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any data reader in the domain participant reports a liveliness changed status.
-    fn on_liveliness_changed<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_liveliness_changed(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: LivelinessChangedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any data reader in the domain participant reports a requested deadline missed status.
-    fn on_requested_deadline_missed<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_requested_deadline_missed(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: RequestedDeadlineMissedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any data reader in the domain participant reports a requested incompatible QoS status.
-    fn on_requested_incompatible_qos<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_requested_incompatible_qos(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: RequestedIncompatibleQosStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
@@ -144,14 +125,11 @@ pub trait DomainParticipantListenerAsync {
     }
 
     /// Method that is called when any data reader in the domain participant reports a subscription matched status.
-    fn on_subscription_matched<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_subscription_matched(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: SubscriptionMatchedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds_async/domain_participant_listener.rs
+++ b/dds/src/dds_async/domain_participant_listener.rs
@@ -1,16 +1,13 @@
 use std::{future::Future, pin::Pin};
 
-use crate::{
-    infrastructure::status::{
-        InconsistentTopicStatus, LivelinessChangedStatus, LivelinessLostStatus,
-        OfferedDeadlineMissedStatus, OfferedIncompatibleQosStatus, PublicationMatchedStatus,
-        RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus, SampleLostStatus,
-        SampleRejectedStatus, SubscriptionMatchedStatus,
-    },
-    publication::data_writer::AnyDataWriter,
+use crate::infrastructure::status::{
+    InconsistentTopicStatus, LivelinessChangedStatus, LivelinessLostStatus,
+    OfferedDeadlineMissedStatus, OfferedIncompatibleQosStatus, PublicationMatchedStatus,
+    RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus, SampleLostStatus,
+    SampleRejectedStatus, SubscriptionMatchedStatus,
 };
 
-use super::{data_reader::DataReaderAsync, topic::TopicAsync};
+use super::{data_reader::DataReaderAsync, data_writer::DataWriterAsync, topic::TopicAsync};
 
 /// This trait represents a listener object which can be associated with the [`DomainParticipantAsync`] entity.
 pub trait DomainParticipantListenerAsync {
@@ -24,38 +21,29 @@ pub trait DomainParticipantListenerAsync {
     }
 
     /// Method that is called when any writer in the domain participant reports a liveliness lost status.
-    fn on_liveliness_lost<'a, 'b>(
-        &'a mut self,
-        _the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_liveliness_lost(
+        &mut self,
+        _the_writer: DataWriterAsync<()>,
         _status: LivelinessLostStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any data writer in the domain participant reports a deadline missed status.
-    fn on_offered_deadline_missed<'a, 'b>(
-        &'a mut self,
-        _the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_offered_deadline_missed(
+        &mut self,
+        _the_writer: DataWriterAsync<()>,
         _status: OfferedDeadlineMissedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any data writer in the domain participant reports an offered incompatible QoS status.
-    fn on_offered_incompatible_qos<'a, 'b>(
-        &'a mut self,
-        _the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_offered_incompatible_qos(
+        &mut self,
+        _the_writer: DataWriterAsync<()>,
         _status: OfferedIncompatibleQosStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
@@ -113,14 +101,11 @@ pub trait DomainParticipantListenerAsync {
     }
 
     /// Method that is called when any data writer in the domain participant reports a publication matched status.
-    fn on_publication_matched<'a, 'b>(
-        &'a mut self,
-        _the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_publication_matched(
+        &mut self,
+        _the_writer: DataWriterAsync<()>,
         _status: PublicationMatchedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 

--- a/dds/src/dds_async/publisher_listener.rs
+++ b/dds/src/dds_async/publisher_listener.rs
@@ -1,60 +1,47 @@
 use std::{future::Future, pin::Pin};
 
-use crate::{
-    infrastructure::status::{
-        LivelinessLostStatus, OfferedDeadlineMissedStatus, OfferedIncompatibleQosStatus,
-        PublicationMatchedStatus,
-    },
-    publication::data_writer::AnyDataWriter,
+use crate::infrastructure::status::{
+    LivelinessLostStatus, OfferedDeadlineMissedStatus, OfferedIncompatibleQosStatus,
+    PublicationMatchedStatus,
 };
+
+use super::data_writer::DataWriterAsync;
 
 /// This trait represents a listener object which can be associated with the [`PublisherAsync`](super::publisher::Publisher) entity.
 pub trait PublisherListenerAsync {
     /// Method that is called when any writer belonging to this publisher reports a liveliness lost status.
-    fn on_liveliness_lost<'a, 'b>(
-        &'a mut self,
-        _the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_liveliness_lost(
+        &mut self,
+        _the_writer: DataWriterAsync<()>,
         _status: LivelinessLostStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any writer belonging to this publisher reports an offered deadline missed status.
-    fn on_offered_deadline_missed<'a, 'b>(
-        &'a mut self,
-        _the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_offered_deadline_missed(
+        &mut self,
+        _the_writer: DataWriterAsync<()>,
         _status: OfferedDeadlineMissedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any writer belonging to this publisher reports an offered incompatible qos status.
-    fn on_offered_incompatible_qos<'a, 'b>(
-        &'a mut self,
-        _the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_offered_incompatible_qos(
+        &mut self,
+        _the_writer: DataWriterAsync<()>,
         _status: OfferedIncompatibleQosStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any writer belonging to this publisher reports a publication matched status.
-    fn on_publication_matched<'a, 'b>(
-        &'a mut self,
-        _the_writer: &'b (dyn AnyDataWriter + Sync),
+    fn on_publication_matched(
+        &mut self,
+        _the_writer: DataWriterAsync<()>,
         _status: PublicationMatchedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/dds_async/subscriber_listener.rs
+++ b/dds/src/dds_async/subscriber_listener.rs
@@ -1,14 +1,11 @@
 use std::{future::Future, pin::Pin};
 
-use crate::{
-    infrastructure::status::{
-        LivelinessChangedStatus, RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus,
-        SampleLostStatus, SampleRejectedStatus, SubscriptionMatchedStatus,
-    },
-    subscription::data_reader::AnyDataReader,
+use crate::infrastructure::status::{
+    LivelinessChangedStatus, RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus,
+    SampleLostStatus, SampleRejectedStatus, SubscriptionMatchedStatus,
 };
 
-use super::subscriber::SubscriberAsync;
+use super::{data_reader::DataReaderAsync, subscriber::SubscriberAsync};
 
 /// This trait represents a listener object which can be associated with the [`SubscriberAsync`](super::subscriber::Subscriber) entity.
 pub trait SubscriberListenerAsync {
@@ -21,85 +18,64 @@ pub trait SubscriberListenerAsync {
     }
 
     /// Method that is called when any reader belonging to this subcriber reports new data available.
-    fn on_data_available<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    fn on_data_available(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a sample rejected status.
-    fn on_sample_rejected<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_sample_rejected(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: SampleRejectedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a liveliness changed status.
-    fn on_liveliness_changed<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_liveliness_changed(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: LivelinessChangedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a requested deadline missed status.
-    fn on_requested_deadline_missed<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_requested_deadline_missed(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: RequestedDeadlineMissedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a requested incompatible QoS status.
-    fn on_requested_incompatible_qos<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_requested_incompatible_qos(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: RequestedIncompatibleQosStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a subscription matched status.
-    fn on_subscription_matched<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_subscription_matched(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: SubscriptionMatchedStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 
     /// Method that is called when any reader belonging to this subcriber reports a sample lost status.
-    fn on_sample_lost<'a, 'b>(
-        &'a mut self,
-        _the_reader: &'b (dyn AnyDataReader + Sync),
+    fn on_sample_lost(
+        &mut self,
+        _the_reader: DataReaderAsync<()>,
         _status: SampleLostStatus,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send + 'b>>
-    where
-        'a: 'b,
-    {
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(std::future::ready(()))
     }
 }

--- a/dds/src/implementation/actors/data_writer_actor.rs
+++ b/dds/src/implementation/actors/data_writer_actor.rs
@@ -69,7 +69,9 @@ use std::{
 
 use super::{
     any_data_writer_listener::{AnyDataWriterListener, DataWriterListenerOperation},
-    domain_participant_actor::{ParticipantListenerMessage, ParticipantListenerOperation},
+    domain_participant_actor::{
+        ListenerKind, ParticipantListenerMessage, ParticipantListenerOperation,
+    },
     message_sender_actor::{self, MessageSenderActor},
     publisher_actor::{PublisherListenerMessage, PublisherListenerOperation},
     status_condition_actor::{self, AddCommunicationState, StatusConditionActor},
@@ -575,20 +577,20 @@ impl DataWriterActor {
                 state: StatusKind::PublicationMatched,
             });
 
+        let type_name = self.type_name.clone();
+        let topic_name = self.topic_name.clone();
+        let participant = publisher.get_participant();
+        let status_condition_address = self.status_condition.address();
+        let topic_status_condition_address = self.topic_status_condition.clone();
+        let topic = TopicAsync::new(
+            self.topic_address.clone(),
+            topic_status_condition_address,
+            type_name,
+            topic_name,
+            participant,
+        );
         if self.status_kind.contains(&StatusKind::PublicationMatched) {
-            let type_name = self.type_name.clone();
-            let topic_name = self.topic_name.clone();
             let status = self.get_publication_matched_status();
-            let participant = publisher.get_participant();
-            let status_condition_address = self.status_condition.address();
-            let topic_status_condition_address = self.topic_status_condition.clone();
-            let topic = TopicAsync::new(
-                self.topic_address.clone(),
-                topic_status_condition_address,
-                type_name,
-                topic_name,
-                participant,
-            );
             if let Some(listener) = &self.data_writer_listener_thread {
                 listener.sender().send(DataWriterListenerMessage {
                     listener_operation: DataWriterListenerOperation::PublicationMatched(status),
@@ -603,6 +605,10 @@ impl DataWriterActor {
             if let Some(listener) = publisher_listener {
                 listener.send(PublisherListenerMessage {
                     listener_operation: PublisherListenerOperation::PublicationMatched(status),
+                    writer_address: data_writer_address,
+                    status_condition_address,
+                    publisher,
+                    topic,
                 })?;
             }
         } else if participant_listener_mask.contains(&StatusKind::PublicationMatched) {
@@ -610,6 +616,12 @@ impl DataWriterActor {
             if let Some(listener) = participant_listener {
                 listener.send(ParticipantListenerMessage {
                     listener_operation: ParticipantListenerOperation::PublicationMatched(status),
+                    listener_kind: ListenerKind::Writer {
+                        writer_address: data_writer_address,
+                        status_condition_address,
+                        publisher,
+                        topic,
+                    },
                 })?;
             }
         }
@@ -634,26 +646,26 @@ impl DataWriterActor {
                 state: StatusKind::OfferedIncompatibleQos,
             });
 
+        let type_name = self.type_name.clone();
+        let topic_name = self.topic_name.clone();
+        let participant = publisher.get_participant();
+        let status_condition_address = self.status_condition.address();
+        let topic_status_condition_address = self.topic_status_condition.clone();
+        let topic = TopicAsync::new(
+            self.topic_address.clone(),
+            topic_status_condition_address,
+            type_name,
+            topic_name,
+            participant,
+        );
+
         if self
             .status_kind
             .contains(&StatusKind::OfferedIncompatibleQos)
         {
-            let type_name = self.type_name.clone();
-            let topic_name = self.topic_name.clone();
             let status = self
                 .incompatible_subscriptions
                 .get_offered_incompatible_qos_status();
-            let participant = publisher.get_participant();
-            let status_condition_address = self.status_condition.address();
-            let topic_status_condition_address = self.topic_status_condition.clone();
-            let topic = TopicAsync::new(
-                self.topic_address.clone(),
-                topic_status_condition_address,
-                type_name,
-                topic_name,
-                participant,
-            );
-
             if let Some(listener) = &self.data_writer_listener_thread {
                 listener.sender().send(DataWriterListenerMessage {
                     listener_operation: DataWriterListenerOperation::OfferedIncompatibleQos(status),
@@ -667,9 +679,14 @@ impl DataWriterActor {
             let status = self
                 .incompatible_subscriptions
                 .get_offered_incompatible_qos_status();
+
             if let Some(listener) = publisher_listener {
                 listener.send(PublisherListenerMessage {
                     listener_operation: PublisherListenerOperation::OfferedIncompatibleQos(status),
+                    writer_address: data_writer_address,
+                    status_condition_address,
+                    publisher,
+                    topic,
                 })?;
             }
         } else if participant_listener_mask.contains(&StatusKind::OfferedIncompatibleQos) {
@@ -681,6 +698,12 @@ impl DataWriterActor {
                     listener_operation: ParticipantListenerOperation::OfferedIncompatibleQos(
                         status,
                     ),
+                    listener_kind: ListenerKind::Writer {
+                        writer_address: data_writer_address,
+                        status_condition_address,
+                        publisher,
+                        topic,
+                    },
                 })?;
             }
         }

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     dds::infrastructure,
     dds_async::{
-        domain_participant::DomainParticipantAsync,
+        data_reader::DataReaderAsync, domain_participant::DomainParticipantAsync,
         domain_participant_listener::DomainParticipantListenerAsync, publisher::PublisherAsync,
         publisher_listener::PublisherListenerAsync, subscriber::SubscriberAsync,
         subscriber_listener::SubscriberListenerAsync, topic::TopicAsync,
@@ -231,25 +231,141 @@ impl ParticipantListenerThread {
                 while let Some(m) = receiver.recv().await {
                     match m.listener_operation {
                         ParticipantListenerOperation::_DataAvailable => {
-                            listener.on_data_available(&()).await
+                            let data_reader = match m.listener_kind {
+                                ListenerKind::Reader {
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                } => DataReaderAsync::new(
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                ),
+                                ListenerKind::Writer { .. } => {
+                                    panic!("Expected Reader on this listener")
+                                }
+                            };
+                            listener.on_data_available(data_reader).await
                         }
                         ParticipantListenerOperation::SampleRejected(status) => {
-                            listener.on_sample_rejected(&(), status).await
+                            let data_reader = match m.listener_kind {
+                                ListenerKind::Reader {
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                } => DataReaderAsync::new(
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                ),
+                                ListenerKind::Writer { .. } => {
+                                    panic!("Expected Reader on this listener")
+                                }
+                            };
+                            listener.on_sample_rejected(data_reader, status).await
                         }
                         ParticipantListenerOperation::_LivenessChanged(status) => {
-                            listener.on_liveliness_changed(&(), status).await
+                            let data_reader = match m.listener_kind {
+                                ListenerKind::Reader {
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                } => DataReaderAsync::new(
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                ),
+                                ListenerKind::Writer { .. } => {
+                                    panic!("Expected Reader on this listener")
+                                }
+                            };
+                            listener.on_liveliness_changed(data_reader, status).await
                         }
                         ParticipantListenerOperation::RequestedDeadlineMissed(status) => {
-                            listener.on_requested_deadline_missed(&(), status).await
+                            let data_reader = match m.listener_kind {
+                                ListenerKind::Reader {
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                } => DataReaderAsync::new(
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                ),
+                                ListenerKind::Writer { .. } => {
+                                    panic!("Expected Reader on this listener")
+                                }
+                            };
+                            listener
+                                .on_requested_deadline_missed(data_reader, status)
+                                .await
                         }
                         ParticipantListenerOperation::RequestedIncompatibleQos(status) => {
-                            listener.on_requested_incompatible_qos(&(), status).await
+                            let data_reader = match m.listener_kind {
+                                ListenerKind::Reader {
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                } => DataReaderAsync::new(
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                ),
+                                ListenerKind::Writer { .. } => {
+                                    panic!("Expected Reader on this listener")
+                                }
+                            };
+                            listener
+                                .on_requested_incompatible_qos(data_reader, status)
+                                .await
                         }
                         ParticipantListenerOperation::SubscriptionMatched(status) => {
-                            listener.on_subscription_matched(&(), status).await
+                            let data_reader = match m.listener_kind {
+                                ListenerKind::Reader {
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                } => DataReaderAsync::new(
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                ),
+                                ListenerKind::Writer { .. } => {
+                                    panic!("Expected Reader on this listener")
+                                }
+                            };
+                            listener.on_subscription_matched(data_reader, status).await
                         }
                         ParticipantListenerOperation::SampleLost(status) => {
-                            listener.on_sample_lost(&(), status).await
+                            let data_reader = match m.listener_kind {
+                                ListenerKind::Reader {
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                } => DataReaderAsync::new(
+                                    reader_address,
+                                    status_condition_address,
+                                    subscriber,
+                                    topic,
+                                ),
+                                ListenerKind::Writer { .. } => {
+                                    panic!("Expected Reader on this listener")
+                                }
+                            };
+                            listener.on_sample_lost(data_reader, status).await
                         }
                         ParticipantListenerOperation::_LivelinessLost(status) => {
                             listener.on_liveliness_lost(&(), status).await

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -16,8 +16,9 @@ use crate::{
     dds::infrastructure,
     dds_async::{
         domain_participant::DomainParticipantAsync,
-        domain_participant_listener::DomainParticipantListenerAsync,
-        publisher_listener::PublisherListenerAsync, subscriber_listener::SubscriberListenerAsync,
+        domain_participant_listener::DomainParticipantListenerAsync, publisher::PublisherAsync,
+        publisher_listener::PublisherListenerAsync, subscriber::SubscriberAsync,
+        subscriber_listener::SubscriberListenerAsync, topic::TopicAsync,
         topic_listener::TopicListenerAsync,
     },
     domain::domain_participant_factory::DomainId,
@@ -183,6 +184,21 @@ impl DynamicTypeInterface for FooTypeSupport {
     }
 }
 
+pub enum ListenerKind {
+    Reader {
+        reader_address: ActorAddress<DataReaderActor>,
+        status_condition_address: ActorAddress<StatusConditionActor>,
+        subscriber: SubscriberAsync,
+        topic: TopicAsync,
+    },
+    Writer {
+        writer_address: ActorAddress<DataWriterActor>,
+        status_condition_address: ActorAddress<StatusConditionActor>,
+        publisher: PublisherAsync,
+        topic: TopicAsync,
+    },
+}
+
 pub enum ParticipantListenerOperation {
     _DataAvailable,
     SampleRejected(SampleRejectedStatus),
@@ -199,6 +215,7 @@ pub enum ParticipantListenerOperation {
 
 pub struct ParticipantListenerMessage {
     pub listener_operation: ParticipantListenerOperation,
+    pub listener_kind: ListenerKind,
 }
 
 struct ParticipantListenerThread {

--- a/dds/src/implementation/actors/domain_participant_actor.rs
+++ b/dds/src/implementation/actors/domain_participant_actor.rs
@@ -15,7 +15,8 @@ use crate::{
     },
     dds::infrastructure,
     dds_async::{
-        data_reader::DataReaderAsync, domain_participant::DomainParticipantAsync,
+        data_reader::DataReaderAsync, data_writer::DataWriterAsync,
+        domain_participant::DomainParticipantAsync,
         domain_participant_listener::DomainParticipantListenerAsync, publisher::PublisherAsync,
         publisher_listener::PublisherListenerAsync, subscriber::SubscriberAsync,
         subscriber_listener::SubscriberListenerAsync, topic::TopicAsync,
@@ -368,16 +369,84 @@ impl ParticipantListenerThread {
                             listener.on_sample_lost(data_reader, status).await
                         }
                         ParticipantListenerOperation::_LivelinessLost(status) => {
-                            listener.on_liveliness_lost(&(), status).await
+                            let data_writer = match m.listener_kind {
+                                ListenerKind::Reader { .. } => {
+                                    panic!("Expected Writer on this listener")
+                                }
+                                ListenerKind::Writer {
+                                    writer_address,
+                                    status_condition_address,
+                                    publisher,
+                                    topic,
+                                } => DataWriterAsync::new(
+                                    writer_address,
+                                    status_condition_address,
+                                    publisher,
+                                    topic,
+                                ),
+                            };
+                            listener.on_liveliness_lost(data_writer, status).await
                         }
                         ParticipantListenerOperation::_OfferedDeadlineMissed(status) => {
-                            listener.on_offered_deadline_missed(&(), status).await
+                            let data_writer = match m.listener_kind {
+                                ListenerKind::Reader { .. } => {
+                                    panic!("Expected Writer on this listener")
+                                }
+                                ListenerKind::Writer {
+                                    writer_address,
+                                    status_condition_address,
+                                    publisher,
+                                    topic,
+                                } => DataWriterAsync::new(
+                                    writer_address,
+                                    status_condition_address,
+                                    publisher,
+                                    topic,
+                                ),
+                            };
+                            listener
+                                .on_offered_deadline_missed(data_writer, status)
+                                .await
                         }
                         ParticipantListenerOperation::OfferedIncompatibleQos(status) => {
-                            listener.on_offered_incompatible_qos(&(), status).await
+                            let data_writer = match m.listener_kind {
+                                ListenerKind::Reader { .. } => {
+                                    panic!("Expected Writer on this listener")
+                                }
+                                ListenerKind::Writer {
+                                    writer_address,
+                                    status_condition_address,
+                                    publisher,
+                                    topic,
+                                } => DataWriterAsync::new(
+                                    writer_address,
+                                    status_condition_address,
+                                    publisher,
+                                    topic,
+                                ),
+                            };
+                            listener
+                                .on_offered_incompatible_qos(data_writer, status)
+                                .await
                         }
                         ParticipantListenerOperation::PublicationMatched(status) => {
-                            listener.on_publication_matched(&(), status).await
+                            let data_writer = match m.listener_kind {
+                                ListenerKind::Reader { .. } => {
+                                    panic!("Expected Writer on this listener")
+                                }
+                                ListenerKind::Writer {
+                                    writer_address,
+                                    status_condition_address,
+                                    publisher,
+                                    topic,
+                                } => DataWriterAsync::new(
+                                    writer_address,
+                                    status_condition_address,
+                                    publisher,
+                                    topic,
+                                ),
+                            };
+                            listener.on_publication_matched(data_writer, status).await
                         }
                     }
                 }

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -75,24 +75,28 @@ impl PublisherListenerThread {
         let thread = std::thread::spawn(move || {
             block_on(async {
                 while let Some(m) = receiver.recv().await {
-                    // let data_writer = DataWriterAsync::new(
-                    //     m.writer_address,
-                    //     m.status_condition_address,
-                    //     m.publisher,
-                    //     m.topic,
-                    // );
+                    let data_writer = DataWriterAsync::new(
+                        m.writer_address,
+                        m.status_condition_address,
+                        m.publisher,
+                        m.topic,
+                    );
                     match m.listener_operation {
                         PublisherListenerOperation::_LivelinessLost(status) => {
-                            listener.on_liveliness_lost(&(), status).await
+                            listener.on_liveliness_lost(data_writer, status).await
                         }
                         PublisherListenerOperation::_OfferedDeadlineMissed(status) => {
-                            listener.on_offered_deadline_missed(&(), status).await
+                            listener
+                                .on_offered_deadline_missed(data_writer, status)
+                                .await
                         }
                         PublisherListenerOperation::OfferedIncompatibleQos(status) => {
-                            listener.on_offered_incompatible_qos(&(), status).await
+                            listener
+                                .on_offered_incompatible_qos(data_writer, status)
+                                .await
                         }
                         PublisherListenerOperation::PublicationMatched(status) => {
-                            listener.on_publication_matched(&(), status).await
+                            listener.on_publication_matched(data_writer, status).await
                         }
                     }
                 }

--- a/dds/src/implementation/actors/publisher_actor.rs
+++ b/dds/src/implementation/actors/publisher_actor.rs
@@ -6,8 +6,8 @@ use tracing::warn;
 use crate::{
     data_representation_builtin_endpoints::discovered_reader_data::DiscoveredReaderData,
     dds_async::{
-        domain_participant::DomainParticipantAsync, publisher::PublisherAsync,
-        publisher_listener::PublisherListenerAsync,
+        data_writer::DataWriterAsync, domain_participant::DomainParticipantAsync,
+        publisher::PublisherAsync, publisher_listener::PublisherListenerAsync, topic::TopicAsync,
     },
     implementation::{
         actor::{Actor, ActorAddress, Mail, MailHandler},
@@ -58,6 +58,10 @@ pub enum PublisherListenerOperation {
 
 pub struct PublisherListenerMessage {
     pub listener_operation: PublisherListenerOperation,
+    pub writer_address: ActorAddress<DataWriterActor>,
+    pub status_condition_address: ActorAddress<StatusConditionActor>,
+    pub publisher: PublisherAsync,
+    pub topic: TopicAsync,
 }
 
 struct PublisherListenerThread {
@@ -71,6 +75,12 @@ impl PublisherListenerThread {
         let thread = std::thread::spawn(move || {
             block_on(async {
                 while let Some(m) = receiver.recv().await {
+                    // let data_writer = DataWriterAsync::new(
+                    //     m.writer_address,
+                    //     m.status_condition_address,
+                    //     m.publisher,
+                    //     m.topic,
+                    // );
                     match m.listener_operation {
                         PublisherListenerOperation::_LivelinessLost(status) => {
                             listener.on_liveliness_lost(&(), status).await

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -13,8 +13,9 @@ use super::{
 use crate::{
     data_representation_builtin_endpoints::discovered_writer_data::DiscoveredWriterData,
     dds_async::{
-        domain_participant::DomainParticipantAsync, subscriber::SubscriberAsync,
-        subscriber_listener::SubscriberListenerAsync,
+        data_reader::DataReaderAsync, domain_participant::DomainParticipantAsync,
+        subscriber::SubscriberAsync, subscriber_listener::SubscriberListenerAsync,
+        topic::TopicAsync,
     },
     implementation::{
         actor::{Actor, ActorAddress, Mail, MailHandler},
@@ -66,6 +67,10 @@ pub enum SubscriberListenerOperation {
 
 pub struct SubscriberListenerMessage {
     pub listener_operation: SubscriberListenerOperation,
+    pub reader_address: ActorAddress<DataReaderActor>,
+    pub status_condition_address: ActorAddress<StatusConditionActor>,
+    pub subscriber: SubscriberAsync,
+    pub topic: TopicAsync,
 }
 
 struct SubscriberListenerThread {
@@ -79,6 +84,12 @@ impl SubscriberListenerThread {
         let thread = std::thread::spawn(move || {
             block_on(async {
                 while let Some(m) = receiver.recv().await {
+                    // let data_reader = DataReaderAsync::new(
+                    //     m.reader_address,
+                    //     m.status_condition_address,
+                    //     m.subscriber,
+                    //     m.topic,
+                    // );
                     match m.listener_operation {
                         SubscriberListenerOperation::DataOnReaders(the_subscriber) => {
                             listener.on_data_on_readers(the_subscriber).await

--- a/dds/src/implementation/actors/subscriber_actor.rs
+++ b/dds/src/implementation/actors/subscriber_actor.rs
@@ -84,36 +84,40 @@ impl SubscriberListenerThread {
         let thread = std::thread::spawn(move || {
             block_on(async {
                 while let Some(m) = receiver.recv().await {
-                    // let data_reader = DataReaderAsync::new(
-                    //     m.reader_address,
-                    //     m.status_condition_address,
-                    //     m.subscriber,
-                    //     m.topic,
-                    // );
+                    let data_reader = DataReaderAsync::new(
+                        m.reader_address,
+                        m.status_condition_address,
+                        m.subscriber,
+                        m.topic,
+                    );
                     match m.listener_operation {
                         SubscriberListenerOperation::DataOnReaders(the_subscriber) => {
                             listener.on_data_on_readers(the_subscriber).await
                         }
                         SubscriberListenerOperation::_DataAvailable => {
-                            listener.on_data_available(&()).await
+                            listener.on_data_available(data_reader).await
                         }
                         SubscriberListenerOperation::SampleRejected(status) => {
-                            listener.on_sample_rejected(&(), status).await
+                            listener.on_sample_rejected(data_reader, status).await
                         }
                         SubscriberListenerOperation::_LivenessChanged(status) => {
-                            listener.on_liveliness_changed(&(), status).await
+                            listener.on_liveliness_changed(data_reader, status).await
                         }
                         SubscriberListenerOperation::RequestedDeadlineMissed(status) => {
-                            listener.on_requested_deadline_missed(&(), status).await
+                            listener
+                                .on_requested_deadline_missed(data_reader, status)
+                                .await
                         }
                         SubscriberListenerOperation::RequestedIncompatibleQos(status) => {
-                            listener.on_requested_incompatible_qos(&(), status).await
+                            listener
+                                .on_requested_incompatible_qos(data_reader, status)
+                                .await
                         }
                         SubscriberListenerOperation::SubscriptionMatched(status) => {
-                            listener.on_subscription_matched(&(), status).await
+                            listener.on_subscription_matched(data_reader, status).await
                         }
                         SubscriberListenerOperation::SampleLost(status) => {
-                            listener.on_sample_lost(&(), status).await
+                            listener.on_sample_lost(data_reader, status).await
                         }
                     }
                 }

--- a/dds/tests/listeners.rs
+++ b/dds/tests/listeners.rs
@@ -18,8 +18,7 @@ use dust_dds::{
         wait_set::{Condition, WaitSet},
     },
     publication::{
-        data_writer::{AnyDataWriter, DataWriter},
-        data_writer_listener::DataWriterListener,
+        data_writer::DataWriter, data_writer_listener::DataWriterListener,
         publisher_listener::PublisherListener,
     },
     subscription::{
@@ -416,7 +415,7 @@ fn publication_matched_listener() {
     impl DomainParticipantListener for PublicationMatchedListener {
         fn on_publication_matched(
             &mut self,
-            _the_reader: &dyn AnyDataWriter,
+            _the_writer: DataWriter<()>,
             status: PublicationMatchedStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -502,7 +501,7 @@ fn offered_incompatible_qos_listener() {
     impl DomainParticipantListener for OfferedIncompatibleQosListener {
         fn on_offered_incompatible_qos(
             &mut self,
-            _the_reader: &dyn AnyDataWriter,
+            _the_writer: DataWriter<()>,
             status: OfferedIncompatibleQosStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -1212,7 +1211,7 @@ fn publisher_publication_matched_listener() {
     impl PublisherListener for PublicationMatchedListener {
         fn on_publication_matched(
             &mut self,
-            _the_reader: &dyn AnyDataWriter,
+            _the_writer: DataWriter<()>,
             status: PublicationMatchedStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -1296,7 +1295,7 @@ fn publisher_offered_incompatible_qos_listener() {
     impl PublisherListener for OfferedIncompatibleQosListener {
         fn on_offered_incompatible_qos(
             &mut self,
-            _the_reader: &dyn AnyDataWriter,
+            _the_writer: DataWriter<()>,
             status: OfferedIncompatibleQosStatus,
         ) {
             self.sender.send(status).unwrap();

--- a/dds/tests/listeners.rs
+++ b/dds/tests/listeners.rs
@@ -23,9 +23,7 @@ use dust_dds::{
         publisher_listener::PublisherListener,
     },
     subscription::{
-        data_reader::{AnyDataReader, DataReader},
-        data_reader_listener::DataReaderListener,
-        subscriber::Subscriber,
+        data_reader::DataReader, data_reader_listener::DataReaderListener, subscriber::Subscriber,
         subscriber_listener::SubscriberListener,
     },
     topic_definition::{topic_listener::TopicListener, type_support::DdsType},
@@ -50,7 +48,7 @@ fn deadline_missed_listener() {
     impl DomainParticipantListener for DeadlineMissedListener {
         fn on_requested_deadline_missed(
             &mut self,
-            _the_reader: &dyn AnyDataReader,
+            _the_reader: DataReader<()>,
             status: RequestedDeadlineMissedStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -141,7 +139,7 @@ fn sample_rejected_listener() {
     impl DomainParticipantListener for SampleRejectedListener {
         fn on_sample_rejected(
             &mut self,
-            _the_reader: &dyn AnyDataReader,
+            _the_reader: DataReader<()>,
             status: SampleRejectedStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -248,7 +246,7 @@ fn subscription_matched_listener() {
     impl DomainParticipantListener for SubscriptionMatchedListener {
         fn on_subscription_matched(
             &mut self,
-            _the_reader: &dyn AnyDataReader,
+            _the_reader: DataReader<()>,
             status: SubscriptionMatchedStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -333,7 +331,7 @@ fn requested_incompatible_qos_listener() {
     impl DomainParticipantListener for RequestedIncompatibleQosListener {
         fn on_requested_incompatible_qos(
             &mut self,
-            _the_reader: &dyn AnyDataReader,
+            _the_reader: DataReader<()>,
             status: RequestedIncompatibleQosStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -1383,7 +1381,7 @@ fn subscriber_deadline_missed_listener() {
     impl SubscriberListener for DeadlineMissedListener {
         fn on_requested_deadline_missed(
             &mut self,
-            _the_reader: &dyn AnyDataReader,
+            _the_reader: DataReader<()>,
             status: RequestedDeadlineMissedStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -1470,7 +1468,7 @@ fn subscriber_sample_rejected_listener() {
     impl SubscriberListener for SampleRejectedListener {
         fn on_sample_rejected(
             &mut self,
-            _the_reader: &dyn AnyDataReader,
+            _the_reader: DataReader<()>,
             status: SampleRejectedStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -1575,7 +1573,7 @@ fn subscriber_subscription_matched_listener() {
     impl SubscriberListener for SubscriptionMatchedListener {
         fn on_subscription_matched(
             &mut self,
-            _the_reader: &dyn AnyDataReader,
+            _the_reader: DataReader<()>,
             status: SubscriptionMatchedStatus,
         ) {
             self.sender.send(status).unwrap();
@@ -1659,7 +1657,7 @@ fn subscriber_requested_incompatible_qos_listener() {
     impl SubscriberListener for RequestedIncompatibleQosListener {
         fn on_requested_incompatible_qos(
             &mut self,
-            _the_reader: &dyn AnyDataReader,
+            _the_reader: DataReader<()>,
             status: RequestedIncompatibleQosStatus,
         ) {
             self.sender.send(status).unwrap();


### PR DESCRIPTION
This PR enables using the DataReader and DataWriter functionality on Listeners which do not have the Foo type.