### PR TITLE
Add loss of ownership after unregistering and deadline missed

### DIFF
--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1726,6 +1726,12 @@ impl DataReaderActor {
                                 instance_handle: change_instance_handle,
                             },
                         )?;
+                        data_reader_address
+                            .send_actor_mail(RemoveInstanceOwnership {
+                                instance: change_instance_handle,
+                            })?
+                            .receive_reply()
+                            .await;
 
                         let reader_address = data_reader_address.clone();
                         let subscriber = subscriber.clone();
@@ -2517,5 +2523,20 @@ impl Mail for GetTopicAddress {
 impl MailHandler<GetTopicAddress> for DataReaderActor {
     fn handle(&mut self, _: GetTopicAddress) -> <GetTopicAddress as Mail>::Result {
         self.topic_address.clone()
+    }
+}
+
+pub struct RemoveInstanceOwnership {
+    pub instance: InstanceHandle,
+}
+impl Mail for RemoveInstanceOwnership {
+    type Result = ();
+}
+impl MailHandler<RemoveInstanceOwnership> for DataReaderActor {
+    fn handle(
+        &mut self,
+        message: RemoveInstanceOwnership,
+    ) -> <RemoveInstanceOwnership as Mail>::Result {
+        self.instance_ownership.remove(&message.instance);
     }
 }

--- a/dds/src/implementation/actors/data_reader_actor.rs
+++ b/dds/src/implementation/actors/data_reader_actor.rs
@@ -1800,13 +1800,13 @@ impl DataReaderActor {
                                     })
                                     .ok();
                             }
-                            reader_status_condition
-                                .send_actor_mail(AddCommunicationState {
-                                    state: StatusKind::RequestedDeadlineMissed,
-                                })?
-                                .receive_reply()
-                                .await;
                         }
+                        reader_status_condition
+                            .send_actor_mail(AddCommunicationState {
+                                state: StatusKind::RequestedDeadlineMissed,
+                            })?
+                            .receive_reply()
+                            .await;
                         Ok(())
                     }
                     .await;

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2763,17 +2763,13 @@ fn reader_with_exclusive_ownership_should_not_read_samples_from_second_weaker_wr
     wait_set.wait(Duration::new(5, 0)).unwrap();
 
     let data1 = KeyedData { id: 1, value: 10 };
-    writer1
-        .write_w_timestamp(&data1, None, Time::new(0, 0))
-        .unwrap();
+    writer1.write(&data1, None).unwrap();
     writer1
         .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
     let data2 = KeyedData { id: 1, value: 20 };
-    writer2
-        .write_w_timestamp(&data2, None, Time::new(0, 0))
-        .unwrap();
+    writer2.write(&data2, None).unwrap();
     writer2
         .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
@@ -3039,4 +3035,127 @@ fn reader_with_exclusive_ownership_should_read_samples_from_second_writer_after_
     assert_eq!(samples.len(), 2);
     assert_eq!(samples[0].data().unwrap(), data1);
     assert_eq!(samples[1].data().unwrap(), data2);
+}
+
+#[test]
+fn reader_with_exclusive_ownership_should_read_samples_from_second_weaker_writer_after_unregister()
+{
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>("MyTopic", "KeyedData", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let writer1_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Exclusive,
+        },
+        ownership_strength: OwnershipStrengthQosPolicy { value: 10 },
+        ..Default::default()
+    };
+    let writer1 = publisher
+        .create_datawriter(&topic, QosKind::Specific(writer1_qos), None, NO_STATUS)
+        .unwrap();
+    let writer2_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Exclusive,
+        },
+        ownership_strength: OwnershipStrengthQosPolicy { value: 1 },
+        ..Default::default()
+    };
+    let writer2 = publisher
+        .create_datawriter(&topic, QosKind::Specific(writer2_qos), None, NO_STATUS)
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Exclusive,
+        },
+        ..Default::default()
+    };
+
+    let reader = subscriber
+        .create_datareader::<KeyedData>(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
+        .unwrap();
+
+    let start_time = std::time::Instant::now();
+    while std::time::Instant::now().duration_since(start_time) < std::time::Duration::from_secs(10)
+    {
+        if reader.get_matched_publications().unwrap().len() >= 2 {
+            break;
+        }
+    }
+    assert_eq!(
+        reader.get_matched_publications().unwrap().len(),
+        2,
+        "Reader must have 2 matched writers"
+    );
+
+    let cond = writer1.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let cond = writer2.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let data1 = KeyedData { id: 1, value: 10 };
+    writer1.write(&data1, None).unwrap();
+    writer1
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    writer1.unregister_instance(&data1, None).unwrap();
+    writer1
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let data2 = KeyedData { id: 1, value: 20 };
+    writer2.write(&data2, None).unwrap();
+    writer2
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .read(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 3);
+    assert_eq!(samples[0].data().unwrap(), data1);
+    assert_eq!(samples[2].data().unwrap(), data2);
 }

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -5,9 +5,9 @@ use dust_dds::{
         instance::InstanceHandle,
         qos::{DataReaderQos, DataWriterQos, QosKind, TopicQos},
         qos_policy::{
-            DestinationOrderQosPolicy, DestinationOrderQosPolicyKind, DurabilityQosPolicy,
-            DurabilityQosPolicyKind, HistoryQosPolicy, HistoryQosPolicyKind, Length,
-            LifespanQosPolicy, OwnershipQosPolicy, OwnershipQosPolicyKind,
+            DeadlineQosPolicy, DestinationOrderQosPolicy, DestinationOrderQosPolicyKind,
+            DurabilityQosPolicy, DurabilityQosPolicyKind, HistoryQosPolicy, HistoryQosPolicyKind,
+            Length, LifespanQosPolicy, OwnershipQosPolicy, OwnershipQosPolicyKind,
             OwnershipStrengthQosPolicy, ReliabilityQosPolicy, ReliabilityQosPolicyKind,
             ResourceLimitsQosPolicy, TimeBasedFilterQosPolicy, WriterDataLifecycleQosPolicy,
         },
@@ -2890,12 +2890,141 @@ fn reader_with_exclusive_ownership_should_read_samples_from_second_writer_with_h
         .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
+    let data2 = KeyedData { id: 1, value: 20 };
+    writer2.write(&data2, None).unwrap();
+    writer2
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
     let samples = reader
         .read(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
 
-    assert_eq!(samples.len(), 1);
+    assert_eq!(samples.len(), 2);
     assert_eq!(samples[0].data().unwrap(), data1);
+    assert_eq!(samples[1].data().unwrap(), data2);
+}
+
+#[test]
+fn reader_with_exclusive_ownership_should_read_samples_from_second_writer_after_deadline_missed() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>("MyTopic", "KeyedData", QosKind::Default, None, NO_STATUS)
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let writer1_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Exclusive,
+        },
+        ownership_strength: OwnershipStrengthQosPolicy { value: 10 },
+        deadline: DeadlineQosPolicy {
+            period: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let writer1 = publisher
+        .create_datawriter(&topic, QosKind::Specific(writer1_qos), None, NO_STATUS)
+        .unwrap();
+
+    let writer2_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Exclusive,
+        },
+        ownership_strength: OwnershipStrengthQosPolicy { value: 1 },
+        deadline: DeadlineQosPolicy {
+            period: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let writer2 = publisher
+        .create_datawriter(&topic, QosKind::Specific(writer2_qos), None, NO_STATUS)
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, None, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Exclusive,
+        },
+        deadline: DeadlineQosPolicy {
+            period: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+
+    let reader = subscriber
+        .create_datareader::<KeyedData>(&topic, QosKind::Specific(reader_qos), None, NO_STATUS)
+        .unwrap();
+
+    let start_time = std::time::Instant::now();
+    while std::time::Instant::now().duration_since(start_time) < std::time::Duration::from_secs(10)
+    {
+        if reader.get_matched_publications().unwrap().len() >= 2 {
+            break;
+        }
+    }
+    assert_eq!(
+        reader.get_matched_publications().unwrap().len(),
+        2,
+        "Reader must have 2 matched writers"
+    );
+
+    let cond = writer1.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let cond = writer2.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let data1 = KeyedData { id: 1, value: 10 };
+    writer1.write(&data1, None).unwrap();
+    writer1
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let cond = reader.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::RequestedDeadlineMissed])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
 
     let data2 = KeyedData { id: 1, value: 20 };
     writer2.write(&data2, None).unwrap();


### PR DESCRIPTION
Add the functionality of the writer losing ownership of an instance either when deadline is missed or the sample is explicitly unregistered by a writer.