### PR TITLE
Fix interoperability executable

### DIFF
--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install tomlq
       run: cargo install tomlq
     - name: Install zip
-      run: apt-get install zip
+      run: sudo apt-get install zip -y
     - name: Rename executable
       run: |
         version=$( tq -f dds/Cargo.toml 'package.version' )

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -24,6 +24,21 @@ jobs:
           requirements.txt
     - uses: dtolnay/rust-toolchain@stable
     - run: cargo build --package dust_dds_shape_main_linux --release
+    - name: Install tomlq
+      run: cargo install tomlq
+    - name: Install zip
+      run: apt-get install zip
+    - name: Rename executable
+      run: |
+        version=$( tq -f dds/Cargo.toml 'package.version' )
+        cp ./target/release/dust_dds_shape_main_linux ./dust_dds-${version}_shape_main_linux
+        mkdir artifacts
+        zip --junk-paths artifacts/dust_dds-${version}_shape_main_linux.zip ./dust_dds-${version}_shape_main_linux
+    - name: Upload executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: interoperability_executable
+        path: ./artifacts/
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11.4'
@@ -51,16 +66,4 @@ jobs:
       with:
         name: interoperability_report
         path: ./index.html
-    - name: Install tomlq
-      run: cargo install tomlq
-    - name: Rename executable
-      run: |
-        version=$( tq -f dds/Cargo.toml 'package.version' )
-        mv ./target/release/dust_dds_shape_main_linux ./target/release/dust_dds-${version}_shape_main_linux
-        mkdir artifacts
-        tar --create --file artifacts/dust_dds-${version}_shape_main_linux.tar ./target/release/dust_dds-${version}_shape_main_linux
-    - name: Upload executable
-      uses: actions/upload-artifact@v4
-      with:
-        name: interoperability_executable
-        path: ./artifacts/
+    

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -51,8 +51,16 @@ jobs:
       with:
         name: interoperability_report
         path: ./index.html
+    - name: Install tomlq
+      run: cargo install tomlq
+    - name: Rename executable
+      run: |
+        version=$( tq -f dds/Cargo.toml 'package.version' )
+        mv ./target/release/dust_dds_shape_main_linux ./target/release/dust_dds-${version}_shape_main_linux
+        mkdir artifacts
+        tar --create --file artifacts/dust_dds-${version}_shape_main_linux.tar ./target/release/dust_dds-${version}_shape_main_linux
     - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
         name: interoperability_executable
-        path: ./target/release/dust_dds_shape_main_linux
+        path: ./artifacts/


### PR DESCRIPTION
- Produce an executable that keeps the execution permission flag.
- Rename the executable with the version in its name (as omg-rtps requires it)

Actions run:
https://github.com/s2e-systems/dust-dds/actions/runs/10717421940/job/29717088048