### PR TITLE
Add an idlgen preprocessor without added functionality

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_python"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["dds", "rtps", "middleware", "network", "udp"]
 categories = ["api-bindings", "network-programming"]
 
 [dependencies]
-dust_dds_derive = { version = "0.12", path = "../dds_derive" }
+dust_dds_derive = { version = "0.13", path = "../dds_derive" }
 
 md5 = "0.7.0" # Chose this crate over other possibilities since it doesn't have any other dependencies
 

--- a/dds_derive/Cargo.toml
+++ b/dds_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_derive"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds_gen/Cargo.toml
+++ b/dds_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust_dds_gen"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
 	"Joao Rebelo <jrebelo@s2e-systems.com>",
 	"Stefan Kimmer <skimmer@s2e-systems.com>",

--- a/dds_gen/Cargo.toml
+++ b/dds_gen/Cargo.toml
@@ -21,3 +21,4 @@ pest_derive = "2.7"
 
 [dev-dependencies]
 syn = { version = "2.0", features = ["full", "extra-traits"] }
+tempfile = "3.17.1"

--- a/dds_gen/src/lib.rs
+++ b/dds_gen/src/lib.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use generator::rust;
 use pest::Parser;
 
@@ -5,8 +7,9 @@ mod generator;
 mod parser;
 mod preprocessor;
 
-pub fn compile_idl(idl_source: &str) -> Result<String, String> {
-    let processed_idl = preprocessor::Preprocessor::new().parse(idl_source)?;
+pub fn compile_idl(idl_filepath: &Path) -> Result<String, String> {
+    let processed_idl =
+        preprocessor::Preprocessor::parse(idl_filepath).map_err(|e| e.to_string())?;
     let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, processed_idl.as_ref())
         .map_err(|e| format!("Error parsing IDL string: {}", e))?
         .next()

--- a/dds_gen/src/lib.rs
+++ b/dds_gen/src/lib.rs
@@ -3,9 +3,11 @@ use pest::Parser;
 
 mod generator;
 mod parser;
+mod preprocessor;
 
 pub fn compile_idl(idl_source: &str) -> Result<String, String> {
-    let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, idl_source)
+    let processed_idl = preprocessor::Preprocessor::new().parse(idl_source)?;
+    let parsed_idl = parser::IdlParser::parse(parser::Rule::specification, processed_idl.as_ref())
         .map_err(|e| format!("Error parsing IDL string: {}", e))?
         .next()
         .expect("Must contain a specification");

--- a/dds_gen/src/preprocessor/mod.rs
+++ b/dds_gen/src/preprocessor/mod.rs
@@ -28,7 +28,7 @@ impl Preprocessor {
             }
 
             output.push_str(&line_buffer);
-            output.push_str("\n");
+            output.push('\n');
         }
 
         Ok(())
@@ -42,7 +42,8 @@ mod tests {
     #[test]
     fn preprocessor_makes_no_changes() {
         let idl_file = Path::new("src/preprocessor/test_resources/simple_struct.idl");
-        let expected = "struct SimpleStruct {\r\n\n    boolean a;\r\n\n    char b;\r\n\n    long i;\r\n\n};\n";
+        let expected =
+            "struct SimpleStruct {\r\n\n    boolean a;\r\n\n    char b;\r\n\n    long i;\r\n\n};\n";
         let output = Preprocessor::parse(idl_file).unwrap();
 
         assert_eq!(output, expected);

--- a/dds_gen/src/preprocessor/mod.rs
+++ b/dds_gen/src/preprocessor/mod.rs
@@ -1,0 +1,35 @@
+use std::fmt::Write;
+
+pub struct Preprocessor;
+
+impl Preprocessor {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn parse(&mut self, idl_source: &str) -> Result<String, String> {
+        let mut output = String::new();
+        for line in idl_source.lines() {
+            output.write_str(line).map_err(|e| e.to_string())?;
+        }
+        Ok(idl_source.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preprocessor_makes_no_changes() {
+        let input = r#"
+        struct A {
+            i32 a
+        };"#;
+
+        let mut preprocessor = Preprocessor::new();
+
+        let output = preprocessor.parse(input).unwrap();
+        assert_eq!(input, output);
+    }
+}

--- a/dds_gen/src/preprocessor/test_resources/simple_struct.idl
+++ b/dds_gen/src/preprocessor/test_resources/simple_struct.idl
@@ -1,0 +1,5 @@
+struct SimpleStruct {
+    boolean a;
+    char b;
+    long i;
+};

--- a/dds_gen/tests/basic_types.idl
+++ b/dds_gen/tests/basic_types.idl
@@ -1,0 +1,17 @@
+struct BasicTypes {
+    boolean a;
+    char b;
+    wchar c;
+    octet d;
+    string e;
+    wstring f;
+    short g;
+    unsigned short h;
+    long i;
+    unsigned long j;
+    long long k;
+    unsigned long long l;
+    float m;
+    double n;
+    // fixed o;
+};

--- a/dds_gen/tests/basic_types.rs
+++ b/dds_gen/tests/basic_types.rs
@@ -1,27 +1,10 @@
+use std::path::Path;
+
 use syn::File;
 
 #[test]
 fn basic_types() {
-    let idl = r#"
-        struct BasicTypes {
-            boolean a;
-            char b;
-            wchar c;
-            octet d;
-            string e;
-            wstring f;
-            short g;
-            unsigned short h;
-            long i;
-            unsigned long j;
-            long long k;
-            unsigned long long l;
-            float m;
-            double n;
-            // fixed o;
-        };
-    "#;
-
+    let idl_file = Path::new("tests/basic_types.idl");
     let expected = syn::parse2::<File>(
         r#"
             #[derive(Debug, dust_dds::topic_definition::type_support::DdsType)]
@@ -47,22 +30,20 @@ fn basic_types() {
     )
     .unwrap();
 
-    let result =
-        syn::parse2::<File>(dust_dds_gen::compile_idl(idl).unwrap().parse().unwrap()).unwrap();
+    let result = syn::parse2::<File>(
+        dust_dds_gen::compile_idl(&idl_file)
+            .unwrap()
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
 
     assert_eq!(result, expected);
 }
 
 #[test]
 fn template_types() {
-    let idl = r#"
-        struct TemplateTypes {
-            sequence<sequence<octet>> a;
-            string<256> b;
-            sequence<short, 128> c;
-            wstring<64> d;
-        };
-    "#;
+    let idl_file = Path::new("tests/template_types.idl");
 
     let expected = syn::parse2::<File>(
         r#"
@@ -79,18 +60,20 @@ fn template_types() {
     )
     .unwrap();
 
-    let result =
-        syn::parse2::<File>(dust_dds_gen::compile_idl(idl).unwrap().parse().unwrap()).unwrap();
+    let result = syn::parse2::<File>(
+        dust_dds_gen::compile_idl(idl_file)
+            .unwrap()
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
 
     assert_eq!(result, expected);
 }
 
 #[test]
 fn enums() {
-    let idl = r#"
-        enum Suits { Spades, Hearts, Diamonds, Clubs };
-        enum Direction { North, East, South, West };
-    "#;
+    let idl_file = Path::new("tests/enums.idl");
 
     let expected = syn::parse2::<File>(
         r#"
@@ -114,8 +97,13 @@ fn enums() {
     )
     .unwrap();
 
-    let result =
-        syn::parse2::<File>(dust_dds_gen::compile_idl(idl).unwrap().parse().unwrap()).unwrap();
+    let result = syn::parse2::<File>(
+        dust_dds_gen::compile_idl(idl_file)
+            .unwrap()
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
 
     assert_eq!(result, expected);
 }

--- a/dds_gen/tests/enums.idl
+++ b/dds_gen/tests/enums.idl
@@ -1,0 +1,2 @@
+enum Suits { Spades, Hearts, Diamonds, Clubs };
+enum Direction { North, East, South, West };

--- a/dds_gen/tests/i11eperf.idl
+++ b/dds_gen/tests/i11eperf.idl
@@ -1,0 +1,98 @@
+module i11eperf {
+    /* The "ts" field stores a time stamp and is used in lieu of the DDS source timestamp
+        for two reasons:
+
+        - Fast-DDS doesn't support write_w_timestamp
+
+        - All variants have different ideas of the representation of a time stamp,
+            this avoids the need for different conversions in the different cases
+
+        @final @data_representation(XCDR1): the spec breaks backwards compatibility, with some
+        implementations (OpenDDS, for example) following it, and some choosing not to break
+        things just because a generally pretty low-quality spec says one must (Cyclone DDS).
+
+        Keep all annotations on a single line starting with @topic for preproc-ospl-idl.gawk */
+
+    @topic @final @data_representation(XCDR1)
+    struct ou {
+        unsigned long long ts;
+        unsigned long s;
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a32 {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[32 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a128 {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[128 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a1024 {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[1024 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a16k {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[16*1024 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a48k {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[48*1024 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a64k {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[64*1024 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a1M {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[1024*1024 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a2M {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[2*1024*1024 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a4M {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[4*1024*1024 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct a8M {
+        unsigned long long ts;
+        unsigned long s;
+        octet xary[8*1024*1024 - 12];
+    };
+
+    @topic @final @data_representation(XCDR1)
+    struct seq {
+        unsigned long long ts;
+        unsigned long s;
+        sequence<octet> xseq;
+    };
+};

--- a/dds_gen/tests/i11eperf.rs
+++ b/dds_gen/tests/i11eperf.rs
@@ -1,107 +1,10 @@
+use std::path::Path;
+
 use syn::File;
 
 #[test]
 fn i11eperf_generation() {
-    let idl = r#"
-    module i11eperf {
-        /* The "ts" field stores a time stamp and is used in lieu of the DDS source timestamp
-           for two reasons:
-
-           - Fast-DDS doesn't support write_w_timestamp
-
-           - All variants have different ideas of the representation of a time stamp,
-             this avoids the need for different conversions in the different cases
-
-           @final @data_representation(XCDR1): the spec breaks backwards compatibility, with some
-           implementations (OpenDDS, for example) following it, and some choosing not to break
-           things just because a generally pretty low-quality spec says one must (Cyclone DDS).
-
-           Keep all annotations on a single line starting with @topic for preproc-ospl-idl.gawk */
-
-        @topic @final @data_representation(XCDR1)
-        struct ou {
-          unsigned long long ts;
-          unsigned long s;
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a32 {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[32 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a128 {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[128 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a1024 {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[1024 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a16k {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[16*1024 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a48k {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[48*1024 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a64k {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[64*1024 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a1M {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[1024*1024 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a2M {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[2*1024*1024 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a4M {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[4*1024*1024 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct a8M {
-          unsigned long long ts;
-          unsigned long s;
-          octet xary[8*1024*1024 - 12];
-        };
-
-        @topic @final @data_representation(XCDR1)
-        struct seq {
-          unsigned long long ts;
-          unsigned long s;
-          sequence<octet> xseq;
-        };
-      };
-    "#;
+    let idl_file = Path::new("tests/i11eperf.idl");
 
     let expected = syn::parse2::<File>(
         r#"
@@ -184,8 +87,13 @@ fn i11eperf_generation() {
     )
     .unwrap();
 
-    let result =
-        syn::parse2::<File>(dust_dds_gen::compile_idl(idl).unwrap().parse().unwrap()).unwrap();
+    let result = syn::parse2::<File>(
+        dust_dds_gen::compile_idl(idl_file)
+            .unwrap()
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
 
     assert_eq!(result, expected);
 }

--- a/dds_gen/tests/module_generation.idl
+++ b/dds_gen/tests/module_generation.idl
@@ -1,0 +1,33 @@
+/*
+* Module IDL example
+*/
+
+/// Game module
+module Game
+{
+    /// Chess
+    module Chess
+    {
+        enum ChessPiece
+        {
+            Pawn, Rook, Knight, Bishop, Queen, King
+        };
+
+        struct ChessSquare
+        {
+            char column;          // A, B, ..., G
+            unsigned short line;  // 1, 2, ..., 8
+        };
+    };
+
+    module Cards
+    {
+        enum Suit { Spades, Hearts, Diamonds, Clubs /*, NoTrumpCard */ };
+    };
+};
+
+struct Point
+{
+    double x;
+    double y;
+};

--- a/dds_gen/tests/nested_types.idl
+++ b/dds_gen/tests/nested_types.idl
@@ -1,0 +1,15 @@
+enum Presence
+{
+    Present, NotPresent
+};
+
+struct Color {
+    uint8 red;
+    uint8 green;
+    uint8 blue;
+};
+
+struct ColorSensor {
+    Presence state;
+    Color value;
+};

--- a/dds_gen/tests/structs.rs
+++ b/dds_gen/tests/structs.rs
@@ -1,33 +1,10 @@
+use std::path::Path;
+
 use syn::File;
 
 #[test]
 fn structs_generation() {
-    let idl = r#"
-        struct Point {
-            double x;
-            double y;
-        };
-
-        struct ChessSquare {
-            @key char column;
-            @key unsigned short line;
-        };
-
-        struct HelloWorld {
-            string message;
-            unsigned long id;
-        };
-
-        struct Sentence {
-            sequence<wstring> words;
-            sequence<sequence<unsigned long, 2> > dependencies;
-        };
-
-        struct User {
-            wstring<8> name;
-            boolean active;
-        };
-    "#;
+    let idl_file = Path::new("tests/structs_generation.idl");
 
     let expected = syn::parse2::<File>(
         r#"
@@ -62,49 +39,20 @@ fn structs_generation() {
     )
     .unwrap();
 
-    let result =
-        syn::parse2::<File>(dust_dds_gen::compile_idl(idl).unwrap().parse().unwrap()).unwrap();
+    let result = syn::parse2::<File>(
+        dust_dds_gen::compile_idl(idl_file)
+            .unwrap()
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
 
     assert_eq!(result, expected);
 }
 
 #[test]
 fn module_generation() {
-    let idl = r#"
-        /*
-        * Module IDL example
-        */
-
-        /// Game module
-        module Game
-        {
-            /// Chess
-            module Chess
-            {
-                enum ChessPiece
-                {
-                    Pawn, Rook, Knight, Bishop, Queen, King
-                };
-
-                struct ChessSquare
-                {
-                    char column;          // A, B, ..., G
-                    unsigned short line;  // 1, 2, ..., 8
-                };
-            };
-
-            module Cards
-            {
-                enum Suit { Spades, Hearts, Diamonds, Clubs /*, NoTrumpCard */ };
-            };
-        };
-
-        struct Point
-        {
-            double x;
-            double y;
-        };
-    "#;
+    let idl_file = Path::new("tests/module_generation.idl");
 
     let expected = syn::parse2::<File>(
         r#"
@@ -146,31 +94,20 @@ fn module_generation() {
     )
     .unwrap();
 
-    let result =
-        syn::parse2::<File>(dust_dds_gen::compile_idl(idl).unwrap().parse().unwrap()).unwrap();
+    let result = syn::parse2::<File>(
+        dust_dds_gen::compile_idl(idl_file)
+            .unwrap()
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
 
     assert_eq!(result, expected);
 }
 
 #[test]
 fn nested_types() {
-    let idl = r#"
-        enum Presence
-        {
-            Present, NotPresent
-        };
-
-        struct Color {
-            uint8 red;
-            uint8 green;
-            uint8 blue;
-        };
-
-        struct ColorSensor {
-            Presence state;
-            Color value;
-        };
-    "#;
+    let idl_file = Path::new("tests/nested_types.idl");
 
     let expected = syn::parse2::<File>(
         r#"
@@ -196,8 +133,13 @@ fn nested_types() {
     )
     .unwrap();
 
-    let result =
-        syn::parse2::<File>(dust_dds_gen::compile_idl(idl).unwrap().parse().unwrap()).unwrap();
+    let result = syn::parse2::<File>(
+        dust_dds_gen::compile_idl(idl_file)
+            .unwrap()
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
 
     assert_eq!(result, expected);
 }

--- a/dds_gen/tests/structs_generation.idl
+++ b/dds_gen/tests/structs_generation.idl
@@ -1,0 +1,24 @@
+struct Point {
+    double x;
+    double y;
+};
+
+struct ChessSquare {
+    @key char column;
+    @key unsigned short line;
+};
+
+struct HelloWorld {
+    string message;
+    unsigned long id;
+};
+
+struct Sentence {
+    sequence<wstring> words;
+    sequence<sequence<unsigned long, 2> > dependencies;
+};
+
+struct User {
+    wstring<8> name;
+    boolean active;
+};

--- a/dds_gen/tests/template_types.idl
+++ b/dds_gen/tests/template_types.idl
@@ -1,0 +1,6 @@
+ struct TemplateTypes {
+    sequence<sequence<octet>> a;
+    string<256> b;
+    sequence<short, 128> c;
+    wstring<64> d;
+};

--- a/interoperability_tests/build.rs
+++ b/interoperability_tests/build.rs
@@ -9,32 +9,28 @@ fn main() {
     fs::create_dir_all(build_path).expect("Creating build path failed");
 
     let idl_path = Path::new("HelloWorld.idl");
-    let idl_src = std::fs::read_to_string(idl_path).expect("Couldn't read IDL source file!");
-    let compiled_idl = dust_dds_gen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
+    let compiled_idl = dust_dds_gen::compile_idl(&idl_path).expect("Couldn't parse IDL file");
     let compiled_idl_path = build_path.join("hello_world.rs");
     let mut file = File::create(compiled_idl_path).expect("Failed to create file");
     file.write_all(compiled_idl.as_bytes())
         .expect("Failed to write to file");
 
     let idl_path = Path::new("BigData.idl");
-    let idl_src = std::fs::read_to_string(idl_path).expect("Couldn't read IDL source file!");
-    let compiled_idl = dust_dds_gen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
+    let compiled_idl = dust_dds_gen::compile_idl(&idl_path).expect("Couldn't parse IDL file");
     let compiled_idl_path = build_path.join("big_data.rs");
     let mut file = File::create(compiled_idl_path).expect("Failed to create file");
     file.write_all(compiled_idl.as_bytes())
         .expect("Failed to write to file");
 
     let idl_path = Path::new("DisposeData.idl");
-    let idl_src = std::fs::read_to_string(idl_path).expect("Couldn't read IDL source file!");
-    let compiled_idl = dust_dds_gen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
+    let compiled_idl = dust_dds_gen::compile_idl(&idl_path).expect("Couldn't parse IDL file");
     let compiled_idl_path = build_path.join("dispose_data.rs");
     let mut file = File::create(compiled_idl_path).expect("Failed to create file");
     file.write_all(compiled_idl.as_bytes())
         .expect("Failed to write to file");
 
     let idl_path = Path::new("NestedType.idl");
-    let idl_src = std::fs::read_to_string(idl_path).expect("Couldn't read IDL source file!");
-    let compiled_idl = dust_dds_gen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
+    let compiled_idl = dust_dds_gen::compile_idl(&idl_path).expect("Couldn't parse IDL file");
     let compiled_idl_path = build_path.join("nested_type.rs");
     let mut file = File::create(compiled_idl_path).expect("Failed to create file");
     file.write_all(compiled_idl.as_bytes())

--- a/omg_interoperability_executable/build.rs
+++ b/omg_interoperability_executable/build.rs
@@ -11,8 +11,7 @@ fn main() {
     let cargo_manifest_path = Path::new(&cargo_manifest_dir);
     let build_path = cargo_target_path.join("idl");
     let idl_path = cargo_manifest_path.join("shape.idl");
-    let idl_src = std::fs::read_to_string(idl_path).expect("Couldn't read IDL source file!");
-    let compiled_idl = dust_dds_gen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
+    let compiled_idl = dust_dds_gen::compile_idl(&idl_path).expect("Couldn't parse IDL file");
     let compiled_idl_path = build_path.as_path().join("shape.rs");
     fs::create_dir_all(build_path).expect("Creating build path failed");
     let mut file = File::create(compiled_idl_path).expect("Failed to create file");

--- a/shapes_demo/build.rs
+++ b/shapes_demo/build.rs
@@ -11,8 +11,7 @@ fn main() {
     let cargo_manifest_path = Path::new(&cargo_manifest_dir);
     let build_path = cargo_target_path.join("idl");
     let idl_path = cargo_manifest_path.join("res/ShapeType.idl");
-    let idl_src = std::fs::read_to_string(idl_path).expect("Couldn't read IDL source file!");
-    let compiled_idl = dust_dds_gen::compile_idl(&idl_src).expect("Couldn't parse IDL file");
+    let compiled_idl = dust_dds_gen::compile_idl(&idl_path).expect("Couldn't parse IDL file");
     let compiled_idl_path = build_path.as_path().join("shapes_type.rs");
     fs::create_dir_all(build_path).expect("Creating build path failed");
     let mut file = File::create(compiled_idl_path).expect("Failed to create file");


### PR DESCRIPTION
Add an idlgen preprocessor without added functionality. This is the preparatory step to add support for #include, #define and other preprocessor tags