### PR TITLE
Fix heartbeat period timing

### DIFF
--- a/dds/src/rtps/behavior_types.rs
+++ b/dds/src/rtps/behavior_types.rs
@@ -29,6 +29,12 @@ impl Duration {
     pub fn fraction(&self) -> u32 {
         self.fraction
     }
+
+    pub fn from_millis(millis: u64) -> Self {
+        let seconds = (millis / 1000) as i32;
+        let fraction = ((millis % 1000) * 2u64.pow(32) / 1000) as u32;
+        Self::new(seconds, fraction)
+    }
 }
 
 impl From<Duration> for std::time::Duration {

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -36,7 +36,7 @@ impl RtpsStatefulWriter {
             guid,
             changes: Vec::new(),
             matched_readers: Vec::new(),
-            heartbeat_period: Duration::new(0, 200_000_000),
+            heartbeat_period: Duration::from_millis(200),
             data_max_size_serialized,
         }
     }


### PR DESCRIPTION
The hearbeat period timing was wrong because of using a fraction as a value in nanosec. This result in heartbeat messages being sent roughly every 48ms instead of the intended 200ms. This PR fixes the issue