### PR TITLE
Add interoperability executable to artifacts

### DIFF
--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -38,9 +38,9 @@ jobs:
     - name: Setting up environment
       run: pip install -r omg-dds-rtps/requirements.txt
     - name: Publisher Dust - Subscriber Connext
-      run: python3 ./omg-dds-rtps/interoperability_report.py -P ./target/debug/dust_dds_shape_main_linux -S ./executables/connext_dds-*_shape_main_linux -o=report.xml
+      run: python3 ./omg-dds-rtps/interoperability_report.py -P ./target/release/dust_dds_shape_main_linux -S ./executables/connext_dds-*_shape_main_linux -o=report.xml
     - name: Publisher Connext - Subscriber Dust
-      run: python3 ./omg-dds-rtps/interoperability_report.py -P ./executables/connext_dds-*_shape_main_linux -S ./target/debug/dust_dds_shape_main_linux -o=report.xml
+      run: python3 ./omg-dds-rtps/interoperability_report.py -P ./executables/connext_dds-*_shape_main_linux -S ./target/release/dust_dds_shape_main_linux -o=report.xml
     - name: XUnit
       uses: AutoModality/action-xunit-viewer@v1
       with:

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -23,7 +23,7 @@ jobs:
           rtps_test_utilities.py
           requirements.txt
     - uses: dtolnay/rust-toolchain@stable
-    - run: cargo build --package dust_dds_shape_main_linux 
+    - run: cargo build --package dust_dds_shape_main_linux --release
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11.4'
@@ -51,3 +51,8 @@ jobs:
       with:
         name: interoperability_report
         path: ./index.html
+    - name: Upload executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: interoperability_executable
+        path: ./target/release/dust_dds_shape_main_linux

--- a/omg_interoperability_executable/Cargo.toml
+++ b/omg_interoperability_executable/Cargo.toml
@@ -14,3 +14,6 @@ dust_dds = { path = "../dds" }
 clap = { version = "4.4.11", features = ["derive", "string"] }
 rand = "0.8.5"
 ctrlc = "3.4"
+
+[build-dependencies]
+dust_dds_gen = { path = "../dds_gen"}

--- a/omg_interoperability_executable/build.rs
+++ b/omg_interoperability_executable/build.rs
@@ -1,0 +1,21 @@
+use std::{
+    fs::{self, File},
+    io::Write,
+    path::Path,
+};
+
+fn main() {
+    let cargo_target_dir = std::env::var("OUT_DIR").unwrap();
+    let cargo_manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let cargo_target_path = Path::new(&cargo_target_dir);
+    let cargo_manifest_path = Path::new(&cargo_manifest_dir);
+    let build_path = cargo_target_path.join("idl");
+    let idl_path = cargo_manifest_path.join("shape.idl");
+    let idl_src = std::fs::read_to_string(idl_path).expect("Couldn't read IDL source file!");
+    let compiled_idl = dust_dds_gen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
+    let compiled_idl_path = build_path.as_path().join("shape.rs");
+    fs::create_dir_all(build_path).expect("Creating build path failed");
+    let mut file = File::create(compiled_idl_path).expect("Failed to create file");
+    file.write_all(compiled_idl.as_bytes())
+        .expect("Failed to write to file");
+}

--- a/omg_interoperability_executable/shape.idl
+++ b/omg_interoperability_executable/shape.idl
@@ -1,0 +1,8 @@
+@appendable
+struct ShapeType {
+  @key
+  string<128> color;
+  int32 x;
+  int32 y;
+  int32 shapesize;
+};

--- a/omg_interoperability_executable/src/main.rs
+++ b/omg_interoperability_executable/src/main.rs
@@ -33,6 +33,8 @@ use std::{
     sync::mpsc::Receiver,
 };
 
+include!(concat!(env!("OUT_DIR"), "/idl/shape.rs"));
+
 fn qos_policy_name(id: i32) -> String {
     match id {
         qos_policy::DATA_REPRESENTATION_QOS_POLICY_ID => "DATAREPRESENTATION",
@@ -245,15 +247,6 @@ impl Options {
             value: self.ownership_strength,
         }
     }
-}
-
-#[derive(Debug, dust_dds::topic_definition::type_support::DdsType)]
-pub struct ShapeType {
-    #[dust_dds(key)]
-    pub color: String,
-    pub x: i32,
-    pub y: i32,
-    pub shapesize: i32,
 }
 
 struct Listener;


### PR DESCRIPTION
Add interoperability executable to artifacts such that it can be downloaded to be put to the OMG-RTPS repo.
Add also ShapeType from idl generation as is done on the omg-rtps repo.

Example actions run: https://github.com/s2e-systems/dust-dds/actions/runs/10635177575