### PR TITLE
Including support for #include in the ddsgen. 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/dds_gen/src/generator/rust.rs
+++ b/dds_gen/src/generator/rust.rs
@@ -81,7 +81,7 @@ pub fn generate_rust_source(pair: IdlPair, writer: &mut String) {
         Rule::struct_def => struct_def(pair, writer),
         Rule::member => member(pair, writer),
         Rule::struct_forward_dcl => (), // Forward declarations are irrelevant in Rust mapping
-        Rule::union_dcl => todo!(),
+        Rule::union_dcl => todo!("Union declaration has not been implemented yet"),
         Rule::union_def => todo!(),
         Rule::switch_type_spec => todo!(),
         Rule::switch_body => todo!(),
@@ -218,7 +218,89 @@ pub fn generate_rust_source(pair: IdlPair, writer: &mut String) {
         Rule::annotation_appl => annotation_appl(pair, writer),
         Rule::annotation_appl_params => todo!(),
         Rule::annotation_appl_param => todo!(),
+        Rule::preprocessor_directive => preprocessor_directive(pair, writer),
+        Rule::preprocessor_command => preprocessor_command(pair, writer),
+        Rule::preprocessor_define => preprocessor_define(pair, writer),
+        Rule::preprocessor_ifdef => preprocessor_ifdef(pair, writer),
+        Rule::preprocessor_ifndef => preprocessor_ifndef(pair, writer),
+        Rule::preprocessor_endif => preprocessor_endif(pair, writer),
+        Rule::preprocessor_include => preprocessor_include(pair, writer),
+        Rule::filename => todo!(),
+        Rule::preprocessor_pragma => preprocessor_pragma(pair, writer),
     }
+}
+
+fn preprocessor_directive(pair: IdlPair, writer: &mut String) {
+    dbg!("PRE_PROCESSOR_DIRECTIVE");
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.clone().into_inner();
+
+    dbg!("preprocessor_directive: ", &pair.as_str());
+    dbg!("preprocessor_rule: ", &pair.as_rule());
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
+}
+
+fn preprocessor_command(pair: IdlPair, writer: &mut String) {
+    dbg!("#");
+    dbg!("preprocessor_command: ", pair.as_str());
+    dbg!("preprocessor_rule: ", pair.as_rule());
+
+    let mut inner_pairs = pair.clone().into_inner();
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!("Must have an element according to the grammar."),
+    };
+}
+
+fn preprocessor_define(pair: IdlPair, writer: &mut String) {
+    dbg!("#define");
+    dbg!("preprocessor_define: ", pair.as_str());
+}
+fn preprocessor_ifdef(pair: IdlPair, writer: &mut String) {
+    dbg!("#ifdef");
+    dbg!("preprocessor_ifdef: ", pair.as_str());
+}
+fn preprocessor_ifndef(pair: IdlPair, writer: &mut String) {
+    dbg!("#ifndef");
+    dbg!("preprocessor_ifndef: ", pair.as_str());
+}
+fn preprocessor_endif(pair: IdlPair, writer: &mut String) {
+    dbg!("#endif");
+    dbg!("preprocessor_endif: ", pair.as_str());
+}
+fn preprocessor_include(pair: IdlPair, writer: &mut String) {
+    dbg!("#include");
+    dbg!("preprocessor_include: ", pair.as_str());
+    dbg!("preprocessor_rule: ", pair.as_rule());
+
+    let mut inner_pairs = pair.clone().into_inner();
+    let include_path = match inner_pairs.next() {
+        Some(pair) => pair.as_str(),
+        None => panic!(
+            "Preprocessor include: Must have an element according to the grammar: {}",
+            &pair.as_str()
+        ),
+    };
+
+    let rust_include = include_path.replace(".idl", ".rs");
+
+    let written = format!("#include!(\"{}\");", rust_include);
+
+    writer.push_str(&written);
+    dbg!("rust_include: ", written);
+    dbg!("include_path: ", include_path);
+}
+
+fn preprocessor_pragma(pair: IdlPair, writer: &mut String) {
+    dbg!("#pragma");
+    dbg!("preprocessor_pragma: ", pair.as_str());
 }
 
 fn specification(pair: IdlPair, writer: &mut String) {
@@ -228,12 +310,16 @@ fn specification(pair: IdlPair, writer: &mut String) {
 }
 
 fn definition(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn module_dcl(pair: IdlPair, writer: &mut String) {
@@ -257,30 +343,42 @@ fn module_dcl(pair: IdlPair, writer: &mut String) {
 }
 
 fn type_dcl(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn constr_type_dcl(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn struct_dcl(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn struct_def(pair: IdlPair, writer: &mut String) {
@@ -326,12 +424,16 @@ fn enum_dcl(pair: IdlPair, writer: &mut String) {
 }
 
 fn enumerator(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn member(pair: IdlPair, writer: &mut String) {
@@ -397,12 +499,16 @@ fn declarators(pair: IdlPair, writer: &mut String) {
 }
 
 fn interface_dcl(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn interface_def(pair: IdlPair, writer: &mut String) {
@@ -464,12 +570,16 @@ fn interface_body(pair: IdlPair, writer: &mut String) {
 }
 
 fn export(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn op_dcl(pair: IdlPair, writer: &mut String) {
@@ -534,26 +644,34 @@ fn param_attribute(pair: IdlPair, writer: &mut String) {
     match pair.as_str() {
         "inout" | "out" => writer.push_str("&mut "),
         "in" => writer.push('&'),
-        _ => panic!("Invalid option by grammar"),
+        _ => panic!("Invalid option by grammar: {}", &pair.as_str()),
     }
 }
 
 fn simple_declarator(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn typedef_dcl(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn type_declarator(pair: IdlPair, writer: &mut String) {
@@ -566,7 +684,7 @@ fn type_declarator(pair: IdlPair, writer: &mut String) {
     let any_declarators = inner_pairs
         .clone()
         .find(|p| p.as_rule() == Rule::any_declarators)
-        .expect("Must have any_declarators according to grammar");
+        .expect("Must have any_declarators according to grammar: {}");
     for any_declarator in any_declarators.into_inner() {
         writer.push_str("pub type ");
         generate_rust_source(any_declarator, writer);
@@ -577,12 +695,16 @@ fn type_declarator(pair: IdlPair, writer: &mut String) {
 }
 
 fn any_declarator(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn identifier(pair: IdlPair, writer: &mut String) {
@@ -590,30 +712,42 @@ fn identifier(pair: IdlPair, writer: &mut String) {
 }
 
 fn type_spec(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn simple_type_spec(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn base_type_spec(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn floating_pt_type(pair: IdlPair, writer: &mut String) {
@@ -626,12 +760,16 @@ fn floating_pt_type(pair: IdlPair, writer: &mut String) {
 }
 
 fn integer_type(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn signed_tiny_int(_pair: IdlPair, writer: &mut String) {
@@ -639,12 +777,16 @@ fn signed_tiny_int(_pair: IdlPair, writer: &mut String) {
 }
 
 fn signed_int(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn signed_short_int(_pair: IdlPair, writer: &mut String) {
@@ -664,12 +806,16 @@ fn unsigned_tiny_int(_pair: IdlPair, writer: &mut String) {
 }
 
 fn unsigned_int(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn unsigned_short_int(_pair: IdlPair, writer: &mut String) {
@@ -689,12 +835,16 @@ fn octet_type(_pair: IdlPair, writer: &mut String) {
 }
 
 fn template_type_spec(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn sequence_type(pair: IdlPair, writer: &mut String) {
@@ -719,21 +869,29 @@ fn wide_string_type(_pair: IdlPair, writer: &mut String) {
 }
 
 fn fixed_array_size(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn positive_int_const(pair: IdlPair, writer: &mut String) {
-    generate_rust_source(
-        pair.into_inner()
-            .next()
-            .expect("Must have an element according to the grammar"),
-        writer,
-    )
+    let pair_details = pair.as_str();
+    let mut inner_pairs = pair.into_inner();
+
+    match inner_pairs.next() {
+        Some(pair) => generate_rust_source(pair, writer),
+        None => panic!(
+            "Must have an element according to the grammar: {}",
+            pair_details
+        ),
+    };
 }
 
 fn const_expr(pair: IdlPair, writer: &mut String) {
@@ -956,5 +1114,21 @@ mod tests {
             "pub trait MyInterface{fn op(s:&mut String,a:&mut i16,u:&char,);\nfn sum(a:&u16,b:&u16,)->u16;\n}\n",
             &out
         );
+    }
+
+    #[test]
+    fn parse_include() {
+        let mut out = String::new();
+
+        let p = IdlParser::parse(
+            Rule::preprocessor_directive,
+            "#include \"hello_world.rs\"\n",
+        )
+        .unwrap()
+        .next()
+        .unwrap();
+
+        generate_rust_source(p, &mut out);
+        assert_eq!("#include!(\"hello_world.rs\");", &out);
     }
 }

--- a/dds_gen/src/generator/rust.rs
+++ b/dds_gen/src/generator/rust.rs
@@ -231,12 +231,11 @@ pub fn generate_rust_source(pair: IdlPair, writer: &mut String) {
 }
 
 fn preprocessor_directive(pair: IdlPair, writer: &mut String) {
-    dbg!("PRE_PROCESSOR_DIRECTIVE");
+    
     let pair_details = pair.as_str();
     let mut inner_pairs = pair.clone().into_inner();
 
-    dbg!("preprocessor_directive: ", &pair.as_str());
-    dbg!("preprocessor_rule: ", &pair.as_rule());
+    
 
     match inner_pairs.next() {
         Some(pair) => generate_rust_source(pair, writer),
@@ -248,11 +247,9 @@ fn preprocessor_directive(pair: IdlPair, writer: &mut String) {
 }
 
 fn preprocessor_command(pair: IdlPair, writer: &mut String) {
-    dbg!("#");
-    dbg!("preprocessor_command: ", pair.as_str());
-    dbg!("preprocessor_rule: ", pair.as_rule());
+    
 
-    let mut inner_pairs = pair.clone().into_inner();
+    let mut inner_pairs = pair.into_inner();
     match inner_pairs.next() {
         Some(pair) => generate_rust_source(pair, writer),
         None => panic!("Must have an element according to the grammar."),
@@ -260,8 +257,7 @@ fn preprocessor_command(pair: IdlPair, writer: &mut String) {
 }
 
 fn preprocessor_define(pair: IdlPair, writer: &mut String) {
-    dbg!("#define");
-    dbg!("preprocessor_define: ", pair.as_str());
+    
 }
 fn preprocessor_ifdef(pair: IdlPair, writer: &mut String) {
     dbg!("#ifdef");
@@ -276,9 +272,7 @@ fn preprocessor_endif(pair: IdlPair, writer: &mut String) {
     dbg!("preprocessor_endif: ", pair.as_str());
 }
 fn preprocessor_include(pair: IdlPair, writer: &mut String) {
-    dbg!("#include");
-    dbg!("preprocessor_include: ", pair.as_str());
-    dbg!("preprocessor_rule: ", pair.as_rule());
+    
 
     let mut inner_pairs = pair.clone().into_inner();
     let include_path = match inner_pairs.next() {

--- a/dds_gen/src/lib.rs
+++ b/dds_gen/src/lib.rs
@@ -5,10 +5,22 @@ mod generator;
 mod parser;
 
 pub fn compile_idl(idl_source: &str) -> Result<String, String> {
-    let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, idl_source)
-        .map_err(|e| format!("Error parsing IDL string: {}", e))?
-        .next()
-        .expect("Must contain a specification");
+    let mut idl_parser = match parser::IdlParser::parse(parser::Rule::specification, idl_source) {
+        Ok(parsed_idl) => parsed_idl,
+        Err(e) => panic!("Error parsing IDL string: {}", e),
+    };
+
+    let parsed_idl = match idl_parser.next() {
+        Some(parsed_idl) => parsed_idl,
+        None => panic!("Must contain a specification"),
+    };
+
+
+
+    // let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, idl_source)
+    //     .map_err(|e| format!("Error parsing IDL string: {}", e))?
+    //     .next()
+    //     .expect("Must contain a specification");
 
     let mut output = String::new();
     rust::generate_rust_source(parsed_idl, &mut output);

--- a/dds_gen/src/parser/idl_v4_grammar.pest
+++ b/dds_gen/src/parser/idl_v4_grammar.pest
@@ -5,172 +5,172 @@
 // Standard Document URL: http://www.omg.org/spec/IDL/4.2/
 
 // From Section 7.2 Lexical Conventions:
-escape = ${ "\\" ~ ("n" | "t" | "v" | "b" | "r" | "f" | "a" | "\\" | "?" | "'" | "\"") | octal_escape | hex_escape | unicode_escape }
-octal_escape = ${ "\\" ~ ASCII_OCT_DIGIT ~ ASCII_OCT_DIGIT? ~ ASCII_OCT_DIGIT? }
-hex_escape = ${ "\\" ~ "x" ~ ASCII_HEX_DIGIT ~ ASCII_HEX_DIGIT? }
-unicode_escape = ${ "\\" ~ "u" ~ ASCII_HEX_DIGIT{1,4} }
+escape         = ${ "\\" ~ ("n" | "t" | "v" | "b" | "r" | "f" | "a" | "\\" | "?" | "'" | "\"") | octal_escape | hex_escape | unicode_escape }
+octal_escape   = ${ "\\" ~ ASCII_OCT_DIGIT ~ ASCII_OCT_DIGIT? ~ ASCII_OCT_DIGIT? }
+hex_escape     = ${ "\\" ~ "x" ~ ASCII_HEX_DIGIT ~ ASCII_HEX_DIGIT? }
+unicode_escape = ${ "\\" ~ "u" ~ ASCII_HEX_DIGIT{1, 4} }
 
-WHITESPACE = _{ " " | "\t" | NEWLINE }
+WHITESPACE    = _{ " " | "\t" | NEWLINE }
 block_comment = @{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
-line_comment = @{ "//" ~ (!NEWLINE ~ ANY)* }
-COMMENT = _{ block_comment | line_comment }
+line_comment  = @{ "//" ~ (!NEWLINE ~ ANY)* }
+COMMENT       = _{ block_comment | line_comment }
 
 // Keywords must be written exactly as shown in the above list.
 // Identifiers that collide with keywords (see 7.2.3, Identifiers) are illegal.
 // For example, boolean is a valid keyword; Boolean and BOOLEAN are illegal identifiers.
 reserved_keyword = {
-      ^"abstract"
-    | ^"any"
-    | ^"bitmask"
-    | ^"alias"
-    | ^"attribute"
-    | ^"bitfield"
-    | ^"bitmask"
-    | ^"bitset"
-    | ^"boolean"
-    | ^"case"
-    | ^"char"
-    | ^"component"
-    | ^"connector"
-    | ^"const"
-    | ^"consumes"
-    | ^"context"
-    | ^"custom"
-    | ^"default"
-    | ^"double"
-    | ^"exception"
-    | ^"emits"
-    | ^"enum"
-    | ^"eventtype"
-    | ^"factory"
-    | ^"FALSE"
-    | ^"finder"
-    | ^"fixed"
-    | ^"float"
-    | ^"getraises"
-    | ^"home"
-    | ^"import"
-    | ^"in"
-    | ^"inout"
-    | ^"interface"
-    | ^"local"
-    | ^"long"
-    | ^"manages"
-    | ^"map"
-    | ^"mirrorport"
-    | ^"module"
-    | ^"multiple"
-    | ^"native"
-    | ^"Object"
-    | ^"octet"
-    | ^"oneway"
-    | ^"out"
-    | ^"primarykey"
-    | ^"private"
-    | ^"port"
-    | ^"porttype"
-    | ^"provides"
-    | ^"public"
-    | ^"publishes"
-    | ^"raises"
-    | ^"readonly"
-    | ^"setraises"
-    | ^"sequence"
-    | ^"short"
-    | ^"string"
-    | ^"struct"
-    | ^"supports"
-    | ^"switch"
-    | ^"TRUE"
-    | ^"truncatable"
-    | ^"typedef"
-    | ^"typeid"
-    | ^"typename"
-    | ^"typeprefix"
-    | ^"unsigned"
-    | ^"union"
-    | ^"uses"
-    | ^"ValueBase"
-    | ^"valuetype"
-    | ^"void"
-    | ^"wchar"
-    | ^"wstring"
-    | ^"int8"
-    | ^"uint8"
-    | ^"int16"
-    | ^"int32"
-    | ^"int64"
-    | ^"uint16"
-    | ^"uint32"
-    | ^"uint64"
+    ^"abstract"
+  | ^"any"
+  | ^"bitmask"
+  | ^"alias"
+  | ^"attribute"
+  | ^"bitfield"
+  | ^"bitmask"
+  | ^"bitset"
+  | ^"boolean"
+  | ^"case"
+  | ^"char"
+  | ^"component"
+  | ^"connector"
+  | ^"const"
+  | ^"consumes"
+  | ^"context"
+  | ^"custom"
+  | ^"default"
+  | ^"double"
+  | ^"exception"
+  | ^"emits"
+  | ^"enum"
+  | ^"eventtype"
+  | ^"factory"
+  | ^"FALSE"
+  | ^"finder"
+  | ^"fixed"
+  | ^"float"
+  | ^"getraises"
+  | ^"home"
+  | ^"import"
+  | ^"in"
+  | ^"inout"
+  | ^"interface"
+  | ^"local"
+  | ^"long"
+  | ^"manages"
+  | ^"map"
+  | ^"mirrorport"
+  | ^"module"
+  | ^"multiple"
+  | ^"native"
+  | ^"Object"
+  | ^"octet"
+  | ^"oneway"
+  | ^"out"
+  | ^"primarykey"
+  | ^"private"
+  | ^"port"
+  | ^"porttype"
+  | ^"provides"
+  | ^"public"
+  | ^"publishes"
+  | ^"raises"
+  | ^"readonly"
+  | ^"setraises"
+  | ^"sequence"
+  | ^"short"
+  | ^"string"
+  | ^"struct"
+  | ^"supports"
+  | ^"switch"
+  | ^"TRUE"
+  | ^"truncatable"
+  | ^"typedef"
+  | ^"typeid"
+  | ^"typename"
+  | ^"typeprefix"
+  | ^"unsigned"
+  | ^"union"
+  | ^"uses"
+  | ^"ValueBase"
+  | ^"valuetype"
+  | ^"void"
+  | ^"wchar"
+  | ^"wstring"
+  | ^"int8"
+  | ^"uint8"
+  | ^"int16"
+  | ^"int32"
+  | ^"int64"
+  | ^"uint16"
+  | ^"uint32"
+  | ^"uint64"
 }
 
 // Identifier can not be a keyword. The optional is used instead of the negative lookahead (!)
 // because the identifier might start with a keyword as long as it has something after it.
 identifier = @{
-    reserved_keyword? ~ (ASCII | "_") ~ ("_" | ASCII_ALPHANUMERIC )*
-    | "_" ~ (ASCII | "_") ~ ("_" | ASCII_ALPHANUMERIC )*
+    reserved_keyword? ~ (ASCII | "_") ~ ("_" | ASCII_ALPHANUMERIC)*
+  | "_" ~ (ASCII | "_") ~ ("_" | ASCII_ALPHANUMERIC)*
 }
 
-character_literal = @{ "'" ~ (!"'" ~ (escape | ANY)) ~ "'" }
-string_literal = @{ "\"" ~ (!"\"" ~ (escape | ANY))* ~ "\"" }
-wide_character_literal = @{ "L'" ~ (!"'" ~ (escape | ANY)) ~ "'" }
-wide_string_literal = @{ "L\"" ~ (!"\"" ~ (escape | ANY))* ~ "\"" }
-integer_literal = ${
+character_literal       = @{ "'" ~ (!"'" ~ (escape | ANY)) ~ "'" }
+string_literal          = @{ "\"" ~ (!"\"" ~ (escape | ANY))* ~ "\"" }
+wide_character_literal  = @{ "L'" ~ (!"'" ~ (escape | ANY)) ~ "'" }
+wide_string_literal     = @{ "L\"" ~ (!"\"" ~ (escape | ANY))* ~ "\"" }
+integer_literal         = ${
     hex_integer_literal
-    | octal_integer_literal
-    | decimal_integer_literal
+  | octal_integer_literal
+  | decimal_integer_literal
 }
 decimal_integer_literal = @{ ASCII_DIGIT+ }
-octal_integer_literal = @{ "0" ~ ASCII_OCT_DIGIT+ }
-hex_integer_literal = @{ ("0x" | "0X") ~ ASCII_HEX_DIGIT+ }
-fixed_pt_literal = ${ floating_pt_literal }
-floating_pt_literal = ${
+octal_integer_literal   = @{ "0" ~ ASCII_OCT_DIGIT+ }
+hex_integer_literal     = @{ ("0x" | "0X") ~ ASCII_HEX_DIGIT+ }
+fixed_pt_literal        = ${ floating_pt_literal }
+floating_pt_literal     = ${
     integral_part ~ "." ~ fractional_part ~ exponent? ~ float_suffix?
-    | "." ~ fractional_part ~ exponent? ~ float_suffix?
-    | integral_part ~ exponent ~ float_suffix?
-    | integral_part ~ float_suffix
+  | "." ~ fractional_part ~ exponent? ~ float_suffix?
+  | integral_part ~ exponent ~ float_suffix?
+  | integral_part ~ float_suffix
 }
-integral_part =  @{ ASCII_DIGIT+ }
-fractional_part =  @{ ASCII_DIGIT+ }
-exponent = ${ ("e" | "E") ~ ("+" | "-")? ~ ASCII_DIGIT+ }
-float_suffix = ${ ("f" | "F" | "d" | "D") }
+integral_part           = @{ ASCII_DIGIT+ }
+fractional_part         = @{ ASCII_DIGIT+ }
+exponent                = ${ ("e" | "E") ~ ("+" | "-")? ~ ASCII_DIGIT+ }
+float_suffix            = ${ ("f" | "F" | "d" | "D") }
 
 // Annex: Consolidated IDL Grammar
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Core Data Types:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (1)
-specification = { SOI ~ definition+ ~ EOI}
+specification = { SOI ~ definition* ~ EOI }
 // (2)
 definition = {
     module_dcl ~ ";"
-    | const_dcl ~ ";"
-    | type_dcl ~ ";"
-    // (71)
-    | except_dcl ~ ";"
-    | interface_dcl ~ ";"
-    // (98)
-    | value_dcl ~ ";"
-    // (111)
-    | type_id_dcl ~ ";"
-    | type_prefix_dcl ~ ";"
-    | import_dcl ~ ";"
-    // (133)
-    | component_dcl ~ ";"
-    // (144)
-    | home_dcl ~ ";"
-    // (153)
-    | event_dcl ~ ";"
-    // (171)
-    | porttype_dcl ~ ";"
-    | connector_dcl ~ ";"
-    // (184)
-    | template_module_dcl ~ ";"
-    | template_module_inst ~ ";"
-    // (218)
-    | annotation_dcl ~ ";"
+  | const_dcl ~ ";"
+  | type_dcl ~ ";" // (71)
 
+  | except_dcl ~ ";"
+  | interface_dcl ~ ";" // (98)
+
+  | value_dcl ~ ";" // (111)
+
+  | type_id_dcl ~ ";"
+  | type_prefix_dcl ~ ";"
+  | import_dcl ~ ";" // (133)
+
+  | component_dcl ~ ";" // (144)
+
+  | home_dcl ~ ";" // (153)
+
+  | event_dcl ~ ";" // (171)
+
+  | porttype_dcl ~ ";"
+  | connector_dcl ~ ";" // (184)
+
+  | template_module_dcl ~ ";"
+  | template_module_inst ~ ";" // (218)
+
+  | annotation_dcl ~ ";"
+  | preprocessor_directive
 }
 // (3)
 module_dcl = { "module" ~ identifier ~ "{" ~ definition+ ~ "}" }
@@ -181,15 +181,15 @@ const_dcl = { "const" ~ const_type ~ identifier ~ "=" ~ const_expr }
 // (6)
 const_type = {
     integer_type
-    | floating_pt_type
-    | fixed_pt_const_type
-    | char_type
-    | wide_char_type
-    | boolean_type
-    | octet_type
-    | string_type
-    | wide_string_type
-    | scoped_name
+  | floating_pt_type
+  | fixed_pt_const_type
+  | char_type
+  | wide_char_type
+  | boolean_type
+  | octet_type
+  | string_type
+  | wide_string_type
+  | scoped_name
 }
 // (7)
 const_expr = { unary_expr ~ (or_expr | xor_expr | and_expr | lshift_expr | rshift_expr | add_expr | sub_expr | mul_expr | div_expr | mod_expr)? }
@@ -232,130 +232,128 @@ mod_expr = {
 // (14)
 unary_expr = {
     unary_operator ~ primary_expr
-    | primary_expr
+  | primary_expr
 }
 // (15)
 unary_operator = {
     "-"
-    | "+"
-    | "~"
+  | "+"
+  | "~"
 }
 // (16)
 primary_expr = {
     literal
-    | scoped_name
-    | "(" ~ const_expr ~ ")"
+  | scoped_name
+  | "(" ~ const_expr ~ ")"
 }
 // (17)
 literal = {
     floating_pt_literal
-    | integer_literal
-    | fixed_pt_literal
-    | character_literal
-    | wide_character_literal
-    | boolean_literal
-    | string_literal
-    | wide_string_literal
+  | integer_literal
+  | fixed_pt_literal
+  | character_literal
+  | wide_character_literal
+  | boolean_literal
+  | string_literal
+  | wide_string_literal
 }
 // (18)
 boolean_literal = {
     "TRUE"
-    | "FALSE"
+  | "FALSE"
 }
 // (19)
 positive_int_const = { const_expr }
 // (20)
 type_dcl = {
     constr_type_dcl
-    | native_dcl
-    | typedef_dcl
+  | native_dcl
+  | typedef_dcl
 }
 // (21)
 type_spec = {
     // (216)
     template_type_spec
-    | simple_type_spec
-
+  | simple_type_spec
 }
 // (22)
 simple_type_spec = {
     base_type_spec
-    | scoped_name
+  | scoped_name
 }
 // (23)
 base_type_spec = {
     floating_pt_type
-    | integer_type
-    | char_type
-    | wide_char_type
-    | boolean_type
-    | octet_type
-    // (69)
-    | any_type
-    // (117)
-    | object_type
-    // (131)
-    | value_base_type
+  | integer_type
+  | char_type
+  | wide_char_type
+  | boolean_type
+  | octet_type // (69)
+
+  | any_type // (117)
+
+  | object_type // (131)
+
+  | value_base_type
 }
 // (24)
 floating_pt_type = {
-    "long" ~" double"
-    | "float"
-    | "double"
+    "long" ~ " double"
+  | "float"
+  | "double"
 }
 // (25)
 integer_type = {
     signed_int
-    | unsigned_int
+  | unsigned_int
 }
 // (26)
 signed_int = {
     signed_longlong_int
-    | signed_short_int
-    | signed_long_int
-    // (206)
-    | signed_tiny_int
+  | signed_short_int
+  | signed_long_int // (206)
+
+  | signed_tiny_int
 }
 // (27)
 signed_short_int = {
     "short"
-    | "int16"
+  | "int16"
 }
 // (28)
 signed_long_int = {
-    "long"
-    // (211)
-    | "int32"
+    "long" // (211)
+
+  | "int32"
 }
 // (29)
 signed_longlong_int = {
-    "long" ~ "long"
-    // (212)
-    | "int64"
+    "long" ~ "long" // (212)
 
+  | "int64"
 }
 // (30)
 unsigned_int = {
     unsigned_longlong_int
-    | unsigned_short_int
-    | unsigned_long_int
-    // (207)
-    | unsigned_tiny_int
+  | unsigned_short_int
+  | unsigned_long_int // (207)
+
+  | unsigned_tiny_int
 }
 // (31)
 unsigned_short_int = {
     "unsigned" ~ "short"
-    | "uint16"
+  | "uint16"
 }
 // (32)
 unsigned_long_int = {
     "unsigned" ~ "long"
-    | "uint32"
+  | "uint32"
 }
 // (33)
 unsigned_longlong_int = {
     "unsigned" ~ "long" ~ "long"
-    | "uint64"
+  | "uint64"
 }
 // (34)
 char_type = { "char" }
@@ -368,11 +366,11 @@ octet_type = { "octet" }
 // (38)
 template_type_spec = {
     sequence_type
-    | string_type
-    | wide_string_type
-    | fixed_pt_type
-    // (197)
-    | map_type
+  | string_type
+  | wide_string_type
+  | fixed_pt_type // (197)
+
+  | map_type
 }
 // (39)
 sequence_type = {
@@ -393,19 +391,20 @@ fixed_pt_const_type = { "fixed" }
 // (44)
 constr_type_dcl = {
     struct_dcl
-    | union_dcl
-    | enum_dcl
-    // (198)
-    | bitset_dcl
-    | bitmask_dcl
+  | union_dcl
+  | enum_dcl // (198)
+
+  | bitset_dcl
+  | bitmask_dcl
 }
 // (45)
 struct_dcl = {
     struct_def
-    | struct_forward_dcl
+  | struct_forward_dcl
 }
 // (46)
-struct_def = { annotation_appl* ~ "struct" ~ identifier ~ /*(195)*/(":" ~ scoped_name)? ~ "{" ~ member* ~ "}" }
+struct_def = { annotation_appl* ~ "struct" ~ identifier ~  /* (195) */
+(":" ~ scoped_name)? ~ "{" ~ member* ~ "}" }
 // (47)
 member = { annotation_appl* ~ type_spec ~ declarators ~ ";" }
 // (48)
@@ -413,19 +412,19 @@ struct_forward_dcl = { "struct" ~ identifier }
 // (49)
 union_dcl = {
     union_def
-    | union_forward_dcl
+  | union_forward_dcl
 }
 // (50)
 union_def = { "union" ~ identifier ~ "switch" ~ "(" ~ switch_type_spec ~ ")" ~ "{" ~ switch_body ~ "}" }
 // (51)
 switch_type_spec = {
     integer_type
-    | char_type
-    | boolean_type
-    | scoped_name
-    // (196)
-    | wide_char_type
-    | octet_type
+  | char_type
+  | boolean_type
+  | scoped_name // (196)
+
+  | wide_char_type
+  | octet_type
 }
 // (52)
 switch_body = { case+ }
@@ -434,7 +433,7 @@ case = { case_label+ ~ element_spec ~ ";" }
 // (54)
 case_label = {
     "case" ~ const_expr ~ ":"
-    | "default" ~ ":"
+  | "default" ~ ":"
 }
 // (55)
 element_spec = { type_spec ~ declarator }
@@ -455,50 +454,51 @@ simple_declarator = { identifier }
 // (63)
 typedef_dcl = { "typedef" ~ type_declarator }
 // (64)
-type_declarator = { (template_type_spec | constr_type_dcl | simple_type_spec ) ~ any_declarators }
+type_declarator = { (template_type_spec | constr_type_dcl | simple_type_spec) ~ any_declarators }
 // (65)
 any_declarators = { any_declarator ~ ("," ~ any_declarator)* }
 // (66)
 any_declarator = {
     array_declarator
-    | simple_declarator
+  | simple_declarator
 }
 // (67)
-declarators = { declarator ~ ("," ~ declarator )* }
+declarators = { declarator ~ ("," ~ declarator)* }
 // (68)
-declarator = {/*(217)*/array_declarator | simple_declarator }
+declarator = { /* (217) */ array_declarator | simple_declarator }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block any:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (69) merged to (23)
 // (70)
 any_type = { "any" }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Interfaces – Basic:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (71) merged to (2)
 // (72)
 except_dcl = { "exception" ~ identifier ~ "{" ~ member* ~ "}" }
 // (73)
 interface_dcl = {
     interface_def
-    | interface_forward_dcl
+  | interface_forward_dcl
 }
 // (74)
 interface_def = { interface_header ~ "{" ~ interface_body ~ "}" }
 // (75)
-interface_forward_dcl = { interface_kind ~ identifier ~!(interface_inheritance_spec | "{") }
+interface_forward_dcl = { interface_kind ~ identifier ~ !(interface_inheritance_spec | "{") }
 // (76)
 interface_header = { interface_kind ~ identifier ~ interface_inheritance_spec? }
 // (77)
 interface_kind = {
-    "interface"
-    // (119)
-    | "local" ~ "interface"
-    // (129)
-    | "abstract" ~ "interface" }
+    "interface" // (119)
+
+  | "local" ~ "interface" // (129)
+
+  | "abstract" ~ "interface"
+}
 // (78)
 interface_inheritance_spec = { ":" ~ interface_name ~ ("," ~ interface_name)* }
 // (79)
@@ -508,24 +508,24 @@ interface_body = { export* }
 // (81)
 export = {
     op_dcl ~ ";"
-    | attr_dcl ~ ";"
-    // (97)
-    | type_dcl ~ ";"
-    | const_dcl ~ ";"
-    | except_dcl ~ ";"
-    // (112)
-    | type_id_dcl ~ ";"
-    | type_prefix_dcl ~ ";"
-    | import_dcl ~ ";"
-    | op_oneway_dcl ~ ";"
-    | op_with_context ~ ";"
+  | attr_dcl ~ ";" // (97)
+
+  | type_dcl ~ ";"
+  | const_dcl ~ ";"
+  | except_dcl ~ ";" // (112)
+
+  | type_id_dcl ~ ";"
+  | type_prefix_dcl ~ ";"
+  | import_dcl ~ ";"
+  | op_oneway_dcl ~ ";"
+  | op_with_context ~ ";"
 }
 // (82)
 op_dcl = { op_type_spec ~ identifier ~ "(" ~ parameter_dcls? ~ ")" ~ raises_expr? }
 // (83)
 op_type_spec = {
     "void"
-    | type_spec
+  | type_spec
 }
 // (84)
 parameter_dcls = { param_dcl ~ ("," ~ param_dcl)* }
@@ -534,34 +534,35 @@ param_dcl = { param_attribute ~ type_spec ~ simple_declarator }
 // (86)
 param_attribute = {
     "inout" // Must be first for matching purposes
-    | "in"
-    | "out"
+
+  | "in"
+  | "out"
 }
 // (87)
 raises_expr = { "raises" ~ "(" ~ scoped_name ~ ("," ~ scoped_name)* ~ ")" }
 // (88)
 attr_dcl = {
     readonly_attr_spec
-    | attr_spec
+  | attr_spec
 }
 // (89)
 readonly_attr_spec = { "readonly" ~ "attribute" ~ type_spec ~ readonly_attr_declarator }
 // (90)
 readonly_attr_declarator = {
     simple_declarator ~ raises_expr
-    | simple_declarator ~ ("," ~ simple_declarator)*
+  | simple_declarator ~ ("," ~ simple_declarator)*
 }
 // (91)
 attr_spec = { "attribute" ~ type_spec ~ attr_declarator }
 // (92)
 attr_declarator = {
     simple_declarator ~ attr_raises_expr
-    | simple_declarator ~ ("," ~ simple_declarator)*
+  | simple_declarator ~ ("," ~ simple_declarator)*
 }
 // (93)
 attr_raises_expr = {
     get_excep_expr ~ set_excep_expr?
-    | set_excep_expr
+  | set_excep_expr
 }
 // (94)
 get_excep_expr = { "getraises" ~ exception_list }
@@ -570,22 +571,22 @@ set_excep_expr = { "setraises" ~ exception_list }
 // (96)
 exception_list = { "(" ~ scoped_name ~ ("," ~ scoped_name)* ~ ")" }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Interfaces – Full:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (97) merged to (81)
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Value Types:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (98) merged to (2)
 // (99)
 value_dcl = {
     value_def
-    | value_forward_dcl
-    // (125)
-    | value_box_def
-    | value_abs_def
+  | value_forward_dcl // (125)
+
+  | value_box_def
+  | value_abs_def
 }
 // (100)
 value_def = { value_header ~ "{" ~ value_element* ~ "}" }
@@ -593,26 +594,27 @@ value_def = { value_header ~ "{" ~ value_element* ~ "}" }
 value_header = { value_kind ~ identifier ~ value_inheritance_spec? }
 // (102)
 value_kind = {
-    "valuetype"
-    // (128)
-    | "custom" ~ "valuetype" }
+    "valuetype" // (128)
+
+  | "custom" ~ "valuetype"
+}
 // (103)
 value_inheritance_spec = {
     // (130)
-    ":" ~ "truncatable"? ~ value_name ~ ("," ~ value_name)* ~ ("supports" ~ interface_name ~ ("," ~ interface_name)* )?
-    // (103) Must stay after for matching purposes
-    | (":" ~ value_name)? ~ ("supports" ~ interface_name)?
+    ":" ~ "truncatable"? ~ value_name ~ ("," ~ value_name)* ~ ("supports" ~ interface_name ~ ("," ~ interface_name)*)? // (103) Must stay after for matching purposes
+
+  | (":" ~ value_name)? ~ ("supports" ~ interface_name)?
 }
 // (104)
 value_name = { scoped_name }
 // (105)
 value_element = {
     export
-    | state_member
-    | init_dcl
+  | state_member
+  | init_dcl
 }
 // (106)
-state_member = { ( "public" | "private" ) ~ type_spec ~ declarators ~ ";" }
+state_member = { ("public" | "private") ~ type_spec ~ declarators ~ ";" }
 // (107)
 init_dcl = { "factory" ~ identifier ~ "(" ~ init_param_dcls? ~ ")" ~ raises_expr? ~ ";" }
 // (108)
@@ -622,9 +624,9 @@ init_param_dcl = { "in" ~ type_spec ~ simple_declarator }
 // (110)
 value_forward_dcl = { value_kind ~ identifier }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block CORBA-Specific – Interfaces:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (111) merged to (2)
 // (112) merged to (81)
 // (113)
@@ -650,9 +652,9 @@ op_with_context = { (op_dcl | op_oneway_dcl) ~ context_expr }
 // (124)
 context_expr = { "context" ~ "(" ~ string_literal ~ ("," ~ string_literal)* ~ ")" }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block CORBA-Specific – Value Types:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (125) merged to (99)
 // (126)
 value_box_def = { "valuetype" ~ identifier ~ type_spec }
@@ -665,9 +667,9 @@ value_abs_def = { "abstract" ~ "valuetype" ~ identifier ~ value_inheritance_spec
 // (132)
 value_base_type = { "ValueBase" }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Components – Basic:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (133) merged to (2)
 // (134)
 component_dcl = { component_def | component_forward_dcl }
@@ -676,7 +678,8 @@ component_forward_dcl = { "component" ~ identifier }
 // (136)
 component_def = { component_header ~ "{" ~ component_body ~ "}" }
 // (137)
-component_header = { "component" ~ identifier ~ component_inheritance_spec? ~ /*(154)*/ supported_interface_spec? }
+component_header = { "component" ~ identifier ~ component_inheritance_spec? ~  /* (154) */
+supported_interface_spec? }
 // (138)
 component_inheritance_spec = { ":" ~ scoped_name }
 // (139)
@@ -684,14 +687,14 @@ component_body = { component_export* }
 // (140)
 component_export = {
     provides_dcl ~ ";"
-    | uses_dcl ~ ";"
-    | attr_dcl ~ ";"
-    // (156)
-    | emits_dcl ~ ";"
-    | publishes_dcl ~ ";"
-    | consumes_dcl ~ ";"
-    // (179)
-    | port_dcl ~ ";"
+  | uses_dcl ~ ";"
+  | attr_dcl ~ ";" // (156)
+
+  | emits_dcl ~ ";"
+  | publishes_dcl ~ ";"
+  | consumes_dcl ~ ";" // (179)
+
+  | port_dcl ~ ";"
 }
 // (141)
 provides_dcl = { "provides" ~ interface_type ~ identifier }
@@ -699,19 +702,21 @@ provides_dcl = { "provides" ~ interface_type ~ identifier }
 interface_type = {
     // (157)
     "Object"
-    | scoped_name
+  | scoped_name
 }
 // (143)
-uses_dcl = { "uses" ~ /*(158)*/"multiple"? ~ interface_type ~ identifier }
+uses_dcl = { "uses" ~  /* (158) */
+"multiple"? ~ interface_type ~ identifier }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Components – Homes:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (144) merged to (2)
 // (145)
 home_dcl = { home_header ~ "{" ~ home_body ~ "}" }
 // (146)
-home_header = { "home" ~ identifier ~ home_inheritance_spec? ~ /*(162)*/supported_interface_spec? ~ "manages" ~ scoped_name ~ primary_key_spec? }
+home_header = { "home" ~ identifier ~ home_inheritance_spec? ~  /* (162) */
+supported_interface_spec? ~ "manages" ~ scoped_name ~ primary_key_spec? }
 // (147)
 home_inheritance_spec = { ":" ~ scoped_name }
 // (148)
@@ -719,9 +724,9 @@ home_body = { home_export* }
 // (149)
 home_export = {
     export
-    | factory_dcl ~ ";"
-    // (164)
-    | finder_dcl ~ ";"
+  | factory_dcl ~ ";" // (164)
+
+  | finder_dcl ~ ";"
 }
 // (150)
 factory_dcl = { "factory" ~ identifier ~ "(" ~ factory_param_dcls? ~ ")" ~ raises_expr? }
@@ -730,9 +735,9 @@ factory_param_dcls = { factory_param_dcl ~ ("," ~ factory_param_dcl)* }
 // (152)
 factory_param_dcl = { "in" ~ type_spec ~ simple_declarator }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block CCM-Specific:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (153) merged to (2)
 // (154) merged to (137)
 // (155)
@@ -755,8 +760,8 @@ finder_dcl = { "finder" ~ identifier ~ "(" ~ init_param_dcls* ~ ")" ~ raises_exp
 // (166)
 event_dcl = {
     event_def
-    | event_abs_def
-    | event_forward_dcl
+  | event_abs_def
+  | event_forward_dcl
 }
 // (167)
 event_forward_dcl = { "abstract"? ~ "eventtype" ~ identifier }
@@ -767,9 +772,9 @@ event_def = { event_header ~ "{" ~ value_element* ~ "}" }
 // (170)
 event_header = { "custom"? ~ "eventtype" ~ identifier ~ value_inheritance_spec? }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Components – Ports and Connectors:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (171) merged to (2)
 // (172)
 porttype_dcl = { porttype_def | porttype_forward_dcl }
@@ -782,13 +787,13 @@ port_body = { port_ref ~ port_export* }
 // (176)
 port_ref = {
     provides_dcl ~ ";"
-    | uses_dcl ~ ";"
-    | port_dcl ~ ";"
+  | uses_dcl ~ ";"
+  | port_dcl ~ ";"
 }
 // (177)
 port_export = {
     port_ref
-    | attr_dcl ~ ";"
+  | attr_dcl ~ ";"
 }
 // (178)
 port_dcl = { ("port" | "mirrorport") ~ scoped_name ~ identifier }
@@ -802,12 +807,12 @@ connector_inherit_spec = { ":" ~ scoped_name }
 // (183)
 connector_export = {
     port_ref
-    | attr_dcl ~ ";"
+  | attr_dcl ~ ";"
 }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Template Modules:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (184) merged to (2)
 // (185)
 template_module_dcl = { "module" ~ identifier ~ "<" ~ formal_parameters ~ ">" ~ "{" ~ tpl_definition+ ~ "}" }
@@ -818,21 +823,21 @@ formal_parameter = { formal_parameter_type ~ identifier }
 // (188)
 formal_parameter_type = {
     "typename"
-    | "interface"
-    | "valuetype"
-    | "eventtype"
-    | "struct"
-    | "union"
-    | "exception"
-    | "enum"
-    | "const" ~ const_type
-    | sequence_type
-    | "sequence"
+  | "interface"
+  | "valuetype"
+  | "eventtype"
+  | "struct"
+  | "union"
+  | "exception"
+  | "enum"
+  | "const" ~ const_type
+  | sequence_type
+  | "sequence"
 }
 // (189)
 tpl_definition = {
     definition
-    | template_module_ref ~ ";"
+  | template_module_ref ~ ";"
 }
 // (190)
 template_module_inst = { "module" ~ scoped_name ~ "<" ~ actual_parameters ~ ">" ~ identifier }
@@ -841,16 +846,16 @@ actual_parameters = { actual_parameter ~ ("," ~ actual_parameter)* }
 // (192)
 actual_parameter = {
     type_spec
-    | const_expr
+  | const_expr
 }
 // (193)
 template_module_ref = { "alias" ~ scoped_name ~ "<" ~ formal_parameter_names ~ ">" ~ identifier }
 // (194)
 formal_parameter_names = { identifier ~ ("," ~ identifier)* }
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Extended Data-Types:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (195) merged to (46)
 // (196) merged to (51)
 // (197) merged to (38)
@@ -884,15 +889,15 @@ unsigned_tiny_int = { "uint8" }
 // (214) merged to (32)
 // (215) merged to (33)
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Anonymous Types:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (216) merged to (21)
 // (217) merged to (68)
 
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // From Building Block Annotations:
-///////////////////////////////////////////////////////////////////////////////
+/// /
 // (218) merged to (2)
 // (219)
 annotation_dcl = { annotation_header ~ "{" ~ annotation_body ~ "}" }
@@ -900,15 +905,10 @@ annotation_dcl = { annotation_header ~ "{" ~ annotation_body ~ "}" }
 annotation_header = { "@annotation" ~ identifier }
 // (221)
 annotation_body = {
-    (
-        annotation_member
-        | enum_dcl ~ ";"
-        | const_dcl ~ ";"
-        | typedef_dcl ~ ";"
-    )*
+    (annotation_member | enum_dcl ~ ";" | const_dcl ~ ";" | typedef_dcl ~ ";")*
 }
 // (222)
-annotation_member = { annotation_member_type ~ simple_declarator ~ ( "default" ~ const_expr )? ~ ";" }
+annotation_member = { annotation_member_type ~ simple_declarator ~ ("default" ~ const_expr)? ~ ";" }
 // (223)
 annotation_member_type = { const_type | any_const_type | scoped_name }
 // (224)
@@ -918,7 +918,37 @@ annotation_appl = { "@" ~ scoped_name ~ ("(" ~ annotation_appl_params ~ ")")? }
 // (226)
 annotation_appl_params = {
     const_expr
-    | annotation_appl_param ~ ("," ~ annotation_appl_param)*
+  | annotation_appl_param ~ ("," ~ annotation_appl_param)*
 }
 // (227)
 annotation_appl_param = { identifier ~ "=" ~ const_expr }
+
+// PreProcessor
+// preprocessor_directive = {"#" ~
+// (preprocessor_define
+// | preprocessor_ifdef
+// | preprocessor_ifndef
+// | preprocessor_endif
+// | preprocessor_include
+// | preprocessor_pragma)
+// }
+
+filename = { ("." | "/" | ASCII_ALPHANUMERIC | "-"| "_")+ }
+
+preprocessor_directive = { "#" ~ preprocessor_command }
+
+preprocessor_command = ${
+    preprocessor_define
+  | preprocessor_ifdef
+  | preprocessor_ifndef
+  | preprocessor_endif
+  | preprocessor_include
+  | preprocessor_pragma
+}
+
+preprocessor_define  = { "define" ~ WHITE_SPACE+ ~ identifier ~ (WHITE_SPACE* ~ (!("\n" | "\r") ~ identifier)*)? }
+preprocessor_ifdef   = { "ifdef" ~ WHITE_SPACE+ ~ identifier }
+preprocessor_ifndef  = { "ifndef" ~ WHITESPACE+ ~ identifier }
+preprocessor_endif   = { "endif" }
+preprocessor_include = { "include" ~ WHITE_SPACE+ ~ ("\"" ~ filename ~ "\"") | ("<" ~ filename ~ ">") }
+preprocessor_pragma  = { "pragma" ~ WHITE_SPACE+ ~ (!("\n" | "\r") ~ ANY)+ }

--- a/dds_gen/test_data/fast_dds/AllocTestType.idl
+++ b/dds_gen/test_data/fast_dds/AllocTestType.idl
@@ -1,0 +1,4 @@
+struct AllocTestType
+{
+	unsigned long index;
+};

--- a/dds_gen/test_data/fast_dds/Benchmark.idl
+++ b/dds_gen/test_data/fast_dds/Benchmark.idl
@@ -1,0 +1,5 @@
+@extensibility(APPENDABLE)
+struct BenchMark
+{
+	unsigned long index;
+};

--- a/dds_gen/test_data/fast_dds/Benchmark_big.idl
+++ b/dds_gen/test_data/fast_dds/Benchmark_big.idl
@@ -1,0 +1,5 @@
+struct BenchMarkBig
+{
+	char data[8388608];
+	unsigned long index;
+};

--- a/dds_gen/test_data/fast_dds/Benchmark_medium.idl
+++ b/dds_gen/test_data/fast_dds/Benchmark_medium.idl
@@ -1,0 +1,5 @@
+struct BenchMarkMedium
+{
+	char data[524288];
+	unsigned long index;
+};

--- a/dds_gen/test_data/fast_dds/Benchmark_small.idl
+++ b/dds_gen/test_data/fast_dds/Benchmark_small.idl
@@ -1,0 +1,5 @@
+@extensibility(APPENDABLE)
+struct BenchMark
+{
+	unsigned long index;
+};

--- a/dds_gen/test_data/fast_dds/Calculator.idl
+++ b/dds_gen/test_data/fast_dds/Calculator.idl
@@ -1,0 +1,24 @@
+@extensibility(APPENDABLE)
+enum CalculatorOperationType
+{
+    ADDITION,
+    SUBTRACTION,
+    MULTIPLICATION,
+    DIVISION
+};
+
+@extensibility(APPENDABLE)
+struct CalculatorRequestType
+{
+    @key string client_id;
+    CalculatorOperationType operation;
+    short x;
+    short y;
+};
+
+@extensibility(APPENDABLE)
+struct CalculatorReplyType
+{
+    @key string client_id;
+    long result;
+};

--- a/dds_gen/test_data/fast_dds/ComprehensiveType.idl
+++ b/dds_gen/test_data/fast_dds/ComprehensiveType.idl
@@ -1,0 +1,124 @@
+struct PrimitivesStruct
+{
+    boolean my_bool;
+    octet my_octet;
+    char my_char;
+    wchar my_wchar;
+    long my_long;
+    unsigned long my_ulong;
+    int8 my_int8;
+    uint8 my_uint8;
+    short my_short;
+    unsigned short my_ushort;
+    long long my_longlong;
+    unsigned long long my_ulonglong;
+    float my_float;
+    double my_double;
+    long double my_longdouble;
+};
+
+enum MyEnum
+{
+    A,
+    B,
+    C
+};
+
+@bit_bound(28)
+bitmask MyBitMask
+{
+    @position(0) flag0,
+    flag1,
+    flag2,
+    @position(26) flag26
+};
+
+typedef PrimitivesStruct MyAliasedStruct;
+typedef MyEnum MyAliasedEnum;
+typedef string<100> MyAliasedBoundedString;
+typedef MyAliasedEnum MyRecursiveAlias;
+
+union InnerUnion switch (short)
+{
+    case 0:
+        @id(0x10) PrimitivesStruct first;
+    case 1:
+    default:
+        long long second;
+};
+
+union ComplexUnion switch (short)
+{
+    case 0:
+    case 1:
+        long third;
+    default:
+        InnerUnion fourth;
+};
+
+bitset MyBitSet
+{
+    bitfield<3> a;
+    bitfield<1> b;
+    bitfield<4>;
+    bitfield<10> c;
+    bitfield<12, short> d;
+};
+
+struct AllStruct : PrimitivesStruct
+{
+    // strings
+    string my_string;
+    wstring my_wstring;
+    string<41925> my_bounded_string;
+    wstring<20925> my_bounded_wstring;
+
+    // enum
+    MyEnum my_enum;
+
+    // bitmask
+    MyBitMask my_bitmask;
+
+    // alias
+    MyAliasedStruct my_aliased_struct;
+    MyAliasedEnum my_aliased_enum;
+    MyAliasedBoundedString my_aliased_bounded_string;
+    MyRecursiveAlias my_recursive_alias;
+
+    // sequence
+    sequence<MyBitMask> bitmask_sequence;
+    sequence<MyEnum> enum_sequence;
+    sequence<short, 5> short_sequence;
+
+    // array
+    long long_array[2][3][4];
+
+    // map
+    map<string, string> string_unbounded_map;
+    map<string, MyAliasedBoundedString> string_alias_unbounded_map;
+    map<short, long, 2> short_long_map;
+
+    // union
+    InnerUnion inner_union;
+    ComplexUnion complex_union;
+
+    // bitset
+    MyBitSet my_bitset;
+};
+
+struct ComprehensiveType
+{
+    unsigned long index;
+
+    // inner struct
+    AllStruct inner_struct;
+
+    // complex sequence
+    sequence<AllStruct> complex_sequence;
+
+    // complex array
+    AllStruct complex_array[2];
+
+    // complex map
+    map<short, AllStruct> complex_map;
+};

--- a/dds_gen/test_data/fast_dds/Configuration.idl
+++ b/dds_gen/test_data/fast_dds/Configuration.idl
@@ -1,0 +1,7 @@
+@extensibility(APPENDABLE)
+struct Configuration
+{
+	unsigned long index;
+	char message[20];
+	sequence<octet> data;
+};

--- a/dds_gen/test_data/fast_dds/ContentFilterTestType.idl
+++ b/dds_gen/test_data/fast_dds/ContentFilterTestType.idl
@@ -1,0 +1,115 @@
+enum Color
+{
+    RED,
+    GREEN,
+    BLUE,
+    YELLOW,
+    MAGENTA
+};
+
+enum Material
+{
+    WOOD,
+    PLASTIC,
+    METAL,
+    CONCRETE,
+    STONE
+};
+
+@nested
+struct StructType
+{
+    char               char_field;
+    octet              uint8_field;
+    short              int16_field;
+    unsigned short     uint16_field;
+    long               int32_field;
+    unsigned long      uint32_field;
+    long long          int64_field;
+    unsigned long long uint64_field;
+    float              float_field;
+    double             double_field;
+    long double        long_double_field;
+    boolean            bool_field;
+    string             string_field;
+    Color              enum_field;
+    Material           enum2_field;
+};
+
+const unsigned long max_array_size = 3;
+const unsigned long max_seq_size = 5;
+
+struct ContentFilterTestType
+{
+    // Direct fields
+    char               char_field;
+    octet              uint8_field;
+    short              int16_field;
+    unsigned short     uint16_field;
+    long               int32_field;
+    unsigned long      uint32_field;
+    long long          int64_field;
+    unsigned long long uint64_field;
+    float              float_field;
+    double             double_field;
+    long double        long_double_field;
+    boolean            bool_field;
+    string             string_field;
+    Color              enum_field;
+    Material           enum2_field;
+    StructType         struct_field;
+
+    // Array fields
+    char               array_char_field[max_array_size];
+    octet              array_uint8_field[max_array_size];
+    short              array_int16_field[max_array_size];
+    unsigned short     array_uint16_field[max_array_size];
+    long               array_int32_field[max_array_size];
+    unsigned long      array_uint32_field[max_array_size];
+    long long          array_int64_field[max_array_size];
+    unsigned long long array_uint64_field[max_array_size];
+    float              array_float_field[max_array_size];
+    double             array_double_field[max_array_size];
+    long double        array_long_double_field[max_array_size];
+    boolean            array_bool_field[max_array_size];
+    string             array_string_field[max_array_size];
+    Color              array_enum_field[max_array_size];
+    Material           array_enum2_field[max_array_size];
+    StructType         array_struct_field[max_array_size];
+
+    // Bounded sequence fields
+    sequence<char, max_seq_size>               bounded_sequence_char_field;
+    sequence<octet, max_seq_size>              bounded_sequence_uint8_field;
+    sequence<short, max_seq_size>              bounded_sequence_int16_field;
+    sequence<unsigned short, max_seq_size>     bounded_sequence_uint16_field;
+    sequence<long, max_seq_size>               bounded_sequence_int32_field;
+    sequence<unsigned long, max_seq_size>      bounded_sequence_uint32_field;
+    sequence<long long, max_seq_size>          bounded_sequence_int64_field;
+    sequence<unsigned long long, max_seq_size> bounded_sequence_uint64_field;
+    sequence<float, max_seq_size>              bounded_sequence_float_field;
+    sequence<double, max_seq_size>             bounded_sequence_double_field;
+    sequence<long double, max_seq_size>        bounded_sequence_long_double_field;
+    sequence<boolean, max_seq_size>            bounded_sequence_bool_field;
+    sequence<string, max_seq_size>             bounded_sequence_string_field;
+    sequence<Color, max_seq_size>              bounded_sequence_enum_field;
+    sequence<Material, max_seq_size>           bounded_sequence_enum2_field;
+    sequence<StructType, max_seq_size>         bounded_sequence_struct_field;
+
+    // Unbounded sequence fields
+    sequence<char>               unbounded_sequence_char_field;
+    sequence<octet>              unbounded_sequence_uint8_field;
+    sequence<short>              unbounded_sequence_int16_field;
+    sequence<unsigned short>     unbounded_sequence_uint16_field;
+    sequence<long>               unbounded_sequence_int32_field;
+    sequence<unsigned long>      unbounded_sequence_uint32_field;
+    sequence<long long>          unbounded_sequence_int64_field;
+    sequence<unsigned long long> unbounded_sequence_uint64_field;
+    sequence<float>              unbounded_sequence_float_field;
+    sequence<double>             unbounded_sequence_double_field;
+    sequence<long double>        unbounded_sequence_long_double_field;
+    sequence<boolean>            unbounded_sequence_bool_field;
+    sequence<string>             unbounded_sequence_string_field;
+    sequence<Color>              unbounded_sequence_enum_field;
+    sequence<Material>           unbounded_sequence_enum2_field;
+    sequence<StructType>         unbounded_sequence_struct_field;
+};

--- a/dds_gen/test_data/fast_dds/DDSReturnCode.idl
+++ b/dds_gen/test_data/fast_dds/DDSReturnCode.idl
@@ -1,0 +1,25 @@
+// The content of this file, related to the DDS's return code values, was extracted from the omg idl
+// https://www.omg.org/spec/DDS/20140501/dds_dcps.idl
+
+module DDS {
+
+    typedef long ReturnCode_t;
+
+    // ----------------------------------------------------------------------
+    // Return codes
+    // ----------------------------------------------------------------------
+    const ReturnCode_t RETCODE_OK                    = 0;
+    const ReturnCode_t RETCODE_ERROR                 = 1;
+    const ReturnCode_t RETCODE_UNSUPPORTED           = 2;
+    const ReturnCode_t RETCODE_BAD_PARAMETER         = 3;
+    const ReturnCode_t RETCODE_PRECONDITION_NOT_MET  = 4;
+    const ReturnCode_t RETCODE_OUT_OF_RESOURCES      = 5;
+    const ReturnCode_t RETCODE_NOT_ENABLED           = 6;
+    const ReturnCode_t RETCODE_IMMUTABLE_POLICY      = 7;
+    const ReturnCode_t RETCODE_INCONSISTENT_POLICY   = 8;
+    const ReturnCode_t RETCODE_ALREADY_DELETED       = 9;
+    const ReturnCode_t RETCODE_TIMEOUT               = 10;
+    const ReturnCode_t RETCODE_NO_DATA               = 11;
+    const ReturnCode_t RETCODE_ILLEGAL_OPERATION     = 12;
+
+};

--- a/dds_gen/test_data/fast_dds/Data1mb.idl
+++ b/dds_gen/test_data/fast_dds/Data1mb.idl
@@ -1,0 +1,4 @@
+struct Data1mb
+{
+    sequence<octet, 1024000> data;
+};

--- a/dds_gen/test_data/fast_dds/Data64kb.idl
+++ b/dds_gen/test_data/fast_dds/Data64kb.idl
@@ -1,0 +1,4 @@
+struct Data64kb
+{
+    sequence<octet, 63996> data;
+};

--- a/dds_gen/test_data/fast_dds/DeliveryMechanism.idl
+++ b/dds_gen/test_data/fast_dds/DeliveryMechanism.idl
@@ -1,0 +1,6 @@
+@extensibility(FINAL)
+struct DeliveryMechanisms
+{
+	unsigned long index;
+	char message[32];
+};

--- a/dds_gen/test_data/fast_dds/FixedSized.idl
+++ b/dds_gen/test_data/fast_dds/FixedSized.idl
@@ -1,0 +1,5 @@
+@final
+struct FixedSized
+{
+	unsigned short index;
+};

--- a/dds_gen/test_data/fast_dds/FlowControl.idl
+++ b/dds_gen/test_data/fast_dds/FlowControl.idl
@@ -1,0 +1,6 @@
+@extensibility(APPENDABLE)
+struct FlowControl
+{
+   unsigned long index;
+   char message[600000];
+};

--- a/dds_gen/test_data/fast_dds/HelloWorld.idl
+++ b/dds_gen/test_data/fast_dds/HelloWorld.idl
@@ -1,0 +1,6 @@
+@extensibility(APPENDABLE)
+struct HelloWorld
+{
+	unsigned long index;
+	string message;
+};

--- a/dds_gen/test_data/fast_dds/KeyedData1mb.idl
+++ b/dds_gen/test_data/fast_dds/KeyedData1mb.idl
@@ -1,0 +1,6 @@
+struct KeyedData1mb
+{
+    @Key
+    unsigned short key;
+    sequence<octet, 1023996> data;
+};

--- a/dds_gen/test_data/fast_dds/KeyedHelloWorld.idl
+++ b/dds_gen/test_data/fast_dds/KeyedHelloWorld.idl
@@ -1,0 +1,7 @@
+struct KeyedHelloWorld
+{
+    @Key
+    unsigned short key;
+	unsigned short index;
+	string<128> message;
+};

--- a/dds_gen/test_data/fast_dds/ShapeType.idl
+++ b/dds_gen/test_data/fast_dds/ShapeType.idl
@@ -1,0 +1,8 @@
+@extensibility(APPENDABLE)
+struct ShapeType
+{
+	@Key string color;
+	long x;
+	long y;
+	long shapesize;
+};

--- a/dds_gen/test_data/fast_dds/StringTest.idl
+++ b/dds_gen/test_data/fast_dds/StringTest.idl
@@ -1,0 +1,4 @@
+struct StringTest
+{
+    string<10000> message;
+};

--- a/dds_gen/test_data/fast_dds/TestIncludeRegression3361.idl
+++ b/dds_gen/test_data/fast_dds/TestIncludeRegression3361.idl
@@ -1,0 +1,10 @@
+#ifndef TESTINCLUDE_REGRESSION_3361
+#define TESTINCLUDE_REGRESSION_3361
+
+module TestModule {
+
+typedef string MACHINEID;
+
+};
+
+#endif // TESTINCLUDE_REGRESSION_3361

--- a/dds_gen/test_data/fast_dds/TestRegression3361.idl
+++ b/dds_gen/test_data/fast_dds/TestRegression3361.idl
@@ -1,0 +1,10 @@
+#ifndef TEST_REGRESSION_3361
+#define TEST_REGRESSION_3361
+
+#include "TestIncludeRegression3361.idl"
+
+struct TestRegression3361 {
+	TestModule::MACHINEID uuid;
+};
+
+#endif // TEST_REGRESSION_3361

--- a/dds_gen/test_data/fast_dds/TypeLookupTypes.idl
+++ b/dds_gen/test_data/fast_dds/TypeLookupTypes.idl
@@ -1,0 +1,84 @@
+/* TypeLookupTypes.idl */
+
+#include "../../../../../../include/fastdds/dds/core/detail/DDSReturnCode.idl"
+#include "../../../../../../include/fastdds/dds/xtypes/type_representation/detail/dds-xtypes_typeobject.idl"
+#include "rpc_types.idl"
+
+module dds {
+module builtin {
+
+    // computed from @hashid("getTypes")
+    const unsigned long TypeLookup_getTypes_HashId = 0x018252d3;
+
+    // computed from @hashid("getDependencies");
+    const unsigned long TypeLookup_getDependencies_HashId = 0x05aafb31;
+
+    // Query the TypeObjects associated with one or more TypeIdentifiers
+    @extensibility(MUTABLE)
+    struct TypeLookup_getTypes_In {
+        @hashid sequence<DDS::XTypes::TypeIdentifier> type_ids;
+    };
+
+    @extensibility(MUTABLE)
+    struct TypeLookup_getTypes_Out {
+        @hashid sequence<DDS::XTypes::TypeIdentifierTypeObjectPair> types;
+        @hashid sequence<DDS::XTypes::TypeIdentifierPair> complete_to_minimal;
+    };
+
+    union TypeLookup_getTypes_Result switch(long) {
+        //TODO case DDS::RETCODE_OK:
+        case eprosima::fastdds::dds::RETCODE_OK:
+            TypeLookup_getTypes_Out result;
+    };
+
+    // Query TypeIdentifiers that the specified types depend on
+    @extensibility(MUTABLE)
+    struct TypeLookup_getTypeDependencies_In {
+        @hashid sequence<DDS::XTypes::TypeIdentifier> type_ids;
+        @hashid sequence<octet, 32> continuation_point;
+    };
+
+    @extensibility(MUTABLE)
+    struct TypeLookup_getTypeDependencies_Out {
+        @hashid sequence<DDS::XTypes::TypeIdentfierWithSize> dependent_typeids;
+        @hashid sequence<octet, 32> continuation_point;
+    };
+
+    union TypeLookup_getTypeDependencies_Result switch(long){
+        //TODO case DDS::RETCODE_OK:
+        case eprosima::fastdds::dds::RETCODE_OK:
+            TypeLookup_getTypeDependencies_Out result;
+    };
+
+    // Service Request
+    union TypeLookup_Call switch(long) {
+        case TypeLookup_getTypes_HashId:
+            TypeLookup_getTypes_In getTypes;
+        case TypeLookup_getDependencies_HashId:
+            TypeLookup_getTypeDependencies_In getTypeDependencies;
+    };
+
+    // @RPCRequestType // Annotation not defined
+    @final
+    struct TypeLookup_Request {
+        rpc::RequestHeader header;
+        TypeLookup_Call data;
+    };
+
+    // Service Reply
+    union TypeLookup_Return switch(long) {
+        case TypeLookup_getTypes_HashId:
+            TypeLookup_getTypes_Result getType;
+        case TypeLookup_getDependencies_HashId:
+            TypeLookup_getTypeDependencies_Result getTypeDependencies;
+    };
+
+    // @RPCReplyType // Annotation not defined
+    @final
+    struct TypeLookup_Reply {
+        rpc::ReplyHeader header;
+        TypeLookup_Return return_value; //This name was changed from "return" to "return_value" to avoid problems in c++
+    };
+
+}; // builtin
+}; // dds

--- a/dds_gen/test_data/fast_dds/UnboundedHelloWorld.idl
+++ b/dds_gen/test_data/fast_dds/UnboundedHelloWorld.idl
@@ -1,0 +1,5 @@
+struct UnboundedHelloWorld
+{
+	unsigned short index;
+	string message;
+};

--- a/dds_gen/test_data/fast_dds/XtypesTestsType1.idl
+++ b/dds_gen/test_data/fast_dds/XtypesTestsType1.idl
@@ -1,0 +1,22 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file test/dds/xtypes/BaseCasesIDLs/XtypesTestsType1.idl
+ */
+
+struct Type1
+{
+	string content;
+};

--- a/dds_gen/test_data/fast_dds/XtypesTestsType2.idl
+++ b/dds_gen/test_data/fast_dds/XtypesTestsType2.idl
@@ -1,0 +1,22 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file test/dds/xtypes/BaseCasesIDLs/XtypesTestsType2.idl
+ */
+ 
+struct Type2
+{
+	string content;
+};

--- a/dds_gen/test_data/fast_dds/XtypesTestsType3.idl
+++ b/dds_gen/test_data/fast_dds/XtypesTestsType3.idl
@@ -1,0 +1,22 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file test/dds/xtypes/BaseCasesIDLs/XtypesTestsType3.idl
+ */
+ 
+struct Type3
+{
+	string content;
+};

--- a/dds_gen/test_data/fast_dds/XtypesTestsTypeBig.idl
+++ b/dds_gen/test_data/fast_dds/XtypesTestsTypeBig.idl
@@ -1,0 +1,516 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeBig.idl
+ */
+ 
+#include "XtypesTestsType1.idl"
+#include "XtypesTestsType2.idl"
+#include "XtypesTestsType3.idl"
+
+struct Type4	
+{	
+	string content;
+};	
+struct Type5	
+{	
+	string content;
+};	
+struct Type6	
+{	
+	string content;
+};	
+struct Type7	
+{	
+	string content;
+};	
+struct Type8	
+{	
+	string content;
+};	
+struct Type9	
+{	
+	string content;
+};	
+struct Type10	
+{	
+	string content;
+};	
+struct Type11	
+{	
+	string content;
+};	
+struct Type12	
+{	
+	string content;
+};	
+struct Type13	
+{	
+	string content;
+};	
+struct Type14	
+{	
+	string content;
+};	
+struct Type15	
+{	
+	string content;
+};	
+struct Type16	
+{	
+	string content;
+};	
+struct Type17	
+{	
+	string content;
+};	
+struct Type18	
+{	
+	string content;
+};	
+struct Type19	
+{	
+	string content;
+};	
+struct Type20	
+{	
+	string content;
+};	
+struct Type21	
+{	
+	string content;
+};	
+struct Type22	
+{	
+	string content;
+};	
+struct Type23	
+{	
+	string content;
+};	
+struct Type24	
+{	
+	string content;
+};	
+struct Type25	
+{	
+	string content;
+};	
+struct Type26	
+{	
+	string content;
+};	
+struct Type27	
+{	
+	string content;
+};	
+struct Type28	
+{	
+	string content;
+};	
+struct Type29	
+{	
+	string content;
+};	
+struct Type30	
+{	
+	string content;
+};	
+struct Type31	
+{	
+	string content;
+};	
+struct Type32	
+{	
+	string content;
+};	
+struct Type33	
+{	
+	string content;
+};	
+struct Type34	
+{	
+	string content;
+};	
+struct Type35	
+{	
+	string content;
+};	
+struct Type36	
+{	
+	string content;
+};	
+struct Type37	
+{	
+	string content;
+};	
+struct Type38	
+{	
+	string content;
+};	
+struct Type39	
+{	
+	string content;
+};	
+struct Type40	
+{	
+	string content;
+};	
+struct Type41	
+{	
+	string content;
+};	
+struct Type42	
+{	
+	string content;
+};	
+struct Type43	
+{	
+	string content;
+};	
+struct Type44	
+{	
+	string content;
+};	
+struct Type45	
+{	
+	string content;
+};	
+struct Type46	
+{	
+	string content;
+};	
+struct Type47	
+{	
+	string content;
+};	
+struct Type48	
+{	
+	string content;
+};	
+struct Type49	
+{	
+	string content;
+};	
+struct Type50	
+{	
+	string content;
+};	
+struct Type51	
+{	
+	string content;
+};	
+struct Type52	
+{	
+	string content;
+};	
+struct Type53	
+{	
+	string content;
+};	
+struct Type54	
+{	
+	string content;
+};	
+struct Type55	
+{	
+	string content;
+};	
+struct Type56	
+{	
+	string content;
+};	
+struct Type57	
+{	
+	string content;
+};	
+struct Type58	
+{	
+	string content;
+};	
+struct Type59	
+{	
+	string content;
+};	
+struct Type60	
+{	
+	string content;
+};	
+struct Type61	
+{	
+	string content;
+};	
+struct Type62	
+{	
+	string content;
+};	
+struct Type63	
+{	
+	string content;
+};	
+struct Type64	
+{	
+	string content;
+};	
+struct Type65	
+{	
+	string content;
+};	
+struct Type66	
+{	
+	string content;
+};	
+struct Type67	
+{	
+	string content;
+};	
+struct Type68	
+{	
+	string content;
+};	
+struct Type69	
+{	
+	string content;
+};	
+struct Type70	
+{	
+	string content;
+};	
+struct Type71	
+{	
+	string content;
+};	
+struct Type72	
+{	
+	string content;
+};	
+struct Type73	
+{	
+	string content;
+};	
+struct Type74	
+{	
+	string content;
+};	
+struct Type75	
+{	
+	string content;
+};	
+struct Type76	
+{	
+	string content;
+};	
+struct Type77	
+{	
+	string content;
+};	
+struct Type78	
+{	
+	string content;
+};	
+struct Type79	
+{	
+	string content;
+};	
+struct Type80	
+{	
+	string content;
+};	
+struct Type81	
+{	
+	string content;
+};	
+struct Type82	
+{	
+	string content;
+};	
+struct Type83	
+{	
+	string content;
+};	
+struct Type84	
+{	
+	string content;
+};	
+struct Type85	
+{	
+	string content;
+};	
+struct Type86	
+{	
+	string content;
+};	
+struct Type87	
+{	
+	string content;
+};	
+struct Type88	
+{	
+	string content;
+};	
+struct Type89	
+{	
+	string content;
+};	
+struct Type90	
+{	
+	string content;
+};	
+struct Type91	
+{	
+	string content;
+};	
+struct Type92	
+{	
+	string content;
+};	
+struct Type93	
+{	
+	string content;
+};	
+struct Type94	
+{	
+	string content;
+};	
+struct Type95	
+{	
+	string content;
+};	
+struct Type96	
+{	
+	string content;
+};	
+struct Type97	
+{	
+	string content;
+};	
+struct Type98	
+{	
+	string content;
+};	
+struct Type99	
+{	
+	string content;
+};	
+struct Type100	
+{	
+	string content;
+};	
+
+
+struct TypeBig			
+{			
+	string content;
+	Type1 dep1;
+	Type2 dep2;
+	Type3 dep3;
+	Type4 dep4;
+	Type5 dep5;
+	Type6 dep6;
+	Type7 dep7;
+	Type8 dep8;
+	Type9 dep9;
+	Type10 dep10;
+	Type11 dep11;
+	Type12 dep12;
+	Type13 dep13;
+	Type14 dep14;
+	Type15 dep15;
+	Type16 dep16;
+	Type17 dep17;
+	Type18 dep18;
+	Type19 dep19;
+	Type20 dep20;
+	Type21 dep21;
+	Type22 dep22;
+	Type23 dep23;
+	Type24 dep24;
+	Type25 dep25;
+	Type26 dep26;
+	Type27 dep27;
+	Type28 dep28;
+	Type29 dep29;
+	Type30 dep30;
+	Type31 dep31;
+	Type32 dep32;
+	Type33 dep33;
+	Type34 dep34;
+	Type35 dep35;
+	Type36 dep36;
+	Type37 dep37;
+	Type38 dep38;
+	Type39 dep39;
+	Type40 dep40;
+	Type41 dep41;
+	Type42 dep42;
+	Type43 dep43;
+	Type44 dep44;
+	Type45 dep45;
+	Type46 dep46;
+	Type47 dep47;
+	Type48 dep48;
+	Type49 dep49;
+	Type50 dep50;
+	Type51 dep51;
+	Type52 dep52;
+	Type53 dep53;
+	Type54 dep54;
+	Type55 dep55;
+	Type56 dep56;
+	Type57 dep57;
+	Type58 dep58;
+	Type59 dep59;
+	Type60 dep60;
+	Type61 dep61;
+	Type62 dep62;
+	Type63 dep63;
+	Type64 dep64;
+	Type65 dep65;
+	Type66 dep66;
+	Type67 dep67;
+	Type68 dep68;
+	Type69 dep69;
+	Type70 dep70;
+	Type71 dep71;
+	Type72 dep72;
+	Type73 dep73;
+	Type74 dep74;
+	Type75 dep75;
+	Type76 dep76;
+	Type77 dep77;
+	Type78 dep78;
+	Type79 dep79;
+	Type80 dep80;
+	Type81 dep81;
+	Type82 dep82;
+	Type83 dep83;
+	Type84 dep84;
+	Type85 dep85;
+	Type86 dep86;
+	Type87 dep87;
+	Type88 dep88;
+	Type89 dep89;
+	Type90 dep90;
+	Type91 dep91;
+	Type92 dep92;
+	Type93 dep93;
+	Type94 dep94;
+	Type95 dep95;
+	Type96 dep96;
+	Type97 dep97;
+	Type98 dep98;
+	Type99 dep99;
+	Type100 dep100;
+};

--- a/dds_gen/test_data/fast_dds/XtypesTestsTypeDep.idl
+++ b/dds_gen/test_data/fast_dds/XtypesTestsTypeDep.idl
@@ -1,0 +1,29 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeDep.idl
+ */
+ 
+#include "XtypesTestsType1.idl"
+#include "XtypesTestsType2.idl"
+#include "XtypesTestsType3.idl"
+
+struct TypeDep
+{
+	string content;
+	Type1 var_type1;
+	Type2 var_type2;
+	Type3 var_type3;
+};

--- a/dds_gen/test_data/fast_dds/XtypesTestsTypeNoTypeObject.idl
+++ b/dds_gen/test_data/fast_dds/XtypesTestsTypeNoTypeObject.idl
@@ -1,0 +1,22 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file test/dds/xtypes/BaseCasesIDLs/XtypesTestsTypeNoTypeObject.idl
+ */
+ 
+struct TypeNoTypeObject
+{
+	string content;
+};

--- a/dds_gen/test_data/fast_dds/alias_struct.idl
+++ b/dds_gen/test_data/fast_dds/alias_struct.idl
@@ -1,0 +1,17 @@
+typedef unsigned long MyLong;
+
+typedef short MyShort;
+
+typedef MyShort MyRecursiveShort;
+
+typedef boolean MyBoolean;
+
+typedef MyBoolean MyRecursiveBoolean;
+
+struct AliasStruct
+{
+    MyLong my_long;
+    MyRecursiveShort my_recursive_short;
+    MyRecursiveBoolean my_recursive_boolean;
+    MyBoolean my_boolean;
+};

--- a/dds_gen/test_data/fast_dds/array_struct.idl
+++ b/dds_gen/test_data/fast_dds/array_struct.idl
@@ -1,0 +1,19 @@
+struct NestedArrayElement
+{
+    string my_string;
+};
+
+struct ComplexArrayElement
+{
+    long my_number;
+    boolean my_boolean;
+    NestedArrayElement my_nested_element;
+};
+
+struct ArrayStruct
+{
+    long my_basic_array[10];
+    long my_multidimensional_array[10][10][10];
+    ComplexArrayElement my_complex_array[10];
+    ComplexArrayElement my_multidimensional_complex_array[10][10];
+};

--- a/dds_gen/test_data/fast_dds/bitmask_struct.idl
+++ b/dds_gen/test_data/fast_dds/bitmask_struct.idl
@@ -1,0 +1,13 @@
+@bit_bound(8)
+bitmask ColorBitmask
+{
+    red,
+    @position(2) green,
+    blue,
+    @position(5) yellow
+};
+
+struct BitmaskStruct
+{
+    ColorBitmask my_bitmask;
+};

--- a/dds_gen/test_data/fast_dds/bitset_struct.idl
+++ b/dds_gen/test_data/fast_dds/bitset_struct.idl
@@ -1,0 +1,13 @@
+bitset ColorBitset
+{
+    bitfield<3> red;
+    bitfield<1> green;
+    bitfield<4>;
+    bitfield<10> blue;
+    bitfield<12, short> yellow;
+};
+
+struct BitsetStruct
+{
+    ColorBitset my_bitset;
+};

--- a/dds_gen/test_data/fast_dds/core_types.idl
+++ b/dds_gen/test_data/fast_dds/core_types.idl
@@ -1,0 +1,220 @@
+// Copyright 2024 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file test/blackbox/types/core/core_types.idl
+ */
+
+module eprosima {
+module fastdds {
+module rtps {
+module core {
+
+module detail {
+
+    struct EntityId_t
+    {
+        octet value[4];
+    };
+
+    struct ProtocolVersion_t
+    {
+        octet major;
+        octet minor;
+    };
+
+    struct VendorId_t
+    {
+        octet vendorId[2];
+    };
+
+    struct GuidPrefix_t
+    {
+        octet value[12];
+    };
+
+    struct GUID_t
+    {
+        GuidPrefix_t guidPrefix;
+        EntityId_t entityId;
+    };
+
+    struct SequenceNumber_t
+    {
+        long high;
+        unsigned long low;
+    };
+
+    struct Count_t
+    {
+        long value;
+    };
+
+    struct Time_t
+    {
+        unsigned long seconds;
+        unsigned long fraction;
+    };
+
+    typedef Time_t Timestamp;
+
+    struct SequenceNumberSet
+    {
+      SequenceNumber_t bitmapBase;
+      unsigned long numBits;
+      octet bitmap[8];
+    };
+
+    struct Locator_t
+    {
+        long kind;
+        unsigned long port;
+        octet address[16];
+    };
+
+    struct Duration_t
+    {
+      long seconds;
+      unsigned long fraction;
+    };
+
+    typedef unsigned long DomainId_t;
+    typedef unsigned long BuiltinEndpointQos_t;
+
+    struct StatusInfo_t
+    {
+        octet value[4];
+    };
+
+    struct KeyHash_t
+    {
+        octet value[16];
+    };
+
+    struct EntityName_t
+    {
+        string name;
+    };
+
+}; // namespace detail
+
+//-------- RTPS 9.4.4 ------------
+struct Header
+{
+    octet prefix[4];
+    detail::ProtocolVersion_t version;
+    detail::VendorId_t vendorId;
+    detail::GuidPrefix_t guidPrefix;
+};
+
+//-------- RTPS 9.4.5.1 ----------
+struct SubmessageHeader
+{
+    octet submessageId;
+    octet flags;
+    unsigned short submessageLength; /* octetsToNextHeader */
+};
+
+//-------- RTPS 9.4.5.1.1 --------
+module SubmessageKind
+{
+    const char RTPS_HE = 0x00;
+    const char PAD = 0x01;
+    const char ACKNACK = 0x06;
+    const char HEARTBEAT = 0x07;
+    const char GAP = 0x08;
+    const char INFO_TS = 0x09;
+    const char INFO_SRC = 0x0c;
+    const char INFO_REPLY_IP4 = 0x0d;
+    const char INFO_DST = 0x0e;
+    const char INFO_REPLY = 0x0f;
+    const char NACK_FRAG = 0x12;
+    const char HEARTBEAT_FRAG = 0x13;
+    const char DATA = 0x15;
+    const char DATA_FRAG = 0x16;
+};
+
+//-------- RTPS 9.4.5.3 --------
+struct AckNackSubmessage
+{
+    SubmessageHeader submsgHeader;
+    detail::EntityId_t readerId;
+    detail::EntityId_t writerId;
+    detail::SequenceNumberSet readerSNState;
+    detail::Count_t count;
+};
+
+//-------- RTPS 9.4.5.7 --------
+struct HeartBeatSubmessage
+{
+    SubmessageHeader submsgHeader;
+    detail::EntityId_t readerId;
+    detail::EntityId_t writerId;
+    detail::SequenceNumber_t firstSN;
+    detail::SequenceNumber_t lastSN;
+    detail::Count_t count;
+};
+
+//-------- RTPS 9.4.5.9 --------
+struct InfoDestinationSubmessage
+{
+    SubmessageHeader submsgHeader;
+    detail::GuidPrefix_t guidPrefix;
+};
+
+//-------- RTPS 9.4.5.11 -------
+struct InfoSourceSubmessage
+{
+    SubmessageHeader submsgHeader;
+    long unused;
+    detail::ProtocolVersion_t version;
+    detail::VendorId_t vendorId;
+    detail::GuidPrefix_t guidPrefix;
+};
+
+//-------- RTPS 9.4.5.12 -------
+struct InfoTimestampSubmessage
+{
+    SubmessageHeader submsgHeader;
+    detail::Timestamp timestamp;
+};
+
+union Submessage switch (char)
+{
+    case SubmessageKind::HEARTBEAT:
+        HeartBeatSubmessage heartbeat_submsg;
+
+    case SubmessageKind::INFO_TS:
+        InfoTimestampSubmessage info_ts_submsg;
+
+    case SubmessageKind::INFO_SRC:
+        InfoSourceSubmessage info_src_submsg;
+
+    case SubmessageKind::INFO_DST:
+        InfoDestinationSubmessage info_dst_submsg;
+
+    default:
+        SubmessageHeader unknown_submsg;
+};
+
+struct RTPSMessage
+{
+    Header msg_header; /* header is illegal */
+    sequence<Submessage> submessages;
+};
+
+}; // namespace core
+}; // namespace rtps
+}; // namespace fastdds
+}; // namespace eprosima

--- a/dds_gen/test_data/fast_dds/dds-xtypes_typeobject.idl
+++ b/dds_gen/test_data/fast_dds/dds-xtypes_typeobject.idl
@@ -1,0 +1,1077 @@
+/* dds-xtypes_typeobject.idl */
+
+// The types in this file shall be serialized with XCDR encoding version 2
+module DDS { module XTypes {
+
+    // ---------- Equivalence Kinds -------------------
+    typedef octet EquivalenceKind;
+    const octet EK_MINIMAL   = 0xF1; // 0x1111 0001
+    const octet EK_COMPLETE  = 0xF2; // 0x1111 0010
+    const octet EK_BOTH      = 0xF3; // 0x1111 0011
+
+    // ---------- TypeKinds (begin) -------------------
+    typedef octet TypeKind;
+
+    // Primitive TKs
+    const octet TK_NONE       = 0x00;
+    const octet TK_BOOLEAN    = 0x01;
+    const octet TK_BYTE       = 0x02;
+    const octet TK_INT16      = 0x03;
+    const octet TK_INT32      = 0x04;
+    const octet TK_INT64      = 0x05;
+    const octet TK_UINT16     = 0x06;
+    const octet TK_UINT32     = 0x07;
+    const octet TK_UINT64     = 0x08;
+    const octet TK_FLOAT32    = 0x09;
+    const octet TK_FLOAT64    = 0x0A;
+    const octet TK_FLOAT128   = 0x0B;
+    const octet TK_INT8       = 0x0C;
+    const octet TK_UINT8      = 0x0D;
+    const octet TK_CHAR8      = 0x10;
+    const octet TK_CHAR16     = 0x11;
+
+    // String TKs
+    const octet TK_STRING8    = 0x20;
+    const octet TK_STRING16   = 0x21;
+
+    // Constructed/Named types
+    const octet TK_ALIAS      = 0x30;
+
+    // Enumerated TKs
+    const octet TK_ENUM       = 0x40;
+    const octet TK_BITMASK    = 0x41;
+
+    // Structured TKs
+    const octet TK_ANNOTATION = 0x50;
+    const octet TK_STRUCTURE  = 0x51;
+    const octet TK_UNION      = 0x52;
+    const octet TK_BITSET     = 0x53;
+
+    // Collection TKs
+    const octet TK_SEQUENCE   = 0x60;
+    const octet TK_ARRAY      = 0x61;
+    const octet TK_MAP        = 0x62;
+    // ---------- TypeKinds (end) -------------------
+
+    // ---------- Extra TypeIdentifiers (begin) ------------
+    typedef octet TypeIdentiferKind;
+    const octet TI_STRING8_SMALL        = 0x70;
+    const octet TI_STRING8_LARGE        = 0x71;
+    const octet TI_STRING16_SMALL       = 0x72;
+    const octet TI_STRING16_LARGE       = 0x73;
+
+    const octet TI_PLAIN_SEQUENCE_SMALL = 0x80;
+    const octet TI_PLAIN_SEQUENCE_LARGE = 0x81;
+
+    const octet TI_PLAIN_ARRAY_SMALL    = 0x90;
+    const octet TI_PLAIN_ARRAY_LARGE    = 0x91;
+
+    const octet TI_PLAIN_MAP_SMALL      = 0xA0;
+    const octet TI_PLAIN_MAP_LARGE      = 0xA1;
+
+    const octet TI_STRONGLY_CONNECTED_COMPONENT = 0xB0;
+    // ---------- Extra TypeIdentifiers (end) --------------
+
+    // The name of some element (e.g. type, type member, module)
+    // Valid characters are alphanumeric plus the "_" cannot start with digit
+    const long MEMBER_NAME_MAX_LENGTH = 256;
+    typedef string<MEMBER_NAME_MAX_LENGTH> MemberName;
+
+    // Qualified type name includes the name of containing modules
+    // using "::" as separator. No leading "::". E.g. "MyModule::MyType"
+    const long TYPE_NAME_MAX_LENGTH = 256;
+    typedef string<TYPE_NAME_MAX_LENGTH> QualifiedTypeName;
+
+    // Every type has an ID. Those of the primitive types are pre-defined.
+    typedef octet PrimitiveTypeId;
+
+    // First 14 bytes of MD5 of the serialized TypeObject using XCDR
+    // version 2 with Little Endian encoding
+    typedef octet EquivalenceHash[14];
+
+    // First 4 bytes of MD5 of of a member name converted to bytes
+    // using UTF-8 encoding and without a 'nul' terminator.
+    // Example: the member name "color" has NameHash {0x70, 0xDD, 0xA5, 0xDF}
+    typedef octet NameHash[4];
+
+    // Long Bound of a collection type
+    typedef unsigned long LBound;
+    typedef sequence<LBound> LBoundSeq;
+    const LBound INVALID_LBOUND = 0;
+
+    // Short Bound of a collection type
+    typedef octet SBound;
+    typedef sequence<SBound> SBoundSeq;
+    const SBound INVALID_SBOUND = 0;
+
+    @extensibility(FINAL) @nested
+    union TypeObjectHashId switch (octet) {
+        case EK_COMPLETE:
+        case EK_MINIMAL:
+            EquivalenceHash  hash;
+    };
+
+    // Flags that apply to struct/union/collection/enum/bitmask/bitset
+    // members/elements and DO affect type assignability
+    // Depending on the flag it may not apply to members of all types
+    // When not all, the applicable member types are listed
+    @bit_bound(16)
+    bitmask MemberFlag {
+        @position(0)  TRY_CONSTRUCT1,     // T1 | 00 = INVALID, 01 = DISCARD
+        @position(1)  TRY_CONSTRUCT2,     // T2 | 10 = USE_DEFAULT, 11 = TRIM
+        @position(2)  IS_EXTERNAL,        // X  StructMember, UnionMember,
+	                                  //    CollectionElement
+        @position(3)  IS_OPTIONAL,        // O  StructMember
+        @position(4)  IS_MUST_UNDERSTAND, // M  StructMember
+        @position(5)  IS_KEY,          // K  StructMember, UnionDiscriminator
+        @position(6)  IS_DEFAULT       // D  UnionMember, EnumerationLiteral
+    };
+    typedef MemberFlag   CollectionElementFlag;   // T1, T2, X
+    typedef MemberFlag   StructMemberFlag;        // T1, T2, O, M, K, X
+    typedef MemberFlag   UnionMemberFlag;         // T1, T2, D, X
+    typedef MemberFlag   UnionDiscriminatorFlag;  // T1, T2, K
+    typedef MemberFlag   EnumeratedLiteralFlag;   // D
+    typedef MemberFlag   AnnotationParameterFlag; // Unused. No flags apply
+    typedef MemberFlag   AliasMemberFlag;         // Unused. No flags apply
+    typedef MemberFlag   BitflagFlag;             // Unused. No flags apply
+    typedef MemberFlag   BitsetMemberFlag;        // Unused. No flags apply
+
+    // Mask used to remove the flags that do no affect assignability
+    // Selects  T1, T2, O, M, K, D
+    const   unsigned short  MemberFlagMinimalMask = 0x003f;
+
+    // Flags that apply to type declarationa and DO affect assignability
+    // Depending on the flag it may not apply to all types
+    // When not all, the applicable  types are listed
+    @bit_bound(16)
+    bitmask TypeFlag {
+        @position(0) IS_FINAL,        // F |
+        @position(1) IS_APPENDABLE,   // A |-  Struct, Union
+        @position(2) IS_MUTABLE,      // M |   (exactly one flag)
+
+        @position(3) IS_NESTED,       // N     Struct, Union
+        @position(4) IS_AUTOID_HASH   // H     Struct
+    };
+    typedef TypeFlag   StructTypeFlag;      // All flags apply
+    typedef TypeFlag   UnionTypeFlag;       // All flags apply
+    typedef TypeFlag   CollectionTypeFlag;  // Unused. No flags apply
+    typedef TypeFlag   AnnotationTypeFlag;  // Unused. No flags apply
+    typedef TypeFlag   AliasTypeFlag;       // Unused. No flags apply
+    typedef TypeFlag   EnumTypeFlag;        // Unused. No flags apply
+    typedef TypeFlag   BitmaskTypeFlag;     // Unused. No flags apply
+    typedef TypeFlag   BitsetTypeFlag;      // Unused. No flags apply
+
+    // Mask used to remove the flags that do no affect assignability
+    const   unsigned short TypeFlagMinimalMask = 0x0007; // Selects  M, A, F
+
+   // Forward declaration
+   union TypeIdentifier;
+
+    // 1 Byte
+    @extensibility(FINAL) @nested
+    struct StringSTypeDefn {
+    	SBound                  bound;
+    };
+
+    // 4 Bytes
+    @extensibility(FINAL) @nested
+    struct StringLTypeDefn {
+        LBound                  bound;
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainCollectionHeader {
+        EquivalenceKind        equiv_kind;
+        CollectionElementFlag  element_flags;
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainSequenceSElemDefn {
+        PlainCollectionHeader  header;
+        SBound                 bound;
+        @external TypeIdentifier element_identifier;
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainSequenceLElemDefn {
+        PlainCollectionHeader  header;
+        LBound                 bound;
+        @external TypeIdentifier element_identifier;
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainArraySElemDefn {
+        PlainCollectionHeader  header;
+        SBoundSeq              array_bound_seq;
+        @external TypeIdentifier element_identifier;
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainArrayLElemDefn {
+        PlainCollectionHeader  header;
+        LBoundSeq              array_bound_seq;
+        @external TypeIdentifier element_identifier;
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainMapSTypeDefn {
+        PlainCollectionHeader  header;
+        SBound                 bound;
+        @external TypeIdentifier element_identifier;
+        CollectionElementFlag  key_flags;
+        @external TypeIdentifier key_identifier;
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainMapLTypeDefn {
+        PlainCollectionHeader  header;
+        LBound                 bound;
+        @external TypeIdentifier element_identifier;
+        CollectionElementFlag  key_flags;
+        @external TypeIdentifier key_identifier;
+    };
+
+    // Used for Types that have cyclic depencencies with other types
+    @extensibility(APPENDABLE) @nested
+    struct StronglyConnectedComponentId {
+        TypeObjectHashId sc_component_id; // Hash StronglyConnectedComponent
+        long   scc_length; // StronglyConnectedComponent.length
+        long   scc_index ; // identify type in Strongly Connected Comp.
+    };
+
+    // Future extensibility
+    @extensibility(MUTABLE) @nested
+    struct ExtendedTypeDefn {
+        // Empty. Available for future extension
+    };
+
+
+    // eProsima extension to support TypeIdentifier no value cases.
+    @final @nested
+    struct Dummy
+    {
+    };
+
+
+    // The TypeIdentifier uniquely identifies a type (a set of equivalent
+    // types according to an equivalence relationship:  COMPLETE, MNIMAL).
+    //
+    // In some cases (primitive types, strings, plain types) the identifier
+    // is a explicit description of the type.
+    // In other cases the Identifier is a Hash of the type description
+    //
+    // In the case of primitive types and strings the implied equivalence
+    // relation is the identity.
+    //
+    // For Plain Types and Hash-defined TypeIdentifiers there are three
+    //  possibilities: MINIMAL, COMPLETE, and COMMON:
+    //   - MINIMAL indicates the TypeIdentifier identifies equivalent types
+    //     according to the MINIMAL equivalence relation
+    //   - COMPLETE indicates the TypeIdentifier identifies equivalent types
+    //     according to the COMPLETE equivalence relation
+    //   - COMMON indicates the TypeIdentifier identifies equivalent types
+    //     according to both the MINIMAL and the COMMON equivalence relation.
+    //     This means the TypeIdentifier is the same for both relationships
+    //
+    @extensibility(FINAL) @nested
+    union TypeIdentifier switch (@default(TK_NONE) octet) {
+        // ============  Primitive types - use TypeKind ====================
+        // All primitive types fall here.
+        case TK_NONE:
+        case TK_BOOLEAN:
+        case TK_BYTE:
+        case TK_INT8:
+        case TK_INT16:
+        case TK_INT32:
+        case TK_INT64:
+        case TK_UINT8:
+        case TK_UINT16:
+        case TK_UINT32:
+        case TK_UINT64:
+        case TK_FLOAT32:
+        case TK_FLOAT64:
+        case TK_FLOAT128:
+        case TK_CHAR8:
+        case TK_CHAR16:
+            Dummy                   no_value;
+
+        // ============ Strings - use TypeIdentifierKind ===================
+        case TI_STRING8_SMALL:
+        case TI_STRING16_SMALL:
+            StringSTypeDefn         string_sdefn;
+
+        case TI_STRING8_LARGE:
+        case TI_STRING16_LARGE:
+            StringLTypeDefn         string_ldefn;
+
+        // ============  Plain collectios - use TypeIdentifierKind =========
+        case TI_PLAIN_SEQUENCE_SMALL:
+            PlainSequenceSElemDefn  seq_sdefn;
+        case TI_PLAIN_SEQUENCE_LARGE:
+            PlainSequenceLElemDefn  seq_ldefn;
+
+        case TI_PLAIN_ARRAY_SMALL:
+            PlainArraySElemDefn     array_sdefn;
+        case TI_PLAIN_ARRAY_LARGE:
+            PlainArrayLElemDefn     array_ldefn;
+
+        case TI_PLAIN_MAP_SMALL:
+            PlainMapSTypeDefn       map_sdefn;
+        case TI_PLAIN_MAP_LARGE:
+            PlainMapLTypeDefn       map_ldefn;
+
+        // ============  Types that are mutually dependent on each other ===
+        case TI_STRONGLY_CONNECTED_COMPONENT:
+            StronglyConnectedComponentId  sc_component_id;
+
+        // ============  The remaining cases - use EquivalenceKind =========
+        case EK_COMPLETE:
+        case EK_MINIMAL:
+            EquivalenceHash         equivalence_hash;
+
+        // ===================  Future extensibility  ============
+        // Future extensions
+        default:
+            ExtendedTypeDefn        extended_defn;
+    };
+    typedef sequence<TypeIdentifier> TypeIdentifierSeq;
+
+
+    // --- Annotation usage: -----------------------------------------------
+
+    // ID of a type member
+    typedef unsigned long MemberId;
+    const unsigned long ANNOTATION_STR_VALUE_MAX_LEN = 128;
+    const unsigned long ANNOTATION_OCTETSEC_VALUE_MAX_LEN = 128;
+
+    @extensibility(MUTABLE) @nested
+    struct ExtendedAnnotationParameterValue {
+        // Empty. Available for future extension
+    };
+
+    /* Literal value of an annotation member: either the default value in its
+     * definition or the value applied in its usage.
+     */
+    @extensibility(FINAL) @nested
+    union AnnotationParameterValue switch (octet) {
+        case TK_BOOLEAN:
+            boolean             boolean_value;
+        case TK_BYTE:
+            octet               byte_value;
+        case TK_INT8:
+            int8                int8_value;
+        case TK_UINT8:
+            uint8               uint8_value;
+        case TK_INT16:
+            short               int16_value;
+        case TK_UINT16:
+            unsigned short      uint_16_value;
+        case TK_INT32:
+            long                int32_value;
+        case TK_UINT32:
+            unsigned long       uint32_value;
+        case TK_INT64:
+            long long           int64_value;
+        case TK_UINT64:
+            unsigned long long  uint64_value;
+        case TK_FLOAT32:
+            float               float32_value;
+        case TK_FLOAT64:
+            double              float64_value;
+        case TK_FLOAT128:
+            long double         float128_value;
+        case TK_CHAR8:
+            char                char_value;
+        case TK_CHAR16:
+            wchar               wchar_value;
+        case TK_ENUM:
+            long                enumerated_value;
+        case TK_STRING8:
+            string<ANNOTATION_STR_VALUE_MAX_LEN>  string8_value;
+        case TK_STRING16:
+            wstring<ANNOTATION_STR_VALUE_MAX_LEN> string16_value;
+        default:
+            ExtendedAnnotationParameterValue      extended_value;
+    };
+
+    // The application of an annotation to some type or type member
+    @extensibility(APPENDABLE) @nested
+    struct AppliedAnnotationParameter {
+       NameHash                  paramname_hash;
+       AnnotationParameterValue  value;
+    };
+    // Sorted by AppliedAnnotationParameter.paramname_hash
+    typedef
+    sequence<AppliedAnnotationParameter> AppliedAnnotationParameterSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct AppliedAnnotation {
+        TypeIdentifier                     annotation_typeid;
+        @optional AppliedAnnotationParameterSeq   param_seq;
+    };
+    // Sorted by AppliedAnnotation.annotation_typeid
+    typedef sequence<AppliedAnnotation> AppliedAnnotationSeq;
+
+    // @verbatim(placement="<placement>", language="<lang>", text="<text>")
+    @extensibility(FINAL) @nested
+    struct AppliedVerbatimAnnotation {
+        string<32> placement;
+        string<32> language;
+        string     text;
+    };
+
+
+    // --- Aggregate types: ------------------------------------------------
+    @extensibility(APPENDABLE) @nested
+    struct AppliedBuiltinMemberAnnotations {
+        @optional string                  unit; // @unit("<unit>")
+        @optional AnnotationParameterValue min; // @min , @range
+        @optional AnnotationParameterValue max; // @max , @range
+        @optional string               hash_id; // @hash_id("<membername>")
+    };
+
+    @extensibility(FINAL) @nested
+    struct CommonStructMember {
+        MemberId                                   member_id;
+        StructMemberFlag                           member_flags;
+        TypeIdentifier                             member_type_id;
+    };
+
+    // COMPLETE Details for a member of an aggregate type
+    @extensibility(FINAL) @nested
+    struct CompleteMemberDetail {
+       MemberName                                 name;
+       @optional AppliedBuiltinMemberAnnotations  ann_builtin;
+       @optional AppliedAnnotationSeq             ann_custom;
+    };
+
+    // MINIMAL Details for a member of an aggregate type
+    @extensibility(FINAL) @nested
+    struct MinimalMemberDetail {
+        NameHash                                  name_hash;
+    };
+
+    // Member of an aggregate type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteStructMember {
+        CommonStructMember                         common;
+        CompleteMemberDetail                       detail;
+    };
+    // Ordered by the member_index
+    typedef sequence<CompleteStructMember> CompleteStructMemberSeq;
+
+    // Member of an aggregate type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalStructMember {
+        CommonStructMember                         common;
+        MinimalMemberDetail                        detail;
+    };
+    // Ordered by common.member_id
+    typedef sequence<MinimalStructMember> MinimalStructMemberSeq;
+
+
+    @extensibility(APPENDABLE) @nested
+    struct AppliedBuiltinTypeAnnotations {
+        @optional AppliedVerbatimAnnotation verbatim;  // @verbatim(...)
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalTypeDetail {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteTypeDetail {
+         @optional AppliedBuiltinTypeAnnotations  ann_builtin;
+         @optional AppliedAnnotationSeq           ann_custom;
+         QualifiedTypeName                        type_name;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteStructHeader {
+        TypeIdentifier                           base_type;
+        CompleteTypeDetail                       detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalStructHeader {
+        TypeIdentifier                           base_type;
+        MinimalTypeDetail                        detail;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteStructType {
+        StructTypeFlag             struct_flags;
+        CompleteStructHeader       header;
+        CompleteStructMemberSeq    member_seq;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalStructType {
+        StructTypeFlag             struct_flags;
+        MinimalStructHeader        header;
+        MinimalStructMemberSeq     member_seq;
+    };
+
+    // --- Union: ----------------------------------------------------------
+
+    // Case labels that apply to a member of a union type
+    // Ordered by their values
+    typedef sequence<long> UnionCaseLabelSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonUnionMember {
+        MemberId                    member_id;
+        UnionMemberFlag             member_flags;
+        TypeIdentifier              type_id;
+        UnionCaseLabelSeq           label_seq;
+    };
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteUnionMember {
+        CommonUnionMember      common;
+        CompleteMemberDetail   detail;
+    };
+    // Ordered by member_index
+    typedef sequence<CompleteUnionMember> CompleteUnionMemberSeq;
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalUnionMember {
+        CommonUnionMember   common;
+        MinimalMemberDetail detail;
+    };
+    // Ordered by MinimalUnionMember.common.member_id
+    typedef sequence<MinimalUnionMember> MinimalUnionMemberSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonDiscriminatorMember {
+        UnionDiscriminatorFlag       member_flags;
+        TypeIdentifier               type_id;
+    };
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteDiscriminatorMember {
+        CommonDiscriminatorMember                common;
+        @optional AppliedBuiltinTypeAnnotations  ann_builtin;
+        @optional AppliedAnnotationSeq           ann_custom;
+    };
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalDiscriminatorMember {
+        CommonDiscriminatorMember   common;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteUnionHeader {
+        CompleteTypeDetail          detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalUnionHeader {
+        MinimalTypeDetail           detail;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteUnionType {
+        UnionTypeFlag                union_flags;
+        CompleteUnionHeader          header;
+        CompleteDiscriminatorMember  discriminator;
+        CompleteUnionMemberSeq       member_seq;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalUnionType {
+        UnionTypeFlag                union_flags;
+        MinimalUnionHeader           header;
+        MinimalDiscriminatorMember   discriminator;
+        MinimalUnionMemberSeq        member_seq;
+    };
+
+    // --- Annotation: ----------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonAnnotationParameter {
+        AnnotationParameterFlag      member_flags;
+        TypeIdentifier               member_type_id;
+    };
+
+    // Member of an annotation type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAnnotationParameter {
+        CommonAnnotationParameter  common;
+        MemberName                 name;
+        AnnotationParameterValue   default_value;
+    };
+    // Ordered by CompleteAnnotationParameter.name
+    typedef
+    sequence<CompleteAnnotationParameter> CompleteAnnotationParameterSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAnnotationParameter {
+        CommonAnnotationParameter  common;
+        NameHash                   name_hash;
+        AnnotationParameterValue   default_value;
+    };
+    // Ordered by MinimalAnnotationParameter.name_hash
+    typedef
+    sequence<MinimalAnnotationParameter> MinimalAnnotationParameterSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAnnotationHeader {
+        QualifiedTypeName         annotation_name;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAnnotationHeader {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteAnnotationType {
+        AnnotationTypeFlag             annotation_flag;
+        CompleteAnnotationHeader       header;
+        CompleteAnnotationParameterSeq member_seq;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalAnnotationType {
+        AnnotationTypeFlag             annotation_flag;
+        MinimalAnnotationHeader        header;
+        MinimalAnnotationParameterSeq  member_seq;
+    };
+
+
+    // --- Alias: ----------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonAliasBody {
+        AliasMemberFlag       related_flags;
+        TypeIdentifier        related_type;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAliasBody {
+        CommonAliasBody       common;
+        @optional AppliedBuiltinMemberAnnotations  ann_builtin;
+        @optional AppliedAnnotationSeq             ann_custom;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAliasBody {
+        CommonAliasBody       common;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAliasHeader {
+        CompleteTypeDetail    detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAliasHeader {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteAliasType {
+        AliasTypeFlag         alias_flags;
+        CompleteAliasHeader   header;
+        CompleteAliasBody     body;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalAliasType {
+        AliasTypeFlag         alias_flags;
+        MinimalAliasHeader    header;
+        MinimalAliasBody      body;
+    };
+
+    // --- Collections: ----------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CompleteElementDetail {
+        @optional AppliedBuiltinMemberAnnotations  ann_builtin;
+        @optional AppliedAnnotationSeq             ann_custom;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CommonCollectionElement {
+        CollectionElementFlag     element_flags;
+        TypeIdentifier            type;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteCollectionElement {
+        CommonCollectionElement   common;
+        CompleteElementDetail     detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalCollectionElement {
+        CommonCollectionElement   common;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CommonCollectionHeader {
+        LBound                    bound;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteCollectionHeader {
+        CommonCollectionHeader        common;
+        @optional CompleteTypeDetail  detail; // not present for anonymous
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalCollectionHeader {
+        CommonCollectionHeader        common;
+    };
+
+    // --- Sequence: ------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CompleteSequenceType {
+        CollectionTypeFlag         collection_flag;
+        CompleteCollectionHeader   header;
+        CompleteCollectionElement  element;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalSequenceType {
+        CollectionTypeFlag         collection_flag;
+        MinimalCollectionHeader    header;
+        MinimalCollectionElement   element;
+    };
+
+    // --- Array: ------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonArrayHeader {
+        LBoundSeq           bound_seq;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteArrayHeader {
+        CommonArrayHeader   common;
+        CompleteTypeDetail  detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalArrayHeader {
+        CommonArrayHeader   common;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteArrayType  {
+        CollectionTypeFlag          collection_flag;
+        CompleteArrayHeader         header;
+        CompleteCollectionElement   element;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalArrayType  {
+        CollectionTypeFlag         collection_flag;
+        MinimalArrayHeader         header;
+        MinimalCollectionElement   element;
+    };
+
+    // --- Map: ------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CompleteMapType {
+        CollectionTypeFlag            collection_flag;
+        CompleteCollectionHeader      header;
+        CompleteCollectionElement     key;
+        CompleteCollectionElement     element;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalMapType {
+        CollectionTypeFlag          collection_flag;
+        MinimalCollectionHeader     header;
+        MinimalCollectionElement    key;
+        MinimalCollectionElement    element;
+    };
+
+    // --- Enumeration: ----------------------------------------------------
+    typedef unsigned short BitBound;
+
+    // Constant in an enumerated type
+    @extensibility(APPENDABLE) @nested
+    struct CommonEnumeratedLiteral {
+        long                     value;
+        EnumeratedLiteralFlag    flags;
+    };
+
+    // Constant in an enumerated type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteEnumeratedLiteral {
+        CommonEnumeratedLiteral  common;
+        CompleteMemberDetail     detail;
+    };
+    // Ordered by EnumeratedLiteral.common.value
+    typedef sequence<CompleteEnumeratedLiteral> CompleteEnumeratedLiteralSeq;
+
+    // Constant in an enumerated type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalEnumeratedLiteral {
+        CommonEnumeratedLiteral  common;
+        MinimalMemberDetail      detail;
+    };
+    // Ordered by EnumeratedLiteral.common.value
+    typedef sequence<MinimalEnumeratedLiteral> MinimalEnumeratedLiteralSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonEnumeratedHeader {
+        BitBound                bit_bound;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteEnumeratedHeader {
+        CommonEnumeratedHeader  common;
+        CompleteTypeDetail      detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalEnumeratedHeader {
+        CommonEnumeratedHeader  common;
+    };
+
+    // Enumerated type
+    @extensibility(FINAL) @nested
+    struct CompleteEnumeratedType  {
+        EnumTypeFlag                    enum_flags; // unused
+        CompleteEnumeratedHeader        header;
+        CompleteEnumeratedLiteralSeq    literal_seq;
+    };
+
+    // Enumerated type
+    @extensibility(FINAL) @nested
+    struct MinimalEnumeratedType  {
+        EnumTypeFlag                  enum_flags; // unused
+        MinimalEnumeratedHeader       header;
+        MinimalEnumeratedLiteralSeq   literal_seq;
+    };
+
+    // --- Bitmask: --------------------------------------------------------
+    // Bit in a bit mask
+    @extensibility(FINAL) @nested
+    struct CommonBitflag {
+        unsigned short         position;
+        BitflagFlag            flags;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitflag {
+        CommonBitflag          common;
+        CompleteMemberDetail   detail;
+    };
+    // Ordered by Bitflag.position
+    typedef sequence<CompleteBitflag> CompleteBitflagSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitflag {
+        CommonBitflag        common;
+        MinimalMemberDetail  detail;
+    };
+    // Ordered by Bitflag.position
+    typedef sequence<MinimalBitflag> MinimalBitflagSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonBitmaskHeader {
+        BitBound             bit_bound;
+    };
+
+    typedef CompleteEnumeratedHeader CompleteBitmaskHeader;
+
+    typedef MinimalEnumeratedHeader  MinimalBitmaskHeader;
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitmaskType {
+        BitmaskTypeFlag          bitmask_flags; // unused
+        CompleteBitmaskHeader    header;
+        CompleteBitflagSeq       flag_seq;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitmaskType {
+        BitmaskTypeFlag          bitmask_flags; // unused
+        MinimalBitmaskHeader     header;
+        MinimalBitflagSeq        flag_seq;
+    };
+
+    // --- Bitset: ----------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonBitfield {
+        unsigned short        position;
+        BitsetMemberFlag      flags;
+        octet                 bitcount;
+        TypeKind              holder_type; // Must be primitive integer type
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitfield {
+        CommonBitfield           common;
+        CompleteMemberDetail     detail;
+    };
+    // Ordered by Bitfield.position
+    typedef sequence<CompleteBitfield> CompleteBitfieldSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitfield {
+        CommonBitfield       common;
+        NameHash             name_hash;
+    };
+    // Ordered by Bitfield.position
+    typedef sequence<MinimalBitfield> MinimalBitfieldSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitsetHeader {
+        CompleteTypeDetail   detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitsetHeader {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitsetType  {
+        BitsetTypeFlag         bitset_flags; // unused
+        CompleteBitsetHeader   header;
+        CompleteBitfieldSeq    field_seq;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitsetType  {
+        BitsetTypeFlag       bitset_flags; // unused
+        MinimalBitsetHeader  header;
+        MinimalBitfieldSeq   field_seq;
+    };
+
+    // --- Type Object: ---------------------------------------------------
+    // The types associated with each case selection must have extensibility
+    // kind APPENDABLE or MUTABLE so that they can be extended in the future
+
+    @extensibility(MUTABLE) @nested
+    struct CompleteExtendedType {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL)     @nested
+    union CompleteTypeObject switch (@default(TK_NONE) octet) {
+        case TK_ALIAS:
+            CompleteAliasType      alias_type;
+        case TK_ANNOTATION:
+            CompleteAnnotationType annotation_type;
+        case TK_STRUCTURE:
+            CompleteStructType     struct_type;
+        case TK_UNION:
+            CompleteUnionType      union_type;
+        case TK_BITSET:
+            CompleteBitsetType     bitset_type;
+        case TK_SEQUENCE:
+            CompleteSequenceType   sequence_type;
+        case TK_ARRAY:
+            CompleteArrayType      array_type;
+        case TK_MAP:
+            CompleteMapType        map_type;
+        case TK_ENUM:
+            CompleteEnumeratedType enumerated_type;
+        case TK_BITMASK:
+            CompleteBitmaskType    bitmask_type;
+
+        // ===================  Future extensibility  ============
+        default:
+            CompleteExtendedType   extended_type;
+    };
+
+    @extensibility(MUTABLE) @nested
+    struct MinimalExtendedType {
+        // Empty. Available for future extension
+    };
+
+
+    @extensibility(FINAL)     @nested
+    union MinimalTypeObject switch (@default(TK_NONE) octet) {
+        case TK_ALIAS:
+            MinimalAliasType       alias_type;
+        case TK_ANNOTATION:
+            MinimalAnnotationType  annotation_type;
+        case TK_STRUCTURE:
+            MinimalStructType      struct_type;
+        case TK_UNION:
+            MinimalUnionType       union_type;
+        case TK_BITSET:
+            MinimalBitsetType      bitset_type;
+        case TK_SEQUENCE:
+            MinimalSequenceType    sequence_type;
+        case TK_ARRAY:
+            MinimalArrayType       array_type;
+        case TK_MAP:
+            MinimalMapType         map_type;
+        case TK_ENUM:
+            MinimalEnumeratedType  enumerated_type;
+        case TK_BITMASK:
+            MinimalBitmaskType     bitmask_type;
+
+        // ===================  Future extensibility  ============
+        default:
+            MinimalExtendedType    extended_type;
+    };
+
+    @extensibility(APPENDABLE)  @nested
+    union TypeObject switch (@default(TK_NONE) octet) { // EquivalenceKind
+        case EK_COMPLETE:
+            CompleteTypeObject   complete;
+        case EK_MINIMAL:
+            MinimalTypeObject    minimal;
+    };
+    typedef sequence<TypeObject> TypeObjectSeq;
+
+    // Set of TypeObjects representing a strong component: Equivalence class
+    // for the Strong Connectivity relationship (mutual reachability between
+    // types).
+    // Ordered by fully qualified typename lexicographic order
+    typedef TypeObjectSeq        StronglyConnectedComponent;
+
+    @extensibility(FINAL)  @nested
+    struct TypeIdentifierTypeObjectPair {
+        TypeIdentifier  type_identifier;
+        TypeObject      type_object;
+    };
+    typedef
+    sequence<TypeIdentifierTypeObjectPair> TypeIdentifierTypeObjectPairSeq;
+
+    @extensibility(FINAL)  @nested
+    struct TypeIdentifierPair {
+        TypeIdentifier  type_identifier1;
+        TypeIdentifier  type_identifier2;
+    };
+    typedef sequence<TypeIdentifierPair> TypeIdentifierPairSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct TypeIdentfierWithSize {
+        DDS::XTypes::TypeIdentifier  type_id;
+        unsigned long                typeobject_serialized_size;
+    };
+    typedef sequence<TypeIdentfierWithSize> TypeIdentfierWithSizeSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct TypeIdentifierWithDependencies {
+        TypeIdentfierWithSize            typeid_with_size;
+        // The total additional types related to minimal_type
+        long                             dependent_typeid_count;
+        sequence<TypeIdentfierWithSize>  dependent_typeids;
+    };
+    typedef
+    sequence<TypeIdentifierWithDependencies> TypeIdentifierWithDependenciesSeq;
+
+    // This appears in the builtin DDS topics PublicationBuiltinTopicData
+    // and SubscriptionBuiltinTopicData
+    @extensibility(MUTABLE) @nested
+    struct TypeInformation {
+        @id(0x1001) TypeIdentifierWithDependencies minimal;
+        @id(0x1002) TypeIdentifierWithDependencies complete;
+    };
+    typedef sequence<TypeInformation> TypeInformationSeq;
+
+};  // end of module XTypes
+};  // end module DDS

--- a/dds_gen/test_data/fast_dds/dynamic_language_binding.idl
+++ b/dds_gen/test_data/fast_dds/dynamic_language_binding.idl
@@ -1,0 +1,89 @@
+// The content of this file, was extracted from DDS-XTypes v1.3 standard.
+
+module DDS
+{
+    typedef sequence<string> IncludePathSeq;
+    typedef string<256> ObjectName;
+
+    // Inserted until defined in standard.
+    typedef sequence<unsigned long> BoundSeq;
+
+    // ---------- TypeKinds (begin) -------------------
+    typedef octet TypeKind;
+
+    // Primitive TKs
+    const TypeKind TK_NONE= 0x00;
+    const TypeKind TK_BOOLEAN= 0x01;
+    const TypeKind TK_BYTE= 0x02;
+    const TypeKind TK_INT16= 0x03;
+    const TypeKind TK_INT32= 0x04;
+    const TypeKind TK_INT64= 0x05;
+    const TypeKind TK_UINT16= 0x06;
+    const TypeKind TK_UINT32= 0x07;
+    const TypeKind TK_UINT64= 0x08;
+    const TypeKind TK_FLOAT32= 0x09;
+    const TypeKind TK_FLOAT64= 0x0A;
+    const TypeKind TK_FLOAT128= 0x0B;
+    const TypeKind TK_INT8= 0x0C;
+    const TypeKind TK_UINT8= 0x0D;
+    const TypeKind TK_CHAR8= 0x10;
+    const TypeKind TK_CHAR16= 0x11;
+
+    // String TKs
+    const TypeKind TK_STRING8= 0x20;
+    const TypeKind TK_STRING16= 0x21;
+
+    // Constructed/Named types
+    const TypeKind TK_ALIAS = 0x30;
+
+    // Enumerated TKs
+    const TypeKind TK_ENUM= 0x40;
+    const TypeKind TK_BITMASK= 0x41;
+
+    // Structured TKs
+    const TypeKind TK_ANNOTATION = 0x50;
+    const TypeKind TK_STRUCTURE= 0x51;
+    const TypeKind TK_UNION= 0x52;
+    const TypeKind TK_BITSET= 0x53;
+
+    // Collection TKs
+    const TypeKind TK_SEQUENCE= 0x60;
+    const TypeKind TK_ARRAY= 0x61;
+    const TypeKind TK_MAP= 0x62;
+    // ---------- TypeKinds (end) -------------------
+
+    typedef map<ObjectName, ObjectName> Parameters;
+
+    enum ExtensibilityKind {
+        FINAL,
+        APPENDABLE,
+        MUTABLE
+    };
+
+    enum TryConstructKind {
+        USE_DEFAULT,
+        DISCARD,
+        TRIM
+    };
+
+    typedef unsigned long MemberId;
+    typedef sequence<long> UnionCaseLabelSeq;
+
+    typedef sequence<long>Int32Seq;
+    typedef sequence<unsigned long>UInt32Seq;
+    typedef sequence<int8>Int8Seq;
+    typedef sequence<uint8>UInt8Seq;
+    typedef sequence<short>Int16Seq;
+    typedef sequence<unsigned short>UInt16Seq;
+    typedef sequence<long long>Int64Seq;
+    typedef sequence<unsigned long long>UInt64Seq;
+    typedef sequence<float>Float32Seq;
+    typedef sequence<double>Float64Seq;
+    typedef sequence<long double>Float128Seq;
+    typedef sequence<char>CharSeq;
+    typedef sequence<wchar>WcharSeq;
+    typedef sequence<boolean>BooleanSeq;
+    typedef sequence<octet>ByteSeq;
+    typedef sequence<string>StringSeq;
+    typedef sequence<wstring>WstringSeq;
+};

--- a/dds_gen/test_data/fast_dds/enum_struct.idl
+++ b/dds_gen/test_data/fast_dds/enum_struct.idl
@@ -1,0 +1,11 @@
+enum ColorEnum
+{
+    RED,
+    GREEN,
+    BLUE
+};
+
+struct EnumStruct
+{
+    ColorEnum enum_value;
+};

--- a/dds_gen/test_data/fast_dds/extensibility_struct.idl
+++ b/dds_gen/test_data/fast_dds/extensibility_struct.idl
@@ -1,0 +1,23 @@
+@extensibility(FINAL)
+struct FinalStruct
+{
+    octet my_value;
+};
+
+@extensibility(MUTABLE)
+struct MutableStruct
+{
+    octet my_value;
+};
+
+struct AppendableStruct
+{
+    octet my_value;
+};
+
+struct ExtensibilityStruct
+{
+    FinalStruct my_final_struct;
+    MutableStruct my_mutable_struct;
+    AppendableStruct my_appendable_struct;
+};

--- a/dds_gen/test_data/fast_dds/key_struct.idl
+++ b/dds_gen/test_data/fast_dds/key_struct.idl
@@ -1,0 +1,14 @@
+struct ImportantStruct
+{
+    @key long my_first_value;
+    long my_second_value;
+    @key long my_third_value;
+};
+
+struct KeyStruct
+{
+    short my_short;
+    @key long my_long;
+    @key string my_string;
+    @key ImportantStruct my_important_struct;
+};

--- a/dds_gen/test_data/fast_dds/map_struct.idl
+++ b/dds_gen/test_data/fast_dds/map_struct.idl
@@ -1,0 +1,12 @@
+struct ValueStruct
+{
+    boolean value;
+};
+
+struct MapStruct
+{
+    map<string, boolean> my_basic_map;
+    map<string, ValueStruct> my_complex_map;
+    map<long, string, 10> my_basic_bounded_map;
+    map<short, ValueStruct, 123> my_complex_bounded_map;
+};

--- a/dds_gen/test_data/fast_dds/monitorservice_types.idl
+++ b/dds_gen/test_data/fast_dds/monitorservice_types.idl
@@ -1,0 +1,134 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file include/fastdds/statistics/monitorservice_types.idl
+ */
+
+#include "types.idl"
+
+module eprosima {
+module fastdds {
+module statistics {
+
+    enum ConnectionMode
+    {
+        DATA_SHARING,
+        INTRAPROCESS,
+        TRANSPORT
+    };
+
+    struct Connection
+    {
+        ConnectionMode mode;
+        detail::GUID_s guid;
+        sequence<detail::Locator_s> announced_locators;
+        sequence<detail::Locator_s> used_locators;
+    };
+
+    struct QosPolicyCount_s
+    {
+        unsigned long policy_id;
+        unsigned long count;
+    };
+
+    struct BaseStatus_s
+    {
+        unsigned long total_count;
+    };
+
+    typedef sequence<QosPolicyCount_s> QosPolicyCountSeq_s;
+
+    struct IncompatibleQoSStatus_s
+    {
+        unsigned long total_count;
+        unsigned long last_policy_id;
+        QosPolicyCountSeq_s policies;
+    };
+
+    struct LivelinessChangedStatus_s
+    {
+        unsigned long alive_count;
+        unsigned long not_alive_count;
+        octet last_publication_handle[16];
+    };
+
+    struct DeadlineMissedStatus_s
+    {
+        unsigned long total_count;
+        octet last_instance_handle[16];
+    };
+
+    typedef BaseStatus_s LivelinessLostStatus_s;
+    typedef BaseStatus_s InconsistentTopicStatus_s;
+    typedef BaseStatus_s SampleLostStatus_s;
+
+    struct ExtendedIncompatibleQoSStatus_s
+    {
+        detail::GUID_s remote_guid;
+        sequence<unsigned long> current_incompatible_policies;
+    };
+
+    typedef sequence<ExtendedIncompatibleQoSStatus_s> ExtendedIncompatibleQoSStatusSeq_s;
+
+    module StatusKind
+    {
+        typedef unsigned long StatusKind;
+
+        const StatusKind PROXY                     = 0;
+        const StatusKind CONNECTION_LIST           = 1;
+        const StatusKind INCOMPATIBLE_QOS          = 2;
+        const StatusKind INCONSISTENT_TOPIC        = 3;
+        const StatusKind LIVELINESS_LOST           = 4;
+        const StatusKind LIVELINESS_CHANGED        = 5;
+        const StatusKind DEADLINE_MISSED           = 6;
+        const StatusKind SAMPLE_LOST               = 7;
+        const StatusKind EXTENDED_INCOMPATIBLE_QOS = 8;
+        const StatusKind STATUSES_SIZE             = 9;
+    }; // module StatusKind
+
+    union MonitorServiceData switch(StatusKind::StatusKind)
+    {
+        case StatusKind::PROXY:
+            sequence<octet> entity_proxy;
+        case StatusKind::CONNECTION_LIST:
+            sequence<Connection> connection_list;
+        case StatusKind::INCOMPATIBLE_QOS:
+            IncompatibleQoSStatus_s incompatible_qos_status;
+        case StatusKind::INCONSISTENT_TOPIC:
+            InconsistentTopicStatus_s inconsistent_topic_status;
+        case StatusKind::LIVELINESS_LOST:
+            LivelinessLostStatus_s liveliness_lost_status;
+        case StatusKind::LIVELINESS_CHANGED:
+            LivelinessChangedStatus_s liveliness_changed_status;
+        case StatusKind::DEADLINE_MISSED:
+            DeadlineMissedStatus_s deadline_missed_status;
+        case StatusKind::SAMPLE_LOST:
+            SampleLostStatus_s sample_lost_status;
+        case StatusKind::EXTENDED_INCOMPATIBLE_QOS:
+            ExtendedIncompatibleQoSStatusSeq_s extended_incompatible_qos_status;
+        case StatusKind::STATUSES_SIZE:
+            octet statuses_size;
+    };
+
+    struct MonitorServiceStatusData
+    {
+        @Key detail::GUID_s local_entity;
+        @Key StatusKind::StatusKind status_kind;
+        MonitorServiceData value;
+    };
+
+}; // namespace statisitcs
+}; // namespace fastdds
+}; // namespace eprosima

--- a/dds_gen/test_data/fast_dds/primitives_struct.idl
+++ b/dds_gen/test_data/fast_dds/primitives_struct.idl
@@ -1,0 +1,18 @@
+struct PrimitivesStruct
+{
+    boolean my_bool;
+    octet my_octet;
+    char my_char;
+    wchar my_wchar;
+    long my_long;
+    unsigned long my_ulong;
+    int8 my_int8;
+    uint8 my_uint8;
+    short my_short;
+    unsigned short my_ushort;
+    long long my_longlong;
+    unsigned long long my_ulonglong;
+    float my_float;
+    double my_double;
+    long double my_longdouble;
+};

--- a/dds_gen/test_data/fast_dds/rpc_types.idl
+++ b/dds_gen/test_data/fast_dds/rpc_types.idl
@@ -1,0 +1,79 @@
+//This directive is not supported yet.
+//#ifdef BASIC
+
+module dds {
+
+//This directive is not supported yet.
+//#ifdef REDEFINE_DDS_TYPES
+
+  // The following DDS related types are
+  // borrowed from the RTPS v1.2 specification
+  typedef octet GuidPrefix_t[12];
+
+  @final @nested
+  struct EntityId_t
+  {
+    octet entityKey[3];
+    octet entityKind;
+  };
+
+  @final @nested
+  struct GUID_t
+  {
+    GuidPrefix_t guidPrefix;
+    EntityId_t entityId;
+  };
+
+  @final @nested
+  struct SequenceNumber_t
+  {
+    long high;
+    unsigned long low;
+  };
+
+//#endif // REDEFINE_DDS_TYPES
+
+@final @nested
+struct SampleIdentity
+{
+  GUID_t           writer_guid;
+  SequenceNumber_t sequence_number;
+};
+
+module rpc {
+
+typedef octet UnknownOperation;
+typedef octet UnknownException;
+typedef octet UnusedMember;
+
+enum RemoteExceptionCode_t
+{
+    REMOTE_EX_OK,
+    REMOTE_EX_UNSUPPORTED,
+    REMOTE_EX_INVALID_ARGUMENT,
+    REMOTE_EX_OUT_OF_RESOURCES,
+    REMOTE_EX_UNKNOWN_OPERATION,
+    REMOTE_EX_UNKNOWN_EXCEPTION
+};
+
+typedef string<255> InstanceName;
+
+@final @nested
+struct RequestHeader
+{
+    dds::SampleIdentity  requestId;
+    InstanceName         instanceName;
+};
+
+@final @nested
+struct ReplyHeader
+{
+    dds::SampleIdentity             relatedRequestId;
+    dds::rpc::RemoteExceptionCode_t remoteEx;
+};
+
+}; // module rpc
+
+}; // module dds
+
+//#endif // BASIC

--- a/dds_gen/test_data/fast_dds/sequence_struct.idl
+++ b/dds_gen/test_data/fast_dds/sequence_struct.idl
@@ -1,0 +1,19 @@
+struct NestedSequenceElement
+{
+    string my_string;
+};
+
+struct ComplexSequenceElement
+{
+    short my_short;
+    long my_long;
+    NestedSequenceElement my_complex_element;
+};
+
+struct SequenceStruct
+{
+    sequence<char> my_basic_sequence;
+    sequence<float, 13> my_bounded_sequence;
+    sequence<ComplexSequenceElement> my_complex_sequence;
+    sequence<ComplexSequenceElement, 123> my_complex_bounded_sequence;
+};

--- a/dds_gen/test_data/fast_dds/string_struct.idl
+++ b/dds_gen/test_data/fast_dds/string_struct.idl
@@ -1,0 +1,7 @@
+struct StringStruct
+{
+    string my_string;
+    wstring my_wstring;
+    string<41925> my_bounded_string;
+    wstring<20925> my_bounded_wstring;
+};

--- a/dds_gen/test_data/fast_dds/struct_struct.idl
+++ b/dds_gen/test_data/fast_dds/struct_struct.idl
@@ -1,0 +1,22 @@
+struct GrandparentStruct
+{
+    long my_long;
+};
+
+struct ParentStruct : GrandparentStruct
+{
+    short my_short;
+    string my_string;
+    GrandparentStruct my_grandparent;
+};
+
+struct NestedStructElement
+{
+    boolean my_boolean;
+};
+
+struct StructStruct : ParentStruct
+{
+    NestedStructElement my_nested_element;
+    char my_char;
+};

--- a/dds_gen/test_data/fast_dds/types.idl
+++ b/dds_gen/test_data/fast_dds/types.idl
@@ -1,0 +1,174 @@
+// Copyright 2021 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file include/fastdds/statistics/types.idl
+ */
+
+module eprosima {
+module fastdds {
+module statistics {
+
+    module detail
+    {
+
+        struct EntityId_s
+        {
+            octet value[4];
+        };
+
+        struct GuidPrefix_s
+        {
+            octet value[12];
+        };
+
+        struct GUID_s
+        {
+            GuidPrefix_s guidPrefix;
+            EntityId_s entityId;
+        };
+
+        struct SequenceNumber_s
+        {
+            long high;
+            unsigned long low;
+        };
+
+        struct SampleIdentity_s
+        {
+            GUID_s writer_guid;
+            SequenceNumber_s sequence_number;
+        };
+
+        struct Locator_s
+        {
+            long kind;
+            unsigned long port;
+            octet address[16];
+        };
+
+    }; // namespace detail
+
+struct DiscoveryTime
+{
+    @Key detail::GUID_s local_participant_guid;
+    @Key detail::GUID_s remote_entity_guid;
+    unsigned long long time;
+    string host;
+    string user;
+    string process;
+};
+
+struct EntityCount
+{
+    @Key detail::GUID_s guid;
+    unsigned long long count;
+};
+
+struct SampleIdentityCount
+{
+    @Key detail::SampleIdentity_s sample_id;
+    unsigned long long count;
+};
+
+struct Entity2LocatorTraffic
+{
+    @Key detail::GUID_s src_guid;
+    @Key detail::Locator_s dst_locator;
+    unsigned long long packet_count;
+    unsigned long long byte_count;
+    short byte_magnitude_order;
+};
+
+struct WriterReaderData
+{
+    @Key detail::GUID_s writer_guid;
+    @Key detail::GUID_s reader_guid;
+    float data;
+};
+
+struct Locator2LocatorData
+{
+    @Key detail::Locator_s src_locator;
+    @Key detail::Locator_s dst_locator;
+    float data;
+};
+
+struct EntityData
+{
+    @Key detail::GUID_s guid;
+    float data;
+};
+
+struct PhysicalData
+{
+    @Key detail::GUID_s participant_guid;
+    string host;
+    string user;
+    string process;
+};
+
+module EventKind
+{
+    const unsigned long HISTORY2HISTORY_LATENCY = 0x1;
+    const unsigned long NETWORK_LATENCY = 0x2;
+    const unsigned long PUBLICATION_THROUGHPUT = 0x4;
+    const unsigned long SUBSCRIPTION_THROUGHPUT = 0x8;
+    const unsigned long RTPS_SENT = 0x10;
+    const unsigned long RTPS_LOST = 0x20;
+    const unsigned long RESENT_DATAS = 0x40;
+    const unsigned long HEARTBEAT_COUNT = 0x80;
+    const unsigned long ACKNACK_COUNT = 0x100;
+    const unsigned long NACKFRAG_COUNT = 0x200;
+    const unsigned long GAP_COUNT = 0x400;
+    const unsigned long DATA_COUNT = 0x800;
+    const unsigned long PDP_PACKETS = 0x1000;
+    const unsigned long EDP_PACKETS = 0x2000;
+    const unsigned long DISCOVERED_ENTITY = 0x4000;
+    const unsigned long SAMPLE_DATAS = 0x8000;
+    const unsigned long PHYSICAL_DATA = 0x10000;
+};
+
+union Data switch(unsigned long)
+{
+    case EventKind::HISTORY2HISTORY_LATENCY:
+        WriterReaderData writer_reader_data;
+    case EventKind::NETWORK_LATENCY:
+        Locator2LocatorData locator2locator_data;
+    case EventKind::PUBLICATION_THROUGHPUT:
+    case EventKind::SUBSCRIPTION_THROUGHPUT:
+        EntityData entity_data;
+    case EventKind::RTPS_SENT:
+    case EventKind::RTPS_LOST:
+        Entity2LocatorTraffic entity2locator_traffic;
+    case EventKind::RESENT_DATAS:
+    case EventKind::HEARTBEAT_COUNT:
+    case EventKind::ACKNACK_COUNT:
+    case EventKind::NACKFRAG_COUNT:
+    case EventKind::GAP_COUNT:
+    case EventKind::DATA_COUNT:
+    case EventKind::PDP_PACKETS:
+    case EventKind::EDP_PACKETS:
+        EntityCount entity_count;
+    case EventKind::DISCOVERED_ENTITY:
+        DiscoveryTime discovery_time;
+    case EventKind::SAMPLE_DATAS:
+        SampleIdentityCount sample_identity_count;
+    case EventKind::PHYSICAL_DATA:
+        PhysicalData physical_data;
+};
+
+}; // namespace statistics
+}; // namespace fastdds
+}; // namespace eprosima

--- a/dds_gen/test_data/fast_dds/union_struct.idl
+++ b/dds_gen/test_data/fast_dds/union_struct.idl
@@ -1,0 +1,22 @@
+union BasicUnion switch (short)
+{
+    case 0:
+        string first;
+    case 1:
+    default:
+        long long second;
+};
+
+union ComplexUnion switch (long)
+{
+    case 0:
+    case 1:
+        long third;
+    default:
+        BasicUnion fourth;
+};
+
+struct UnionStruct
+{
+    ComplexUnion my_complex_union;
+};

--- a/dds_gen/test_data/omg_dds/dds-xtypes_discovery_buildin_topics.idl
+++ b/dds_gen/test_data/omg_dds/dds-xtypes_discovery_buildin_topics.idl
@@ -1,0 +1,1068 @@
+/* dds-xtypes_typeobject.idl */
+
+// The types in this file shall be serialized with XCDR encoding version 2
+module DDS { module XTypes {
+    
+    // ---------- Equivalence Kinds -------------------
+    typedef octet EquivalenceKind;
+    const octet EK_MINIMAL   = 0xF1; // 0x1111 0001
+    const octet EK_COMPLETE  = 0xF2; // 0x1111 0010
+    const octet EK_BOTH      = 0xF3; // 0x1111 0011
+
+    // ---------- TypeKinds (begin) -------------------
+    typedef octet TypeKind;
+    
+    // Primitive TKs
+    const octet TK_NONE       = 0x00;
+    const octet TK_BOOLEAN    = 0x01;
+    const octet TK_BYTE       = 0x02;
+    const octet TK_INT16      = 0x03;
+    const octet TK_INT32      = 0x04;
+    const octet TK_INT64      = 0x05;
+    const octet TK_UINT16     = 0x06;
+    const octet TK_UINT32     = 0x07;
+    const octet TK_UINT64     = 0x08;
+    const octet TK_FLOAT32    = 0x09;
+    const octet TK_FLOAT64    = 0x0A;
+    const octet TK_FLOAT128   = 0x0B;
+    const octet TK_CHAR8      = 0x10;
+    const octet TK_CHAR16     = 0x11;
+
+    // String TKs
+    const octet TK_STRING8    = 0x20;
+    const octet TK_STRING16   = 0x21;
+
+    // Constructed/Named types
+    const octet TK_ALIAS      = 0x30;
+
+    // Enumerated TKs
+    const octet TK_ENUM       = 0x40;
+    const octet TK_BITMASK    = 0x41;
+
+    // Structured TKs
+    const octet TK_ANNOTATION = 0x50;
+    const octet TK_STRUCTURE  = 0x51;
+    const octet TK_UNION      = 0x52;
+    const octet TK_BITSET     = 0x53;
+      
+    // Collection TKs
+    const octet TK_SEQUENCE   = 0x60;
+    const octet TK_ARRAY      = 0x61;
+    const octet TK_MAP        = 0x62;
+    // ---------- TypeKinds (end) -------------------
+
+    // ---------- Extra TypeIdentifiers (begin) ------------
+    typedef octet TypeIdentiferKind;
+    const octet TI_STRING8_SMALL        = 0x70;
+    const octet TI_STRING8_LARGE        = 0x71;
+    const octet TI_STRING16_SMALL       = 0x72;
+    const octet TI_STRING16_LARGE       = 0x73;
+
+    const octet TI_PLAIN_SEQUENCE_SMALL = 0x80;
+    const octet TI_PLAIN_SEQUENCE_LARGE = 0x81;
+    
+    const octet TI_PLAIN_ARRAY_SMALL    = 0x90;
+    const octet TI_PLAIN_ARRAY_LARGE    = 0x91;
+    
+    const octet TI_PLAIN_MAP_SMALL      = 0xA0;
+    const octet TI_PLAIN_MAP_LARGE      = 0xA1;
+
+    const octet TI_STRONGLY_CONNECTED_COMPONENT = 0xB0;
+    // ---------- Extra TypeIdentifiers (end) --------------
+
+    // The name of some element (e.g. type, type member, module)
+    // Valid characters are alphanumeric plus the "_" cannot start with digit
+    const long MEMBER_NAME_MAX_LENGTH = 256;
+    typedef string<MEMBER_NAME_MAX_LENGTH> MemberName;
+
+    // Qualified type name includes the name of containing modules
+    // using "::" as separator. No leading "::". E.g. "MyModule::MyType"
+    const long TYPE_NAME_MAX_LENGTH = 256;
+    typedef string<TYPE_NAME_MAX_LENGTH> QualifiedTypeName;
+
+    // Every type has an ID. Those of the primitive types are pre-defined.
+    typedef octet PrimitiveTypeId;
+
+    // First 14 bytes of MD5 of the serialized TypeObject using XCDR
+    // version 2 with Little Endian encoding
+    typedef octet EquivalenceHash[14];
+
+    // First 4 bytes of MD5 of of a member name converted to bytes
+    // using UTF-8 encoding and without a 'nul' terminator.
+    // Example: the member name "color" has NameHash {0x70, 0xDD, 0xA5, 0xDF}
+    typedef octet NameHash[4];
+    
+    // Long Bound of a collection type
+    typedef unsigned long LBound;
+    typedef sequence<LBound> LBoundSeq;
+    const LBound INVALID_LBOUND = 0;
+    
+    // Short Bound of a collection type
+    typedef octet SBound;
+    typedef sequence<SBound> SBoundSeq;
+    const SBound INVALID_SBOUND = 0;
+
+    @extensibility(FINAL) @nested
+    union TypeObjectHashId switch (octet) {
+        case EK_COMPLETE:
+        case EK_MINIMAL:
+            EquivalenceHash  hash;
+    };
+       
+    // Flags that apply to struct/union/collection/enum/bitmask/bitset
+    // members/elements and DO affect type assignability
+    // Depending on the flag it may not apply to members of all types
+    // When not all, the applicable member types are listed
+    @bit_bound(16)
+    bitmask MemberFlag {
+        @position(0)  TRY_CONSTRUCT1,     // T1 | 00 = INVALID, 01 = DISCARD
+        @position(1)  TRY_CONSTRUCT2,     // T2 | 10 = USE_DEFAULT, 11 = TRIM
+        @position(2)  IS_EXTERNAL,        // X  StructMember, UnionMember,
+	                                  //    CollectionElement
+        @position(3)  IS_OPTIONAL,        // O  StructMember 
+        @position(4)  IS_MUST_UNDERSTAND, // M  StructMember
+        @position(5)  IS_KEY,          // K  StructMember, UnionDiscriminator
+        @position(6)  IS_DEFAULT       // D  UnionMember, EnumerationLiteral 
+    };
+    typedef MemberFlag   CollectionElementFlag;   // T1, T2, X
+    typedef MemberFlag   StructMemberFlag;        // T1, T2, O, M, K, X
+    typedef MemberFlag   UnionMemberFlag;         // T1, T2, D, X
+    typedef MemberFlag   UnionDiscriminatorFlag;  // T1, T2, K
+    typedef MemberFlag   EnumeratedLiteralFlag;   // D
+    typedef MemberFlag   AnnotationParameterFlag; // Unused. No flags apply
+    typedef MemberFlag   AliasMemberFlag;         // Unused. No flags apply
+    typedef MemberFlag   BitflagFlag;             // Unused. No flags apply
+    typedef MemberFlag   BitsetMemberFlag;        // Unused. No flags apply
+
+    // Mask used to remove the flags that do no affect assignability
+    // Selects  T1, T2, O, M, K, D
+    const   unsigned short  MemberFlagMinimalMask = 0x003f;  
+
+    // Flags that apply to type declarationa and DO affect assignability
+    // Depending on the flag it may not apply to all types
+    // When not all, the applicable  types are listed
+    @bit_bound(16)
+    bitmask TypeFlag {
+        @position(0) IS_FINAL,        // F |  
+        @position(1) IS_APPENDABLE,   // A |-  Struct, Union 
+        @position(2) IS_MUTABLE,      // M |   (exactly one flag)
+
+        @position(3) IS_NESTED,       // N     Struct, Union
+        @position(4) IS_AUTOID_HASH   // H     Struct
+    };
+    typedef TypeFlag   StructTypeFlag;      // All flags apply
+    typedef TypeFlag   UnionTypeFlag;       // All flags apply
+    typedef TypeFlag   CollectionTypeFlag;  // Unused. No flags apply
+    typedef TypeFlag   AnnotationTypeFlag;  // Unused. No flags apply
+    typedef TypeFlag   AliasTypeFlag;       // Unused. No flags apply
+    typedef TypeFlag   EnumTypeFlag;        // Unused. No flags apply
+    typedef TypeFlag   BitmaskTypeFlag;     // Unused. No flags apply
+    typedef TypeFlag   BitsetTypeFlag;      // Unused. No flags apply
+
+    // Mask used to remove the flags that do no affect assignability
+    const   unsigned short TypeFlagMinimalMask = 0x0007; // Selects  M, A, F
+
+   // Forward declaration
+   union TypeIdentifier;
+     
+    // 1 Byte
+    @extensibility(FINAL) @nested
+    struct StringSTypeDefn {
+    	SBound                  bound;
+    };
+    
+    // 4 Bytes
+    @extensibility(FINAL) @nested
+    struct StringLTypeDefn {
+        LBound                  bound;
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainCollectionHeader {
+        EquivalenceKind        equiv_kind;
+        CollectionElementFlag  element_flags;
+    };
+    
+    @extensibility(FINAL) @nested
+    struct PlainSequenceSElemDefn {
+        PlainCollectionHeader  header;
+        SBound                 bound;
+        @external TypeIdentifier element_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainSequenceLElemDefn {
+        PlainCollectionHeader  header;
+        LBound                 bound;
+        @external TypeIdentifier element_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainArraySElemDefn {
+        PlainCollectionHeader  header;
+        SBoundSeq              array_bound_seq;
+        @external TypeIdentifier element_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainArrayLElemDefn {
+        PlainCollectionHeader  header;
+        LBoundSeq              array_bound_seq;
+        @external TypeIdentifier element_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainMapSTypeDefn {
+        PlainCollectionHeader  header;
+        SBound                 bound;
+        @external TypeIdentifier element_identifier; 
+        CollectionElementFlag  key_flags;
+        @external TypeIdentifier key_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainMapLTypeDefn {
+        PlainCollectionHeader  header;
+        LBound                 bound;
+        @external TypeIdentifier element_identifier; 
+        CollectionElementFlag  key_flags;
+        @external TypeIdentifier key_identifier; 
+    };
+
+    // Used for Types that have cyclic depencencies with other types
+    @extensibility(APPENDABLE) @nested
+    struct StronglyConnectedComponentId {
+        TypeObjectHashId sc_component_id; // Hash StronglyConnectedComponent
+        long   scc_length; // StronglyConnectedComponent.length 
+        long   scc_index ; // identify type in Strongly Connected Comp.
+    };
+
+    // Future extensibility
+    @extensibility(MUTABLE) @nested
+    struct ExtendedTypeDefn {
+        // Empty. Available for future extension
+    };
+ 
+
+    
+    // The TypeIdentifier uniquely identifies a type (a set of equivalent 
+    // types according to an equivalence relationship:  COMPLETE, MNIMAL).
+    //
+    // In some cases (primitive types, strings, plain types) the identifier 
+    // is a explicit description of the type.
+    // In other cases the Identifier is a Hash of the type description
+    //
+    // In the case of primitive types and strings the implied equivalence
+    // relation is the identity.
+    //
+    // For Plain Types and Hash-defined TypeIdentifiers there are three
+    //  possibilities: MINIMAL, COMPLETE, and COMMON:
+    //   - MINIMAL indicates the TypeIdentifier identifies equivalent types
+    //     according to the MINIMAL equivalence relation
+    //   - COMPLETE indicates the TypeIdentifier identifies equivalent types
+    //     according to the COMPLETE equivalence relation
+    //   - COMMON indicates the TypeIdentifier identifies equivalent types
+    //     according to both the MINIMAL and the COMMON equivalence relation.
+    //     This means the TypeIdentifier is the same for both relationships
+    // 
+    @extensibility(FINAL) @nested
+    union TypeIdentifier switch (octet) { 
+        // ============  Primitive types - use TypeKind ====================
+        // All primitive types fall here. 
+        // Commented-out because Unions cannot have cases with no member.
+        /*
+        case TK_NONE:
+        case TK_BOOLEAN:       
+        case TK_BYTE_TYPE:
+        case TK_INT16_TYPE:
+        case TK_INT32_TYPE:
+        case TK_INT64_TYPE:
+        case TK_UINT16_TYPE:
+        case TK_UINT32_TYPE:
+        case TK_UINT64_TYPE:
+        case TK_FLOAT32_TYPE:
+        case TK_FLOAT64_TYPE:
+        case TK_FLOAT128_TYPE:        
+        case TK_CHAR8_TYPE:
+        case TK_CHAR16_TYPE:
+            // No Value
+        */
+
+        // ============ Strings - use TypeIdentifierKind ===================
+        case TI_STRING8_SMALL:
+        case TI_STRING16_SMALL:
+            StringSTypeDefn         string_sdefn;
+
+        case TI_STRING8_LARGE:
+        case TI_STRING16_LARGE:
+            StringLTypeDefn         string_ldefn;
+
+        // ============  Plain collectios - use TypeIdentifierKind =========
+        case TI_PLAIN_SEQUENCE_SMALL:
+            PlainSequenceSElemDefn  seq_sdefn;
+        case TI_PLAIN_SEQUENCE_LARGE:
+            PlainSequenceLElemDefn  seq_ldefn;
+
+        case TI_PLAIN_ARRAY_SMALL:
+            PlainArraySElemDefn     array_sdefn;
+        case TI_PLAIN_ARRAY_LARGE:
+            PlainArrayLElemDefn     array_ldefn;
+
+        case TI_PLAIN_MAP_SMALL:
+            PlainMapSTypeDefn       map_sdefn;
+        case TI_PLAIN_MAP_LARGE:
+            PlainMapLTypeDefn       map_ldefn;
+    
+        // ============  Types that are mutually dependent on each other ===
+        case TI_STRONGLY_CONNECTED_COMPONENT:
+            StronglyConnectedComponentId  sc_component_id;
+
+        // ============  The remaining cases - use EquivalenceKind ========= 
+        case EK_COMPLETE:
+        case EK_MINIMAL:
+            EquivalenceHash         equivalence_hash;
+
+        // ===================  Future extensibility  ============
+        // Future extensions
+        default:
+            ExtendedTypeDefn        extended_defn;
+    };   
+    typedef sequence<TypeIdentifier> TypeIdentifierSeq;
+
+
+    // --- Annotation usage: -----------------------------------------------
+
+    // ID of a type member
+    typedef unsigned long MemberId;
+    const unsigned long ANNOTATION_STR_VALUE_MAX_LEN = 128;
+    const unsigned long ANNOTATION_OCTETSEC_VALUE_MAX_LEN = 128;
+
+    @extensibility(MUTABLE) @nested
+    struct ExtendedAnnotationParameterValue {
+        // Empty. Available for future extension
+    };
+    
+    /* Literal value of an annotation member: either the default value in its
+     * definition or the value applied in its usage.
+     */
+    @extensibility(FINAL) @nested
+    union AnnotationParameterValue switch (octet) {
+        case TK_BOOLEAN:
+            boolean             boolean_value;
+        case TK_BYTE:
+            octet               byte_value;
+        case TK_INT16:
+            short               int16_value;
+        case TK_UINT16:
+            unsigned short      uint_16_value;
+        case TK_INT32:
+            long                int32_value;
+        case TK_UINT32:
+            unsigned long       uint32_value;
+        case TK_INT64:
+            long long           int64_value;
+        case TK_UINT64:
+            unsigned long long  uint64_value;
+        case TK_FLOAT32:
+            float               float32_value;
+        case TK_FLOAT64:
+            double              float64_value;
+        case TK_FLOAT128:
+            long double         float128_value;
+        case TK_CHAR8:
+            char                char_value;
+        case TK_CHAR16:
+            wchar               wchar_value;
+        case TK_ENUM:
+            long                enumerated_value;
+        case TK_STRING8:
+            string<ANNOTATION_STR_VALUE_MAX_LEN>  string8_value;   
+        case TK_STRING16:
+            wstring<ANNOTATION_STR_VALUE_MAX_LEN> string16_value;  
+        default:
+            ExtendedAnnotationParameterValue      extended_value;
+    };
+
+    // The application of an annotation to some type or type member
+    @extensibility(APPENDABLE) @nested
+    struct AppliedAnnotationParameter {
+       NameHash                  paramname_hash;          
+       AnnotationParameterValue  value;      
+    };
+    // Sorted by AppliedAnnotationParameter.paramname_hash
+    typedef
+    sequence<AppliedAnnotationParameter> AppliedAnnotationParameterSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct AppliedAnnotation {
+        TypeIdentifier                     annotation_typeid;
+        @optional AppliedAnnotationParameterSeq   param_seq;
+    };
+    // Sorted by AppliedAnnotation.annotation_typeid
+    typedef sequence<AppliedAnnotation> AppliedAnnotationSeq;
+
+    // @verbatim(placement="<placement>", language="<lang>", text="<text>")
+    @extensibility(FINAL) @nested
+    struct AppliedVerbatimAnnotation {
+        string<32> placement;
+        string<32> language;
+        string     text;
+    };
+
+
+    // --- Aggregate types: ------------------------------------------------
+    @extensibility(APPENDABLE) @nested
+    struct AppliedBuiltinMemberAnnotations {
+        @optional string                  unit; // @unit("<unit>")
+        @optional AnnotationParameterValue min; // @min , @range
+        @optional AnnotationParameterValue max; // @max , @range
+        @optional string               hash_id; // @hash_id("<membername>")
+    };
+
+    @extensibility(FINAL) @nested
+    struct CommonStructMember {
+        MemberId                                   member_id;
+        StructMemberFlag                           member_flags;
+        TypeIdentifier                             member_type_id;
+    };
+
+    // COMPLETE Details for a member of an aggregate type
+    @extensibility(FINAL) @nested
+    struct CompleteMemberDetail {
+       MemberName                                 name;
+       @optional AppliedBuiltinMemberAnnotations  ann_builtin;
+       @optional AppliedAnnotationSeq             ann_custom;
+    };
+
+    // MINIMAL Details for a member of an aggregate type
+    @extensibility(FINAL) @nested
+    struct MinimalMemberDetail {
+        NameHash                                  name_hash;
+    };
+
+    // Member of an aggregate type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteStructMember {
+        CommonStructMember                         common;
+        CompleteMemberDetail                       detail;
+    };
+    // Ordered by the member_index
+    typedef sequence<CompleteStructMember> CompleteStructMemberSeq;
+    
+    // Member of an aggregate type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalStructMember {
+        CommonStructMember                         common;
+        MinimalMemberDetail                        detail;
+    };
+    // Ordered by common.member_id
+    typedef sequence<MinimalStructMember> MinimalStructMemberSeq;
+
+    
+    @extensibility(APPENDABLE) @nested
+    struct AppliedBuiltinTypeAnnotations {
+        @optional AppliedVerbatimAnnotation verbatim;  // @verbatim(...)
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalTypeDetail {
+        // Empty. Available for future extension
+    };
+ 
+    @extensibility(FINAL) @nested
+    struct CompleteTypeDetail {
+         @optional AppliedBuiltinTypeAnnotations  ann_builtin;        
+         @optional AppliedAnnotationSeq           ann_custom;     
+         QualifiedTypeName                        type_name;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteStructHeader {
+        TypeIdentifier                           base_type;
+        CompleteTypeDetail                       detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalStructHeader {
+        TypeIdentifier                           base_type;
+        MinimalTypeDetail                        detail;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteStructType {
+        StructTypeFlag             struct_flags;
+        CompleteStructHeader       header;
+        CompleteStructMemberSeq    member_seq;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalStructType {
+        StructTypeFlag             struct_flags;
+        MinimalStructHeader        header;
+        MinimalStructMemberSeq     member_seq;
+    };
+
+    // --- Union: ----------------------------------------------------------
+
+    // Case labels that apply to a member of a union type
+    // Ordered by their values
+    typedef sequence<long> UnionCaseLabelSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonUnionMember {
+        MemberId                    member_id;
+        UnionMemberFlag             member_flags;
+        TypeIdentifier              type_id;
+        UnionCaseLabelSeq           label_seq;
+    };
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteUnionMember {
+        CommonUnionMember      common;
+        CompleteMemberDetail   detail;
+    };
+    // Ordered by member_index
+    typedef sequence<CompleteUnionMember> CompleteUnionMemberSeq;
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalUnionMember {
+        CommonUnionMember   common;
+        MinimalMemberDetail detail;
+    };
+    // Ordered by MinimalUnionMember.common.member_id
+    typedef sequence<MinimalUnionMember> MinimalUnionMemberSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonDiscriminatorMember {
+        UnionDiscriminatorFlag       member_flags;
+        TypeIdentifier               type_id;
+    };
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteDiscriminatorMember {
+        CommonDiscriminatorMember                common;
+        @optional AppliedBuiltinTypeAnnotations  ann_builtin;
+        @optional AppliedAnnotationSeq           ann_custom;
+    };
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalDiscriminatorMember {
+        CommonDiscriminatorMember   common;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteUnionHeader {
+        CompleteTypeDetail          detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalUnionHeader {
+        MinimalTypeDetail           detail;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteUnionType {
+        UnionTypeFlag                union_flags;
+        CompleteUnionHeader          header;
+        CompleteDiscriminatorMember  discriminator;
+        CompleteUnionMemberSeq       member_seq;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalUnionType {
+        UnionTypeFlag                union_flags;
+        MinimalUnionHeader           header;
+        MinimalDiscriminatorMember   discriminator;
+        MinimalUnionMemberSeq        member_seq;
+    };
+
+    // --- Annotation: ----------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonAnnotationParameter {
+        AnnotationParameterFlag      member_flags;
+        TypeIdentifier               member_type_id;
+    };
+
+    // Member of an annotation type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAnnotationParameter {
+        CommonAnnotationParameter  common;
+        MemberName                 name;
+        AnnotationParameterValue   default_value;
+    };
+    // Ordered by CompleteAnnotationParameter.name
+    typedef
+    sequence<CompleteAnnotationParameter> CompleteAnnotationParameterSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAnnotationParameter {
+        CommonAnnotationParameter  common;
+        NameHash                   name_hash;
+        AnnotationParameterValue   default_value;
+    };
+    // Ordered by MinimalAnnotationParameter.name_hash
+    typedef
+    sequence<MinimalAnnotationParameter> MinimalAnnotationParameterSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAnnotationHeader {
+        QualifiedTypeName         annotation_name;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAnnotationHeader {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteAnnotationType {
+        AnnotationTypeFlag             annotation_flag;
+        CompleteAnnotationHeader       header;
+        CompleteAnnotationParameterSeq member_seq;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalAnnotationType {
+        AnnotationTypeFlag             annotation_flag;
+        MinimalAnnotationHeader        header;
+        MinimalAnnotationParameterSeq  member_seq;
+    };
+
+
+    // --- Alias: ----------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonAliasBody {
+        AliasMemberFlag       related_flags;
+        TypeIdentifier        related_type;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAliasBody {
+        CommonAliasBody       common;
+        @optional AppliedBuiltinMemberAnnotations  ann_builtin;
+        @optional AppliedAnnotationSeq             ann_custom;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAliasBody {
+        CommonAliasBody       common;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAliasHeader {
+        CompleteTypeDetail    detail;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAliasHeader {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteAliasType {
+        AliasTypeFlag         alias_flags;
+        CompleteAliasHeader   header;
+        CompleteAliasBody     body;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalAliasType {
+        AliasTypeFlag         alias_flags;
+        MinimalAliasHeader    header;
+        MinimalAliasBody      body;
+    };
+
+    // --- Collections: ----------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CompleteElementDetail {
+        @optional AppliedBuiltinMemberAnnotations  ann_builtin;
+        @optional AppliedAnnotationSeq             ann_custom;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CommonCollectionElement {
+        CollectionElementFlag     element_flags;
+        TypeIdentifier            type;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteCollectionElement {
+        CommonCollectionElement   common;
+        CompleteElementDetail     detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalCollectionElement {
+        CommonCollectionElement   common;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CommonCollectionHeader {
+        LBound                    bound;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct CompleteCollectionHeader {
+        CommonCollectionHeader        common;
+        @optional CompleteTypeDetail  detail; // not present for anonymous
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalCollectionHeader {
+        CommonCollectionHeader        common;
+    };
+
+    // --- Sequence: ------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CompleteSequenceType {
+        CollectionTypeFlag         collection_flag;
+        CompleteCollectionHeader   header;
+        CompleteCollectionElement  element;
+    };
+    
+    @extensibility(FINAL) @nested
+    struct MinimalSequenceType {
+        CollectionTypeFlag         collection_flag;
+        MinimalCollectionHeader    header;
+        MinimalCollectionElement   element;
+    };
+
+    // --- Array: ------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonArrayHeader {
+        LBoundSeq           bound_seq;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct CompleteArrayHeader {
+        CommonArrayHeader   common;
+        CompleteTypeDetail  detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalArrayHeader {
+        CommonArrayHeader   common;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteArrayType  {
+        CollectionTypeFlag          collection_flag;
+        CompleteArrayHeader         header;
+        CompleteCollectionElement   element;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalArrayType  {
+        CollectionTypeFlag         collection_flag;
+        MinimalArrayHeader         header;
+        MinimalCollectionElement   element;
+    };
+
+    // --- Map: ------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CompleteMapType {
+        CollectionTypeFlag            collection_flag;
+        CompleteCollectionHeader      header;
+        CompleteCollectionElement     key;
+        CompleteCollectionElement     element;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalMapType {
+        CollectionTypeFlag          collection_flag;
+        MinimalCollectionHeader     header;
+        MinimalCollectionElement    key;
+        MinimalCollectionElement    element;
+    };
+ 
+    // --- Enumeration: ----------------------------------------------------
+    typedef unsigned short BitBound;
+
+    // Constant in an enumerated type
+    @extensibility(APPENDABLE) @nested
+    struct CommonEnumeratedLiteral {
+        long                     value;
+        EnumeratedLiteralFlag    flags;
+    };
+      
+    // Constant in an enumerated type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteEnumeratedLiteral {
+        CommonEnumeratedLiteral  common;
+        CompleteMemberDetail     detail;
+    };
+    // Ordered by EnumeratedLiteral.common.value
+    typedef sequence<CompleteEnumeratedLiteral> CompleteEnumeratedLiteralSeq;
+
+    // Constant in an enumerated type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalEnumeratedLiteral {
+        CommonEnumeratedLiteral  common;
+        MinimalMemberDetail      detail;
+    };
+    // Ordered by EnumeratedLiteral.common.value
+    typedef sequence<MinimalEnumeratedLiteral> MinimalEnumeratedLiteralSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonEnumeratedHeader {
+        BitBound                bit_bound;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteEnumeratedHeader {
+        CommonEnumeratedHeader  common;
+        CompleteTypeDetail      detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalEnumeratedHeader {
+        CommonEnumeratedHeader  common;
+    };
+    
+    // Enumerated type
+    @extensibility(FINAL) @nested
+    struct CompleteEnumeratedType  {
+        EnumTypeFlag                    enum_flags; // unused
+        CompleteEnumeratedHeader        header; 
+        CompleteEnumeratedLiteralSeq    literal_seq;
+    };
+
+    // Enumerated type
+    @extensibility(FINAL) @nested
+    struct MinimalEnumeratedType  {
+        EnumTypeFlag                  enum_flags; // unused
+        MinimalEnumeratedHeader       header; 
+        MinimalEnumeratedLiteralSeq   literal_seq;
+    };  
+
+    // --- Bitmask: --------------------------------------------------------
+    // Bit in a bit mask
+    @extensibility(FINAL) @nested
+    struct CommonBitflag {
+        unsigned short         position;
+        BitflagFlag            flags;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitflag {
+        CommonBitflag          common;
+        CompleteMemberDetail   detail;
+    }; 
+    // Ordered by Bitflag.position
+    typedef sequence<CompleteBitflag> CompleteBitflagSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitflag {
+        CommonBitflag        common;
+        MinimalMemberDetail  detail;
+    }; 
+    // Ordered by Bitflag.position
+    typedef sequence<MinimalBitflag> MinimalBitflagSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonBitmaskHeader {
+        BitBound             bit_bound;
+    };
+
+    typedef CompleteEnumeratedHeader CompleteBitmaskHeader;
+
+    typedef MinimalEnumeratedHeader  MinimalBitmaskHeader;
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitmaskType {
+        BitmaskTypeFlag          bitmask_flags; // unused 
+        CompleteBitmaskHeader    header;
+        CompleteBitflagSeq       flag_seq;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitmaskType {
+        BitmaskTypeFlag          bitmask_flags; // unused 
+        MinimalBitmaskHeader     header;
+        MinimalBitflagSeq        flag_seq;
+    };
+
+    // --- Bitset: ----------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonBitfield {
+        unsigned short        position;
+        BitsetMemberFlag      flags;
+        octet                 bitcount;
+        TypeKind              holder_type; // Must be primitive integer type      
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitfield {
+        CommonBitfield           common;
+        CompleteMemberDetail     detail;
+    };  
+    // Ordered by Bitfield.position
+    typedef sequence<CompleteBitfield> CompleteBitfieldSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitfield {
+        CommonBitfield       common;
+        NameHash             name_hash;
+    };  
+    // Ordered by Bitfield.position
+    typedef sequence<MinimalBitfield> MinimalBitfieldSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitsetHeader {
+        CompleteTypeDetail   detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitsetHeader {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitsetType  {
+        BitsetTypeFlag         bitset_flags; // unused 
+        CompleteBitsetHeader   header;
+        CompleteBitfieldSeq    field_seq;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitsetType  {
+        BitsetTypeFlag       bitset_flags; // unused 
+        MinimalBitsetHeader  header;   
+        MinimalBitfieldSeq   field_seq;
+    };
+ 
+    // --- Type Object: ---------------------------------------------------
+    // The types associated with each case selection must have extensibility
+    // kind APPENDABLE or MUTABLE so that they can be extended in the future
+
+    @extensibility(MUTABLE) @nested
+    struct CompleteExtendedType {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL)     @nested
+    union CompleteTypeObject switch (octet) {
+        case TK_ALIAS:
+            CompleteAliasType      alias_type;
+        case TK_ANNOTATION:
+            CompleteAnnotationType annotation_type;
+        case TK_STRUCTURE:
+            CompleteStructType     struct_type;
+        case TK_UNION:
+            CompleteUnionType      union_type;
+        case TK_BITSET:
+            CompleteBitsetType     bitset_type;
+        case TK_SEQUENCE:
+            CompleteSequenceType   sequence_type;
+        case TK_ARRAY:
+            CompleteArrayType      array_type;
+        case TK_MAP:
+            CompleteMapType        map_type;
+        case TK_ENUM:
+            CompleteEnumeratedType enumerated_type;
+        case TK_BITMASK:
+            CompleteBitmaskType    bitmask_type;
+    
+        // ===================  Future extensibility  ============
+        default:
+            CompleteExtendedType   extended_type;    
+    };
+
+    @extensibility(MUTABLE) @nested
+    struct MinimalExtendedType {
+        // Empty. Available for future extension
+    };
+
+
+    @extensibility(FINAL)     @nested
+    union MinimalTypeObject switch (octet) {
+        case TK_ALIAS:
+            MinimalAliasType       alias_type;
+        case TK_ANNOTATION:
+            MinimalAnnotationType  annotation_type;
+        case TK_STRUCTURE:
+            MinimalStructType      struct_type;
+        case TK_UNION:
+            MinimalUnionType       union_type;
+        case TK_BITSET:
+            MinimalBitsetType      bitset_type;
+        case TK_SEQUENCE:
+            MinimalSequenceType    sequence_type;
+        case TK_ARRAY:
+            MinimalArrayType       array_type;
+        case TK_MAP:
+            MinimalMapType         map_type;
+        case TK_ENUM:
+            MinimalEnumeratedType  enumerated_type;
+        case TK_BITMASK:
+            MinimalBitmaskType     bitmask_type;
+    
+        // ===================  Future extensibility  ============
+        default:
+            MinimalExtendedType    extended_type;    
+    };
+
+    @extensibility(APPENDABLE)  @nested
+    union TypeObject switch (octet) { // EquivalenceKind
+    case EK_COMPLETE:
+        CompleteTypeObject   complete;
+    case EK_MINIMAL:
+        MinimalTypeObject    minimal;
+    };
+    typedef sequence<TypeObject> TypeObjectSeq;
+
+    // Set of TypeObjects representing a strong component: Equivalence class
+    // for the Strong Connectivity relationship (mutual reachability between
+    // types).
+    // Ordered by fully qualified typename lexicographic order 
+    typedef TypeObjectSeq        StronglyConnectedComponent;
+
+    @extensibility(FINAL)  @nested
+    struct TypeIdentifierTypeObjectPair {
+        TypeIdentifier  type_identifier;
+        TypeObject      type_object;
+    };
+    typedef
+    sequence<TypeIdentifierTypeObjectPair> TypeIdentifierTypeObjectPairSeq;
+
+    @extensibility(FINAL)  @nested
+    struct TypeIdentifierPair {
+        TypeIdentifier  type_identifier1;
+        TypeIdentifier  type_identifier2;
+    };
+    typedef sequence<TypeIdentifierPair> TypeIdentifierPairSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct TypeIdentfierWithSize {
+        DDS::Xtypes::TypeIdentifier  type_id;
+        unsigned long                typeobject_serialized_size;
+    };
+    typedef sequence<TypeIdentfierWithSize> TypeIdentfierWithSizeSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct TypeIdentifierWithDependencies {
+        TypeIdentfierWithSize            typeid_with_size;
+        // The total additional types related to minimal_type
+        long                             dependent_typeid_count;
+        sequence<TypeIdentfierWithSize>  dependent_typeids;
+    };
+    typedef
+    sequence<TypeIdentifierWithDependencies> TypeIdentifierWithDependenciesSeq;
+
+    // This appears in the builtin DDS topics PublicationBuiltinTopicData
+    // and SubscriptionBuiltinTopicData
+    @extensibility(MUTABLE) @nested
+    struct TypeInformation {
+        @id(0x1001) TypeIdentifierWithDependencies minimal;
+        @id(0x1002) TypeIdentifierWithDependencies complete;
+    };
+    typedef sequence<TypeInformation> TypeInformationSeq;
+
+};  // end of module XTypes
+};  // end module DDS
+
+

--- a/dds_gen/test_data/omg_dds/dds-xtypes_typeobject.idl
+++ b/dds_gen/test_data/omg_dds/dds-xtypes_typeobject.idl
@@ -1,0 +1,1068 @@
+/* dds-xtypes_typeobject.idl */
+
+// The types in this file shall be serialized with XCDR encoding version 2
+module DDS { module XTypes {
+    
+    // ---------- Equivalence Kinds -------------------
+    typedef octet EquivalenceKind;
+    const octet EK_MINIMAL   = 0xF1; // 0x1111 0001
+    const octet EK_COMPLETE  = 0xF2; // 0x1111 0010
+    const octet EK_BOTH      = 0xF3; // 0x1111 0011
+
+    // ---------- TypeKinds (begin) -------------------
+    typedef octet TypeKind;
+    
+    // Primitive TKs
+    const octet TK_NONE       = 0x00;
+    const octet TK_BOOLEAN    = 0x01;
+    const octet TK_BYTE       = 0x02;
+    const octet TK_INT16      = 0x03;
+    const octet TK_INT32      = 0x04;
+    const octet TK_INT64      = 0x05;
+    const octet TK_UINT16     = 0x06;
+    const octet TK_UINT32     = 0x07;
+    const octet TK_UINT64     = 0x08;
+    const octet TK_FLOAT32    = 0x09;
+    const octet TK_FLOAT64    = 0x0A;
+    const octet TK_FLOAT128   = 0x0B;
+    const octet TK_CHAR8      = 0x10;
+    const octet TK_CHAR16     = 0x11;
+
+    // String TKs
+    const octet TK_STRING8    = 0x20;
+    const octet TK_STRING16   = 0x21;
+
+    // Constructed/Named types
+    const octet TK_ALIAS      = 0x30;
+
+    // Enumerated TKs
+    const octet TK_ENUM       = 0x40;
+    const octet TK_BITMASK    = 0x41;
+
+    // Structured TKs
+    const octet TK_ANNOTATION = 0x50;
+    const octet TK_STRUCTURE  = 0x51;
+    const octet TK_UNION      = 0x52;
+    const octet TK_BITSET     = 0x53;
+      
+    // Collection TKs
+    const octet TK_SEQUENCE   = 0x60;
+    const octet TK_ARRAY      = 0x61;
+    const octet TK_MAP        = 0x62;
+    // ---------- TypeKinds (end) -------------------
+
+    // ---------- Extra TypeIdentifiers (begin) ------------
+    typedef octet TypeIdentiferKind;
+    const octet TI_STRING8_SMALL        = 0x70;
+    const octet TI_STRING8_LARGE        = 0x71;
+    const octet TI_STRING16_SMALL       = 0x72;
+    const octet TI_STRING16_LARGE       = 0x73;
+
+    const octet TI_PLAIN_SEQUENCE_SMALL = 0x80;
+    const octet TI_PLAIN_SEQUENCE_LARGE = 0x81;
+    
+    const octet TI_PLAIN_ARRAY_SMALL    = 0x90;
+    const octet TI_PLAIN_ARRAY_LARGE    = 0x91;
+    
+    const octet TI_PLAIN_MAP_SMALL      = 0xA0;
+    const octet TI_PLAIN_MAP_LARGE      = 0xA1;
+
+    const octet TI_STRONGLY_CONNECTED_COMPONENT = 0xB0;
+    // ---------- Extra TypeIdentifiers (end) --------------
+
+    // The name of some element (e.g. type, type member, module)
+    // Valid characters are alphanumeric plus the "_" cannot start with digit
+    const long MEMBER_NAME_MAX_LENGTH = 256;
+    typedef string<MEMBER_NAME_MAX_LENGTH> MemberName;
+
+    // Qualified type name includes the name of containing modules
+    // using "::" as separator. No leading "::". E.g. "MyModule::MyType"
+    const long TYPE_NAME_MAX_LENGTH = 256;
+    typedef string<TYPE_NAME_MAX_LENGTH> QualifiedTypeName;
+
+    // Every type has an ID. Those of the primitive types are pre-defined.
+    typedef octet PrimitiveTypeId;
+
+    // First 14 bytes of MD5 of the serialized TypeObject using XCDR
+    // version 2 with Little Endian encoding
+    typedef octet EquivalenceHash[14];
+
+    // First 4 bytes of MD5 of of a member name converted to bytes
+    // using UTF-8 encoding and without a 'nul' terminator.
+    // Example: the member name "color" has NameHash {0x70, 0xDD, 0xA5, 0xDF}
+    typedef octet NameHash[4];
+    
+    // Long Bound of a collection type
+    typedef unsigned long LBound;
+    typedef sequence<LBound> LBoundSeq;
+    const LBound INVALID_LBOUND = 0;
+    
+    // Short Bound of a collection type
+    typedef octet SBound;
+    typedef sequence<SBound> SBoundSeq;
+    const SBound INVALID_SBOUND = 0;
+
+    @extensibility(FINAL) @nested
+    union TypeObjectHashId switch (octet) {
+        case EK_COMPLETE:
+        case EK_MINIMAL:
+            EquivalenceHash  hash;
+    };
+       
+    // Flags that apply to struct/union/collection/enum/bitmask/bitset
+    // members/elements and DO affect type assignability
+    // Depending on the flag it may not apply to members of all types
+    // When not all, the applicable member types are listed
+    @bit_bound(16)
+    bitmask MemberFlag {
+        @position(0)  TRY_CONSTRUCT1,     // T1 | 00 = INVALID, 01 = DISCARD
+        @position(1)  TRY_CONSTRUCT2,     // T2 | 10 = USE_DEFAULT, 11 = TRIM
+        @position(2)  IS_EXTERNAL,        // X  StructMember, UnionMember,
+	                                  //    CollectionElement
+        @position(3)  IS_OPTIONAL,        // O  StructMember 
+        @position(4)  IS_MUST_UNDERSTAND, // M  StructMember
+        @position(5)  IS_KEY,          // K  StructMember, UnionDiscriminator
+        @position(6)  IS_DEFAULT       // D  UnionMember, EnumerationLiteral 
+    };
+    typedef MemberFlag   CollectionElementFlag;   // T1, T2, X
+    typedef MemberFlag   StructMemberFlag;        // T1, T2, O, M, K, X
+    typedef MemberFlag   UnionMemberFlag;         // T1, T2, D, X
+    typedef MemberFlag   UnionDiscriminatorFlag;  // T1, T2, K
+    typedef MemberFlag   EnumeratedLiteralFlag;   // D
+    typedef MemberFlag   AnnotationParameterFlag; // Unused. No flags apply
+    typedef MemberFlag   AliasMemberFlag;         // Unused. No flags apply
+    typedef MemberFlag   BitflagFlag;             // Unused. No flags apply
+    typedef MemberFlag   BitsetMemberFlag;        // Unused. No flags apply
+
+    // Mask used to remove the flags that do no affect assignability
+    // Selects  T1, T2, O, M, K, D
+    const   unsigned short  MemberFlagMinimalMask = 0x003f;  
+
+    // Flags that apply to type declarationa and DO affect assignability
+    // Depending on the flag it may not apply to all types
+    // When not all, the applicable  types are listed
+    @bit_bound(16)
+    bitmask TypeFlag {
+        @position(0) IS_FINAL,        // F |  
+        @position(1) IS_APPENDABLE,   // A |-  Struct, Union 
+        @position(2) IS_MUTABLE,      // M |   (exactly one flag)
+
+        @position(3) IS_NESTED,       // N     Struct, Union
+        @position(4) IS_AUTOID_HASH   // H     Struct
+    };
+    typedef TypeFlag   StructTypeFlag;      // All flags apply
+    typedef TypeFlag   UnionTypeFlag;       // All flags apply
+    typedef TypeFlag   CollectionTypeFlag;  // Unused. No flags apply
+    typedef TypeFlag   AnnotationTypeFlag;  // Unused. No flags apply
+    typedef TypeFlag   AliasTypeFlag;       // Unused. No flags apply
+    typedef TypeFlag   EnumTypeFlag;        // Unused. No flags apply
+    typedef TypeFlag   BitmaskTypeFlag;     // Unused. No flags apply
+    typedef TypeFlag   BitsetTypeFlag;      // Unused. No flags apply
+
+    // Mask used to remove the flags that do no affect assignability
+    const   unsigned short TypeFlagMinimalMask = 0x0007; // Selects  M, A, F
+
+   // Forward declaration
+   union TypeIdentifier;
+     
+    // 1 Byte
+    @extensibility(FINAL) @nested
+    struct StringSTypeDefn {
+    	SBound                  bound;
+    };
+    
+    // 4 Bytes
+    @extensibility(FINAL) @nested
+    struct StringLTypeDefn {
+        LBound                  bound;
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainCollectionHeader {
+        EquivalenceKind        equiv_kind;
+        CollectionElementFlag  element_flags;
+    };
+    
+    @extensibility(FINAL) @nested
+    struct PlainSequenceSElemDefn {
+        PlainCollectionHeader  header;
+        SBound                 bound;
+        @external TypeIdentifier element_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainSequenceLElemDefn {
+        PlainCollectionHeader  header;
+        LBound                 bound;
+        @external TypeIdentifier element_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainArraySElemDefn {
+        PlainCollectionHeader  header;
+        SBoundSeq              array_bound_seq;
+        @external TypeIdentifier element_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainArrayLElemDefn {
+        PlainCollectionHeader  header;
+        LBoundSeq              array_bound_seq;
+        @external TypeIdentifier element_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainMapSTypeDefn {
+        PlainCollectionHeader  header;
+        SBound                 bound;
+        @external TypeIdentifier element_identifier; 
+        CollectionElementFlag  key_flags;
+        @external TypeIdentifier key_identifier; 
+    };
+
+    @extensibility(FINAL) @nested
+    struct PlainMapLTypeDefn {
+        PlainCollectionHeader  header;
+        LBound                 bound;
+        @external TypeIdentifier element_identifier; 
+        CollectionElementFlag  key_flags;
+        @external TypeIdentifier key_identifier; 
+    };
+
+    // Used for Types that have cyclic depencencies with other types
+    @extensibility(APPENDABLE) @nested
+    struct StronglyConnectedComponentId {
+        TypeObjectHashId sc_component_id; // Hash StronglyConnectedComponent
+        long   scc_length; // StronglyConnectedComponent.length 
+        long   scc_index ; // identify type in Strongly Connected Comp.
+    };
+
+    // Future extensibility
+    @extensibility(MUTABLE) @nested
+    struct ExtendedTypeDefn {
+        // Empty. Available for future extension
+    };
+ 
+
+    
+    // The TypeIdentifier uniquely identifies a type (a set of equivalent 
+    // types according to an equivalence relationship:  COMPLETE, MNIMAL).
+    //
+    // In some cases (primitive types, strings, plain types) the identifier 
+    // is a explicit description of the type.
+    // In other cases the Identifier is a Hash of the type description
+    //
+    // In the case of primitive types and strings the implied equivalence
+    // relation is the identity.
+    //
+    // For Plain Types and Hash-defined TypeIdentifiers there are three
+    //  possibilities: MINIMAL, COMPLETE, and COMMON:
+    //   - MINIMAL indicates the TypeIdentifier identifies equivalent types
+    //     according to the MINIMAL equivalence relation
+    //   - COMPLETE indicates the TypeIdentifier identifies equivalent types
+    //     according to the COMPLETE equivalence relation
+    //   - COMMON indicates the TypeIdentifier identifies equivalent types
+    //     according to both the MINIMAL and the COMMON equivalence relation.
+    //     This means the TypeIdentifier is the same for both relationships
+    // 
+    @extensibility(FINAL) @nested
+    union TypeIdentifier switch (octet) { 
+        // ============  Primitive types - use TypeKind ====================
+        // All primitive types fall here. 
+        // Commented-out because Unions cannot have cases with no member.
+        /*
+        case TK_NONE:
+        case TK_BOOLEAN:       
+        case TK_BYTE_TYPE:
+        case TK_INT16_TYPE:
+        case TK_INT32_TYPE:
+        case TK_INT64_TYPE:
+        case TK_UINT16_TYPE:
+        case TK_UINT32_TYPE:
+        case TK_UINT64_TYPE:
+        case TK_FLOAT32_TYPE:
+        case TK_FLOAT64_TYPE:
+        case TK_FLOAT128_TYPE:        
+        case TK_CHAR8_TYPE:
+        case TK_CHAR16_TYPE:
+            // No Value
+        */
+
+        // ============ Strings - use TypeIdentifierKind ===================
+        case TI_STRING8_SMALL:
+        case TI_STRING16_SMALL:
+            StringSTypeDefn         string_sdefn;
+
+        case TI_STRING8_LARGE:
+        case TI_STRING16_LARGE:
+            StringLTypeDefn         string_ldefn;
+
+        // ============  Plain collectios - use TypeIdentifierKind =========
+        case TI_PLAIN_SEQUENCE_SMALL:
+            PlainSequenceSElemDefn  seq_sdefn;
+        case TI_PLAIN_SEQUENCE_LARGE:
+            PlainSequenceLElemDefn  seq_ldefn;
+
+        case TI_PLAIN_ARRAY_SMALL:
+            PlainArraySElemDefn     array_sdefn;
+        case TI_PLAIN_ARRAY_LARGE:
+            PlainArrayLElemDefn     array_ldefn;
+
+        case TI_PLAIN_MAP_SMALL:
+            PlainMapSTypeDefn       map_sdefn;
+        case TI_PLAIN_MAP_LARGE:
+            PlainMapLTypeDefn       map_ldefn;
+    
+        // ============  Types that are mutually dependent on each other ===
+        case TI_STRONGLY_CONNECTED_COMPONENT:
+            StronglyConnectedComponentId  sc_component_id;
+
+        // ============  The remaining cases - use EquivalenceKind ========= 
+        case EK_COMPLETE:
+        case EK_MINIMAL:
+            EquivalenceHash         equivalence_hash;
+
+        // ===================  Future extensibility  ============
+        // Future extensions
+        default:
+            ExtendedTypeDefn        extended_defn;
+    };   
+    typedef sequence<TypeIdentifier> TypeIdentifierSeq;
+
+
+    // --- Annotation usage: -----------------------------------------------
+
+    // ID of a type member
+    typedef unsigned long MemberId;
+    const unsigned long ANNOTATION_STR_VALUE_MAX_LEN = 128;
+    const unsigned long ANNOTATION_OCTETSEC_VALUE_MAX_LEN = 128;
+
+    @extensibility(MUTABLE) @nested
+    struct ExtendedAnnotationParameterValue {
+        // Empty. Available for future extension
+    };
+    
+    /* Literal value of an annotation member: either the default value in its
+     * definition or the value applied in its usage.
+     */
+    @extensibility(FINAL) @nested
+    union AnnotationParameterValue switch (octet) {
+        case TK_BOOLEAN:
+            boolean             boolean_value;
+        case TK_BYTE:
+            octet               byte_value;
+        case TK_INT16:
+            short               int16_value;
+        case TK_UINT16:
+            unsigned short      uint_16_value;
+        case TK_INT32:
+            long                int32_value;
+        case TK_UINT32:
+            unsigned long       uint32_value;
+        case TK_INT64:
+            long long           int64_value;
+        case TK_UINT64:
+            unsigned long long  uint64_value;
+        case TK_FLOAT32:
+            float               float32_value;
+        case TK_FLOAT64:
+            double              float64_value;
+        case TK_FLOAT128:
+            long double         float128_value;
+        case TK_CHAR8:
+            char                char_value;
+        case TK_CHAR16:
+            wchar               wchar_value;
+        case TK_ENUM:
+            long                enumerated_value;
+        case TK_STRING8:
+            string<ANNOTATION_STR_VALUE_MAX_LEN>  string8_value;   
+        case TK_STRING16:
+            wstring<ANNOTATION_STR_VALUE_MAX_LEN> string16_value;  
+        default:
+            ExtendedAnnotationParameterValue      extended_value;
+    };
+
+    // The application of an annotation to some type or type member
+    @extensibility(APPENDABLE) @nested
+    struct AppliedAnnotationParameter {
+       NameHash                  paramname_hash;          
+       AnnotationParameterValue  value;      
+    };
+    // Sorted by AppliedAnnotationParameter.paramname_hash
+    typedef
+    sequence<AppliedAnnotationParameter> AppliedAnnotationParameterSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct AppliedAnnotation {
+        TypeIdentifier                     annotation_typeid;
+        @optional AppliedAnnotationParameterSeq   param_seq;
+    };
+    // Sorted by AppliedAnnotation.annotation_typeid
+    typedef sequence<AppliedAnnotation> AppliedAnnotationSeq;
+
+    // @verbatim(placement="<placement>", language="<lang>", text="<text>")
+    @extensibility(FINAL) @nested
+    struct AppliedVerbatimAnnotation {
+        string<32> placement;
+        string<32> language;
+        string     text;
+    };
+
+
+    // --- Aggregate types: ------------------------------------------------
+    @extensibility(APPENDABLE) @nested
+    struct AppliedBuiltinMemberAnnotations {
+        @optional string                  unit; // @unit("<unit>")
+        @optional AnnotationParameterValue min; // @min , @range
+        @optional AnnotationParameterValue max; // @max , @range
+        @optional string               hash_id; // @hash_id("<membername>")
+    };
+
+    @extensibility(FINAL) @nested
+    struct CommonStructMember {
+        MemberId                                   member_id;
+        StructMemberFlag                           member_flags;
+        TypeIdentifier                             member_type_id;
+    };
+
+    // COMPLETE Details for a member of an aggregate type
+    @extensibility(FINAL) @nested
+    struct CompleteMemberDetail {
+       MemberName                                 name;
+       @optional AppliedBuiltinMemberAnnotations  ann_builtin;
+       @optional AppliedAnnotationSeq             ann_custom;
+    };
+
+    // MINIMAL Details for a member of an aggregate type
+    @extensibility(FINAL) @nested
+    struct MinimalMemberDetail {
+        NameHash                                  name_hash;
+    };
+
+    // Member of an aggregate type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteStructMember {
+        CommonStructMember                         common;
+        CompleteMemberDetail                       detail;
+    };
+    // Ordered by the member_index
+    typedef sequence<CompleteStructMember> CompleteStructMemberSeq;
+    
+    // Member of an aggregate type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalStructMember {
+        CommonStructMember                         common;
+        MinimalMemberDetail                        detail;
+    };
+    // Ordered by common.member_id
+    typedef sequence<MinimalStructMember> MinimalStructMemberSeq;
+
+    
+    @extensibility(APPENDABLE) @nested
+    struct AppliedBuiltinTypeAnnotations {
+        @optional AppliedVerbatimAnnotation verbatim;  // @verbatim(...)
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalTypeDetail {
+        // Empty. Available for future extension
+    };
+ 
+    @extensibility(FINAL) @nested
+    struct CompleteTypeDetail {
+         @optional AppliedBuiltinTypeAnnotations  ann_builtin;        
+         @optional AppliedAnnotationSeq           ann_custom;     
+         QualifiedTypeName                        type_name;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteStructHeader {
+        TypeIdentifier                           base_type;
+        CompleteTypeDetail                       detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalStructHeader {
+        TypeIdentifier                           base_type;
+        MinimalTypeDetail                        detail;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteStructType {
+        StructTypeFlag             struct_flags;
+        CompleteStructHeader       header;
+        CompleteStructMemberSeq    member_seq;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalStructType {
+        StructTypeFlag             struct_flags;
+        MinimalStructHeader        header;
+        MinimalStructMemberSeq     member_seq;
+    };
+
+    // --- Union: ----------------------------------------------------------
+
+    // Case labels that apply to a member of a union type
+    // Ordered by their values
+    typedef sequence<long> UnionCaseLabelSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonUnionMember {
+        MemberId                    member_id;
+        UnionMemberFlag             member_flags;
+        TypeIdentifier              type_id;
+        UnionCaseLabelSeq           label_seq;
+    };
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteUnionMember {
+        CommonUnionMember      common;
+        CompleteMemberDetail   detail;
+    };
+    // Ordered by member_index
+    typedef sequence<CompleteUnionMember> CompleteUnionMemberSeq;
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalUnionMember {
+        CommonUnionMember   common;
+        MinimalMemberDetail detail;
+    };
+    // Ordered by MinimalUnionMember.common.member_id
+    typedef sequence<MinimalUnionMember> MinimalUnionMemberSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonDiscriminatorMember {
+        UnionDiscriminatorFlag       member_flags;
+        TypeIdentifier               type_id;
+    };
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteDiscriminatorMember {
+        CommonDiscriminatorMember                common;
+        @optional AppliedBuiltinTypeAnnotations  ann_builtin;
+        @optional AppliedAnnotationSeq           ann_custom;
+    };
+
+    // Member of a union type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalDiscriminatorMember {
+        CommonDiscriminatorMember   common;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteUnionHeader {
+        CompleteTypeDetail          detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalUnionHeader {
+        MinimalTypeDetail           detail;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteUnionType {
+        UnionTypeFlag                union_flags;
+        CompleteUnionHeader          header;
+        CompleteDiscriminatorMember  discriminator;
+        CompleteUnionMemberSeq       member_seq;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalUnionType {
+        UnionTypeFlag                union_flags;
+        MinimalUnionHeader           header;
+        MinimalDiscriminatorMember   discriminator;
+        MinimalUnionMemberSeq        member_seq;
+    };
+
+    // --- Annotation: ----------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonAnnotationParameter {
+        AnnotationParameterFlag      member_flags;
+        TypeIdentifier               member_type_id;
+    };
+
+    // Member of an annotation type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAnnotationParameter {
+        CommonAnnotationParameter  common;
+        MemberName                 name;
+        AnnotationParameterValue   default_value;
+    };
+    // Ordered by CompleteAnnotationParameter.name
+    typedef
+    sequence<CompleteAnnotationParameter> CompleteAnnotationParameterSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAnnotationParameter {
+        CommonAnnotationParameter  common;
+        NameHash                   name_hash;
+        AnnotationParameterValue   default_value;
+    };
+    // Ordered by MinimalAnnotationParameter.name_hash
+    typedef
+    sequence<MinimalAnnotationParameter> MinimalAnnotationParameterSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAnnotationHeader {
+        QualifiedTypeName         annotation_name;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAnnotationHeader {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteAnnotationType {
+        AnnotationTypeFlag             annotation_flag;
+        CompleteAnnotationHeader       header;
+        CompleteAnnotationParameterSeq member_seq;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalAnnotationType {
+        AnnotationTypeFlag             annotation_flag;
+        MinimalAnnotationHeader        header;
+        MinimalAnnotationParameterSeq  member_seq;
+    };
+
+
+    // --- Alias: ----------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonAliasBody {
+        AliasMemberFlag       related_flags;
+        TypeIdentifier        related_type;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAliasBody {
+        CommonAliasBody       common;
+        @optional AppliedBuiltinMemberAnnotations  ann_builtin;
+        @optional AppliedAnnotationSeq             ann_custom;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAliasBody {
+        CommonAliasBody       common;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteAliasHeader {
+        CompleteTypeDetail    detail;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct MinimalAliasHeader {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL) @nested
+    struct CompleteAliasType {
+        AliasTypeFlag         alias_flags;
+        CompleteAliasHeader   header;
+        CompleteAliasBody     body;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalAliasType {
+        AliasTypeFlag         alias_flags;
+        MinimalAliasHeader    header;
+        MinimalAliasBody      body;
+    };
+
+    // --- Collections: ----------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CompleteElementDetail {
+        @optional AppliedBuiltinMemberAnnotations  ann_builtin;
+        @optional AppliedAnnotationSeq             ann_custom;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CommonCollectionElement {
+        CollectionElementFlag     element_flags;
+        TypeIdentifier            type;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteCollectionElement {
+        CommonCollectionElement   common;
+        CompleteElementDetail     detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalCollectionElement {
+        CommonCollectionElement   common;
+    };
+
+    @extensibility(FINAL) @nested
+    struct CommonCollectionHeader {
+        LBound                    bound;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct CompleteCollectionHeader {
+        CommonCollectionHeader        common;
+        @optional CompleteTypeDetail  detail; // not present for anonymous
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalCollectionHeader {
+        CommonCollectionHeader        common;
+    };
+
+    // --- Sequence: ------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CompleteSequenceType {
+        CollectionTypeFlag         collection_flag;
+        CompleteCollectionHeader   header;
+        CompleteCollectionElement  element;
+    };
+    
+    @extensibility(FINAL) @nested
+    struct MinimalSequenceType {
+        CollectionTypeFlag         collection_flag;
+        MinimalCollectionHeader    header;
+        MinimalCollectionElement   element;
+    };
+
+    // --- Array: ------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonArrayHeader {
+        LBoundSeq           bound_seq;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct CompleteArrayHeader {
+        CommonArrayHeader   common;
+        CompleteTypeDetail  detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalArrayHeader {
+        CommonArrayHeader   common;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteArrayType  {
+        CollectionTypeFlag          collection_flag;
+        CompleteArrayHeader         header;
+        CompleteCollectionElement   element;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalArrayType  {
+        CollectionTypeFlag         collection_flag;
+        MinimalArrayHeader         header;
+        MinimalCollectionElement   element;
+    };
+
+    // --- Map: ------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CompleteMapType {
+        CollectionTypeFlag            collection_flag;
+        CompleteCollectionHeader      header;
+        CompleteCollectionElement     key;
+        CompleteCollectionElement     element;
+    };
+
+    @extensibility(FINAL) @nested
+    struct MinimalMapType {
+        CollectionTypeFlag          collection_flag;
+        MinimalCollectionHeader     header;
+        MinimalCollectionElement    key;
+        MinimalCollectionElement    element;
+    };
+ 
+    // --- Enumeration: ----------------------------------------------------
+    typedef unsigned short BitBound;
+
+    // Constant in an enumerated type
+    @extensibility(APPENDABLE) @nested
+    struct CommonEnumeratedLiteral {
+        long                     value;
+        EnumeratedLiteralFlag    flags;
+    };
+      
+    // Constant in an enumerated type
+    @extensibility(APPENDABLE) @nested
+    struct CompleteEnumeratedLiteral {
+        CommonEnumeratedLiteral  common;
+        CompleteMemberDetail     detail;
+    };
+    // Ordered by EnumeratedLiteral.common.value
+    typedef sequence<CompleteEnumeratedLiteral> CompleteEnumeratedLiteralSeq;
+
+    // Constant in an enumerated type
+    @extensibility(APPENDABLE) @nested
+    struct MinimalEnumeratedLiteral {
+        CommonEnumeratedLiteral  common;
+        MinimalMemberDetail      detail;
+    };
+    // Ordered by EnumeratedLiteral.common.value
+    typedef sequence<MinimalEnumeratedLiteral> MinimalEnumeratedLiteralSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonEnumeratedHeader {
+        BitBound                bit_bound;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteEnumeratedHeader {
+        CommonEnumeratedHeader  common;
+        CompleteTypeDetail      detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalEnumeratedHeader {
+        CommonEnumeratedHeader  common;
+    };
+    
+    // Enumerated type
+    @extensibility(FINAL) @nested
+    struct CompleteEnumeratedType  {
+        EnumTypeFlag                    enum_flags; // unused
+        CompleteEnumeratedHeader        header; 
+        CompleteEnumeratedLiteralSeq    literal_seq;
+    };
+
+    // Enumerated type
+    @extensibility(FINAL) @nested
+    struct MinimalEnumeratedType  {
+        EnumTypeFlag                  enum_flags; // unused
+        MinimalEnumeratedHeader       header; 
+        MinimalEnumeratedLiteralSeq   literal_seq;
+    };  
+
+    // --- Bitmask: --------------------------------------------------------
+    // Bit in a bit mask
+    @extensibility(FINAL) @nested
+    struct CommonBitflag {
+        unsigned short         position;
+        BitflagFlag            flags;
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitflag {
+        CommonBitflag          common;
+        CompleteMemberDetail   detail;
+    }; 
+    // Ordered by Bitflag.position
+    typedef sequence<CompleteBitflag> CompleteBitflagSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitflag {
+        CommonBitflag        common;
+        MinimalMemberDetail  detail;
+    }; 
+    // Ordered by Bitflag.position
+    typedef sequence<MinimalBitflag> MinimalBitflagSeq;
+
+    @extensibility(FINAL) @nested
+    struct CommonBitmaskHeader {
+        BitBound             bit_bound;
+    };
+
+    typedef CompleteEnumeratedHeader CompleteBitmaskHeader;
+
+    typedef MinimalEnumeratedHeader  MinimalBitmaskHeader;
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitmaskType {
+        BitmaskTypeFlag          bitmask_flags; // unused 
+        CompleteBitmaskHeader    header;
+        CompleteBitflagSeq       flag_seq;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitmaskType {
+        BitmaskTypeFlag          bitmask_flags; // unused 
+        MinimalBitmaskHeader     header;
+        MinimalBitflagSeq        flag_seq;
+    };
+
+    // --- Bitset: ----------------------------------------------------------
+    @extensibility(FINAL) @nested
+    struct CommonBitfield {
+        unsigned short        position;
+        BitsetMemberFlag      flags;
+        octet                 bitcount;
+        TypeKind              holder_type; // Must be primitive integer type      
+    };
+    
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitfield {
+        CommonBitfield           common;
+        CompleteMemberDetail     detail;
+    };  
+    // Ordered by Bitfield.position
+    typedef sequence<CompleteBitfield> CompleteBitfieldSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitfield {
+        CommonBitfield       common;
+        NameHash             name_hash;
+    };  
+    // Ordered by Bitfield.position
+    typedef sequence<MinimalBitfield> MinimalBitfieldSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitsetHeader {
+        CompleteTypeDetail   detail;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitsetHeader {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct CompleteBitsetType  {
+        BitsetTypeFlag         bitset_flags; // unused 
+        CompleteBitsetHeader   header;
+        CompleteBitfieldSeq    field_seq;
+    };
+
+    @extensibility(APPENDABLE) @nested
+    struct MinimalBitsetType  {
+        BitsetTypeFlag       bitset_flags; // unused 
+        MinimalBitsetHeader  header;   
+        MinimalBitfieldSeq   field_seq;
+    };
+ 
+    // --- Type Object: ---------------------------------------------------
+    // The types associated with each case selection must have extensibility
+    // kind APPENDABLE or MUTABLE so that they can be extended in the future
+
+    @extensibility(MUTABLE) @nested
+    struct CompleteExtendedType {
+        // Empty. Available for future extension
+    };
+
+    @extensibility(FINAL)     @nested
+    union CompleteTypeObject switch (octet) {
+        case TK_ALIAS:
+            CompleteAliasType      alias_type;
+        case TK_ANNOTATION:
+            CompleteAnnotationType annotation_type;
+        case TK_STRUCTURE:
+            CompleteStructType     struct_type;
+        case TK_UNION:
+            CompleteUnionType      union_type;
+        case TK_BITSET:
+            CompleteBitsetType     bitset_type;
+        case TK_SEQUENCE:
+            CompleteSequenceType   sequence_type;
+        case TK_ARRAY:
+            CompleteArrayType      array_type;
+        case TK_MAP:
+            CompleteMapType        map_type;
+        case TK_ENUM:
+            CompleteEnumeratedType enumerated_type;
+        case TK_BITMASK:
+            CompleteBitmaskType    bitmask_type;
+    
+        // ===================  Future extensibility  ============
+        default:
+            CompleteExtendedType   extended_type;    
+    };
+
+    @extensibility(MUTABLE) @nested
+    struct MinimalExtendedType {
+        // Empty. Available for future extension
+    };
+
+
+    @extensibility(FINAL)     @nested
+    union MinimalTypeObject switch (octet) {
+        case TK_ALIAS:
+            MinimalAliasType       alias_type;
+        case TK_ANNOTATION:
+            MinimalAnnotationType  annotation_type;
+        case TK_STRUCTURE:
+            MinimalStructType      struct_type;
+        case TK_UNION:
+            MinimalUnionType       union_type;
+        case TK_BITSET:
+            MinimalBitsetType      bitset_type;
+        case TK_SEQUENCE:
+            MinimalSequenceType    sequence_type;
+        case TK_ARRAY:
+            MinimalArrayType       array_type;
+        case TK_MAP:
+            MinimalMapType         map_type;
+        case TK_ENUM:
+            MinimalEnumeratedType  enumerated_type;
+        case TK_BITMASK:
+            MinimalBitmaskType     bitmask_type;
+    
+        // ===================  Future extensibility  ============
+        default:
+            MinimalExtendedType    extended_type;    
+    };
+
+    @extensibility(APPENDABLE)  @nested
+    union TypeObject switch (octet) { // EquivalenceKind
+    case EK_COMPLETE:
+        CompleteTypeObject   complete;
+    case EK_MINIMAL:
+        MinimalTypeObject    minimal;
+    };
+    typedef sequence<TypeObject> TypeObjectSeq;
+
+    // Set of TypeObjects representing a strong component: Equivalence class
+    // for the Strong Connectivity relationship (mutual reachability between
+    // types).
+    // Ordered by fully qualified typename lexicographic order 
+    typedef TypeObjectSeq        StronglyConnectedComponent;
+
+    @extensibility(FINAL)  @nested
+    struct TypeIdentifierTypeObjectPair {
+        TypeIdentifier  type_identifier;
+        TypeObject      type_object;
+    };
+    typedef
+    sequence<TypeIdentifierTypeObjectPair> TypeIdentifierTypeObjectPairSeq;
+
+    @extensibility(FINAL)  @nested
+    struct TypeIdentifierPair {
+        TypeIdentifier  type_identifier1;
+        TypeIdentifier  type_identifier2;
+    };
+    typedef sequence<TypeIdentifierPair> TypeIdentifierPairSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct TypeIdentfierWithSize {
+        DDS::Xtypes::TypeIdentifier  type_id;
+        unsigned long                typeobject_serialized_size;
+    };
+    typedef sequence<TypeIdentfierWithSize> TypeIdentfierWithSizeSeq;
+
+    @extensibility(APPENDABLE) @nested
+    struct TypeIdentifierWithDependencies {
+        TypeIdentfierWithSize            typeid_with_size;
+        // The total additional types related to minimal_type
+        long                             dependent_typeid_count;
+        sequence<TypeIdentfierWithSize>  dependent_typeids;
+    };
+    typedef
+    sequence<TypeIdentifierWithDependencies> TypeIdentifierWithDependenciesSeq;
+
+    // This appears in the builtin DDS topics PublicationBuiltinTopicData
+    // and SubscriptionBuiltinTopicData
+    @extensibility(MUTABLE) @nested
+    struct TypeInformation {
+        @id(0x1001) TypeIdentifierWithDependencies minimal;
+        @id(0x1002) TypeIdentifierWithDependencies complete;
+    };
+    typedef sequence<TypeInformation> TypeInformationSeq;
+
+};  // end of module XTypes
+};  // end module DDS
+
+

--- a/dds_gen/test_data/omg_dds/dds_dcps.idl
+++ b/dds_gen/test_data/omg_dds/dds_dcps.idl
@@ -1,0 +1,1354 @@
+#define DOMAINID_TYPE_NATIVE    long
+#define HANDLE_TYPE_NATIVE      long
+#define HANDLE_NIL_NATIVE       0
+#define BUILTIN_TOPIC_KEY_TYPE_NATIVE     long
+
+#define TheParticipantFactory
+#define PARTICIPANT_QOS_DEFAULT
+#define TOPIC_QOS_DEFAULT
+#define PUBLISHER_QOS_DEFAULT
+#define SUBSCRIBER_QOS_DEFAULT
+#define DATAWRITER_QOS_DEFAULT
+#define DATAREADER_QOS_DEFAULT
+#define DATAWRITER_QOS_USE_TOPIC_QOS
+#define DATAREADER_QOS_USE_TOPIC_QOS
+
+module DDS {
+    typedef DOMAINID_TYPE_NATIVE  DomainId_t;
+    typedef HANDLE_TYPE_NATIVE    InstanceHandle_t;
+
+    struct BuiltinTopicKey_t { 
+        BUILTIN_TOPIC_KEY_TYPE_NATIVE value[3];
+    };
+
+    typedef sequence<InstanceHandle_t> InstanceHandleSeq;
+
+    typedef long ReturnCode_t;
+    typedef long QosPolicyId_t;
+    typedef sequence<string> StringSeq;
+    
+    struct Duration_t { 
+        long sec; 
+        unsigned long nanosec; 
+    };
+    
+    struct Time_t {
+        long sec; 
+        unsigned long nanosec; 
+    };
+    
+    // ----------------------------------------------------------------------
+    // Pre-defined values
+    // ----------------------------------------------------------------------
+    const InstanceHandle_t HANDLE_NIL = HANDLE_NIL_NATIVE;
+    
+    const long LENGTH_UNLIMITED = -1;
+    
+    const long            DURATION_INFINITE_SEC   = 0x7fffffff;
+    const unsigned long   DURATION_INFINITE_NSEC  = 0x7fffffff;
+
+    const long            DURATION_ZERO_SEC       = 0;
+    const unsigned long   DURATION_ZERO_NSEC      = 0;
+
+    const long            TIME_INVALID_SEC        = -1;
+    const unsigned long   TIME_INVALID_NSEC       = 0xffffffff;
+
+    // ----------------------------------------------------------------------
+    // Return codes
+    // ----------------------------------------------------------------------
+    const ReturnCode_t RETCODE_OK                    = 0;
+    const ReturnCode_t RETCODE_ERROR                 = 1;
+    const ReturnCode_t RETCODE_UNSUPPORTED           = 2;
+    const ReturnCode_t RETCODE_BAD_PARAMETER         = 3;
+    const ReturnCode_t RETCODE_PRECONDITION_NOT_MET  = 4;
+    const ReturnCode_t RETCODE_OUT_OF_RESOURCES      = 5;
+    const ReturnCode_t RETCODE_NOT_ENABLED           = 6;
+    const ReturnCode_t RETCODE_IMMUTABLE_POLICY      = 7;
+    const ReturnCode_t RETCODE_INCONSISTENT_POLICY   = 8;
+    const ReturnCode_t RETCODE_ALREADY_DELETED       = 9;
+    const ReturnCode_t RETCODE_TIMEOUT               = 10;
+    const ReturnCode_t RETCODE_NO_DATA               = 11;
+    const ReturnCode_t RETCODE_ILLEGAL_OPERATION     = 12;
+    
+    // ----------------------------------------------------------------------
+    // Status to support listeners and conditions
+    // ----------------------------------------------------------------------
+
+    typedef unsigned long StatusKind;
+    typedef unsigned long StatusMask;    // bit-mask StatusKind
+
+    const StatusKind INCONSISTENT_TOPIC_STATUS            = 0x0001 << 0;
+    const StatusKind OFFERED_DEADLINE_MISSED_STATUS       = 0x0001 << 1;
+    const StatusKind REQUESTED_DEADLINE_MISSED_STATUS     = 0x0001 << 2;
+    const StatusKind OFFERED_INCOMPATIBLE_QOS_STATUS      = 0x0001 << 5;
+    const StatusKind REQUESTED_INCOMPATIBLE_QOS_STATUS    = 0x0001 << 6;
+    const StatusKind SAMPLE_LOST_STATUS                   = 0x0001 << 7;
+    const StatusKind SAMPLE_REJECTED_STATUS               = 0x0001 << 8;
+    const StatusKind DATA_ON_READERS_STATUS               = 0x0001 << 9;
+    const StatusKind DATA_AVAILABLE_STATUS                = 0x0001 << 10;
+    const StatusKind LIVELINESS_LOST_STATUS               = 0x0001 << 11;
+    const StatusKind LIVELINESS_CHANGED_STATUS            = 0x0001 << 12;
+    const StatusKind PUBLICATION_MATCHED_STATUS           = 0x0001 << 13;
+    const StatusKind SUBSCRIPTION_MATCHED_STATUS          = 0x0001 << 14;
+
+    struct InconsistentTopicStatus {
+        long total_count;
+        long total_count_change;
+    };
+
+    struct SampleLostStatus {
+        long total_count;
+        long total_count_change;
+    };
+
+    enum SampleRejectedStatusKind {
+        NOT_REJECTED,
+        REJECTED_BY_INSTANCES_LIMIT,
+        REJECTED_BY_SAMPLES_LIMIT,
+        REJECTED_BY_SAMPLES_PER_INSTANCE_LIMIT
+    };
+
+    struct SampleRejectedStatus {
+        long                         total_count;
+        long                         total_count_change;
+        SampleRejectedStatusKind     last_reason;
+        InstanceHandle_t             last_instance_handle;
+    };
+
+    struct LivelinessLostStatus { 
+        long                 total_count;
+        long                 total_count_change;
+    };
+
+    struct LivelinessChangedStatus {
+        long                 alive_count;
+        long                 not_alive_count;
+        long                 alive_count_change;
+        long                 not_alive_count_change;
+        InstanceHandle_t     last_publication_handle;
+    };
+
+    struct OfferedDeadlineMissedStatus {
+        long                 total_count;
+        long                 total_count_change;
+        InstanceHandle_t     last_instance_handle;
+    };
+
+    struct RequestedDeadlineMissedStatus {
+        long                 total_count;
+        long                 total_count_change;
+        InstanceHandle_t     last_instance_handle;
+    };
+
+    struct QosPolicyCount {
+        QosPolicyId_t        policy_id;
+        long                 count;
+    };
+
+    typedef sequence<QosPolicyCount> QosPolicyCountSeq;
+
+    struct OfferedIncompatibleQosStatus {
+        long                 total_count;
+        long                 total_count_change;
+        QosPolicyId_t        last_policy_id;
+        QosPolicyCountSeq    policies;
+    };
+
+    struct RequestedIncompatibleQosStatus {
+        long                 total_count;
+        long                 total_count_change;
+        QosPolicyId_t        last_policy_id;
+        QosPolicyCountSeq    policies;
+    };
+
+
+    struct PublicationMatchedStatus {
+        long                 total_count;
+        long                 total_count_change;
+        long                 current_count;
+        long                 current_count_change;
+        InstanceHandle_t     last_subscription_handle;
+    };
+
+
+    struct SubscriptionMatchedStatus {
+        long                 total_count;
+        long                 total_count_change;
+        long                 current_count;
+        long                 current_count_change;
+        InstanceHandle_t     last_publication_handle;
+    };
+
+    // ----------------------------------------------------------------------
+    // Listeners 
+    // ----------------------------------------------------------------------
+
+    interface Listener;
+    interface Entity;
+    interface TopicDescription;
+    interface Topic;
+    interface ContentFilteredTopic;
+    interface MultiTopic;
+    interface DataWriter;
+    interface DataReader;
+    interface Subscriber;
+    interface Publisher;
+
+    typedef sequence<DataReader> DataReaderSeq;
+    
+    interface Listener {};
+    
+    interface TopicListener : Listener {
+    void on_inconsistent_topic(in Topic the_topic, 
+        in InconsistentTopicStatus status);
+    };
+
+    interface DataWriterListener : Listener {
+        void on_offered_deadline_missed(
+            in DataWriter writer, 
+            in OfferedDeadlineMissedStatus status);
+        void on_offered_incompatible_qos(
+            in DataWriter writer, 
+            in OfferedIncompatibleQosStatus status);
+        void on_liveliness_lost(
+            in DataWriter writer, 
+            in LivelinessLostStatus status);
+        void on_publication_matched(
+            in DataWriter writer, 
+            in PublicationMatchedStatus status);
+    };
+
+    interface PublisherListener : DataWriterListener {
+    };
+
+    interface DataReaderListener : Listener {
+        void on_requested_deadline_missed(
+            in DataReader the_reader,
+            in RequestedDeadlineMissedStatus status);
+        void on_requested_incompatible_qos(
+            in DataReader the_reader,
+            in RequestedIncompatibleQosStatus status);
+        void on_sample_rejected(
+            in DataReader the_reader, 
+            in SampleRejectedStatus status);
+        void on_liveliness_changed(
+            in DataReader the_reader,
+            in LivelinessChangedStatus status);
+        void on_data_available(
+            in DataReader the_reader);
+        void on_subscription_matched(
+            in DataReader the_reader, 
+            in SubscriptionMatchedStatus status);
+        void on_sample_lost(
+            in DataReader the_reader, 
+            in SampleLostStatus status);
+    };
+
+    interface SubscriberListener : DataReaderListener {
+        void on_data_on_readers(
+            in Subscriber the_subscriber);
+    };
+
+
+    interface DomainParticipantListener : TopicListener, 
+                                      PublisherListener, 
+                                      SubscriberListener {
+    };
+
+
+    // ----------------------------------------------------------------------
+    // Conditions
+    // ----------------------------------------------------------------------
+
+    interface Condition {
+        boolean get_trigger_value();
+    };
+    
+    typedef sequence<Condition> ConditionSeq;
+
+    interface WaitSet {
+        ReturnCode_t wait(
+            inout ConditionSeq active_conditions, 
+            in Duration_t timeout);
+        ReturnCode_t attach_condition(
+            in Condition cond);
+        ReturnCode_t detach_condition(
+            in Condition cond);
+        ReturnCode_t get_conditions(
+            inout ConditionSeq attached_conditions);
+    };
+
+    interface GuardCondition : Condition {
+        ReturnCode_t set_trigger_value(
+            in boolean value);
+    };
+
+    interface StatusCondition : Condition {
+        StatusMask get_enabled_statuses();
+        ReturnCode_t set_enabled_statuses(
+            in StatusMask mask);
+        Entity get_entity();
+    };
+
+    // Sample states to support reads
+    typedef unsigned long SampleStateKind;
+    const SampleStateKind READ_SAMPLE_STATE                     = 0x0001 << 0;
+    const SampleStateKind NOT_READ_SAMPLE_STATE                 = 0x0001 << 1;
+   
+    // This is a bit-mask SampleStateKind
+    typedef unsigned long SampleStateMask;
+    const SampleStateMask ANY_SAMPLE_STATE                      = 0xffff;
+
+    // View states to support reads
+    typedef unsigned long ViewStateKind;
+    const ViewStateKind NEW_VIEW_STATE                          = 0x0001 << 0;
+    const ViewStateKind NOT_NEW_VIEW_STATE                      = 0x0001 << 1;
+
+    // This is a bit-mask ViewStateKind
+    typedef unsigned long ViewStateMask;
+    const ViewStateMask ANY_VIEW_STATE                          = 0xffff;
+
+    // Instance states to support reads
+    typedef unsigned long InstanceStateKind;
+    const InstanceStateKind ALIVE_INSTANCE_STATE                = 0x0001 << 0;
+    const InstanceStateKind NOT_ALIVE_DISPOSED_INSTANCE_STATE   = 0x0001 << 1;
+    const InstanceStateKind NOT_ALIVE_NO_WRITERS_INSTANCE_STATE = 0x0001 << 2;
+   
+    // This is a bit-mask InstanceStateKind
+    typedef unsigned long InstanceStateMask;
+    const InstanceStateMask ANY_INSTANCE_STATE                  = 0xffff;
+    const InstanceStateMask NOT_ALIVE_INSTANCE_STATE            = 0x006;
+   
+
+    interface ReadCondition : Condition {
+        SampleStateMask     get_sample_state_mask();
+        ViewStateMask       get_view_state_mask();
+        InstanceStateMask   get_instance_state_mask();
+        DataReader          get_datareader();
+    };
+
+    interface QueryCondition : ReadCondition {
+        string         get_query_expression();
+        ReturnCode_t   get_query_parameters(
+            inout StringSeq query_parameters);
+        ReturnCode_t   set_query_parameters(
+            in StringSeq query_parameters);
+    };
+
+    // ----------------------------------------------------------------------
+    // Qos
+    // ----------------------------------------------------------------------
+    const string USERDATA_QOS_POLICY_NAME              = "UserData";
+    const string DURABILITY_QOS_POLICY_NAME            = "Durability";
+    const string PRESENTATION_QOS_POLICY_NAME          = "Presentation";
+    const string DEADLINE_QOS_POLICY_NAME              = "Deadline";
+    const string LATENCYBUDGET_QOS_POLICY_NAME         = "LatencyBudget";
+    const string OWNERSHIP_QOS_POLICY_NAME             = "Ownership";
+    const string OWNERSHIPSTRENGTH_QOS_POLICY_NAME     = "OwnershipStrength";
+    const string LIVELINESS_QOS_POLICY_NAME            = "Liveliness";
+    const string TIMEBASEDFILTER_QOS_POLICY_NAME       = "TimeBasedFilter";
+    const string PARTITION_QOS_POLICY_NAME             = "Partition";
+    const string RELIABILITY_QOS_POLICY_NAME           = "Reliability";
+    const string DESTINATIONORDER_QOS_POLICY_NAME      = "DestinationOrder";
+    const string HISTORY_QOS_POLICY_NAME               = "History";
+    const string RESOURCELIMITS_QOS_POLICY_NAME        = "ResourceLimits";
+    const string ENTITYFACTORY_QOS_POLICY_NAME         = "EntityFactory";
+    const string WRITERDATALIFECYCLE_QOS_POLICY_NAME   = "WriterDataLifecycle";
+    const string READERDATALIFECYCLE_QOS_POLICY_NAME   = "ReaderDataLifecycle";
+    const string TOPICDATA_QOS_POLICY_NAME             = "TopicData";
+    const string GROUPDATA_QOS_POLICY_NAME             = "TransportPriority";
+    const string LIFESPAN_QOS_POLICY_NAME              = "Lifespan";
+    const string DURABILITYSERVICE_POLICY_NAME         = "DurabilityService";
+
+    const QosPolicyId_t INVALID_QOS_POLICY_ID              = 0;
+    const QosPolicyId_t USERDATA_QOS_POLICY_ID             = 1;
+    const QosPolicyId_t DURABILITY_QOS_POLICY_ID           = 2;
+    const QosPolicyId_t PRESENTATION_QOS_POLICY_ID         = 3;
+    const QosPolicyId_t DEADLINE_QOS_POLICY_ID             = 4;
+    const QosPolicyId_t LATENCYBUDGET_QOS_POLICY_ID        = 5;
+    const QosPolicyId_t OWNERSHIP_QOS_POLICY_ID            = 6;
+    const QosPolicyId_t OWNERSHIPSTRENGTH_QOS_POLICY_ID    = 7;
+    const QosPolicyId_t LIVELINESS_QOS_POLICY_ID           = 8;
+    const QosPolicyId_t TIMEBASEDFILTER_QOS_POLICY_ID      = 9;
+    const QosPolicyId_t PARTITION_QOS_POLICY_ID            = 10;
+    const QosPolicyId_t RELIABILITY_QOS_POLICY_ID          = 11;
+    const QosPolicyId_t DESTINATIONORDER_QOS_POLICY_ID     = 12;
+    const QosPolicyId_t HISTORY_QOS_POLICY_ID              = 13;
+    const QosPolicyId_t RESOURCELIMITS_QOS_POLICY_ID       = 14;
+    const QosPolicyId_t ENTITYFACTORY_QOS_POLICY_ID        = 15;
+    const QosPolicyId_t WRITERDATALIFECYCLE_QOS_POLICY_ID  = 16;
+    const QosPolicyId_t READERDATALIFECYCLE_QOS_POLICY_ID  = 17;
+    const QosPolicyId_t TOPICDATA_QOS_POLICY_ID            = 18;
+    const QosPolicyId_t GROUPDATA_QOS_POLICY_ID            = 19;
+    const QosPolicyId_t TRANSPORTPRIORITY_QOS_POLICY_ID    = 20;
+    const QosPolicyId_t LIFESPAN_QOS_POLICY_ID             = 21;
+    const QosPolicyId_t DURABILITYSERVICE_QOS_POLICY_ID    = 22;
+
+    struct UserDataQosPolicy {
+        sequence<octet> value;
+    };
+
+    struct TopicDataQosPolicy {
+        sequence<octet> value;
+    };
+
+    struct GroupDataQosPolicy {
+        sequence<octet> value;
+    };
+
+    struct TransportPriorityQosPolicy {
+        long value;
+    };
+
+    struct LifespanQosPolicy {
+        Duration_t duration;
+    };
+
+    enum DurabilityQosPolicyKind {
+        VOLATILE_DURABILITY_QOS,
+        TRANSIENT_LOCAL_DURABILITY_QOS,
+        TRANSIENT_DURABILITY_QOS,
+        PERSISTENT_DURABILITY_QOS
+    };
+    struct DurabilityQosPolicy {
+        DurabilityQosPolicyKind kind;
+    };
+
+    enum PresentationQosPolicyAccessScopeKind {
+        INSTANCE_PRESENTATION_QOS,
+        TOPIC_PRESENTATION_QOS,
+        GROUP_PRESENTATION_QOS
+    };
+    struct PresentationQosPolicy {
+        PresentationQosPolicyAccessScopeKind access_scope;
+        boolean coherent_access;
+        boolean ordered_access;
+    };
+
+    struct DeadlineQosPolicy {
+        Duration_t period;
+    };
+
+    struct LatencyBudgetQosPolicy {
+        Duration_t duration;
+    };
+
+    enum OwnershipQosPolicyKind {
+        SHARED_OWNERSHIP_QOS,
+        EXCLUSIVE_OWNERSHIP_QOS
+    };
+    struct OwnershipQosPolicy {
+        OwnershipQosPolicyKind kind;
+    };
+
+    struct OwnershipStrengthQosPolicy {
+        long value;
+    };
+
+    enum LivelinessQosPolicyKind {
+        AUTOMATIC_LIVELINESS_QOS,
+        MANUAL_BY_PARTICIPANT_LIVELINESS_QOS,
+        MANUAL_BY_TOPIC_LIVELINESS_QOS
+    };
+
+    struct LivelinessQosPolicy {
+        LivelinessQosPolicyKind kind;
+        Duration_t lease_duration;
+    };
+
+    struct TimeBasedFilterQosPolicy {
+        Duration_t minimum_separation;
+    };
+
+    struct PartitionQosPolicy {
+        StringSeq name;
+    };
+
+    enum ReliabilityQosPolicyKind {
+        BEST_EFFORT_RELIABILITY_QOS,
+        RELIABLE_RELIABILITY_QOS
+    };
+
+    struct ReliabilityQosPolicy {
+        ReliabilityQosPolicyKind kind;
+        Duration_t max_blocking_time;
+    };
+
+   enum DestinationOrderQosPolicyKind {
+        BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS,
+        BY_SOURCE_TIMESTAMP_DESTINATIONORDER_QOS
+    };
+    struct DestinationOrderQosPolicy {
+        DestinationOrderQosPolicyKind kind;
+    };
+
+    enum HistoryQosPolicyKind {
+        KEEP_LAST_HISTORY_QOS,
+        KEEP_ALL_HISTORY_QOS
+    };
+    struct HistoryQosPolicy {
+        HistoryQosPolicyKind kind;
+        long depth;
+    };
+
+    struct ResourceLimitsQosPolicy {
+        long max_samples;
+        long max_instances;
+        long max_samples_per_instance;
+    };
+
+    struct EntityFactoryQosPolicy {
+        boolean autoenable_created_entities;
+    };
+
+    struct WriterDataLifecycleQosPolicy {
+        boolean autodispose_unregistered_instances;
+    };
+
+    struct ReaderDataLifecycleQosPolicy {
+        Duration_t autopurge_nowriter_samples_delay;
+        Duration_t autopurge_disposed_samples_delay;
+    };
+
+    struct DurabilityServiceQosPolicy {
+        Duration_t              service_cleanup_delay;
+        HistoryQosPolicyKind    history_kind;
+        long                    history_depth;
+        long                    max_samples;
+        long                    max_instances;
+        long                    max_samples_per_instance;
+    }; 
+
+    struct DomainParticipantFactoryQos {
+        EntityFactoryQosPolicy entity_factory;
+    };
+
+    struct DomainParticipantQos {
+        UserDataQosPolicy  user_data;
+        EntityFactoryQosPolicy entity_factory;
+    };
+
+    struct TopicQos {
+        TopicDataQosPolicy                   topic_data;
+        DurabilityQosPolicy                  durability;
+        DurabilityServiceQosPolicy           durability_service;
+        DeadlineQosPolicy                    deadline;
+        LatencyBudgetQosPolicy               latency_budget;
+        LivelinessQosPolicy                  liveliness;
+        ReliabilityQosPolicy                 reliability;
+        DestinationOrderQosPolicy            destination_order;
+        HistoryQosPolicy                     history;
+        ResourceLimitsQosPolicy              resource_limits;
+        TransportPriorityQosPolicy           transport_priority;
+        LifespanQosPolicy                    lifespan;
+
+        OwnershipQosPolicy                   ownership;
+    };
+
+    struct DataWriterQos {
+        DurabilityQosPolicy                  durability;
+        DurabilityServiceQosPolicy           durability_service;
+        DeadlineQosPolicy                    deadline;
+        LatencyBudgetQosPolicy               latency_budget;
+        LivelinessQosPolicy                  liveliness;
+        ReliabilityQosPolicy                 reliability;
+        DestinationOrderQosPolicy            destination_order;
+        HistoryQosPolicy                     history;
+        ResourceLimitsQosPolicy              resource_limits;
+        TransportPriorityQosPolicy           transport_priority;
+        LifespanQosPolicy                    lifespan;
+
+        UserDataQosPolicy                    user_data;
+        OwnershipQosPolicy                   ownership;
+        OwnershipStrengthQosPolicy           ownership_strength;
+        WriterDataLifecycleQosPolicy         writer_data_lifecycle;
+    };
+
+    struct PublisherQos {
+        PresentationQosPolicy                presentation;
+        PartitionQosPolicy                   partition;
+        GroupDataQosPolicy                   group_data;
+        EntityFactoryQosPolicy               entity_factory;
+    };
+
+    struct DataReaderQos {
+        DurabilityQosPolicy                  durability;
+        DeadlineQosPolicy                    deadline;
+        LatencyBudgetQosPolicy               latency_budget;
+        LivelinessQosPolicy                  liveliness;
+        ReliabilityQosPolicy                 reliability;
+        DestinationOrderQosPolicy            destination_order;
+        HistoryQosPolicy                     history;
+        ResourceLimitsQosPolicy              resource_limits;
+
+        UserDataQosPolicy                    user_data;
+        OwnershipQosPolicy                   ownership;
+        TimeBasedFilterQosPolicy             time_based_filter;
+        ReaderDataLifecycleQosPolicy         reader_data_lifecycle;
+    };
+
+    struct SubscriberQos {
+        PresentationQosPolicy                presentation;
+        PartitionQosPolicy                   partition;
+        GroupDataQosPolicy                   group_data;
+        EntityFactoryQosPolicy               entity_factory;
+    };
+
+    // ----------------------------------------------------------------------
+
+    struct ParticipantBuiltinTopicData {
+        BuiltinTopicKey_t                    key;
+        UserDataQosPolicy                    user_data;
+    };
+
+    struct TopicBuiltinTopicData {
+        BuiltinTopicKey_t                    key;
+        string                               name;
+        string                               type_name;
+        DurabilityQosPolicy                  durability;
+        DurabilityServiceQosPolicy           durability_service;
+        DeadlineQosPolicy                    deadline;
+        LatencyBudgetQosPolicy               latency_budget;
+        LivelinessQosPolicy                  liveliness;
+        ReliabilityQosPolicy                 reliability;
+        TransportPriorityQosPolicy           transport_priority;
+        LifespanQosPolicy                    lifespan;
+        DestinationOrderQosPolicy            destination_order;
+        HistoryQosPolicy                     history;
+        ResourceLimitsQosPolicy              resource_limits;
+        OwnershipQosPolicy                   ownership;
+        TopicDataQosPolicy                   topic_data;
+    };
+
+    struct PublicationBuiltinTopicData {
+        BuiltinTopicKey_t                    key;
+        BuiltinTopicKey_t                    participant_key;
+        string                               topic_name;
+        string                               type_name;
+
+        DurabilityQosPolicy                  durability;
+        DurabilityServiceQosPolicy           durability_service;
+        DeadlineQosPolicy                    deadline;
+        LatencyBudgetQosPolicy               latency_budget;
+        LivelinessQosPolicy                  liveliness;
+        ReliabilityQosPolicy                 reliability;
+        LifespanQosPolicy                    lifespan;
+        UserDataQosPolicy                    user_data;
+        OwnershipQosPolicy                   ownership;
+        OwnershipStrengthQosPolicy           ownership_strength;
+        DestinationOrderQosPolicy            destination_order;
+
+        PresentationQosPolicy                presentation;
+        PartitionQosPolicy                   partition;
+        TopicDataQosPolicy                   topic_data;
+        GroupDataQosPolicy                   group_data;
+    };
+
+    struct SubscriptionBuiltinTopicData {
+        BuiltinTopicKey_t                    key;
+        BuiltinTopicKey_t                    participant_key;
+        string                               topic_name;
+        string                               type_name;
+
+        DurabilityQosPolicy                  durability;
+        DeadlineQosPolicy                    deadline;
+        LatencyBudgetQosPolicy               latency_budget;
+        LivelinessQosPolicy                  liveliness;
+        ReliabilityQosPolicy                 reliability;
+        OwnershipQosPolicy                   ownership;
+        DestinationOrderQosPolicy            destination_order;
+        UserDataQosPolicy                    user_data;
+        TimeBasedFilterQosPolicy             time_based_filter;
+
+        PresentationQosPolicy                presentation;
+        PartitionQosPolicy                   partition;
+        TopicDataQosPolicy                   topic_data;
+        GroupDataQosPolicy                   group_data;
+    };
+
+    // ----------------------------------------------------------------------
+    interface Entity {
+    //  ReturnCode_t set_qos(
+    //      in EntityQos qos);
+    //  ReturnCode_t get_qos(
+    //      inout EntityQos qos);
+    //  ReturnCode_t set_listener(
+    //      in Listener l, 
+    //      in StatusMask mask);
+    //  Listener get_listener();
+
+        ReturnCode_t enable();
+
+        StatusCondition get_statuscondition();
+
+        StatusMask get_status_changes();
+
+        InstanceHandle_t get_instance_handle();
+    };
+    
+    // ----------------------------------------------------------------------
+    interface DomainParticipant : Entity {
+        // Factory interfaces
+        Publisher create_publisher(
+            in PublisherQos qos, 
+            in PublisherListener a_listener,
+            in StatusMask mask);
+        ReturnCode_t delete_publisher(
+            in Publisher p);
+
+        Subscriber create_subscriber(
+            in SubscriberQos qos,
+            in SubscriberListener a_listener,
+            in StatusMask mask);
+        ReturnCode_t delete_subscriber(
+            in Subscriber s);
+        Subscriber get_builtin_subscriber();
+
+        Topic create_topic(
+            in string topic_name, 
+            in string type_name,
+            in TopicQos qos, 
+            in TopicListener a_listener,
+            in StatusMask mask);
+
+        ReturnCode_t delete_topic(
+            in Topic a_topic);
+
+        Topic find_topic(
+            in string topic_name, 
+            in Duration_t timeout);
+        TopicDescription lookup_topicdescription(
+            in string name);
+
+        ContentFilteredTopic create_contentfilteredtopic(
+            in string name,
+            in Topic related_topic,
+            in string filter_expression,
+            in StringSeq expression_parameters);
+
+        ReturnCode_t delete_contentfilteredtopic(
+            in ContentFilteredTopic a_contentfilteredtopic);
+
+        MultiTopic create_multitopic(
+            in string name,
+            in string type_name, 
+            in string subscription_expression,
+            in StringSeq expression_parameters);
+
+        ReturnCode_t delete_multitopic(
+            in MultiTopic a_multitopic);
+
+        ReturnCode_t delete_contained_entities();
+
+        ReturnCode_t set_qos(
+            in DomainParticipantQos qos);
+        ReturnCode_t get_qos(
+            inout DomainParticipantQos qos);
+
+        ReturnCode_t set_listener(
+            in DomainParticipantListener a_listener, 
+            in StatusMask mask);
+        DomainParticipantListener get_listener();
+
+        ReturnCode_t ignore_participant(
+            in InstanceHandle_t handle);
+        ReturnCode_t ignore_topic(
+            in InstanceHandle_t handle);
+        ReturnCode_t ignore_publication(
+            in InstanceHandle_t handle);
+        ReturnCode_t ignore_subscription(
+            in InstanceHandle_t handle);
+
+        DomainId_t get_domain_id();
+        ReturnCode_t assert_liveliness();
+
+        ReturnCode_t set_default_publisher_qos(
+            in PublisherQos qos);
+        ReturnCode_t get_default_publisher_qos(
+            inout PublisherQos qos);
+
+        ReturnCode_t set_default_subscriber_qos(
+            in SubscriberQos qos);
+        ReturnCode_t get_default_subscriber_qos(
+            inout SubscriberQos qos);
+
+        ReturnCode_t set_default_topic_qos(
+            in TopicQos qos);
+        ReturnCode_t get_default_topic_qos(
+            inout TopicQos qos);
+
+        ReturnCode_t get_discovered_participants(
+            inout InstanceHandleSeq participant_handles);
+        ReturnCode_t get_discovered_participant_data(
+            inout ParticipantBuiltinTopicData participant_data,
+            in InstanceHandle_t participant_handle);
+
+        ReturnCode_t get_discovered_topics(
+            inout InstanceHandleSeq topic_handles);
+        ReturnCode_t get_discovered_topic_data(
+            inout TopicBuiltinTopicData topic_data,
+            in InstanceHandle_t topic_handle);
+
+        boolean contains_entity(
+            in InstanceHandle_t a_handle);
+
+        ReturnCode_t get_current_time(
+            inout Time_t current_time);
+    };
+
+    interface DomainParticipantFactory {
+        DomainParticipant create_participant(
+            in DomainId_t domain_id, 
+            in DomainParticipantQos qos, 
+            in DomainParticipantListener a_listener,
+            in StatusMask mask);
+        ReturnCode_t delete_participant(
+            in DomainParticipant a_participant);
+
+        DomainParticipant lookup_participant(
+            in DomainId_t domain_id);
+
+        ReturnCode_t set_default_participant_qos(
+            in DomainParticipantQos qos);
+        ReturnCode_t get_default_participant_qos(
+            inout DomainParticipantQos qos);
+
+        ReturnCode_t set_qos(
+            in DomainParticipantFactoryQos qos);
+        ReturnCode_t get_qos(
+            inout DomainParticipantFactoryQos qos);
+    };
+      
+    interface TypeSupport {
+    //     ReturnCode_t register_type(
+    //         in DomainParticipant domain, 
+    //         in string type_name);
+    //     string get_type_name();
+    };
+
+    // ----------------------------------------------------------------------
+    interface TopicDescription {
+        string get_type_name();
+        string get_name();
+
+        DomainParticipant get_participant();
+    };
+    
+    interface Topic : Entity, TopicDescription {
+        ReturnCode_t set_qos(
+            in TopicQos qos);
+        ReturnCode_t get_qos( 
+            inout TopicQos qos);
+        ReturnCode_t set_listener(
+            in TopicListener a_listener, 
+            in StatusMask mask);
+        TopicListener get_listener();
+        // Access the status
+        ReturnCode_t get_inconsistent_topic_status(
+            inout InconsistentTopicStatus a_status);
+    };
+
+    interface ContentFilteredTopic : TopicDescription {
+        string get_filter_expression();
+        ReturnCode_t get_expression_parameters(
+            inout StringSeq);
+        ReturnCode_t set_expression_parameters(
+            in StringSeq expression_parameters);
+        Topic get_related_topic();
+    };
+
+    interface MultiTopic : TopicDescription {
+        string get_subscription_expression();
+        ReturnCode_t get_expression_parameters(
+            inout StringSeq);
+        ReturnCode_t set_expression_parameters(
+            in StringSeq expression_parameters);
+    };
+
+    // ----------------------------------------------------------------------
+    interface Publisher : Entity {
+        DataWriter create_datawriter(
+            in Topic a_topic, 
+            in DataWriterQos qos,
+            in DataWriterListener a_listener,
+            in StatusMask mask);
+        ReturnCode_t delete_datawriter(
+            in DataWriter a_datawriter);
+        DataWriter lookup_datawriter(
+            in string topic_name);
+
+        ReturnCode_t delete_contained_entities();
+
+        ReturnCode_t set_qos(
+            in PublisherQos qos);
+        ReturnCode_t get_qos(
+            inout PublisherQos qos);
+
+        ReturnCode_t set_listener(
+            in PublisherListener a_listener, 
+            in StatusMask mask);
+        PublisherListener get_listener();
+
+        ReturnCode_t suspend_publications();
+        ReturnCode_t resume_publications();
+
+        ReturnCode_t begin_coherent_changes();
+        ReturnCode_t end_coherent_changes();
+
+        ReturnCode_t wait_for_acknowledgments(
+            in Duration_t max_wait);
+
+        DomainParticipant get_participant();
+
+        ReturnCode_t set_default_datawriter_qos(
+            in DataWriterQos qos);
+        ReturnCode_t get_default_datawriter_qos(
+            inout DataWriterQos qos);
+
+        ReturnCode_t copy_from_topic_qos(
+            inout DataWriterQos a_datawriter_qos, 
+            in TopicQos a_topic_qos);
+    };
+
+    interface DataWriter : Entity {
+    //  InstanceHandle_t register_instance(
+    //      in Data instance_data);
+    //  InstanceHandle_t register_instance_w_timestamp(
+    //      in Data instance_data,
+    //      in Time_t source_timestamp);
+    //  ReturnCode_t unregister_instance(
+    //      in Data instance_data, 
+    //      in InstanceHandle_t  handle);
+    //  ReturnCode_t unregister_instance_w_timestamp(
+    //      in Data instance_data, 
+    //      in InstanceHandle_t  handle,
+    //      in Time_t source_timestamp);
+    //  ReturnCode_t write(
+    //      in Data instance_data, 
+    //      in InstanceHandle_t handle);
+    //  ReturnCode_t write_w_timestamp(
+    //      in Data instance_data, 
+    //      in InstanceHandle_t handle, 
+    //      in Time_t source_timestamp);
+    //  ReturnCode_t dispose(
+    //      in Data instance_data, 
+    //      in InstanceHandle_t instance_handle);
+    //  ReturnCode_t dispose_w_timestamp(
+    //      in Data instance_data, 
+    //      in InstanceHandle_t instance_handle, 
+    //      in Time_t source_timestamp);
+    //  ReturnCode_t get_key_value(
+    //      inout Data key_holder, 
+    //      in InstanceHandle_t handle);
+    //  InstanceHandle_t lookup_instance(
+    //      in Data instance_data);
+
+        ReturnCode_t set_qos(
+            in DataWriterQos qos);
+        ReturnCode_t get_qos(
+            inout DataWriterQos qos);
+
+        ReturnCode_t set_listener(
+            in DataWriterListener a_listener, 
+            in StatusMask mask);
+        DataWriterListener get_listener();
+
+        Topic get_topic();
+        Publisher get_publisher();
+
+        ReturnCode_t wait_for_acknowledgments(
+            in Duration_t max_wait);
+
+        // Access the status
+        ReturnCode_t get_liveliness_lost_status(
+            inout LivelinessLostStatus);
+        ReturnCode_t get_offered_deadline_missed_status(
+            inout OfferedDeadlineMissedStatus status);
+        ReturnCode_t get_offered_incompatible_qos_status(
+            inout OfferedIncompatibleQosStatus status);
+        ReturnCode_t get_publication_matched_status(
+            inout PublicationMatchedStatus status);
+
+        ReturnCode_t assert_liveliness();
+
+        ReturnCode_t get_matched_subscriptions(
+            inout InstanceHandleSeq subscription_handles);
+        ReturnCode_t get_matched_subscription_data(
+            inout SubscriptionBuiltinTopicData subscription_data,
+            in InstanceHandle_t subscription_handle);
+    };
+
+    // ----------------------------------------------------------------------
+    interface Subscriber : Entity {
+        DataReader create_datareader(
+            in TopicDescription a_topic,
+            in DataReaderQos qos,
+            in DataReaderListener a_listener,
+            in StatusMask mask);
+        ReturnCode_t delete_datareader(
+            in DataReader a_datareader);
+        ReturnCode_t delete_contained_entities();
+        DataReader lookup_datareader(
+            in string topic_name);
+        ReturnCode_t get_datareaders(
+            inout DataReaderSeq readers,
+            in SampleStateMask sample_states,
+            in ViewStateMask view_states,
+            in InstanceStateMask instance_states);
+        ReturnCode_t notify_datareaders();
+
+        ReturnCode_t set_qos(
+            in SubscriberQos qos);
+        ReturnCode_t get_qos(
+            inout SubscriberQos qos);
+
+        ReturnCode_t set_listener(
+            in SubscriberListener a_listener, 
+            in StatusMask mask);
+        SubscriberListener get_listener();
+
+        ReturnCode_t begin_access();
+        ReturnCode_t end_access();
+
+        DomainParticipant get_participant();
+
+        ReturnCode_t set_default_datareader_qos(
+            in DataReaderQos qos);
+        ReturnCode_t get_default_datareader_qos(
+            inout DataReaderQos qos);
+
+        ReturnCode_t copy_from_topic_qos(
+            inout DataReaderQos a_datareader_qos, 
+            in TopicQos a_topic_qos);
+    };
+
+    interface DataReader : Entity {
+    //  ReturnCode_t read(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in SampleStateMask sample_states, 
+    //      in ViewStateMask view_states, 
+    //      in InstanceStateMask instance_states);
+
+    //  ReturnCode_t take(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in SampleStateMask sample_states, 
+    //      in ViewStateMask view_states, 
+    //      in InstanceStateMask instance_states);
+
+    //  ReturnCode_t read_w_condition(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in ReadCondition a_condition);
+
+    //  ReturnCode_t take_w_condition(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in ReadCondition a_condition);
+
+    //  ReturnCode_t read_next_sample(
+    //      inout Data data_values,
+    //      inout SampleInfo sample_info);
+
+    //  ReturnCode_t take_next_sample(
+    //      inout Data data_values,
+    //      inout SampleInfo sample_info);
+
+    //  ReturnCode_t read_instance(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in InstanceHandle_t a_handle,
+    //      in SampleStateMask sample_states, 
+    //      in ViewStateMask view_states, 
+    //      in InstanceStateMask instance_states);
+
+    //  ReturnCode_t take_instance(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in InstanceHandle_t a_handle,
+    //      in SampleStateMask sample_states, 
+    //      in ViewStateMask view_states, 
+    //      in InstanceStateMask instance_states);
+
+    //  ReturnCode_t read_next_instance(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in InstanceHandle_t previous_handle,
+    //      in SampleStateMask sample_states, 
+    //      in ViewStateMask view_states, 
+    //      in InstanceStateMask instance_states);
+
+    //  ReturnCode_t take_next_instance(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in InstanceHandle_t previous_handle,
+    //      in SampleStateMask sample_states, 
+    //      in ViewStateMask view_states, 
+    //      in InstanceStateMask instance_states);
+
+    //  ReturnCode_t read_next_instance_w_condition(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in InstanceHandle_t previous_handle,
+    //      in ReadCondition a_condition);
+
+    //  ReturnCode_t take_next_instance_w_condition(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos,
+    //      in long max_samples,
+    //      in InstanceHandle_t previous_handle,
+    //      in ReadCondition a_condition);
+
+    //  ReturnCode_t return_loan(
+    //      inout DataSeq data_values,
+    //      inout SampleInfoSeq sample_infos);
+
+    //  ReturnCode_t get_key_value(
+    //      inout Data key_holder, 
+    //      in InstanceHandle_t handle);
+
+    //  InstanceHandle_t lookup_instance(
+    //      in Data instance_data);
+
+        ReadCondition create_readcondition(
+            in SampleStateMask sample_states, 
+            in ViewStateMask view_states,
+            in InstanceStateMask instance_states);
+
+        QueryCondition create_querycondition(
+            in SampleStateMask sample_states, 
+            in ViewStateMask view_states,
+            in InstanceStateMask instance_states,
+            in string query_expression,
+            in StringSeq query_parameters);
+
+        ReturnCode_t delete_readcondition(
+            in ReadCondition a_condition);
+
+        ReturnCode_t delete_contained_entities();
+
+        ReturnCode_t set_qos(
+            in DataReaderQos qos);
+        ReturnCode_t get_qos(
+            inout DataReaderQos qos);
+
+        ReturnCode_t set_listener(
+            in DataReaderListener a_listener, 
+            in StatusMask mask);
+        DataReaderListener get_listener();
+
+        TopicDescription get_topicdescription();
+        Subscriber get_subscriber();
+
+        ReturnCode_t get_sample_rejected_status(
+            inout SampleRejectedStatus status);
+        ReturnCode_t get_liveliness_changed_status(
+            inout LivelinessChangedStatus status);
+        ReturnCode_t get_requested_deadline_missed_status(
+            inout RequestedDeadlineMissedStatus status);
+        ReturnCode_t get_requested_incompatible_qos_status(
+            inout RequestedIncompatibleQosStatus status);
+        ReturnCode_t get_subscription_matched_status(
+            inout SubscriptionMatchedStatus status);
+        ReturnCode_t get_sample_lost_status(
+            inout SampleLostStatus status); 
+
+        ReturnCode_t wait_for_historical_data(
+            in Duration_t max_wait);
+
+        ReturnCode_t get_matched_publications(
+            inout InstanceHandleSeq publication_handles);
+        ReturnCode_t get_matched_publication_data(
+            inout PublicationBuiltinTopicData publication_data,
+            in InstanceHandle_t publication_handle);
+    };
+   
+
+    struct SampleInfo {
+        SampleStateKind      sample_state;
+        ViewStateKind        view_state;
+        InstanceStateKind    instance_state;
+        Time_t               source_timestamp;
+        InstanceHandle_t     instance_handle;
+        InstanceHandle_t     publication_handle;
+        long                 disposed_generation_count;
+        long                 no_writers_generation_count;
+        long                 sample_rank;
+        long                 generation_rank;
+        long                 absolute_generation_rank;
+        boolean              valid_data;
+    };
+
+    typedef sequence<SampleInfo> SampleInfoSeq;
+};    
+
+// Implied IDL for type "Foo"
+// Example user defined structure 
+struct Foo {
+    long dummy;
+}; 
+
+typedef sequence<Foo> FooSeq;
+
+#include "dds_dcps.idl"
+
+interface FooTypeSupport : DDS::TypeSupport {
+    DDS::ReturnCode_t register_type(
+        in DDS::DomainParticipant participant, 
+        in string type_name);
+    string get_type_name();
+};
+
+interface FooDataWriter : DDS::DataWriter {
+
+    DDS::InstanceHandle_t register_instance(
+        in Foo instance_data);
+    DDS::InstanceHandle_t register_instance_w_timestamp(
+        in Foo instance_data, 
+        in DDS::Time_t source_timestamp);
+
+
+    DDS::ReturnCode_t unregister_instance(
+        in Foo instance_data, 
+        in DDS::InstanceHandle_t  handle);
+    DDS::ReturnCode_t unregister_instance_w_timestamp(
+        in Foo instance_data, 
+        in DDS::InstanceHandle_t  handle,
+        in DDS::Time_t source_timestamp);
+
+    DDS::ReturnCode_t write(
+        in Foo instance_data, 
+        in DDS::InstanceHandle_t handle);
+
+    DDS::ReturnCode_t write_w_timestamp(
+        in Foo instance_data, 
+        in DDS::InstanceHandle_t handle, 
+        in DDS::Time_t source_timestamp);
+
+    DDS::ReturnCode_t dispose(
+        in Foo instance_data, 
+        in DDS::InstanceHandle_t instance_handle);
+
+    DDS::ReturnCode_t dispose_w_timestamp(
+        in Foo instance_data, 
+        in DDS::InstanceHandle_t instance_handle, 
+        in DDS::Time_t source_timestamp);
+
+    DDS::ReturnCode_t get_key_value(
+        inout Foo key_holder, 
+        in DDS::InstanceHandle_t handle);
+
+    DDS::InstanceHandle_t lookup_instance(
+        in Foo key_holder);
+};
+
+interface FooDataReader : DDS::DataReader {
+    DDS::ReturnCode_t read(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in  DDS::SampleStateMask sample_states, 
+        in  DDS::ViewStateMask view_states, 
+        in  DDS::InstanceStateMask instance_states);
+    
+    DDS::ReturnCode_t take(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in  DDS::SampleStateMask sample_states, 
+        in  DDS::ViewStateMask view_states, 
+        in  DDS::InstanceStateMask instance_states);
+    
+    DDS::ReturnCode_t read_w_condition(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in  DDS::ReadCondition a_condition);
+    
+    DDS::ReturnCode_t take_w_condition(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in  DDS::ReadCondition a_condition);
+
+    DDS::ReturnCode_t read_next_sample(
+        inout Foo data_value,
+        inout DDS::SampleInfo sample_info);
+
+    DDS::ReturnCode_t take_next_sample(
+        inout Foo data_value,
+        inout DDS::SampleInfo sample_info);
+
+
+    DDS::ReturnCode_t read_instance(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in DDS::InstanceHandle_t a_handle,
+        in DDS::SampleStateMask sample_states, 
+        in DDS::ViewStateMask view_states, 
+        in DDS::InstanceStateMask instance_states);
+
+    DDS::ReturnCode_t take_instance(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in DDS::InstanceHandle_t a_handle,
+        in DDS::SampleStateMask sample_states, 
+        in DDS::ViewStateMask view_states, 
+        in DDS::InstanceStateMask instance_states);
+
+    DDS::ReturnCode_t read_next_instance(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in DDS::InstanceHandle_t previous_handle,
+        in DDS::SampleStateMask sample_states, 
+        in DDS::ViewStateMask view_states, 
+        in DDS::InstanceStateMask instance_states);
+
+    DDS::ReturnCode_t take_next_instance(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in DDS::InstanceHandle_t previous_handle,
+        in DDS::SampleStateMask sample_states, 
+        in DDS::ViewStateMask view_states, 
+        in DDS::InstanceStateMask instance_states);
+
+    DDS::ReturnCode_t read_next_instance_w_condition(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in DDS::InstanceHandle_t previous_handle,
+        in DDS::ReadCondition a_condition);
+
+    DDS::ReturnCode_t take_next_instance_w_condition(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos,
+        in long max_samples,
+        in DDS::InstanceHandle_t previous_handle,
+        in DDS::ReadCondition a_condition);
+
+
+    DDS::ReturnCode_t return_loan(
+        inout FooSeq data_values,
+        inout DDS::SampleInfoSeq sample_infos);
+
+    DDS::ReturnCode_t get_key_value(
+        inout Foo key_holder, 
+        in DDS::InstanceHandle_t handle);
+
+    DDS::InstanceHandle_t lookup_instance(
+        in Foo key_holder);
+}; 

--- a/dds_gen/test_data/omg_dds/dds_dlrl.idl
+++ b/dds_gen/test_data/omg_dds/dds_dlrl.idl
@@ -1,0 +1,658 @@
+#include "dds_dcps.idl"
+
+#define DLRL_OID_TYPE_NATIVE long
+
+module DDS {
+
+
+// Type definitions
+// =================
+
+// Scope of action
+// ---------------
+
+enum ReferenceScope {
+	SIMPLE_CONTENT_SCOPE,           // only the reference content
+	REFERENCED_CONTENTS_SCOPE       // + referenced contents
+	};
+
+enum ObjectScope {
+	SIMPLE_OBJECT_SCOPE,            // only the object
+	CONTAINED_OBJECTS_SCOPE,        // + contained objects
+	RELATED_OBJECTS_SCOPE           // + all related objects
+	};
+
+// State of the underlying infrastructure
+// --------------------------------------
+
+enum DCPSState {
+    INITIAL,
+    REGISTERED,
+    ENABLED
+    };
+
+// Usage of the Cache
+// ------------------
+
+enum CacheUsage {
+    READ_ONLY,
+    WRITE_ONLY,
+    READ_WRITE
+    };
+
+// Object State
+// ------------
+enum ObjectState { 
+    OBJECT_VOID, 
+    OBJECT_NEW, 
+    OBJECT_NOT_MODIFIED, 
+    OBJECT_MODIFIED, 
+    OBJECT_DELETED 
+};
+
+// OID
+// ---
+
+struct DLRLOid {
+    DLRL_OID_TYPE_NATIVE value[3];
+    };
+
+
+// Miscellaneous
+// ------------
+
+typedef sequence<long>      LongSeq;
+
+typedef string          ClassName;
+typedef string          CacheName;
+typedef string          RelationName;
+
+
+// Exceptions
+// ==========
+
+exception DCPSError { string message; };
+exception BadHomeDefinition { string message; };
+exception NotFound { string message; };
+exception AlreadyExisting { string message; };
+exception AlreadyDeleted { string message; };
+exception PreconditionNotMet { string message; };
+exception NoSuchElement { string message; };
+exception SQLError { string message; };
+
+// DLRL Entities
+// =============
+
+/********************
+ * Forward References
+ ********************/
+
+valuetype ObjectRoot;
+typedef sequence<ObjectRoot> ObjectRootSeq;
+
+local interface ObjectHome;
+typedef sequence<ObjectHome> ObjectHomeSeq;
+
+local interface ObjectListener;
+typedef sequence<ObjectListener> ObjectListenerSeq;
+
+local interface Selection;
+typedef sequence<Selection> SelectionSeq;
+
+local interface CacheBase;
+typedef sequence<CacheBase> CacheBaseSeq;
+
+local interface CacheAccess;
+typedef sequence<CacheAccess> CacheAccessSeq;
+
+local interface CacheListener;
+typedef sequence<CacheListener> CacheListenerSeq;
+
+local interface Cache;
+
+local interface Contract;
+typedef sequence<Contract> ContractSeq;
+
+/*****************************************************
+ * ObjectListener : Root for Listeners to be attached to 
+ *      Home objects
+ *****************************************************/
+
+local interface ObjectListener {
+    boolean on_object_created (
+        in ObjectRoot the_object);
+
+    /**** will be generated with the proper Foo type* in the derived 
+		*	FooListener
+		*  boolean on_object_modified (    
+		*		in ObjectRoot the_object);
+		****/
+
+    boolean on_object_deleted (
+        in ObjectRoot the_object);
+    };
+
+
+/**********************************************************
+ * SelectionListener : Root for Listeners to be attached to 
+ *      Selection objects
+ **********************************************************/
+
+local interface SelectionListener {
+    /***
+     * will be generated with the proper Foo type 
+     * in the derived FooSelectionListener
+     *
+    void on_object_in (
+        in ObjectRoot the_object);
+    void on_object_modified (
+        in ObjectRoot the_object);
+     *
+     ***/
+    void on_object_out (
+        in ObjectRoot the_object);
+    };
+    
+
+/********************************************************
+ * CacheListener : Listener to be associated with a Cache
+ ********************************************************/
+
+local interface CacheListener {
+    void on_begin_updates ();
+    void on_end_updates ();
+    void on_updates_enabled( );
+    void on_updates_disabled( );
+};
+
+
+/********************************************************
+ * Contract : Control objects cloned on a CacheAccess refresh
+ ********************************************************/
+
+local interface Contract {
+    readonly attribute long depth;
+    readonly attribute ObjectScope scope;
+    readonly attribute ObjectRoot contracted_object.
+
+    void set_depth(
+	in long depth);
+    void set_scope(
+        in ObjectScope scope);
+};
+
+
+/******************************************
+ * ObjectRoot : Root fot the shared objects
+ ******************************************/
+enum RelationKind {
+    REF_RELATION,
+    LIST_RELATION,
+    INT_MAP_RELATION,
+    STR_MAP_RELATION};
+
+valuetype RelationDescription {
+    public RelationKind    kind;
+    public RelationName    name;
+    };
+valuetype ListRelationDescription : RelationDescription {
+    public long index;
+    };
+valuetype IntMapRelationDescription : RelationDescription {
+    public long key;
+    };
+valuetype StrMapRelationDescription : RelationDescription {
+    public string key;
+    };
+typedef sequence<RelationDescription> RelationDescriptionSeq;
+
+typedef short   RelatedObjectDepth;
+const RelatedObjectDepth UNLIMITED_RELATED_OBJECTS  = -1;
+
+valuetype ObjectRoot {
+
+    // State
+    // -----
+    private DLRLOid     m_oid;
+    private ClassName   m_class_name;
+    
+    // Attributes
+    // ----------
+    readonly attribute  DLRLOid             oid;
+    readonly attribute  ObjectState         read_state;
+    readonly attribute  ObjectState         write_state;
+    readonly attribute  ObjectHome          object_home;
+    readonly attribute  ClassName           class_name;
+    readonly attribute  CacheBase           owner;
+
+    // Operations
+    // ---------- 
+    void destroy ()
+        raises (
+            PreconditionNotMet);
+    boolean is_modified (
+        in ObjectScope scope);
+    RelationDescriptionSeq which_contained_modified ();
+    };
+
+/***********************************************
+* SelectionCriterion: Root of all filters and queries
+***********************************************/
+enum CriterionKind {
+    QUERY,
+    FILTER
+};
+
+local interface SelectionCriterion {
+    readonly attribute CriterionKind kind;
+};
+
+/***********************************************
+* FilterCriterion: Root of all the objects filters
+***********************************************/
+enum MembershipState {
+    UNDEFINED_MEMBERSHIP,
+    ALREADY_MEMBER,
+    NOT_MEMBER
+};
+
+local interface FilterCriterion : SelectionCriterion {
+    /***
+    * Following method will be generated properly typed
+    * in the generated derived classes
+    *
+    boolean check_object (
+    in ObjectRoot an_object,
+    in MembershipState membership_state);
+    *
+    ***/
+};
+/*******************************************************
+* QueryCriterion : Specialized SelectionCriterion to make a 
+* Query
+******************************************************/
+local interface QueryCriterion : SelectionCriterion {
+    // Attributes
+    // ---------
+    readonly attribute string expression;
+    readonly attribute StringSeq parameters;
+    //--- Methods
+    boolean set_query (
+        in string expression,
+        in StringSeq parameters) raises (SQLError);
+    boolean set_parameters ( in StringSeq parameters ) raises (SQLError);
+};
+
+
+/**********************************************************
+ * Selection : Root of all the selections (dynamic subsets)
+ **********************************************************/
+
+local interface Selection {
+ 
+    // Attributes
+    // ----------
+    readonly attribute boolean              auto_refresh;
+    readonly attribute boolean              concerns_contained;
+
+    /***
+     * Following attributes will be generated properly typed 
+     * in the generated derived classes
+     *
+    readonly attribute SelectionCriterion   criterion;
+    readonly attribute ObjectRootSeq        members;
+    readonly attribute SelectionListener    listener;
+     *
+     */
+
+    // Operations
+    // ----------
+    /***
+     * Following method will be generated properly typed
+     * in the generated derived classes
+     *
+    SelectionListener set_listener (
+        in SelectionListener listener);
+     *
+     ***/
+    void refresh ();
+    };
+
+
+/*********************************************************************
+ * ObjectHome : Root of all the representatives of applicative classes
+ *********************************************************************/
+
+local interface ObjectHome {
+    
+    // Attributes
+    // ----------
+    readonly attribute string           name;   // Shared name of the class
+    readonly attribute string           content_filter;
+    readonly attribute ObjectHome       parent;
+    readonly attribute ObjectHomeSeq    children;
+    readonly attribute unsigned long    registration_index;
+    readonly attribute boolean          auto_deref;
+    
+    /***
+     * Following attributes will be generated properly typed 
+     * in the generated derived classes
+     *
+    readonly attribute SelectionSeq         selections;
+    readonly attribute ObjectListenerSeq    listeners;
+     *
+     ***/
+
+    // Operations
+    // ----------
+
+    void set_content_filter (
+        in string expression)
+        raises (
+            SQLError,
+            PreconditionNotMet);
+
+    void set_auto_deref (
+        in boolean value);
+    void deref_all();
+    void underef_all ();
+
+    //--- Relations to topics
+
+    string get_topic_name (
+        in string attribute_name)
+        raises (
+            PreconditionNotMet);
+    StringSeq get_all_topic_names ()
+        raises (
+            PreconditionNotMet);
+
+            
+    // --- Listener management
+
+    /***
+     * Following methods will be generated properly typed
+     * in the generated derived classes
+     *
+		void attach_listener ( 
+			in ObjectListener listener,
+			in boolean concerns_contained_objects);
+		void detach_listener (
+			in ObjectListener listener);
+     *
+     ***/
+
+    // --- Selection management
+
+    /***
+     * Following methods will be generated properly typed
+     * in the generated derived classes
+     *
+    Selection create_selection(
+        in SelectionCriterion criterion,  
+        in boolean auto_refresh,  
+        in boolean concerns_contained_objects ) 
+        raises ( 
+            PreconditionNotMet );
+    void delete_selection (
+        in Selection a_selection)
+        raises (
+            PreconditionNotMet);           
+     *
+     ***/
+
+    // --- Object management
+
+    /***
+     * Following methods will be generated properly typed
+     * in the generated derived classes
+     *
+    ObjectRoot create_object(
+        in CacheAccess access)
+        raises (
+            PreconditionNotMet);
+    ObjectRoot create_unregistered_object (
+        in CacheAccess access)
+        raises (
+            PreconditionNotMet);
+    void register_object (
+        in ObjectRoot   unregistered_object)
+        raises (
+            AlreadyExisting,
+            PreconditionNotMet);
+
+    ObjectRoot find_object (
+        in DLRLOid  oid,
+        in CacheBase source)
+        raises (
+            NotFound);
+
+    ObjectRootSeq get_objects (
+        in CacheBase source);
+    ObjectRootSeq get_created_objects (
+        in CacheBase source);
+    ObjectRootSeq get_modified_objects (
+        in CacheBase source);
+    ObjectRootSeq get_deleted_objects (
+        in CacheBase source);
+
+
+     *
+     ***/
+    };
+
+/***********************
+ * Collection operations
+ ***********************/
+abstract valuetype Collection {
+
+    readonly attribute long length;
+
+    /***
+     * The following methods will be generated properly typed
+     * in the generated derived classes
+     *
+     readonly attribute ObjectRootSeq values;
+      *
+      ***/
+};
+
+abstract valuetype List : Collection {
+
+    void remove( );
+    LongSeq added_elements( );
+    LongSeq removed_elements( );
+    LongSeq modified_elements( );
+
+    /***
+     * The following methods will be generated properly typed
+     * in the generated derived classes
+     *
+     void add( in ObjectRoot value );
+     void put( in long key, in ObjectRoot value );
+     ObjectRoot get( in long key );
+      *
+      ***/
+};
+
+valuetype Set : Collection {
+    /***
+     * The following methods will be generated properly typed in 
+     * the generated derived classes. 
+     *
+    ObjectRootSeq added_elements( );
+    ObjectRootSeq removed_elements( );
+    boolean contains( ObjectRoot value );
+    void add( ObjectRoot value );
+    void remove( ObjectRoot value );
+     *
+     ***/ 
+};
+
+abstract valuetype StrMap : Collection {
+
+    readonly attribute StringSeq keys;
+    void remove( in string key );
+    StringSeq added_elements( );
+    StringSeq removed_elements( );
+    StringSeq modified_elements( );
+
+    /***
+     * The following methods will be generated properly typed
+     * in the generated derived classes
+     *
+     void put( in string key, in ObjectRoot value );
+     ObjectRoot get( in string key );
+      *
+      ***/
+};
+
+abstract valuetype IntMap : Collection {
+
+    readonly attribute LongSeq keys;
+    void remove( in long key );
+    LongSeq added_elements( );
+    LongSeq removed_elements( );
+    LongSeq modified_elements( );
+
+    /***
+     * The following methods will be generated properly typed
+     * in the generated derived classes
+     *
+     void put( in long key, in ObjectRoot value );
+     ObjectRoot get( in long key );
+      *
+      ***/
+};
+
+/************************************************************
+ * CacheBase : Base class to CacheAccess and Cache
+ ************************************************************/
+enum CacheKind {
+    CACHE_KIND,
+    CACHEACCESS_KIND
+};
+
+local interface CacheBase {
+    readonly attribute CacheUsage cache_usage;
+    readonly attribute ObjectRootSeq objects;
+    readonly attribute CacheKind kind;
+
+    void refresh( )  raises (DCPSError);
+};
+
+/************************************************************
+ * CacheAccess : Manager of the access of a subset of objects
+ *      (cloned) from a Cache
+ ************************************************************/
+
+local interface CacheAccess : CacheBase {
+
+    // Attributes
+    // ==========
+    readonly attribute Cache                owner;
+    readonly attribute ContractSeq          contracts;
+    readonly attribute StringSeq            type_names;
+
+    // Operations
+    // ==========
+    void write ()
+        raises (
+            ReadOnlyMode,
+            DCPSError);
+    void purge ();
+    void create_contract( 
+        in ObjectRoot object, 
+        in ObjectScope scope, in long depth ) 
+        raises (PreconditionNotMet);
+    void delete_contract( 
+        in Contract a_contract ) 
+        raises (PreconditionNotMet);
+}; 
+
+
+/***********************************************************************
+ * Cache : Manager of a set of related objects
+ *      is associated to one DDS::Publisher and/or one DDS::Subscriber
+ ***********************************************************************/
+
+local interface Cache : CacheBase {
+
+    // Attributes
+    // ----------    
+    readonly attribute DCPSState            pubsub_state;
+    readonly attribute DDS::Publisher       the_publisher;
+    readonly attribute DDS::Subscriber      the_subscriber;
+    readonly attribute boolean              updates_enabled;
+    readonly attribute ObjectHomeSeq        homes;
+    readonly attribute CacheAccessSeq       sub_accesses;
+    readonly attribute CacheListenerSeq     listeners;
+
+    // Operations
+    // ----------
+
+    //-- Infrastructure management
+    void register_all_for_pubsub()
+        raises (
+            BadHomeDefinition,
+            DCPSError,
+            PreconditionNotMet);
+    void enable_all_for_pubsub()
+        raises (
+            DCPSError,
+            PreconditionNotMet);
+
+    // -- Home management
+    unsigned long register_home (
+        in ObjectHome  a_home)
+        raises (
+            PreconditionNotMet);
+    ObjectHome find_home_by_name (
+        in ClassName class_name);
+    ObjectHome find_home_by_index (
+        in unsigned long index);
+
+    // -- Listener Management
+    void attach_listener (
+        in CacheListener listener);
+    void detach_listener (
+        in CacheListener listener);
+
+    // --- Updates management
+    void enable_updates ();
+    void disable_updates ();
+
+    // --- CacheAccess Management
+    CacheAccess create_access (
+        in CacheUsage purpose)
+        raises (
+            PreconditionNotMet);
+    void delete_access (
+        in CacheAccess access)
+        raises (
+            PreconditionNotMet);
+    };
+
+/************************************************
+ * CacheFactory : Factory to create Cache objects
+ ************************************************/
+
+valuetype CacheDescription {
+    public CacheName               name;
+    public DDS::DomainParticipant domain;
+    };
+
+local interface CacheFactory {
+    Cache create_cache (
+        in CacheUsage       cache_usage,
+        in CacheDescription cache_description)
+        raises (
+            DCPSError,
+            AlreadyExisting);
+    Cache find_cache_by_name(
+        in CacheName        name);
+    void delete_cache (
+        in Cache            a_cache);
+    };
+
+};

--- a/dds_gen/test_data/omg_dds/dds_security_plugins_spis.idl
+++ b/dds_gen/test_data/omg_dds/dds_security_plugins_spis.idl
@@ -1,0 +1,1212 @@
+/*
+ * dds-xtypes_discovery.idl needed for the declarations
+ * of DDS Entities and DDS Entity Qos
+ */
+ // DDSSEC11-96
+#include "dds-xtypes_discovery.idl"  /* http://www.omg.org/spec/DDS-XTypes/20170301/dds-xtypes_discovery.idl */
+
+// The types in this file shall be serialized with XCDR encoding version 1
+module DDS {
+    module Security {
+
+        // DynamicData is in DDS-XTYPES but including the XTYPES IDL
+        // Would make the file not compilable by legacy IDL compilers
+        // that do not understand the new anotation syntax
+        native DynamicData;
+
+        typedef sequence<octet>         OctetSeq;
+        typedef sequence<long long>     LongLongSeq;
+
+        // DDSSEC12-29
+        @extensibility(FINAL)
+        struct Property_t {
+            string name;
+            string value;
+            @non_serialized boolean propagate;
+        };
+        typedef sequence< Property_t >  PropertySeq;
+
+        // DDSSEC12-29
+        @extensibility(FINAL)
+        struct BinaryProperty_t {
+            string name;
+            OctetSeq value;
+            @non_serialized boolean propagate;
+        };
+        typedef sequence< BinaryProperty_t >  BinaryPropertySeq;
+
+        // DDSSEC11-96
+        // DDSSEC12-29
+        @extensibility(FINAL)
+        struct DataHolder {
+            string                        class_id;
+            @optional  PropertySeq        properties; 
+            @optional  BinaryPropertySeq  binary_properties; 
+        };
+        typedef sequence<DataHolder> DataHolderSeq;
+        typedef DataHolder Token;
+
+        // DDSSEC11-43
+        typedef Token MessageToken;
+        typedef MessageToken AuthRequestMessageToken;
+        typedef MessageToken HandshakeMessageToken;
+      
+        // DDSSEC11-82
+        typedef sequence<HandshakeMessageToken> HandshakeMessageTokenSeq;
+        typedef Token  IdentityToken;
+        typedef Token  IdentityStatusToken;
+        typedef Token  PermissionsToken;
+        typedef Token  AuthenticatedPeerCredentialToken;
+        typedef Token  PermissionsCredentialToken;
+
+        typedef Token  CryptoToken;
+        typedef Token  ParticipantCryptoToken;
+        typedef Token  DatawriterCryptoToken;
+        typedef Token  DatareaderCryptoToken;
+
+        typedef sequence<CryptoToken>  CryptoTokenSeq;
+        typedef CryptoTokenSeq  ParticipantCryptoTokenSeq;
+        typedef CryptoTokenSeq  DatawriterCryptoTokenSeq;
+        typedef CryptoTokenSeq  DatareaderCryptoTokenSeq;
+
+        // DDSSEC12-90
+        typedef string<64> CryptoAlgorithmName;
+        // Symmetric Ciphers 
+        const string CNAME_AES128_GMAC                          = "AES128+GCM";
+        const string CNAME_AES128_GCM                           = "AES128+GCM";
+        const string CNAME_AES256_GMAC                          = "AES256+GCM";
+        const string CNAME_AES256_GCM                           = "AES256+GCM";
+        // Digital Signature 
+        const string CNAME_RSASSA_PSS_MGF1SHA256_2048_SHA256    = "RSASSA-PSS-MGF1SHA256+2048+SHA256";
+        const string CNAME_RSASSA_PKCS1_V15_2048_SHA256         = "RSASSA-PKCS1-V1_5+2048+SHA256";
+        const string CNAME_ECDSA_P256_SHA256_NAME               = "ECDSA+P256+SHA256";
+        const string CNAME_ECDSA_P384_SHA384                    = "ECDSA+P384+SHA384";
+        // Key Establishment 
+        const string CNAME_DHE_MODP_2048_256                    = "DHE+MODP-2048-256";
+        const string CNAME_ECDHE_CEUM_P256                      = "ECDHE-CEUM+P256";
+        const string CNAME_ECDHE_CEUM_P384                      = "ECDHE-CEUM+P384";
+
+        // DDSSEC12-90
+        @doc("Range 0x01 <= value <  0x80 reserved for DDS-Sec. spec.")
+        @doc("Range 0x80 <= value <=  0xFF are reserved for implementation-specific algos.")    
+        typedef octet CryptoAlgorithmId;
+        const CryptoAlgorithmId   CID_INVALID                           = 0x00;
+        // Symmetric Ciphers 
+        const CryptoAlgorithmId   CID_AES128_GMAC                       = 0x01;
+        const CryptoAlgorithmId   CID_AES128_GCM                        = 0x02;
+        const CryptoAlgorithmId   CID_AES256_GMAC                       = 0x03;
+        const CryptoAlgorithmId   CID_AES256_GCM                        = 0x04;
+        // Digital Signature 
+        const CryptoAlgorithmId   CID_RSASSA_PSS_MGF1SHA256_2048_SHA256 = 0x10;
+        const CryptoAlgorithmId   CID_RSASSA_PKCS1_V15_2048_SHA256      = 0x11;
+        const CryptoAlgorithmId   CID_ECDSA_P256_SHA256                 = 0x12;
+        const CryptoAlgorithmId   CID_ECDSA_P384_SHA384                 = 0x13;
+        // Key Establishment 
+        const CryptoAlgorithmId   CID_DHE_MODP_2048_256                 = 0x20;
+        const CryptoAlgorithmId   CID_ECDHE_CEUM_P256                   = 0x21;
+        const CryptoAlgorithmId   CID_ECDHE_CEUM_P384                   = 0x22;
+
+        // DDSSEC12-90
+        @doc("Range 0x00000001 <= value <  0x00010000 reserved DDS-Sec. spec.")
+        @doc("Range 0x00010000 <= value <  0x80000000 reserved vendor-specific algos.")
+        typedef uint32 CryptoAlgorithmBit;
+        const CryptoAlgorithmBit  CRYPTO_ALGORITHM_COMPATIBILITY_MODE       = (0x80000000);
+        // Symmetric Ciphers 
+        const CryptoAlgorithmBit  CBIT_AES128_GMAC                          =  1 << 0;
+        const CryptoAlgorithmBit  CBIT_AES128_GCM                           =  1 << 0;
+        const CryptoAlgorithmBit  CBIT_AES256_GMAC                          =  1 << 1;
+        const CryptoAlgorithmBit  CBIT_AES256_GCM                           =  1 << 1;
+        // Digital Signature 
+        const CryptoAlgorithmBit  CBIT_RSASSA_PSS_MGF1SHA256_2048_SHA256    = 1 << 0;
+        const CryptoAlgorithmBit  CBIT_RSASSA_PKCS1_V15_2048_SHA256         = 1 << 1;
+        const CryptoAlgorithmBit  CBIT_ECDSA_P256_SHA256                    = 1 << 2;
+        const CryptoAlgorithmBit  CBIT_ECDSA_P384_SHA384                    = 1 << 3;
+        // Key Establishment 
+        const CryptoAlgorithmBit  CBIT_DHE_MODP_2048_256                    = 1 << 0;
+        const CryptoAlgorithmBit  CBIT_ECDHE_CEUM_P256                      = 1 << 1;
+        const CryptoAlgorithmBit  CBIT_ECDHE_CEUM_P384                      = 1 << 2;
+
+        // DDSSEC12-90
+        typedef uint32  CryptoAlgorithmSet;
+        const CryptoAlgorithmSet CRYPTO_ALGORITHM_SET_ALL   = 0xffffffff;
+        const CryptoAlgorithmSet CRYPTO_ALGORITHM_SET_EMPTY = 0x00000000;
+
+        // DDSSEC12-90
+        @extensibility (FINAL)
+        struct CryptoAlgorithmRequirements {
+            CryptoAlgorithmSet  supported_mask; 
+            CryptoAlgorithmSet  required_mask;
+        };
+
+        // DDSSEC12-90
+        @extensibility (APPENDABLE)
+        struct ParticipantSecurityDigitalSignatureAlgorithmInfo {
+            CryptoAlgorithmRequirements trust_chain;
+            CryptoAlgorithmRequirements message_auth;
+        }; 
+
+        // DDSSEC12-90
+        @extensibility (APPENDABLE)
+        struct ParticipantSecurityKeyEstablishmentAlgorithmInfo  {
+            CryptoAlgorithmRequirements shared_secret;
+        }; 
+
+        // DDSSEC12-90
+        @extensibility (APPENDABLE)
+        struct ParticipantSecuritySymmetricCipherAlgorithmInfo  {
+            CryptoAlgorithmSet  supported_mask;
+            CryptoAlgorithmSet  builtin_endpoints_required_mask;
+            CryptoAlgorithmSet  builtin_kx_endpoints_required_mask;
+            CryptoAlgorithmSet  user_endpoints_default_required_mask;
+        };
+
+        // DDSSEC12-90
+        @extensibility (APPENDABLE)
+        struct ParticipantSecurityAlgorithmInfo  {
+            ParticipantSecurityDigitalSignatureAlgorithmInfo  digital_signature;
+            ParticipantSecurityKeyEstablishmentAlgorithmInfo  key_establishment;
+            ParticipantSecuritySymmetricCipherAlgorithmInfo   symmetric_cipher;
+        }; 
+
+        // DDSSEC12-90
+        @extensibility (APPENDABLE)
+        struct EndpointSecuritySymmetricCipherAlgorithmInfo  {
+            CryptoAlgorithmSet  required_mask;
+            @non_serialized
+            CryptoAlgorithmSet  supported_mask;
+        };
+
+        // DDSSEC12-90
+        @extensibility (APPENDABLE)
+        struct EndpointSecurityAlgorithmInfo  {
+            EndpointSecuritySymmetricCipherAlgorithmInfo   symmetric_cipher;
+        };
+
+        // DDSSEC12-122
+        typedef octet CryptoTransformKeyRevision[3];
+        #define  CRYPTO_TRANSFORM_KEY_REVISION_NONE    {0x00, 0x00, 0x00}
+        typedef int32 CryptoTransformKeyRevisionIntHolder;
+
+        // DDSSEC12-90 DDSSEC12-122
+        @extensibility(FINAL)
+        struct CryptoTransformKind {
+            CryptoTransformKeyRevision      transformation_key_revision;
+            CryptoAlgorithmId               transformation_algorithm_id;
+        };
+        #define  CRYPTO_TRANSFORM_KIND_INVALID  {{0x00, 0x00, 0x00}, 0x00}
+
+        // DDSSEC12-90
+        typedef octet    CryptoTransformKeyId[4];
+
+        // DDSSEC12-90
+        @extensibility(FINAL)
+        struct CryptoTransformIdentifier {
+            CryptoTransformKind   transformation_kind;
+            CryptoTransformKeyId  transformation_key_id;
+        };  
+
+        // DDSSEC11-96
+        @extensibility(APPENDABLE)
+        struct PropertyQosPolicy {
+            PropertySeq        value;
+            BinaryPropertySeq  binary_value;
+        }; 
+
+        // DDSSEC12-29
+        @extensibility(FINAL)
+        struct Tag {
+            string name;
+            string value;
+        };
+        typedef sequence< Tag > TagSeq;
+
+        // DDSSEC11-34 DDSSEC12-29
+        @extensibility(APPENDABLE)
+        struct DataTags {
+            TagSeq tags;
+        };
+        typedef DataTags DataTagQosPolicy;
+
+        // DDSSEC11-96
+        // See http://www.omg.org/spec/DDS-XTypes/20170301/dds-xtypes_discovery.idl
+        @extensibility(MUTABLE)
+	    struct DomainParticipantQos :  DDS::DomainParticipantQos {
+            PropertyQosPolicy  property;
+        };
+
+        // DDSSEC11-96
+        // See http://www.omg.org/spec/DDS-XTypes/20170301/dds-xtypes_discovery.idl
+        // DDSSEC11-34
+        @extensibility(MUTABLE)
+        struct DataWriterQos  :  DDS::DataWriterQos {
+            PropertyQosPolicy  property;
+            DataTagQosPolicy   data_tags;
+        };
+
+        // DDSSEC11-96
+        // See http://www.omg.org/spec/DDS-XTypes/20170301/dds-xtypes_discovery.idl
+        // DDSSEC11-34
+        @extensibility(MUTABLE)
+        struct DataReaderQos  :  DDS::DataReaderQos {
+            PropertyQosPolicy  property;
+            DataTagQosPolicy   data_tags;
+        };
+    
+        // DDSSEC12-29
+        typedef octet GUID_t[16];
+
+        // DDSSEC11-88 DDSSEC12-29
+        @extensibility(FINAL)
+        struct MessageIdentity {
+            GUID_t     source_guid;
+            long long  sequence_number;
+        };
+        typedef string GenericMessageClassId;
+
+        @extensibility(APPENDABLE)
+        struct ParticipantGenericMessage {
+            /* target for the request. Can be GUID_UNKNOWN */
+            MessageIdentity         message_identity;
+            MessageIdentity         related_message_identity;
+            GUID_t                  destination_participant_guid; 
+            GUID_t                  destination_endpoint_guid; 
+            GUID_t                  source_endpoint_guid; 
+            GenericMessageClassId   message_class_id;
+            DataHolderSeq           message_data;
+        }; 
+
+        // DDSSEC11-137
+        typedef unsigned long ParticipantSecurityAttributesMask;
+        typedef unsigned long PluginParticipantSecurityAttributesMask;
+
+        // DDSSEC12-94
+        struct ParticipantSecurityAttributesMaskExt {
+            unsigned short  is_set;
+            unsigned short  value;
+        };
+
+        // DDSEC12-90 DDSEC12-94
+        @extensibility(APPENDABLE)
+        struct ParticipantSecurityProtectionInfo  {
+            ParticipantSecurityAttributesMask        participant_security_attributes; 
+            PluginParticipantSecurityAttributesMask  plugin_participant_security_attributes; 
+            ParticipantSecurityAttributesMaskExt     participant_security_optional_attributes;
+        };
+        #define PARTICIPANT_SECURITY_ATTRIBUTES_INFO_DEFAULT  {0}
+
+        // DDSSEC12-90 DDSEC12-92 DDSEC12-94
+        // Used in ParticipantSecurityAttributesMask
+        #define PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_VALID                   (0x00000001 << 31)
+        #define PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_AXK_PROTECTED      (0x00000001 << 0)
+        #define PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_DISCOVERY_PROTECTED     (0x00000001 << 1)
+        #define PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_PROTECTED    (0x00000001 << 2)
+        #define PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_KEY_REVISION_ENABLED    (0x00000001 << 3)
+        #define PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_PSK_PROTECTED      (0x00000001 << 4)
+
+
+        // Used in ParticipantSecurityAttributesMaskExt
+        #define PARTICIPANT_SECURITY_OPT_ATTRIBUTES_FLAG_ALLOW_UNAUTHENTICATED_PARTICIPANTS (0x0001 << 0)
+        #define PARTICIPANT_SECURITY_OPT_ATTRIBUTES_FLAG_IS_ACCESS_PROTECTED                (0x0001 << 1)
+
+        // These are plugin-specific
+        #define PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_AXK_ENCRYPTED               (0x00000001 << 0)
+        #define PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_BUILTIN_IS_DISCOVERY_ENCRYPTED      (0x00000001 << 1)
+        #define PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_ENCRYPTED             (0x00000001 << 2)
+        #define PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_ORIGIN_AUTHENTICATED        (0x00000001 << 3)
+        #define PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_DISCOVERY_ORIGIN_AUTHENTICATED   (0x00000001 << 4)
+        #define PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_ORIGIN_AUTHENTICATED  (0x00000001 << 5)
+        #define PLUGIN_PARTICIPANT_SECURITY_ATTRIBUTES_FLAG_IS_RTPS_PSK_ENCRYPTED               (0x00000001 << 6)
+
+
+        // DDSSEC11-106
+        typedef unsigned long EndpointSecurityAttributesMask;
+        typedef unsigned long PluginEndpointSecurityAttributesMask;
+
+        // DDSSEC12-90 
+        @extensibility(APPENDABLE)
+        struct EndpointSecurityProtectionInfo  {
+            EndpointSecurityAttributesMask        endpoint_security_attributes; 
+            PluginEndpointSecurityAttributesMask  plugin_endpoint_security_attributes; 
+        };     
+        #define ENDPOINT_SECURITY_ATTRIBUTES_INFO_DEFAULT  {0}
+
+        // DDSSEC12-90 
+        // Used in EndpointSecurityAttributesMask
+        #define ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_READ_PROTECTED         (0x00000001 << 0)
+        #define ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_WRITE_PROTECTED        (0x00000001 << 1)
+        #define ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_DISCOVERY_PROTECTED    (0x00000001 << 2)
+        #define ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_PROTECTED   (0x00000001 << 3)
+        #define ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_PROTECTED      (0x00000001 << 4)
+        #define ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_KEY_PROTECTED          (0x00000001 << 5)
+        #define ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_LIVELINESS_PROTECTED   (0x00000001 << 6)
+        #define ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_VALID                  (0x00000001 << 31)
+
+        // These are plugin-specific
+        #define PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ENCRYPTED            (0x00000001 << 0)
+        #define PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_PAYLOAD_ENCRYPTED               (0x00000001 << 1)
+        #define PLUGIN_ENDPOINT_SECURITY_ATTRIBUTES_FLAG_IS_SUBMESSAGE_ORIGIN_AUTHENTICATED (0x00000001 << 2)
+
+        typedef unsigned long AvailableBuiltinEndpointsExtSet_t;
+
+        // See http://www.omg.org/spec/DDS-XTypes/20170301/dds-xtypes_discovery.idl
+        // DDSSEC11-96 DDSSEC11-137
+        // DDSSEC12-86 DDSSEC12-90
+        @extensibility(MUTABLE)
+        struct ParticipantBuiltinTopicData  :  DDS::ParticipantBuiltinTopicData {
+            @id(0x1001)  IdentityToken     identity_token;     
+            @id(0x1002)  PermissionsToken  permissions_token;  
+            @id(0x0059)  PropertyQosPolicy property;
+            @id(0x1005)  ParticipantSecurityProtectionInfo   protection_info;
+            @id(0x1007)  AvailableBuiltinEndpointsExtSet_t   available_builtin_endpoints_ext;
+            @id(0x1010)  ParticipantSecurityDigitalSignatureAlgorithmInfo  digital_signature;
+            @id(0x1011)  ParticipantSecurityKeyEstablishmentAlgorithmInfo  key_establishment;
+            @id(0x1012)  ParticipantSecuritySymmetricCipherAlgorithmInfo   symmetric_cipher;
+        };
+
+        // DDSSEC11-82
+        @extensibility(MUTABLE)
+        struct ParticipantBuiltinTopicDataSecure  :  ParticipantBuiltinTopicData {
+            @id(0x1006) @optional IdentityStatusToken identity_status_token;
+        };
+
+        // DDSSEC11-85
+        // DDSSEC12-90
+        @extensibility(MUTABLE) 
+        struct PublicationBuiltinTopicData  : DDS::PublicationBuiltinTopicData {
+            @id(0x1004) @optional EndpointSecurityProtectionInfo                protection_info;
+            @id(0x1013) @optional EndpointSecuritySymmetricCipherAlgorithmInfo  symmetric_cipher;
+        };
+
+        // DDSSEC11-85
+        // DDSSEC12-90
+        @extensibility(MUTABLE) 
+        struct SubscriptionBuiltinTopicData  : DDS::SubscriptionBuiltinTopicData {
+            @id(0x1004) @optional EndpointSecurityProtectionInfo                protection_info;
+            @id(0x1013) @optional EndpointSecuritySymmetricCipherAlgorithmInfo  symmetric_cipher;
+        };
+      
+        // DDSSEC11-96
+        // See http://www.omg.org/spec/DDS-XTypes/20170301/dds-xtypes_discovery.idl
+        @extensibility(MUTABLE)
+        struct PublicationBuiltinTopicDataSecure  :  PublicationBuiltinTopicData {
+            @id(0x1003)  DataTags data_tags;
+        };
+
+        // DDSSEC11-96
+        // See http://www.omg.org/spec/DDS-XTypes/20170301/dds-xtypes_discovery.idl
+        @extensibility(MUTABLE)
+        struct SubscriptionBuiltinTopicDataSecure  :  DDS::SubscriptionBuiltinTopicData {
+            @id(0x1003)  DataTags data_tags;
+        };
+
+
+        // DDSSEC11-24
+        typedef long ReturnCode_t;
+        const ReturnCode_t RETCODE_NOT_ALLOWED_BY_SECURITY = 1000;
+
+        // DDSSEC11-15 typedef long SecurityExceptionCode;
+        typedef long SecurityExceptionCode;
+
+        struct SecurityException {
+            string  message;
+            long    code;      // DDSSEC11-15
+            long    minor_code;
+        };
+
+        enum ValidationResult_t {
+            VALIDATION_OK,
+            VALIDATION_FAILED,
+            VALIDATION_PENDING_RETRY,
+            VALIDATION_PENDING_HANDSHAKE_REQUEST,
+            VALIDATION_PENDING_HANDSHAKE_MESSAGE,
+            VALIDATION_OK_FINAL_MESSAGE
+        };
+
+        native IdentityHandle;
+        native HandshakeHandle;
+        native SharedSecretHandle;
+        native PermissionsHandle;
+        native ParticipantCryptoHandle;
+        native ParticipantCryptoHandleSeq;
+        native DatawriterCryptoHandle;
+        native DatawriterCryptoHandleSeq;
+        native DatareaderCryptoHandle;
+        native DatareaderCryptoHandleSeq;
+
+        // DDSSEC11-96
+        interface Authentication;
+
+        // DDSSEC11-82
+        enum AuthStatusKind {
+	        @value(1) IDENTITY_STATUS
+        };
+      
+        // DDSSEC11-96
+        interface AuthenticationListener {
+            boolean
+                on_revoke_identity(
+                    in    Authentication     plugin,
+                    in    IdentityHandle     handle,
+                    inout SecurityException  ex);
+
+            // DDSSEC11-82
+            boolean
+                on_status_changed(
+                    in    Authentication     plugin,
+                    in    IdentityHandle     handle,
+                    in    AuthStatusKind     status_kind,
+                    inout SecurityException  ex);
+         };
+
+        // DDSSEC11-96
+        interface Authentication {
+            // DDSSEC11-88
+            ValidationResult_t
+                validate_local_identity(
+                    inout IdentityHandle        local_identity_handle,
+                    inout GUID_t                adjusted_participant_guid,
+                    in    DomainId_t            domain_id,
+                    in    DomainParticipantQos  participant_qos,
+                    in    GUID_t                candidate_participant_guid,
+                    inout SecurityException     ex );
+
+            boolean
+                get_identity_token(
+                    inout IdentityToken      identity_token,
+                    in    IdentityHandle     handle,
+                    inout SecurityException  ex );
+
+	        // DDSSEC11-82
+            boolean
+                get_identity_status_token(
+                    inout IdentityStatusToken      identity_status_token,
+                    in    IdentityHandle           handle,
+                    inout SecurityException        ex );
+
+            // DDSSEC12-90
+            boolean
+                set_participant_security_config(
+                    inout ParticipantSecurityAlgorithmInfo  adjusted_algorithm_info,
+                    in    IdentityHandle                    handle,
+                    in    ParticipantSecurityConfig         participant_security_config,
+                    inout SecurityException                 ex );
+
+            boolean
+                set_permissions_credential_and_token(
+                    in    IdentityHandle         handle,
+                    in    PermissionsCredential  permissions_credential,
+                    in    PermissionsToken       permissions_token,
+                    inout SecurityException      ex );
+
+            // DDSSEC11-21
+            // DDSSEC11-88
+            // DDSSEC11-85
+            ValidationResult_t
+                validate_remote_identity(
+                    inout  IdentityHandle           remote_identity_handle,
+                    inout  AuthRequestMessageToken  local_auth_request_token,	
+                    in     AuthRequestMessageToken  remote_auth_request_token,	
+                    in     IdentityHandle           local_identity_handle,
+                    in     IdentityToken            remote_identity_token,
+                    in     GUID_t                   remote_participant_guid,
+                    inout  SecurityException        ex );
+
+            // DDSSEC11-46
+            // DDSSEC11-118
+            ValidationResult_t
+                begin_handshake_request(
+                    inout HandshakeHandle        handshake_handle,
+                    inout HandshakeMessageToken  handshake_message,
+                    in    IdentityHandle         initiator_identity_handle,
+                    in    IdentityHandle         replier_identity_handle,
+                    in    OctetSeq               serialized_local_participant_data,
+                    inout SecurityException      ex );
+
+            // DDSSEC11-46
+            ValidationResult_t
+                begin_handshake_reply(
+                    inout HandshakeHandle        handshake_handle,
+                    inout HandshakeMessageToken  handshake_message_out,
+                    in    IdentityHandle         initiator_identity_handle,
+                    in    IdentityHandle         replier_identity_handle,
+                    in    OctetSeq               serialized_local_participant_data,
+                    inout SecurityException      ex );
+
+            ValidationResult_t
+                process_handshake(
+                    inout HandshakeMessageToken  handshake_message_out,
+                    in    HandshakeMessageToken  handshake_message_in,
+                    in    HandshakeHandle        handshake_handle,
+                    inout SecurityException      ex );
+
+            SharedSecretHandle
+                get_shared_secret(
+                    in    HandshakeHandle    handshake_handle,
+                    inout SecurityException  ex );
+
+            boolean
+                get_authenticated_peer_credential_token(
+                    inout AuthenticatedPeerCredentialToken  peer_credential_token,
+                    in    HandshakeHandle                   handshake_handle,
+                    inout SecurityException                 ex );
+
+            boolean
+                set_listener(
+                    in   AuthenticationListener  listener,
+                    inout SecurityException   ex );
+
+            boolean
+                return_identity_token(
+                    in    IdentityToken      token,
+                    inout SecurityException  ex);
+
+	        // DDSSEC11-82
+            boolean
+                return_identity_status_token(
+                    in    IdentityStatusToken  token,
+                    inout SecurityException    ex);
+
+            boolean
+                return_authenticated_peer_credential_token(
+                    in   AuthenticatedPeerCredentialToken peer_credential_token,
+                    inout SecurityException  ex);
+
+            boolean
+                return_handshake_handle(
+                    in    HandshakeHandle    handshake_handle,
+                    inout SecurityException  ex);
+
+            boolean
+                return_identity_handle(
+                    in   IdentityHandle      identity_handle,
+                    inout SecurityException  ex);
+
+            boolean
+                return_sharedsecret_handle(
+                    in    SharedSecretHandle  sharedsecret_handle,
+                    inout SecurityException   ex);
+        };
+
+        // DDSSEC11-137 DDSEC11-85
+        // DDSSEC12-90  DDSSEC12-94 DDSSEC12-122
+        @extensibility (APPENDABLE)
+        struct ParticipantSecurityConfig  {
+            boolean     allow_unauthenticated_participants;
+            boolean     is_access_protected;
+            boolean     is_rtps_axk_protected;
+            boolean     is_rtps_psk_protected;
+            boolean     is_discovery_protected;
+            boolean     is_liveliness_protected;
+            boolean     is_key_revision_enabled;
+            PluginParticipantSecurityAttributesMask  plugin_participant_attributes;
+            PropertySeq                              ac_endpoint_properties;
+            ParticipantSecurityAlgorithmInfo         algorithm_info;
+        };
+
+        // DDSSEC11-16
+        // DDSSEC12-90
+        @extensibility (APPENDABLE)
+        struct TopicSecurityConfig  {
+            boolean  is_read_protected;
+            boolean  is_write_protected;
+            boolean  is_discovery_protected;
+            boolean  is_liveliness_protected;
+        };
+      
+        // DDSSEC11-16 DDSSEC11-106 DDSEC11-85
+        // DDSSEC12-90
+        struct EndpointSecurityConfig  : TopicSecurityConfig {
+            boolean     is_submessage_protected;
+            boolean     is_payload_protected;
+            boolean     is_key_protected;
+            PluginEndpointSecurityAttributesMask    plugin_endpoint_attributes; 
+            PropertySeq                             ac_endpoint_properties; 
+            EndpointSecurityAlgorithmInfo           algorithm_info;
+        };
+
+       // DDSSEC12-90 
+        // Used in EndpointSecurityAttributesMask
+
+        // DDSSEC11-106      
+        struct PluginEndpointSecurityAttributes {
+            boolean     is_submessage_encrypted;
+            boolean     is_payload_encrypted;
+            boolean     is_submessage_origin_authenticated;
+        };
+      
+        // DDSSEC11-96
+        interface AccessControl;
+        typedef long  DomainId_t;
+
+        // DDSSEC11-96
+        interface AccessControlListener {
+            boolean on_revoke_permissions(
+                in   AccessControl plugin,
+                in   PermissionsHandle handle);
+        };
+
+        // DDSSEC11-96
+        interface AccessControl {
+            PermissionsHandle
+                validate_local_permissions(
+                    in    Authentication         auth_plugin,
+                    in    IdentityHandle         identity,
+                    in    DomainId_t             domain_id,
+                    in    DomainParticipantQos   participant_qos,
+                    inout SecurityException      ex );
+
+            PermissionsHandle
+                validate_remote_permissions(
+                    in    Authentication                    auth_plugin,
+                    in    IdentityHandle                    local_identity_handle,
+                    in    IdentityHandle                    remote_identity_handle,
+                    in    PermissionsToken                  remote_permissions_token,
+                    in    AuthenticatedPeerCredentialToken  remote_credential_token,
+                    inout SecurityException                 ex );
+
+            boolean
+                check_create_participant(
+                    in    PermissionsHandle     permissions_handle,
+                    in    DomainId_t            domain_id,
+                    in    DomainParticipantQos  qos,
+                    inout SecurityException     ex );
+
+            boolean
+                check_create_datawriter(
+                    in    PermissionsHandle   permissions_handle,
+                    in    DomainId_t          domain_id,
+                    in    string              topic_name,
+                    in    DataWriterQos       qos,
+                    in    PartitionQosPolicy  partition,
+                    in    DataTags            data_tag,
+                    inout SecurityException   ex);
+
+            boolean
+                check_create_datareader(
+                    in    PermissionsHandle   permissions_handle,
+                    in    DomainId_t          domain_id,
+                    in    string              topic_name,
+                    in    DataReaderQos       qos,
+                    in    PartitionQosPolicy  partition,
+                    in    DataTags            data_tag,
+                    inout SecurityException   ex);
+
+            // DDSSEC11-33
+            boolean
+                check_create_topic(
+                    in    PermissionsHandle permissions_handle,
+                    in    DomainId_t         domain_id,
+                    in    string             topic_name,
+                    in    TopicQos           qos,
+                    inout SecurityException  ex);
+
+            boolean
+                check_local_datawriter_register_instance(
+                    in    PermissionsHandle  permissions_handle,
+                    in    DataWriter         writer,
+                    in    DynamicData        key,
+                    inout SecurityException  ex);
+
+            boolean
+                check_local_datawriter_dispose_instance(
+                    in    PermissionsHandle  permissions_handle,
+                    in    DataWriter         writer,
+                    in    DynamicData        key,
+                    inout SecurityException  ex);
+
+            boolean
+                check_remote_participant(
+                    in    PermissionsHandle                  permissions_handle,
+                    in    DomainId_t                         domain_id,
+                    in    ParticipantBuiltinTopicDataSecure  participant_data,
+                    inout SecurityException                  ex);
+
+            boolean
+                check_remote_datawriter(
+                    in   PermissionsHandle                  permissions_handle,
+                    in   DomainId_t                         domain_id,
+                    in   PublicationBuiltinTopicDataSecure  publication_data,
+                    inout SecurityException                 ex);
+
+            boolean
+                check_remote_datareader(
+                    in    PermissionsHandle                   permissions_handle,
+                    in    DomainId_t                          domain_id,
+                    in    SubscriptionBuiltinTopicDataSecure  subscription_data,
+                    inout boolean                             relay_only,
+                    inout SecurityException                   ex);
+
+            boolean
+                check_remote_topic(
+                    in    PermissionsHandle      permissions_handle,
+                    in    DomainId_t             domain_id,
+                    in    TopicBuiltinTopicData  topic_data,
+                    inout SecurityException      ex);
+
+            // DDSSEC11-34
+            boolean
+                check_local_datawriter_match(
+                    in    PermissionsHandle  writer_permissions_handle,
+                    in    PermissionsHandle  reader_permissions_handle,
+                    in    PublicationBuiltinTopicDataSecure  publication_data,
+                    in    SubscriptionBuiltinTopicDataSecure subscription_data,
+                    inout SecurityException  ex);
+
+            // DDSSEC11-34
+            boolean
+                check_local_datareader_match(
+                    in    PermissionsHandle  reader_permissions_handle,
+                    in    PermissionsHandle  writer_permissions_handle,
+                    in    SubscriptionBuiltinTopicDataSecure subscription_data,
+                    in    PublicationBuiltinTopicDataSecure  publication_data,
+                    inout SecurityException  ex);
+
+            boolean
+                check_remote_datawriter_register_instance(
+                    in    PermissionsHandle   permissions_handle,
+                    in    DataReader          reader,
+                    in    InstanceHandle_t    publication_handle,
+                    in    DynamicData         key,
+                    in    InstanceHandle_t    instance_handle,
+                    inout SecurityException   ex);
+
+            boolean
+                check_remote_datawriter_dispose_instance(
+                    in    PermissionsHandle  permissions_handle,
+                    in    DataReader         reader,
+                    in    InstanceHandle_t   publication_handle,
+                    in    DynamicData        key,
+                    inout SecurityException  ex);
+
+            boolean
+                get_permissions_token(
+                    inout PermissionsToken   permissions_token,
+                    in    PermissionsHandle  handle,
+                    inout SecurityException  ex);
+
+            boolean
+                get_permissions_credential_token(
+                    inout PermissionsCredentialToken permissions_credential_token,
+                    in    PermissionsHandle  handle,
+                    inout SecurityException  ex);
+
+            boolean
+                set_listener(
+                    in    AccessControlListener  listener,
+                    inout SecurityException      ex);
+
+            boolean
+                return_permissions_token(
+                    in    PermissionsToken   token,
+                    inout SecurityException  ex);
+
+            boolean
+                return_permissions_credential_token(
+                    in    PermissionsCredentialToken  permissions_credential_token,
+                    inout SecurityException           ex);
+
+            // DDSSEC12-90
+            boolean
+                get_participant_security_config(
+                    in    PermissionsHandle         permissions_handle,
+                    inout ParticipantSecurityConfig participant_security_config,
+                    inout SecurityException         ex);
+
+            // DDSSEC11-16
+            // DDSSEC12-90
+            boolean
+                get_topic_security_config (
+                    in    PermissionsHandle         permissions_handle, 
+                    in    String                    topic_name, 
+                    inout TopicSecurityConfig       topic_security_config, 
+                    inout SecurityException         ex);
+                 
+            // DDSSEC11-16
+            // DDSSEC12-90
+           boolean
+                get_datawriter_security_config(
+                    in    PermissionsHandle         permissions_handle,
+                    in    PartitionQosPolicy        partition,
+                    in    DataTagQosPolicy          data_tag,
+                    inout EndpointSecurityConfig    endpoint_security_config,
+                    inout SecurityException         ex);
+		    
+            // DDSSEC11-16
+            // DDSSEC12-90
+            boolean
+                get_datareader_security_config(
+                    in    PermissionsHandle         permissions_handle,
+                    in    PartitionQosPolicy        partition,
+                    in    DataTagQosPolicy          data_tag,
+                    inout EndpointSecurityConfig    endpoint_security_config,
+                    inout SecurityException         ex);
+
+            // DDSSEC11-112
+            // DDSSEC12-90
+            boolean
+                return_participant_sec_config(
+                    in ParticipantSecurityConfig    config,
+                    inout SecurityException         ex);
+
+            // DDSSEC12-90
+            boolean
+                return_topic_sec_config(
+                    in TopicSecurityConfig          config,
+                    inout SecurityException         ex);
+
+            // DDSSEC11-112
+            // DDSSEC12-90
+            boolean
+                return_datawriter_sec_config(
+                    in EndpointSecurityConfig       config,
+                    inout SecurityException         ex);
+
+            // DDSSEC11-112
+            // DDSSEC12-90
+            boolean
+                return_datareader_sec_config(
+                    in EndpointSecurityConfig       config,
+                    inout SecurityException         ex);
+        };
+
+        // DDSSEC11-96
+        interface CryptoKeyFactory {
+
+            // DDSSEC11-3 DDSSEC11-85
+            // DDSSEC12-90
+            ParticipantCryptoHandle
+                register_local_participant(
+                    inout ParticipantSecurityAlgorithmInfo  adjusted_algorithm_info,        
+                    in    IdentityHandle                    participant_identity,
+                    in    PermissionsHandle                 participant_permissions,
+                    in    PropertySeq                       participant_properties,
+                    in    ParticipantSecurityConfig         participant_security_config,
+                    inout SecurityException                 ex  );
+
+            ParticipantCryptoHandle
+                register_matched_remote_participant(
+                    in    ParticipantCryptoHandle  local_participant_crypto_handle,
+                    in    IdentityHandle           remote_participant_identity,
+                    in    PermissionsHandle        remote_participant_permissions,
+                    in    SharedSecretHandle       shared_secret,
+                    inout SecurityException        ex);
+
+            // DDSSEC11-3 DDSSEC11-85
+            // DDSSEC12-90
+            DatawriterCryptoHandle
+                register_local_datawriter(
+                    inout EndpointSecurityAlgorithmInfo adjusted_algorithm_info,        
+                    in    ParticipantCryptoHandle       participant_crypto,
+                    in    PropertySeq                   datawriter_properties,
+                    in    EndpointSecurityConfig        datawriter_security_config,
+                    in    GUID_t                        endpoint_guid,
+                    inout SecurityException             ex);
+
+            DatareaderCryptoHandle
+                register_matched_remote_datareader(
+                    in    DatawriterCryptoHandle   local_datawriter_crypto_handle,
+                    in    ParticipantCryptoHandle  remote_participant_crypto,
+                    in    SharedSecretHandle       shared_secret,
+                    in    boolean                  relay_only,
+                    inout SecurityException        ex);
+
+            // DDSSEC11-3 DDSSEC11-85
+            // DDSSEC12-90
+            DatareaderCryptoHandle
+                register_local_datareader(
+                    inout EndpointSecurityAlgorithmInfo adjusted_algorithm_info,        
+                    in    ParticipantCryptoHandle       participant_crypto,
+                    in    PropertySeq                   datareader_properties,
+                    in    EndpointSecurityConfig        datareader_security_config,
+                    in    GUID_t                        endpoint_guid,
+                    inout SecurityException             ex);
+
+            DatawriterCryptoHandle
+                register_matched_remote_datawriter(
+                    in    DatareaderCryptoHandle   local_datareader_crypto_handle,
+                    in    ParticipantCryptoHandle  remote_participant_crypt,
+                    in    SharedSecretHandle       shared_secret,
+                    inout SecurityException        ex );
+
+            // DDSSEC12-122
+            CryptoTransformKeyRevisionIntHolder 
+                revise_local_entity_keys(
+                    in    ParticipantCryptoHandle  participant_crypto_handle,
+                    inout SecurityException        ex );
+
+            // DDSSEC12-122
+            boolean 
+                activate_key_revision(
+                    in    ParticipantCryptoHandle           local_participant_crypto_handle,
+                    CryptoTransformKeyRevisionIntHolder     key_revision,
+                    inout SecurityException                 ex );
+
+            boolean
+                unregister_participant(
+                    in    ParticipantCryptoHandle  participant_crypto_handle,
+                    inout SecurityException        ex);
+
+            boolean
+                unregister_datawriter(
+                    in    DatawriterCryptoHandle  datawriter_crypto_handle,
+                    inout SecurityException       ex  );
+
+            boolean
+                unregister_datareader(
+                    in    DatareaderCryptoHandle  datareader_crypto_handle,
+                    inout SecurityException       ex  );
+        };
+
+
+        // DDSSEC11-96
+        interface CryptoKeyExchange {
+            // DDSSEC12-122
+            boolean
+                create_local_participant_crypto_tokens(
+                    inout ParticipantCryptoTokenSeq             local_participant_crypto_tokens,
+                    in    ParticipantCryptoHandle               local_participant_crypto,
+                    in    ParticipantCryptoHandle               remote_participant_crypto,
+                    in    CryptoTransformKeyRevisionIntHolder   key_revision,
+                    inout SecurityException                     ex);
+
+            boolean
+                set_remote_participant_crypto_tokens(
+                    in    ParticipantCryptoHandle    local_participant_crypto,
+                    in    ParticipantCryptoHandle    remote_participant_crypto,
+                    in    ParticipantCryptoTokenSeq  remote_participant_tokens,
+                    inout SecurityException          ex);
+
+            // DDSSEC12-122
+            boolean
+                create_local_datawriter_crypto_tokens(
+                    inout DatawriterCryptoTokenSeq              local_datawriter_crypto_tokens,
+                    in    DatawriterCryptoHandle                local_datawriter_crypto,
+                    in    DatareaderCryptoHandle                remote_datareader_crypto,
+                    in    CryptoTransformKeyRevisionIntHolder   key_revision,
+                    inout SecurityException                     ex);
+
+            boolean
+                set_remote_datawriter_crypto_tokens(
+                    in    DatareaderCryptoHandle    local_datareader_crypto,
+                    in    DatawriterCryptoHandle    remote_datawriter_crypto,
+                    in    DatawriterCryptoTokenSeq  remote_datawriter_tokens,
+                    inout SecurityException         ex);
+
+            // DDSSEC12-122
+            boolean
+                create_local_datareader_crypto_tokens(
+                    inout DatareaderCryptoTokenSeq              local_datareader_cryto_tokens,
+                    in    DatareaderCryptoHandle                local_datareader_crypto,
+                    in    DatawriterCryptoHandle                remote_datawriter_crypto,
+                    in    CryptoTransformKeyRevisionIntHolder   key_revision,
+                    inout SecurityException                     ex);
+
+            boolean
+                set_remote_datareader_crypto_tokens(
+                    in    DatawriterCryptoHandle    local_datawriter_crypto,
+                    in    DatareaderCryptoHandle    remote_datareader_crypto,
+                    in    DatareaderCryptoTokenSeq  remote_datareader_tokens,
+                    inout SecurityException         ex);
+
+            boolean
+                return_crypto_tokens(
+                    in    CryptoTokenSeq     crypto_tokens,
+                    inout SecurityException  ex);
+        };
+
+        enum SecureSumessageCategory_t {
+            INFO_SUBMESSAGE,
+            DATAWRITER_SUBMESSAGE,
+            DATAREADER_SUBMESSAGE
+        };
+
+        // DDSSEC11-96
+        // DDSSEC11-123
+        interface CryptoTransform {
+            boolean
+                encode_serialized_payload(
+                    inout OctetSeq                encoded_buffer,
+                    inout OctetSeq                extra_inline_qos,
+                    in    OctetSeq                plain_buffer,
+                    in    DatawriterCryptoHandle  sending_datawriter_crypto,
+                    inout SecurityException       ex);
+
+	    // DDSSEC11-66
+            boolean
+                encode_datawriter_submessage(
+                    inout OctetSeq                   encoded_rtps_submessage,
+                    in    OctetSeq                   plain_rtps_submessage,
+                    in    DatawriterCryptoHandle     sending_datawriter_crypto,
+                    in    DatareaderCryptoHandleSeq  receiving_datareader_crypto_list,
+                    inout long                       receiving_datareader_crypto_list_index,
+                    inout SecurityException          ex);
+
+            boolean
+                encode_datareader_submessage(
+                    inout OctetSeq                   encoded_rtps_submessage,
+                    in    OctetSeq                   plain_rtps_submessage,
+                    in    DatareaderCryptoHandle     sending_datareader_crypto,
+                    in    DatawriterCryptoHandleSeq  receiving_datawriter_crypto_list,
+                    inout SecurityException          ex);
+
+            // DDSSEC11-66
+            // DDSSEC12-94
+            boolean
+                encode_rtps_message(
+                    inout OctetSeq encoded_rtps_message,
+                    in    OctetSeq plain_rtps_message,
+                    in    ParticipantCryptoHandle sending_participant_crypto,
+                    in    ParticipantCryptoHandleSeq receiving_participant_crypto_list,
+                    inout long                       receiving_participant_crypto_list_index,
+                    in    boolean                    transform_with_psk,
+                    inout SecurityException ex);
+
+            boolean
+                decode_rtps_message(
+                    inout OctetSeq                 plain_buffer,
+                    in    OctetSeq                 encoded_buffer,
+                    in    ParticipantCryptoHandle  receiving_participant_crypto,
+                    in    ParticipantCryptoHandle  sending_participant_crypto,
+                    inout SecurityException        ex);
+
+            boolean
+                preprocess_secure_submsg(
+                    inout DatawriterCryptoHandle         datawriter_crypto,
+                    inout DatareaderCryptoHandle         datareader_crypto,
+                    inout SecureSumessageCategory_t      secure_submessage_category,
+                    in    OctetSeq                       encoded_rtps_submessage,
+                    in    ParticipantCryptoHandle        receiving_participant_crypto,
+                    in    ParticipantCryptoHandle        sending_participant_crypto,
+                    inout SecurityException              ex);
+
+            boolean
+                decode_datawriter_submessage(
+                    inout OctetSeq                plain_rtps_submessage,
+                    in    OctetSeq                encoded_rtps_submessage,
+                    in    DatareaderCryptoHandle  receiving_datareader_crypto,
+                    in    DatawriterCryptoHandle  sending_datawriter_crypto,
+                    in    SecurityException       ex);
+
+            boolean
+                decode_datareader_submessage(
+                    inout OctetSeq                plain_rtps_message,
+                    in    OctetSeq                encoded_rtps_message,
+                    in    DatawriterCryptoHandle  receiving_datawriter_crypto,
+                    in    DatareaderCryptoHandle  sending_datareader_crypto,
+                    inout SecurityException       ex );
+
+            // DDSSEC11-123
+            boolean
+                decode_serialized_payload(
+                    inout OctetSeq                plain_buffer,
+                    in    OctetSeq                encoded_buffer,
+                    in    OctetSeq                inline_qos,
+                    in    DatareaderCryptoHandle  receiving_datareader_crypto,
+                    in    DatawriterCryptoHandle  sending_datawriter_crypto,
+                    inout SecurityException       ex);
+        };
+
+        enum LoggingLevel {
+            EMERGENCY_LEVEL, // System is unusable. Should not continue use.
+            ALERT_LEVEL,     // Should be corrected immediately
+            CRITICAL_LEVEL,  // A failure in primary application.
+            ERROR_LEVEL,     // General error conditions
+            WARNING_LEVEL,   // May indicate future error if action not taken.
+            NOTICE_LEVEL,    // Unusual, but nor erroneous event or condition.
+            INFORMATIONAL_LEVEL, // Normal operational. Requires no action.
+            DEBUG_LEVEL
+        };
+        
+        // DDSSEC11-96
+        @extensibility(FINAL)
+        struct NameValuePair {
+            string name;
+            string value;
+        }; 
+
+        // DDSSEC11-85
+        typedef sequence<NameValuePair> NameValuePairSeq;
+
+
+        // DDSSEC12-108
+        @extensibility(FINAL)
+        struct LegacyTime_t {
+            long sec;
+            unsigned long nanosec;
+        };
+
+        // DDSSEC12-108
+        @extensibility(FINAL)
+        struct Time_t {
+            long long sec;
+            unsigned long nanosec;
+        };
+
+        // DDSSEC11-96
+        // DDSSEC12-29 DDSSEC12-108
+        @extensibility(APPENDABLE)
+        struct BuiltinLoggingType {
+            octet  facility;  // Set to 0x10. Indicates sec/auth msgs
+            LoggingLevel severity;
+            LegacyTime_t timestamp; // Since epoch 1970-01-01 00:00:00 +0000 (UTC)
+            string hostname;  // IP host name of originator
+            string hostip;    // IP address of originator
+            string appname;   // Identify the device or application 
+            string procid;    // Process name/ID for syslog system
+            string msgid;     // Identify the type of message
+            string message;   // Free-form message
+                
+            // Note that certain string keys (SD-IDs) are reserved by IANA
+            map<string, NameValuePairSeq>  structured_data; 
+        };
+
+        // DDSSEC12-108
+        @extensibility(APPENDABLE)
+        struct BuiltinLoggingTypeV2 {
+            octet  facility;  // Set to 0x10. Indicates sec/auth msgs
+            LoggingLevel severity;
+            Time_t timestamp; // Since epoch 1970-01-01 00:00:00 +0000 (UTC)
+            string hostname;  // IP host name of originator
+            string hostip;    // IP address of originator
+            string appname;   // Identify the device or application 
+            string procid;    // Process name/ID for syslog system
+            string msgid;     // Identify the type of message
+            string message;   // Free-form message
+                
+            // Note that certain string keys (SD-IDs) are reserved by IANA
+            map<string, NameValuePairSeq>  structured_data; 
+        };
+    
+        // DDSSEC11-85
+        struct LogOptions {
+            LoggingLevel logging_level;
+            string       log_file;
+            boolean      distribute;
+        };
+
+        // DDSSEC11-96
+        interface LoggerListener {
+            boolean on_log_message(in BuiltinLoggingType msg);
+        };
+        
+        // DDSSEC11-96
+        interface Logging {
+            boolean set_log_options(
+                    in    LogOptions options,
+                    inout SecurityException ex);
+
+            boolean log(
+                    in    BuiltinLoggingType msg,
+                    inout SecurityException ex);
+
+            boolean enable_logging(
+                    inout SecurityException ex);
+                    
+            boolean set_listener(
+                    in LoggerListener listener, 
+                    inout SecurityException ex);
+
+        };
+    };
+};
+

--- a/dds_gen/test_data/omg_dds/dds_xrce_types.idl
+++ b/dds_gen/test_data/omg_dds/dds_xrce_types.idl
@@ -1,0 +1,656 @@
+module dds { module xrce {
+
+    typedef octet ClientKey[4];
+
+// IDL does not have a syntax to express array constants so we
+// use #define with is legal in IDL
+#define CLIENTKEY_INVALID {0x00, 0x00, 0x00, 0x00}
+
+    typedef octet ObjectKind;
+
+    const ObjectKind OBJK_INVALID     = 0x00;
+    const ObjectKind OBJK_PARTICIPANT = 0x01;
+    const ObjectKind OBJK_TOPIC       = 0x02;
+    const ObjectKind OBJK_PUBLISHER   = 0x03;
+    const ObjectKind OBJK_SUBSCRIBER  = 0x04;
+    const ObjectKind OBJK_DATAWRITER  = 0x05;
+    const ObjectKind OBJK_DATAREADER  = 0x06;
+    const ObjectKind OBJK_TYPE        = 0x0A;
+    const ObjectKind OBJK_QOSPROFILE  = 0x0B;
+    const ObjectKind OBJK_APPLICATION = 0x0C;
+    const ObjectKind OBJK_AGENT       = 0x0D;
+    const ObjectKind OBJK_CLIENT      = 0x0E;
+    const ObjectKind OBJK_OTHER       = 0x0F;
+
+    typedef octet ObjectId     [2];
+    typedef octet ObjectPrefix [2];
+
+    // There are three predefined values ObjectId
+    // IDL does not have a syntax to express array constants so we
+    // use #define with is legal in IDL
+#define  OBJECTID_INVALID {0x00,0x00}
+#define  OBJECTID_AGENT   {0xFF,0xFD}
+#define  OBJECTID_CLIENT  {0xFF,0xFE}
+#define  OBJECTID_SESSION {0xFF,0xFF}
+
+    typedef octet XrceCookie[4];
+    // Spells ‘X’ ‘R’ ‘C’ ‘E’
+#define XRCE_COOKIE { 0x58, 0x52, 0x43, 0x45 }
+
+    typedef octet XrceVersion[2];
+#define XRCE_VERSION_MAJOR     0x01
+#define XRCE_VERSION_MINOR     0x00
+#define XRCE_VERSION  { XRCE_VERSION_MAJOR, XRCE_VERSION_MINOR }
+
+    typedef octet XrceVendorId[2];
+#define XRCE_VENDOR_INVALID1  0x00
+#define XRCE_VENDOR_INVALID1  0x00
+
+
+    struct Time_t {
+        long           seconds;
+        unsigned long  nanoseconds;
+    };
+
+    typedef octet SessionId;
+    const SessionId SESSIONID_NONE_WITH_CLIENT_KEY     = 0x00;
+    const SessionId SESSIONID_NONE_WITHOUT_CLIENT_KEY  = 0x80;
+
+    typedef octet StreamId;
+    const StreamId STREAMID_NONE                        = 0x00;
+    const StreamId STREAMID_BUILTIN_BEST_EFFORTS        = 0x01;
+    const StreamId STREAMID_BUILTIN_RELIABLE            = 0x80;
+
+    @bit_bound(8)
+    enum TransportLocatorFormat {
+        ADDRESS_FORMAT_SMALL,
+        ADDRESS_FORMAT_MEDIUM,
+        ADDRESS_FORMAT_LARGE,
+        ADDRESS_FORMAT_STRING
+    };
+
+    struct TransportLocatorSmall {
+        octet address[2];
+        octet locator_port;
+    };
+    struct TransportLocatorMedium {
+        octet address[4];
+        unsigned short locator_port;
+    };
+    struct TransportLocatorLarge {
+        octet address[16];
+        unsigned long locator_port;
+    };
+    struct TransportLocatorString {
+        string value;
+    };
+
+    union TransportLocator switch (TransportLocatorFormat) {
+        case ADDRESS_FORMAT_SMALL:
+        TransportLocatorSmall small_locator;
+        case ADDRESS_FORMAT_MEDIUM:
+        TransportLocatorMedium medium_locator;
+        case ADDRESS_FORMAT_LARGE:
+        TransportLocatorLarge medium_locator;
+        case ADDRESS_FORMAT_STRING:
+        TransportLocatorString string_locator;
+    };
+    typedef sequence<TransportLocator> TransportLocatorSeq;
+
+    struct Property {
+        string name;
+        string value;
+    };
+    typedef sequence<Property> PropertySeq;
+
+    @extensibility(FINAL)
+    struct CLIENT_Representation {
+        XrceCookie   xrce_cookie;  // XRCE_COOKIE
+        XrceVersion  xrce_version;
+        XrceVendorId xrce_vendor_id;
+
+        ClientKey    client_key;
+        SessionId    session_id;
+        @optional  PropertySeq properties;
+    };
+
+    @extensibility(FINAL)
+    struct AGENT_Representation {
+        XrceCookie   xrce_cookie;  // XRCE_COOKIE
+        XrceVersion  xrce_version;
+        XrceVendorId xrce_vendor_id;
+        @optional  PropertySeq  properties;
+    };
+
+    typedef octet RepresentationFormat;
+    const RepresentationFormat REPRESENTATION_BY_REFERENCE  = 0x01;
+    const RepresentationFormat REPRESENTATION_AS_XML_STRING = 0x02;
+    const RepresentationFormat REPRESENTATION_IN_BINARY     = 0x03;
+
+    const long REFERENCE_MAX_LEN  = 128;
+
+    @extensibility(FINAL)
+    union OBJK_Representation3Formats switch(RepresentationFormat) {
+      case REPRESENTATION_BY_REFERENCE :
+        string<REFERENCE_MAX_LEN>  object_reference;
+      case REPRESENTATION_AS_XML_STRING :
+        string           xml_string_representation;
+      case REPRESENTATION_IN_BINARY :
+        sequence<octet>  binary_representation;
+    };
+
+    @extensibility(FINAL)
+    union OBJK_RepresentationRefAndXMLFormats switch(RepresentationFormat) {
+      case REPRESENTATION_BY_REFERENCE :
+        string<REFERENCE_MAX_LEN>  object_reference;
+      case REPRESENTATION_AS_XML_STRING :
+        string           string_representation;
+    };
+
+    @extensibility(FINAL)
+    union OBJK_RepresentationBinAndXMLFormats switch(RepresentationFormat) {
+      case REPRESENTATION_IN_BINARY :
+        sequence<octet>  binary_representation;
+      case REPRESENTATION_AS_XML_STRING :
+        string           string_representation;
+    };
+
+    @extensibility(FINAL)
+    struct OBJK_RepresentationRefAndXML_Base {
+      OBJK_RepresentationRefAndXMLFormats representation;
+    };
+
+    @extensibility(FINAL)
+    struct OBJK_RepresentationBinAndXML_Base {
+      OBJK_RepresentationBinAndXMLFormats representation;
+    };
+
+    @extensibility(FINAL)
+    struct OBJK_Representation3_Base {
+      OBJK_Representation3Formats representation;
+    };
+
+    /* Objects supporting by Reference and XML formats */
+
+    @extensibility(FINAL)
+    struct OBJK_QOSPROFILE_Representation : OBJK_RepresentationRefAndXML_Base {
+    };
+
+    @extensibility(FINAL)
+    struct OBJK_TYPE_Representation       : OBJK_RepresentationRefAndXML_Base {
+    };
+
+    @extensibility(FINAL)
+    struct OBJK_DOMAIN_Representation : OBJK_RepresentationRefAndXML_Base {
+    };
+
+    @extensibility(FINAL)
+    struct OBJK_APPLICATION_Representation : OBJK_RepresentationRefAndXML_Base {
+    };
+
+
+    /* Objects supporting Binary and XML formats */
+    @extensibility(FINAL)
+    struct OBJK_PUBLISHER_Representation   : OBJK_RepresentationBinAndXML_Base {
+        ObjectId participant_id;
+    };
+
+    @extensibility(FINAL)
+    struct OBJK_SUBSCRIBER_Representation : OBJK_RepresentationBinAndXML_Base {
+        ObjectId participant_id;
+    };
+
+    @extensibility(FINAL)
+    struct DATAWRITER_Representation    : OBJK_RepresentationBinAndXML_Base {
+        ObjectId publisher_id;
+    };
+
+    @extensibility(FINAL)
+    struct DATAREADER_Representation    : OBJK_RepresentationBinAndXML_Base {
+        ObjectId subscriber_id;
+    };
+
+    /* Objects supporting all 3 representation formats */
+    @extensibility(FINAL)
+    struct OBJK_PARTICIPANT_Representation : OBJK_Representation3_Base {
+        short     domain_id;
+    };
+
+    @extensibility(FINAL)
+    struct OBJK_TOPIC_Representation : OBJK_Representation3_Base {
+        ObjectId participant_id;
+    };
+
+
+    /* Binary representations */
+    @extensibility(APPENDABLE)
+    struct  OBJK_DomainParticipant_Binary {
+        @optional string<128> domain_reference;
+        @optional string<128> qos_profile_reference;
+    };
+
+    @extensibility(APPENDABLE)
+    struct  OBJK_Topic_Binary {
+        string<256> topic_name;
+        @optional string<256> type_reference;
+        @optional DDS:XTypes::TypeIdentifier type_identifier;
+    };
+
+    @extensibility(FINAL)
+    struct  OBJK_Publisher_Binary_Qos {
+        @optional sequence<string>  partitions;
+        @optional sequence<octet>   group_data;
+    };
+
+    @extensibility(APPENDABLE)
+    struct  OBJK_Publisher_Binary {
+        @optional string publisher_name;
+        @optional OBJK_Publisher_Binary_Qos  qos;
+    };
+
+    @extensibility(FINAL)
+    struct  OBJK_Subscriber_Binary_Qos {
+        @optional sequence<string>  partitions;
+        @optional sequence<octet>   group_data;
+    };
+
+    @extensibility(APPENDABLE)
+    struct  OBJK_Subscriber_Binary {
+        @optional string subscriber_name;
+        @optional OBJK_Subscriber_Binary_Qos  qos;
+    };
+
+    @bit_bound(16)
+    bitmask EndpointQosFlags {
+        @position(0) is_reliable,
+        @position(1) is_history_keep_all,
+        @position(2) is_ownership_exclusive,
+        @position(3) is_durability_transient_local,
+        @position(4) is_durability_transient,
+        @position(5) is_durability_persistent,
+    };
+
+    @extensibility(FINAL)
+    struct  OBJK_Endpoint_Binary_Qos {
+        EndpointQosFlags            qos_flags;
+        @optional unsigned short    history_depth;
+        @optional unsigned long     deadline_msec;
+        @optional unsigned long     lifespan_msec;
+        @optional sequence<octet>   user_data;
+    };
+
+    @extensibility(FINAL)
+    struct  OBJK_DataWriter_Binary_Qos :  OBJK_Endpoint_Binary_Qos {
+        @optional unsigned long     ownership_strength;
+    };
+
+    @extensibility(FINAL)
+    struct  OBJK_DataReader_Binary_Qos :  OBJK_Endpoint_Binary_Qos {
+        @optional unsigned long     timebasedfilter_msec;
+        @optional string            contentbased_filter;
+   };
+
+    @extensibility(APPENDABLE)
+    struct  OBJK_DataReader_Binary {
+        string                                  topic_name;
+        @optional OBJK_DataReader_Binary_Qos    qos;
+    };
+
+    @extensibility(APPENDABLE)
+    struct  OBJK_DataWriter_Binary {
+        string                               topic_name;
+        @optonal OBJK_DataWriter_Binary_Qos  qos;
+    };
+
+    @extensibility(FINAL)
+    union ObjectVariant switch(ObjectKind) {
+      // case OBJK_INVALID : indicates default or selected by Agent. No data.
+    case OBJK_AGENT :
+      AGENT_Representation client;
+    case OBJK_CLIENT :
+      CLIENT_Representation client;
+    case OBJK_APPLICATION :
+      OBJK_APPLICATION_Representation application;
+    case OBJK_PARTICIPANT :
+      OBJK_PARTICIPANT_Representation participant;
+    case OBJK_QOSPROFILE :
+      OBJK_QOSPROFILE_Representation qos_profile;
+    case OBJK_TYPE :
+      OBJK_TYPE_Representation type;
+    case OBJK_TOPIC :
+      OBJK_TOPIC_Representation topic;
+    case OBJK_PUBLISHER :
+      OBJK_PUBLISHER_Representation publisher;
+    case OBJK_SUBSCRIBER :
+      OBJK_SUBSCRIBER_Representation subscriber;
+    case OBJK_DATAWRITER :
+      DATAWRITER_Representation data_writer;
+    case OBJK_DATAREADER :
+      DATAREADER_Representation data_reader;
+    };
+
+    struct CreationMode {
+      boolean reuse;
+      boolean replace;
+    };
+
+
+    typedef octet RequestId[2];
+
+    @bit_bound(8)
+    enum StatusValue {
+        @value(0x00) STATUS_OK,
+        @value(0x01) STATUS_OK_MATCHED,
+        @value(0x80) STATUS_ERR_DDS_ERROR,
+        @value(0x81) STATUS_ERR_MISMATCH,
+        @value(0x82) STATUS_ERR_ALREADY_EXISTS,
+        @value(0x83) STATUS_ERR_DENIED,
+        @value(0x84) STATUS_ERR_UNKNOWN_REFERENCE,
+        @value(0x85) STATUS_ERR_INVALID_DATA,
+        @value(0x86) STATUS_ERR_INCOMPATIBLE,
+        @value(0x87) STATUS_ERR_RESOURCES
+    };
+
+    struct ResultStatus {
+      StatusValue  status;
+      octet        implementation_status;
+    };
+
+    bitmask InfoMask {
+      @position(0) INFO_CONFIGURATION,
+      @position(1) INFO_ACTIVITY
+    };
+
+    @extensibility(APPENDABLE)
+    struct AGENT_ActivityInfo {
+        short availability;
+        TransportLocatorSeq address_seq;
+    };
+
+    @extensibility(APPENDABLE)
+    struct DATAREADER_ActivityInfo {
+        short highest_acked_num;
+    };
+
+    @extensibility(APPENDABLE)
+    struct DATAWRITER_ActivityInfo {
+        unsigned long long sample_seq_num;
+        short stream_seq_num;
+    };
+
+    @extensibility(FINAL)
+    union ActivityInfoVariant switch (ObjectKind) {
+      case OBJECTID_AGENT :
+        AGENT_ActivityInfo  agent;
+      case OBJK_DATAWRITER :
+        DATAWRITER_ActivityInfo data_writer;
+      case OBJK_DATAREADER :
+        DATAREADER_ActivityInfo data_reader;
+    };
+
+    @extensibility(FINAL)
+    struct ObjectInfo {
+        @optional  ActivityInfoVariant  activity;
+        @optional  ObjectVariant        config;
+    };
+
+    @extensibility(FINAL)
+    struct BaseObjectRequest {
+      RequestId     request_id;
+      ObjectId      object_id;
+    };
+
+    typedef RelatedObjectRequest BaseObjectRequest;
+
+    @extensibility(FINAL)
+    struct BaseObjectReply {
+      BaseObjectRequest  related_request;
+      ResultStatus       result;
+    };
+
+    typedef octet DataFormat;
+    const DataFormat FORMAT_DATA           = 0x00; // 0b0000 0000
+    const DataFormat FORMAT_SAMPLE         = 0x02; // 0b0000 0010
+    const DataFormat FORMAT_DATA_SEQ       = 0x08; // 0b0000 1000
+    const DataFormat FORMAT_SAMPLE_SEQ     = 0x0A; // 0b0000 1010
+    const DataFormat FORMAT_PACKED_SAMPLES = 0x0E; // 0b0000 1110
+    const DataFormat FORMAT_MASK           = 0x0E; // 0b0000 1110
+
+    @extensibility(APPENDABLE)
+    struct DataDeliveryControl {
+        unsigned short max_samples;
+        unsigned short max_elapsed_time;
+        unsigned short max_bytes_per_second;
+        unsigned short min_pace_period;  // milliseconds
+    };
+
+    @extensibility(FINAL)
+    struct ReadSpecification  {
+        StreamId    preferred_stream_id;
+        DataFormat data_format;
+        @optional string              content_filter_expression;
+        @optional DataDeliveryControl delivery_control;
+    };
+
+    @bit_bound(8)
+    bitmask SampleInfoFlags {
+        @position(0) INSTANCE_STATE_UNREGISTERED,
+        @position(1) INSTANCE_STATE DISPOSED,
+        @position(2) VIEW_STATE_NEW,
+        @position(3) SAMPLE_STATE_READ,
+    };
+
+    typedef octet SampleInfoFormat;
+    const SampleInfoFormat FORMAT_EMPTY      = 0x00; // 0b0000 0000
+    const SampleInfoFormat FORMAT_SEQNUM     = 0x01; // 0b0000 0001
+    const SampleInfoFormat FORMAT_TIMESTAMP  = 0x02; // 0b0000 0010
+    const SampleInfoFormat FORMAT_SEQN_TIMS  = 0x03; // 0b0000 0011
+
+    @extensibility(FINAL)
+    struct SeqNumberAndTimestamp {
+        unsigned long   sequence_number;
+        unsigned long   session_time_offset; // milliseconds up to 53 days
+    };
+
+    @extensibility(FINAL)
+    union SampleInfoDetail switch(SampleInfoFormat) {
+      case FORMAT_EMPTY:
+      case FORMAT_SEQNUM:
+        unsigned long   sequence_number;
+      case FORMAT_TIMESTAMP:
+        unsigned long   session_time_offset; // milliseconds up to 53 days
+      case FORMAT_TIMESTAMP:
+        SeqNumberAndTimestamp seqnum_n_timestamp;
+    };
+
+    @extensibility(FINAL)
+    struct SampleInfo {
+        SampleInfoFlags  state; //Combines SampleState, InstanceState, ViewState
+        SampleInfoDetail detail;
+    };
+
+    typedef unsigned short  DeciSecond; // 10e-1 seconds
+    @extensibility(FINAL)
+    struct SampleInfoDelta {
+      SampleInfoFlags state;  // Combines SampleState, InstanceState, ViewState
+      octet           seq_number_delta;
+      DeciSecond      timestamp_delta; // In 1/10 of seconds
+    };
+
+    @extensibility(FINAL)
+    struct SampleData {
+        XCDRSerializedBuffer serialized_data;
+    };
+    typedef sequence<SampleData> SampleDataSeq;
+
+    @extensibility(FINAL)
+    struct Sample {
+      SampleInfo   info;
+      SampleData   data;
+    };
+    typedef sequence<Sample> SampleSeq;
+
+    @extensibility(FINAL)
+    struct SampleDelta {
+      SampleInfoDelta   info_delta;
+      SampleData        data;
+    };
+
+    @extensibility(FINAL)
+    struct PackedSamples {
+      SampleInfo             info_base;
+      sequence<SampleDelta>  sample_delta_seq;
+    };
+
+    @extensibility(FINAL)
+    union DataRepresentation switch(DataFormat) {
+      case FORMAT_DATA:
+        SampleData data;
+      case FORMAT_SAMPLE:
+        Sample sample;
+      case FORMAT_DATA_SEQ:
+        SampleDataSeq data_seq;
+      case FORMAT_SAMPLE_SEQ:
+        SampleSeq sample_seq;
+      case FORMAT_PACKED_SAMPLES:
+        PackedSamples packed_samples;
+    };
+
+    // Message Payloads
+    @extensibility(FINAL)
+    struct CREATE_CLIENT_Payload {
+        CLIENT_Representation client_representation;
+    };
+
+    @extensibility(FINAL)
+    struct CREATE_Payload : BaseObjectRequest {
+        ObjectVariant  object_representation;
+    };
+
+    @extensibility(FINAL)
+    struct GET_INFO_Payload : BaseObjectRequest {
+        InfoMask  info_mask;
+    };
+
+    @extensibility(FINAL)
+    struct DELETE_Payload : BaseObjectRequest {
+    };
+
+    @extensibility(FINAL)
+    struct STATUS_AGENT_Payload {
+        AGENT_Representation agent_info;
+    };
+
+    @extensibility(FINAL)
+    struct STATUS_Payload : BaseObjectReply {
+    };
+
+    @extensibility(FINAL)
+    struct INFO_Payload : BaseObjectReply {
+        ObjectInfo     object_info;
+    };
+
+    @extensibility(FINAL)
+    struct READ_DATA_Payload : BaseObjectRequest {
+        ReadSpecification                read_specification;
+    };
+
+    // There are 5 types of DATA and WRITE_DATA payloads
+    @extensibility(FINAL)
+    struct WRITE_DATA_Payload_Data : BaseObjectRequest {
+        SampleData              data;
+    };
+
+    @extensibility(FINAL)
+    struct WRITE_DATA_Payload_Sample : BaseObjectRequest {
+        Sample                sample;
+    };
+
+    @extensibility(FINAL)
+    struct WRITE_DATA_Payload_DataSeq : BaseObjectRequest {
+        SampleDataSeq           data_seq;
+    };
+
+    @extensibility(FINAL)
+    struct WRITE_DATA_Payload_SampleSeq : BaseObjectRequest {
+        SampleSeq               sample_seq;
+    };
+
+    @extensibility(FINAL)
+    struct WRITE_DATA_Payload_PackedSamples : BaseObjectRequest {
+        PackedSamples           packed_samples;
+    };
+
+    @extensibility(FINAL)
+    struct DATA_Payload_Data : RelatedObjectRequest {
+        SampleData              data;
+    };
+
+    @extensibility(FINAL)
+    struct DATA_Payload_Sample : RelatedObjectRequest {
+          Sample                sample;
+    };
+
+    @extensibility(FINAL)
+    struct DATA_Payload_DataSeq : RelatedObjectRequest {
+        SampleDataSeq           data_seq;
+    };
+
+    @extensibility(FINAL)
+    struct DATA_Payload_SampleSeq : RelatedObjectRequest {
+        SampleSeq               sample_seq;
+    };
+
+    @extensibility(FINAL)
+    struct DATA_Payload_PackedSamples : RelatedObjectRequest {
+        PackedSamples           packed_samples;
+    };
+
+    struct ACKNACK_Payload {
+        unsigned short  first_unacked_seq_num;
+        octet           nack_bitmap[2];
+        octet           stream_id;
+    };
+
+    @extensibility(FINAL)
+    struct HEARTBEAT_Payload {
+        unsigned short  first_unacked_seq_num;
+        unsigned short  last_unacked_seq_num;
+        octet           stream_id;
+    };
+
+    @extensibility(FINAL)
+    struct TIMESTAMP_Payload {
+        Time_t  transmit_timestamp;
+    };
+
+    @extensibility(FINAL)
+    struct TIMESTAMP_REPLY_Payload {
+        Time_t  transmit_timestamp;
+        Time_t  receive_timestamp;
+        Time_t  originate_timestamp;
+    };
+
+    @bit_bound(8)
+    enum SubmessageId {
+        @value(0)  CREATE_CLIENT,
+        @value(1)  CREATE,
+        @value(2)  GET_INFO,
+        @value(3)  DELETE,
+        @value(4)  STATUS_AGENT,
+        @value(5)  STATUS,
+        @value(6)  INFO,
+        @value(7)  WRITE_DATA,
+        @value(8)  READ_DATA,
+        @value(9)  DATA,
+        @value(10)  ACKNACK,
+        @value(11) HEARTBEAT,
+        @value(12) RESET,
+        @value(13) FRAGMENT,
+        @value(14) TIMESTAMP,
+        @value(15) TIMESTAMP_REPLY
+    };
+
+
+  }; };
+

--- a/dds_gen/test_data/omg_dds/rpc-idl/robot.idl
+++ b/dds_gen/test_data/omg_dds/rpc-idl/robot.idl
@@ -1,0 +1,212 @@
+#ifdef INTERFACE
+
+module robot {
+
+exception TooFast {};
+
+enum Command { START_COMMAND, STOP_COMMAND };
+
+struct Status 
+{
+  string msg;
+};
+
+@DDSService
+interface RobotControl 
+{
+  void  command(Command com);
+  float setSpeed(float speed) raises (TooFast);
+  float getSpeed();
+  void  getStatus(out Status status);
+};
+
+}; //module robot
+
+#endif // INTERFACE
+
+#ifdef BASIC
+
+#include <rpc_types.idl>
+/******************************************/
+/*    Interface Specific Types Below      */
+/******************************************/
+
+module robot {
+
+@nested
+struct TooFast 
+{ 
+  dds::rpc::UnusedMember dummy; 
+};
+
+enum Command { START_COMMAND, STOP_COMMAND };
+
+@nested
+struct Status
+{
+  string msg;
+};
+
+@nested
+struct RobotControl_command_In 
+{ 
+  Command com; 
+};
+
+@nested
+struct RobotControl_setSpeed_In 
+{
+    float speed;
+};
+
+@nested
+struct RobotControl_getSpeed_In 
+{ 
+  dds::rpc::UnusedMember dummy; 
+};
+
+@nested
+struct RobotControl_getStatus_In 
+{ 
+  dds::rpc::UnusedMember dummy; 
+};
+
+const long RobotControl_command_Hash   = 1;
+const long RobotControl_setSpeed_Hash  = 2;
+const long RobotControl_getSpeed_Hash  = 3;
+const long RobotControl_getStatus_Hash = 4;
+
+@nested
+union RobotControl_Call switch(long) 
+{
+    default:
+       dds::rpc::UnknownOperation unknownOp;
+
+    case RobotControl_command_Hash:     
+       RobotControl_command_In command;
+
+    case RobotControl_setSpeed_Hash:
+       RobotControl_setSpeed_In setSpeed;
+
+    case RobotControl_getSpeed_Hash:
+       RobotControl_getSpeed_In getSpeed;
+    
+    case RobotControl_getStatus_Hash:
+       RobotControl_getStatus_In getStatus;
+};
+
+struct RobotControl_Request 
+{
+  dds::rpc::RequestHeader header;
+  RobotControl_Call       data;
+};
+
+/***********************************************/
+/*                   Reply Types               */
+/***********************************************/
+
+
+@nested
+struct RobotControl_command_Out 
+{ 
+  dds::rpc::UnusedMember dummy; 
+};
+
+@nested
+struct RobotControl_setSpeed_Out 
+{
+    float return_;
+};
+
+@nested
+struct RobotControl_getSpeed_Out 
+{ 
+  float return_; 
+};
+
+const long TooFast_Ex_Hash = 0xAFED; // HASH
+
+@nested
+struct RobotControl_getStatus_Out 
+{ 
+  Status status;
+};
+
+@nested
+union RobotControl_command_Result switch(long)
+{
+  default:
+    dds::rpc::UnknownException unknownEx;
+  
+  case dds::rpc::REMOTE_EX_OK:
+    RobotControl_command_Out result;
+};
+
+@nested
+union RobotControl_setSpeed_Result switch(long)
+{
+  default:
+    dds::rpc::UnknownException unknownEx;
+  
+  case dds::rpc::REMOTE_EX_OK:
+    RobotControl_setSpeed_Out result;
+
+  case TooFast_Ex_Hash:
+    TooFast toofast_ex;
+};
+
+@nested
+union RobotControl_getSpeed_Result switch(long)
+{
+  default:
+    dds::rpc::UnknownException unknownEx;
+  
+  case dds::rpc::REMOTE_EX_OK:
+    RobotControl_getSpeed_Out result;
+};
+
+@nested
+union RobotControl_getStatus_Result switch(long)
+{
+  default:
+    dds::rpc::UnknownException unknownEx;
+  
+  case dds::rpc::REMOTE_EX_OK:
+    RobotControl_getStatus_Out result;
+};
+
+@nested
+union RobotControl_Return switch(long)
+{
+  default: 
+    dds::rpc::UnknownOperation unknownOp;
+
+  case RobotControl_command_Hash:
+    RobotControl_command_Result command;
+
+  case RobotControl_setSpeed_Hash:
+    RobotControl_setSpeed_Result setSpeed;
+
+  case RobotControl_getSpeed_Hash:
+    RobotControl_getSpeed_Result getSpeed;
+
+  case RobotControl_getStatus_Hash:
+    RobotControl_getStatus_Result getStatus;
+};
+
+struct RobotControl_Reply
+{
+  dds::rpc::ReplyHeader  header;
+  RobotControl_Return    data;
+};
+
+}; // module robot
+
+#endif // BASIC
+
+
+
+#ifdef ENHANCED
+
+
+#endif // ENHANCED

--- a/dds_gen/test_data/omg_dds/rpc-idl/rpc_annotations.idl
+++ b/dds_gen/test_data/omg_dds/rpc-idl/rpc_annotations.idl
@@ -1,0 +1,45 @@
+module dds { 
+
+module rpc {
+
+@annotation
+local interface DDSRequestTopic {
+  attribute string name;
+};
+
+@annotation
+local interface DDSReplyTopic {
+  attribute string name;
+};
+
+@annotation 
+local interface Choice { 
+  attribute boolean value default true;
+};
+
+@annotation 
+local interface AutoId { 
+  attribute boolean value default true;
+};
+
+@annotation 
+local interface Empty { 
+  attribute boolean value default true;
+};
+
+@annotation 
+local interface Mutable { 
+  attribute boolean value default true;
+};
+
+@annotation
+local interface Qos 
+{
+  attribute string RequestProfile; 
+  attribute string ReplyProfile; 
+};
+
+
+}; // module rpc
+
+}; // module dds

--- a/dds_gen/test_data/omg_dds/rpc-idl/rpc_types.idl
+++ b/dds_gen/test_data/omg_dds/rpc-idl/rpc_types.idl
@@ -1,0 +1,78 @@
+#ifdef BASIC
+
+module dds { 
+
+#ifdef REDEFINE_DDS_TYPES
+
+  // The following DDS related types are 
+  // borrowed from the RTPS v1.2 specification
+  typedef octet GuidPrefix_t[12];
+
+  @nested
+  struct EntityId_t
+  {
+    octet entityKey[3];
+    octet entityKind;
+  };
+
+  @nested
+  struct GUID_t
+  {
+    GuidPrefix_t guidPrefix;
+    EntityId_t entityId;
+  };
+
+  @nested
+  struct SequenceNumber_t
+  {
+    long high;
+    unsigned long low;
+  };
+
+#endif // REDEFINE_DDS_TYPES
+
+@nested
+struct SampleIdentity
+{
+  GUID_t           writer_guid;
+  SequenceNumber_t sequence_number;
+};
+
+module rpc {
+
+typedef octet UnknownOperation;
+typedef octet UnknownException;
+typedef octet UnusedMember;
+
+enum RemoteExceptionCode_t
+{
+    REMOTE_EX_OK,
+    REMOTE_EX_UNSUPPORTED,
+    REMOTE_EX_INVALID_ARGUMENT,
+    REMOTE_EX_OUT_OF_RESOURCES,
+    REMOTE_EX_UNKNOWN_OPERATION,
+    REMOTE_EX_UNKNOWN_EXCEPTION
+};
+
+typedef string<255> InstanceName;
+
+@nested
+struct RequestHeader 
+{
+    dds::SampleIdentity  requestId;
+    InstanceName         instanceName;
+};
+
+@nested
+struct ReplyHeader 
+{
+    dds::SampleIdentity             relatedRequestId;
+    dds::rpc::RemoteExceptionCode_t remoteEx;
+};
+
+}; // module rpc
+
+}; // module dds
+
+#endif // BASIC 
+

--- a/dds_gen/tests/fast_dds_idl_reference.rs
+++ b/dds_gen/tests/fast_dds_idl_reference.rs
@@ -1,0 +1,796 @@
+mod fast_dds_idl {
+    use std::{env, fs};
+
+    #[test]
+    fn AllocTestType() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/AllocTestType.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn Benchmark() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/Benchmark.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn Benchmark_big() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/Benchmark_big.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn Benchmark_medium() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/Benchmark_medium.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn extensibility_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/extensibility_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn FixedSized() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/FixedSized.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn FlowControl() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/FlowControl.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn HelloWorld() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/HelloWorld.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn key_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/key_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn map_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/map_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn monitorservice_types() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/monitorservice_types.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn KeyedData1mb() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/KeyedData1mb.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn primitives_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/primitives_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn Benchmark_small() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/Benchmark_small.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn KeyedHelloWorld() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/KeyedHelloWorld.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn alias_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/alias_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn rpc_types() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/rpc_types.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn Calculator() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/Calculator.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn ShapeType() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/ShapeType.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn array_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/array_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn sequence_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/sequence_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn ComprehensiveType() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/ComprehensiveType.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn StringTest() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/StringTest.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn bitmask_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/bitmask_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn string_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/string_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn Configuration() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/Configuration.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn TestIncludeRegression3361() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/TestIncludeRegression3361.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn bitset_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/bitset_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn struct_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/struct_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn ContentFilterTestType() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/ContentFilterTestType.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn TestRegression3361() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/TestRegression3361.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn core_types() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/core_types.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn types() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/types.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn DDSReturnCode() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/DDSReturnCode.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn TypeLookupTypes() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/TypeLookupTypes.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn dds_xtypes_typeobject() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/dds-xtypes_typeobject.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn union_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/union_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn Data1mb() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/Data1mb.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn UnboundedHelloWorld() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/UnboundedHelloWorld.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn dynamic_language_binding() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/dynamic_language_binding.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn Data64kb() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/Data64kb.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn enum_struct() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/enum_struct.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn DeliveryMechanism() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/DeliveryMechanism.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn XtypesTestsType1() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/XtypesTestsType1.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    fn XtypesTestsType2() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/XtypesTestsType2.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn XtypesTestsType3() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/XtypesTestsType3.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn XtypesTestsTypeBig() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/XtypesTestsTypeBig.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn XtypesTestsTypeDep() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/XtypesTestsTypeDep.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn XtypesTestsTypeNoTypeObject() {
+        let dds_idl = match fs::read_to_string("test_data/fast_dds/XtypesTestsTypeNoTypeObject.idl")
+        {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                panic!("Unable to read file: {}\n", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}\n", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+}

--- a/dds_gen/tests/omg_idl_reference.rs
+++ b/dds_gen/tests/omg_idl_reference.rs
@@ -1,0 +1,167 @@
+//! The purpose of this test is to ensure that the IDL parser is able to handle
+//! the default `IDL` files provided by OMG.
+//!
+//!
+
+mod omg_idl {
+    use std::{env, fs};
+
+    /*************  ✨ Codeium Command ⭐  *************/
+    /// This test function reads the content of the `robot.idl` file located in `tests/reference_idl`.
+    /// It ensures that the file can be successfully read without any errors.
+
+    /******  99784f6b-3e59-4be0-91be-2204a78a858d  *******/
+    #[test]
+    pub fn test_rpc_idl_robot() {
+        let dds_idl = match fs::read_to_string("test_data/omg_dds/rpc-idl/robot.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                dbg!("Reference directory: ", env::current_dir());
+                panic!("Unable to read file: {}", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    pub fn test_rpc_annotations() {
+        let dds_idl = match fs::read_to_string("test_data/omg_dds/rpc-idl/rpc_annotations.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                dbg!("Reference directory: ", env::current_dir());
+                panic!("Unable to read file: {}", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    pub fn test_rpc_types() {
+        let dds_idl = match fs::read_to_string("test_data/omg_dds/rpc-idl/rpc_types.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                dbg!("Reference directory: ", env::current_dir());
+                panic!("Unable to read file: {}", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    pub fn test_dds_dcps() {
+        let dds_idl = match fs::read_to_string("test_data/omg_dds/dds_dcps.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                dbg!("Reference directory: ", env::current_dir());
+                panic!("Unable to read file: {}", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    pub fn dds_dlrl() {
+        let dds_idl = match fs::read_to_string("test_data/omg_dds/dds_dlrl.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                dbg!("Reference directory: ", env::current_dir());
+                panic!("Unable to read file: {}", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    pub fn test_dds_security_plugin_spis() {
+        let dds_idl = match fs::read_to_string("test_data/omg_dds/dds_security_plugin_spis.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                dbg!("Reference directory: ", env::current_dir());
+                panic!("Unable to read file: {}", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    pub fn test_dds_xrce_types() {
+        let dds_idl = match fs::read_to_string("test_data/omg_dds/dds_xrce_types.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                dbg!("Reference directory: ", env::current_dir());
+                panic!("Unable to read file: {}", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    pub fn test_dds_xtypes_discovery_buildin_topics() {
+        let dds_idl = match fs::read_to_string("test_data/omg_dds/dds_xtypes_discovery_buildin_topics.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                dbg!("Reference directory: ", env::current_dir());
+                panic!("Unable to read file: {}", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+    #[test]
+    pub fn test_dds_xtypes_typeobject() {
+        let dds_idl = match fs::read_to_string("test_data/omg_dds/dds_xtypes_typeobject.idl") {
+            Ok(dds_idl) => dds_idl,
+            Err(e) => {
+                dbg!("Reference directory: ", env::current_dir());
+                panic!("Unable to read file: {}", e)
+            }
+        };
+
+        let result = match dust_dds_gen::compile_idl(&dds_idl) {
+            Ok(parsed_idl) => parsed_idl,
+            Err(e) => panic!("Error parsing IDL string: {}", e),
+        };
+
+        assert!(!result.is_empty());
+    }
+}


### PR DESCRIPTION
Support was added for the pre processor. `#include` will insert a `#include!();`. The other preprocessor commands have been templated out, and can run while not doing anything. Other idl files from both fast-dds and OMG have been included to perform integration testing. 

Following steps after here:
- Finish preprocessor macros
- Resolve issues with unions and other parsing issues. 