### PR TITLE
Update dynamic topic interface and add deserialization of CDR2 data

### DIFF
--- a/bindings/python/src/domain/domain_participant.rs
+++ b/bindings/python/src/domain/domain_participant.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{Mutex, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use pyo3::prelude::*;
@@ -154,7 +154,7 @@ impl DomainParticipant {
             .unwrap()
             .insert(type_name.clone(), type_.clone());
 
-        let dynamic_type_representation = Box::new(PythonTypeRepresentation::try_from(type_)?);
+        let dynamic_type_representation = Arc::new(PythonTypeRepresentation::try_from(type_)?);
         match self.0.create_dynamic_topic(
             &topic_name,
             &type_name,

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -171,7 +171,7 @@ impl DomainParticipant {
         qos: QosKind<TopicQos>,
         a_listener: Option<Box<dyn TopicListener + Send>>,
         mask: &[StatusKind],
-        dynamic_type_representation: Box<dyn DynamicType + Send + Sync>,
+        dynamic_type_representation: std::sync::Arc<dyn DynamicType + Send + Sync>,
     ) -> DdsResult<Topic> {
         block_on(self.participant_async.create_dynamic_topic(
             topic_name,

--- a/dds/src/dds/topic_definition/type_support.rs
+++ b/dds/src/dds/topic_definition/type_support.rs
@@ -1,4 +1,10 @@
-use crate::{infrastructure::error::DdsResult, xtypes::dynamic_type::DynamicType};
+use crate::{
+    infrastructure::error::DdsResult,
+    xtypes::{
+        dynamic_type::DynamicType,
+        xcdr_deserializer::{Xcdr2BeDeserializer, Xcdr2LeDeserializer},
+    },
+};
 pub use dust_dds_derive::{DdsDeserialize, DdsSerialize};
 use std::io::{Read, Write};
 
@@ -84,8 +90,8 @@ type RepresentationOptions = [u8; 2];
 
 const CDR_BE: RepresentationIdentifier = [0x00, 0x00];
 const CDR_LE: RepresentationIdentifier = [0x00, 0x01];
-const _CDR2_BE: RepresentationIdentifier = [0x00, 0x06];
-const _CDR2_LE: RepresentationIdentifier = [0x00, 0x07];
+const CDR2_BE: RepresentationIdentifier = [0x00, 0x06];
+const CDR2_LE: RepresentationIdentifier = [0x00, 0x07];
 const _D_CDR2_BE: RepresentationIdentifier = [0x00, 0x08];
 const _D_CDR2_LE: RepresentationIdentifier = [0x00, 0x09];
 const _PL_CDR_BE: RepresentationIdentifier = [0x00, 0x02];
@@ -142,6 +148,8 @@ where
     let value = match representation_identifier {
         CDR_BE => XTypesDeserialize::deserialize(&mut Xcdr1BeDeserializer::new(serialized_data)),
         CDR_LE => XTypesDeserialize::deserialize(&mut Xcdr1LeDeserializer::new(serialized_data)),
+        CDR2_BE => XTypesDeserialize::deserialize(&mut Xcdr2BeDeserializer::new(serialized_data)),
+        CDR2_LE => XTypesDeserialize::deserialize(&mut Xcdr2LeDeserializer::new(serialized_data)),
         _ => Err(XTypesError::InvalidData),
     }?;
     Ok(value)

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -13,9 +13,7 @@ use crate::{
         actor::{Actor, ActorAddress},
         actors::{
             data_reader_actor, data_writer_actor,
-            domain_participant_actor::{
-                self, DomainParticipantActor, BUILT_IN_TOPIC_NAME_LIST,
-            },
+            domain_participant_actor::{self, DomainParticipantActor, BUILT_IN_TOPIC_NAME_LIST},
             publisher_actor,
             status_condition_actor::StatusConditionActor,
             subscriber_actor::{self, SubscriberActor},
@@ -279,7 +277,7 @@ impl DomainParticipantAsync {
     where
         Foo: TypeSupport,
     {
-        let type_support = Box::new(Foo::get_type());
+        let type_support = Arc::new(Foo::get_type());
 
         self.create_dynamic_topic(topic_name, type_name, qos, a_listener, mask, type_support)
             .await
@@ -294,7 +292,7 @@ impl DomainParticipantAsync {
         qos: QosKind<TopicQos>,
         a_listener: Option<Box<dyn TopicListenerAsync + Send>>,
         mask: &[StatusKind],
-        dynamic_type_representation: Box<dyn DynamicType + Send + Sync>,
+        dynamic_type_representation: Arc<dyn DynamicType + Send + Sync>,
     ) -> DdsResult<TopicAsync> {
         let (topic_address, topic_status_condition) = self
             .participant_address
@@ -304,7 +302,7 @@ impl DomainParticipantAsync {
                 qos,
                 a_listener,
                 mask: mask.to_vec(),
-                type_support: dynamic_type_representation.into(),
+                type_support: dynamic_type_representation,
                 executor_handle: self.executor_handle.clone(),
             })?
             .receive_reply()


### PR DESCRIPTION
Update the create_dynamic_topic interface to use an Arc instead of a Box. Internally it was already converted to Arc so it doesn't change the behaviour.

Add the deserialization of CDR2 in the payload data.