### PR TITLE
Fix a compile error when using a constant to define an array's size

### DIFF
--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -31,6 +31,13 @@ struct MutableType {
     another_id: u64,
 }
 
+// This tests the ability of the DdsType derive macro to work with
+// arrays whose length is given by a separate constant.
+// If this compiles, the test passes.
+const ARRAY_LENGTH: usize = 10;
+#[derive(DdsType)]
+struct ArrayContainingType([u8; ARRAY_LENGTH]);
+
 #[test]
 fn foo_with_lifetime_should_read_and_write() {
     #[derive(Clone, Debug, PartialEq, DdsType)]

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -24,7 +24,7 @@ fn get_type_identifier(type_: &Type) -> Result<TokenStream> {
                                         is_external: false,
                                     }
                                 },
-                                array_bound_seq: vec![#len],
+                                array_bound_seq: vec![dust_dds::xtypes::type_object::SBound::try_from(#len).unwrap()],
                                 element_identifier: #element_identifier,
                             })
                         }
@@ -38,7 +38,7 @@ fn get_type_identifier(type_: &Type) -> Result<TokenStream> {
                                         is_external: false,
                                     }
                                 },
-                                array_bound_seq: vec![#len],
+                                array_bound_seq: vec![dust_dds::xtypes::type_object::LBound::try_from(#len).unwrap()],
                                 element_identifier: #element_identifier,
                             })
                         }

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -24,7 +24,7 @@ fn get_type_identifier(type_: &Type) -> Result<TokenStream> {
                                         is_external: false,
                                     }
                                 },
-                                array_bound_seq: vec![dust_dds::xtypes::type_object::SBound::try_from(#len).unwrap()],
+                                array_bound_seq: vec![#len as dust_dds::xtypes::type_object::SBound],
                                 element_identifier: #element_identifier,
                             })
                         }
@@ -38,7 +38,7 @@ fn get_type_identifier(type_: &Type) -> Result<TokenStream> {
                                         is_external: false,
                                     }
                                 },
-                                array_bound_seq: vec![dust_dds::xtypes::type_object::LBound::try_from(#len).unwrap()],
+                                array_bound_seq: vec![#len as dust_dds::xtypes::type_object::LBound],
                                 element_identifier: #element_identifier,
                             })
                         }


### PR DESCRIPTION
Using `#[derive(DdsType)]` on a type like `struct ArrayContainingType([u8; ARRAY_LENGTH]);` led to a compile error in `get_type_identifier`. The problem is that the member `array_bound_seq` of  `PlainArraySElemDefn` and `PlainArrayLElemDefn` is of type `u8` or `u32`, respectively. When using an actual integer to define the arrays size, the integer expression is used in the proc macro and the compiler happily casts (?) it to the right integer type. But when using a `usize` constant, the constant expression is put into the `vec![...]` call and the compiler fails, as it expects a smaller integer type.

This patch adds proper casts to handle this situation as well as a compile time test case.