### PR TITLE
Bugfix: Use reader requested reliability/durability instead of writer offered for matched writer proxies

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -137,7 +137,7 @@ jobs:
       - run:
           name: Gather coverage data
           command: |
-            curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
+            curl -L https://github.com/mozilla/grcov/releases/tag/v0.8.20/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
             ./grcov . -s . --binary-path ./target/debug/ -t html --ignore-not-existing -o /tmp/coverage
 
       - store_artifacts:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -137,7 +137,7 @@ jobs:
       - run:
           name: Gather coverage data
           command: |
-            curl -L https://github.com/mozilla/grcov/releases/v0.8.20/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
+            curl -L https://github.com/mozilla/grcov/releases/download/v0.8.20/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
             ./grcov . -s . --binary-path ./target/debug/ -t html --ignore-not-existing -o /tmp/coverage
 
       - store_artifacts:

--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -137,7 +137,7 @@ jobs:
       - run:
           name: Gather coverage data
           command: |
-            curl -L https://github.com/mozilla/grcov/releases/tag/v0.8.20/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
+            curl -L https://github.com/mozilla/grcov/releases/v0.8.20/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
             ./grcov . -s . --binary-path ./target/debug/ -t html --ignore-not-existing -o /tmp/coverage
 
       - store_artifacts:

--- a/dds/src/implementation/domain_participant_backend/services/discovery_service.rs
+++ b/dds/src/implementation/domain_participant_backend/services/discovery_service.rs
@@ -1051,21 +1051,11 @@ impl MailHandler<AddDiscoveredWriter> for DomainParticipantActor {
                             .writer_proxy
                             .multicast_locator_list
                     };
-                    let reliability_kind = match message
-                        .discovered_writer_data
-                        .dds_publication_data
-                        .reliability
-                        .kind
-                    {
+                    let reliability_kind = match data_reader.qos().reliability.kind {
                         ReliabilityQosPolicyKind::BestEffort => ReliabilityKind::BestEffort,
                         ReliabilityQosPolicyKind::Reliable => ReliabilityKind::Reliable,
                     };
-                    let durability_kind = match message
-                        .discovered_writer_data
-                        .dds_publication_data
-                        .durability
-                        .kind
-                    {
+                    let durability_kind = match data_reader.qos().durability.kind {
                         DurabilityQosPolicyKind::Volatile => DurabilityKind::Volatile,
                         DurabilityQosPolicyKind::TransientLocal => DurabilityKind::TransientLocal,
                         DurabilityQosPolicyKind::Transient => DurabilityKind::Transient,


### PR DESCRIPTION
Use reader requested reliability/durability instead of writer offered for matched writer proxies. This fixes a bug in which a best effort reader, which is correctly matched with a reliable writer was behaving a reliable data writer, whereas the writer was behaving as a best effort writer. This mismatch caused problems whenever messages were dropped since no further data would be received after that point.