### PR TITLE
Use a custom Write trait instead of Extend

### DIFF
--- a/dds/src/xtypes/serialize.rs
+++ b/dds/src/xtypes/serialize.rs
@@ -4,6 +4,11 @@ pub use super::{
 };
 pub use dust_dds_derive::XTypesSerialize;
 
+/// A trait to Write bytes into a potentially growing buffer
+pub trait Write {
+    fn write(&mut self, buf: &[u8]);
+}
+
 /// A trait representing a structure that can be serialized into a CDR format.
 pub trait XTypesSerialize {
     /// Method to serialize this value using the given serializer.
@@ -163,5 +168,12 @@ where
 impl XTypesSerialize for String {
     fn serialize(&self, serializer: impl XTypesSerializer) -> Result<(), XTypesError> {
         serializer.serialize_string(self.as_str())
+    }
+}
+
+#[cfg(feature = "std")]
+impl Write for std::vec::Vec<u8> {
+    fn write(&mut self, buf: &[u8]) {
+        self.extend_from_slice(buf)
     }
 }


### PR DESCRIPTION
Use a custom Write trait instead of Extend. This allows custom implementation of Write for example slices while Extend only allows writing of 1 byte at a time