### PR TITLE
Add xcdr2 support

### DIFF
--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -158,6 +158,8 @@ type RepresentationOptions = [u8; 2];
 
 const CDR_BE: RepresentationIdentifier = [0x00, 0x00];
 const CDR_LE: RepresentationIdentifier = [0x00, 0x01];
+const CDR2_BE: RepresentationIdentifier = [0x00, 0x06];
+const CDR2_LE: RepresentationIdentifier = [0x00, 0x07];
 const D_CDR2_BE: RepresentationIdentifier = [0x00, 0x08];
 const D_CDR2_LE: RepresentationIdentifier = [0x00, 0x09];
 const PL_CDR_BE: RepresentationIdentifier = [0x00, 0x02];
@@ -240,24 +242,36 @@ where
     let value = match representation_identifier {
         CDR_BE => {
             let mut deserializer =
-                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian);
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian, false);
             Ok(CdrDeserialize::deserialize(&mut deserializer)?)
         }
         CDR_LE => {
             let mut deserializer =
-                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian);
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian, false);
+            Ok(CdrDeserialize::deserialize(&mut deserializer)?)
+        }
+        CDR2_BE => {
+            let mut deserializer =
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian, true);
+            Ok(CdrDeserialize::deserialize(&mut deserializer)?)
+        }
+        CDR2_LE => {
+            let mut deserializer =
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian, true);
             Ok(CdrDeserialize::deserialize(&mut deserializer)?)
         }
         D_CDR2_BE => {
+            // Ignore DHEADER
             serialized_data.consume(4);
             let mut deserializer =
-                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian);
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian, true);
             Ok(CdrDeserialize::deserialize(&mut deserializer)?)
         }
         D_CDR2_LE => {
+            // Ignore DHEADER
             serialized_data.consume(4);
             let mut deserializer =
-                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian);
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian, true);
             Ok(CdrDeserialize::deserialize(&mut deserializer)?)
         }
         PL_CDR_BE => {

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -17,7 +17,7 @@ use crate::{
         },
     },
 };
-use std::io::{Read, Write};
+use std::io::{BufRead, Read, Write};
 
 pub use dust_dds_derive::{DdsDeserialize, DdsHasKey, DdsSerialize, DdsTypeXml};
 
@@ -158,6 +158,8 @@ type RepresentationOptions = [u8; 2];
 
 const CDR_BE: RepresentationIdentifier = [0x00, 0x00];
 const CDR_LE: RepresentationIdentifier = [0x00, 0x01];
+const D_CDR2_BE: RepresentationIdentifier = [0x00, 0x08];
+const D_CDR2_LE: RepresentationIdentifier = [0x00, 0x09];
 const PL_CDR_BE: RepresentationIdentifier = [0x00, 0x02];
 const PL_CDR_LE: RepresentationIdentifier = [0x00, 0x03];
 const REPRESENTATION_OPTIONS: RepresentationOptions = [0x00, 0x00];
@@ -242,6 +244,18 @@ where
             Ok(CdrDeserialize::deserialize(&mut deserializer)?)
         }
         CDR_LE => {
+            let mut deserializer =
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian);
+            Ok(CdrDeserialize::deserialize(&mut deserializer)?)
+        }
+        D_CDR2_BE => {
+            serialized_data.consume(4);
+            let mut deserializer =
+                ClassicCdrDeserializer::new(serialized_data, CdrEndianness::BigEndian);
+            Ok(CdrDeserialize::deserialize(&mut deserializer)?)
+        }
+        D_CDR2_LE => {
+            serialized_data.consume(4);
             let mut deserializer =
                 ClassicCdrDeserializer::new(serialized_data, CdrEndianness::LittleEndian);
             Ok(CdrDeserialize::deserialize(&mut deserializer)?)

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1269,7 +1269,7 @@ impl DataReaderActor {
             .find(|&x| x.parameter_id() == PID_STATUS_INFO)
         {
             let mut deserializer =
-                ClassicCdrDeserializer::new(p.value(), CdrEndianness::LittleEndian);
+                ClassicCdrDeserializer::new(p.value(), CdrEndianness::LittleEndian, false);
             let status_info: StatusInfo = CdrDeserialize::deserialize(&mut deserializer).unwrap();
             match status_info {
                 STATUS_INFO_DISPOSED => Ok(ChangeKind::NotAliveDisposed),

--- a/dds/src/implementation/payload_serializer_deserializer/cdr_deserializer.rs
+++ b/dds/src/implementation/payload_serializer_deserializer/cdr_deserializer.rs
@@ -257,7 +257,7 @@ mod tests {
     where
         T: CdrDeserialize<'de> + ?Sized,
     {
-        let mut deserializer = ClassicCdrDeserializer::new(bytes, CdrEndianness::BigEndian);
+        let mut deserializer = ClassicCdrDeserializer::new(bytes, CdrEndianness::BigEndian, false);
         Ok(T::deserialize(&mut deserializer)?)
     }
 
@@ -265,7 +265,7 @@ mod tests {
     where
         T: CdrDeserialize<'de> + ?Sized,
     {
-        let mut deserializer = ClassicCdrDeserializer::new(bytes, CdrEndianness::LittleEndian);
+        let mut deserializer = ClassicCdrDeserializer::new(bytes, CdrEndianness::LittleEndian, false);
         Ok(T::deserialize(&mut deserializer)?)
     }
 

--- a/dds/src/implementation/payload_serializer_deserializer/parameter_list_deserializer.rs
+++ b/dds/src/implementation/payload_serializer_deserializer/parameter_list_deserializer.rs
@@ -84,7 +84,11 @@ impl<'de> ParameterListDeserializer<'de> for ParameterListCdrDeserializer<'de> {
         let mut parameter_iterator = ParameterIterator::new(&mut bytes, self.endianness);
         while let Some(p) = parameter_iterator.next()? {
             if p.id() == id {
-                return T::deserialize(&mut ClassicCdrDeserializer::new(p.data(), self.endianness));
+                return T::deserialize(&mut ClassicCdrDeserializer::new(
+                    p.data(),
+                    self.endianness,
+                    false,
+                ));
             }
         }
 
@@ -102,7 +106,11 @@ impl<'de> ParameterListDeserializer<'de> for ParameterListCdrDeserializer<'de> {
         let mut parameter_iterator = ParameterIterator::new(&mut bytes, self.endianness);
         while let Some(p) = parameter_iterator.next()? {
             if p.id() == id {
-                return T::deserialize(&mut ClassicCdrDeserializer::new(p.data(), self.endianness));
+                return T::deserialize(&mut ClassicCdrDeserializer::new(
+                    p.data(),
+                    self.endianness,
+                    false,
+                ));
             }
         }
 
@@ -121,6 +129,7 @@ impl<'de> ParameterListDeserializer<'de> for ParameterListCdrDeserializer<'de> {
                 parameter_values.push(T::deserialize(&mut ClassicCdrDeserializer::new(
                     p.data(),
                     self.endianness,
+                    false,
                 ))?);
             }
         }

--- a/omg_interoperability_executable/src/main.rs
+++ b/omg_interoperability_executable/src/main.rs
@@ -722,7 +722,7 @@ fn main() -> Result<(), Return> {
     ctrlc::set_handler(move || tx.send(()).expect("Could not send signal on channel."))
         .expect("Error setting Ctrl-C handler");
 
-    let options = Options::parse();
+    let options = Options::parse();    
     options.validate()?;
     let participant = initialize(&options)?;
     if options.publish {


### PR DESCRIPTION
Add interpretation for appendable and plain  XCDR2 types in subscription. This ensures interoperability with Connext DDS, see https://github.com/s2e-systems/dust-dds/actions/runs/10373864841