### PR TITLE
Refactor: Remove hash types from entities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1.0.0
+  path-filtering: circleci/path-filtering@1.3.0
 
 workflows:
   setup-workflow:

--- a/dds/src/implementation/domain_participant_backend/entities/data_reader.rs
+++ b/dds/src/implementation/domain_participant_backend/entities/data_reader.rs
@@ -146,7 +146,7 @@ pub struct DataReaderEntity {
     _sample_lost_status: SampleLostStatus,
     sample_rejected_status: SampleRejectedStatus,
     subscription_matched_status: SubscriptionMatchedStatus,
-    matched_publication_list: HashMap<InstanceHandle, PublicationBuiltinTopicData>,
+    matched_publication_list: Vec<PublicationBuiltinTopicData>,
     enabled: bool,
     data_available_status_changed_flag: bool,
     incompatible_writer_list: Vec<InstanceHandle>,
@@ -185,7 +185,7 @@ impl DataReaderEntity {
             _sample_lost_status: SampleLostStatus::default(),
             sample_rejected_status: SampleRejectedStatus::default(),
             subscription_matched_status: SubscriptionMatchedStatus::default(),
-            matched_publication_list: HashMap::new(),
+            matched_publication_list: Vec::new(),
             enabled: false,
             data_available_status_changed_flag: false,
             incompatible_writer_list: Vec::new(),
@@ -555,13 +555,23 @@ impl DataReaderEntity {
             {
                 let instance_owner = InstanceHandle::new(instance_owner_handle);
                 let instance_writer = InstanceHandle::new(sample.writer_guid);
+                let Some(sample_owner) = self
+                    .matched_publication_list
+                    .iter()
+                    .find(|x| &x.key().value == instance_owner.as_ref())
+                else {
+                    return Ok(AddChangeResult::NotAdded);
+                };
+                let Some(sample_writer) = self
+                    .matched_publication_list
+                    .iter()
+                    .find(|x| &x.key().value == instance_writer.as_ref())
+                else {
+                    return Ok(AddChangeResult::NotAdded);
+                };
                 if instance_owner_handle != sample.writer_guid
-                    && self.matched_publication_list[&instance_writer]
-                        .ownership_strength()
-                        .value
-                        <= self.matched_publication_list[&instance_owner]
-                            .ownership_strength()
-                            .value
+                    && sample_writer.ownership_strength().value
+                        <= sample_owner.ownership_strength().value
                 {
                     return Ok(AddChangeResult::NotAdded);
                 }
@@ -769,10 +779,16 @@ impl DataReaderEntity {
         &mut self,
         publication_builtin_topic_data: PublicationBuiltinTopicData,
     ) {
-        self.matched_publication_list.insert(
-            InstanceHandle::new(publication_builtin_topic_data.key.value),
-            publication_builtin_topic_data,
-        );
+        match self
+            .matched_publication_list
+            .iter_mut()
+            .find(|x| x.key() == publication_builtin_topic_data.key())
+        {
+            Some(x) => *x = publication_builtin_topic_data,
+            None => self
+                .matched_publication_list
+                .push(publication_builtin_topic_data),
+        }
         self.subscription_matched_status.current_count +=
             self.matched_publication_list.len() as i32;
         self.subscription_matched_status.current_count_change += 1;
@@ -781,7 +797,14 @@ impl DataReaderEntity {
     }
 
     pub fn remove_matched_publication(&mut self, publication_handle: &InstanceHandle) {
-        self.matched_publication_list.remove(publication_handle);
+        let Some(i) = self
+            .matched_publication_list
+            .iter()
+            .position(|x| &x.key().value == publication_handle.as_ref())
+        else {
+            return;
+        };
+        self.matched_publication_list.remove(i);
         self.subscription_matched_status.current_count = self.matched_publication_list.len() as i32;
         self.subscription_matched_status.current_count_change -= 1;
         self.status_condition
@@ -885,11 +908,16 @@ impl DataReaderEntity {
         &self,
         handle: &InstanceHandle,
     ) -> Option<&PublicationBuiltinTopicData> {
-        self.matched_publication_list.get(handle)
+        self.matched_publication_list
+            .iter()
+            .find(|x| &x.key().value == handle.as_ref())
     }
 
     pub fn get_matched_publications(&self) -> Vec<InstanceHandle> {
-        self.matched_publication_list.keys().cloned().collect()
+        self.matched_publication_list
+            .iter()
+            .map(|x| InstanceHandle::new(x.key().value))
+            .collect()
     }
 
     pub fn insert_instance_deadline_missed_task(

--- a/dds/src/implementation/domain_participant_backend/entities/data_writer.rs
+++ b/dds/src/implementation/domain_participant_backend/entities/data_writer.rs
@@ -27,7 +27,7 @@ use crate::{
     xtypes::dynamic_type::DynamicType,
 };
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, VecDeque},
     sync::Arc,
 };
 
@@ -59,7 +59,7 @@ pub struct DataWriterEntity {
     type_support: Arc<dyn DynamicType + Send + Sync>,
     matched_subscription_list: HashMap<InstanceHandle, SubscriptionBuiltinTopicData>,
     publication_matched_status: PublicationMatchedStatus,
-    incompatible_subscription_list: HashSet<InstanceHandle>,
+    incompatible_subscription_list: Vec<InstanceHandle>,
     offered_incompatible_qos_status: OfferedIncompatibleQosStatus,
     enabled: bool,
     status_condition: Actor<StatusConditionActor>,
@@ -68,7 +68,7 @@ pub struct DataWriterEntity {
     max_seq_num: Option<i64>,
     last_change_sequence_number: i64,
     qos: DataWriterQos,
-    registered_instance_list: HashSet<InstanceHandle>,
+    registered_instance_list: Vec<InstanceHandle>,
     offered_deadline_missed_status: OfferedDeadlineMissedStatus,
     instance_deadline_missed_task: HashMap<InstanceHandle, TaskHandle>,
     instance_samples: HashMap<InstanceHandle, VecDeque<i64>>,
@@ -95,7 +95,7 @@ impl DataWriterEntity {
             type_support,
             matched_subscription_list: HashMap::new(),
             publication_matched_status: PublicationMatchedStatus::default(),
-            incompatible_subscription_list: HashSet::new(),
+            incompatible_subscription_list: Vec::new(),
             offered_incompatible_qos_status: OfferedIncompatibleQosStatus::default(),
             enabled: false,
             status_condition,
@@ -104,7 +104,7 @@ impl DataWriterEntity {
             max_seq_num: None,
             last_change_sequence_number: 0,
             qos,
-            registered_instance_list: HashSet::new(),
+            registered_instance_list: Vec::new(),
             offered_deadline_missed_status: OfferedDeadlineMissedStatus::default(),
             instance_deadline_missed_task: HashMap::new(),
             instance_samples: HashMap::new(),
@@ -172,7 +172,7 @@ impl DataWriterEntity {
 
         if !self.registered_instance_list.contains(&instance_handle) {
             if self.registered_instance_list.len() < self.qos.resource_limits.max_instances {
-                self.registered_instance_list.insert(instance_handle);
+                self.registered_instance_list.push(instance_handle);
             } else {
                 return Err(DdsError::OutOfResources);
             }
@@ -419,7 +419,7 @@ impl DataWriterEntity {
             self.offered_incompatible_qos_status.total_count_change += 1;
             self.offered_incompatible_qos_status.last_policy_id = incompatible_qos_policy_list[0];
 
-            self.incompatible_subscription_list.insert(handle);
+            self.incompatible_subscription_list.push(handle);
             for incompatible_qos_policy in incompatible_qos_policy_list.into_iter() {
                 if let Some(policy_count) = self
                     .offered_incompatible_qos_status

--- a/dds/src/implementation/domain_participant_backend/entities/domain_participant.rs
+++ b/dds/src/implementation/domain_participant_backend/entities/domain_participant.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashSet,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{
     builtin_topics::TopicBuiltinTopicData,
@@ -46,10 +43,10 @@ pub struct DomainParticipantEntity {
     discovered_reader_list: Vec<DiscoveredReaderData>,
     discovered_writer_list: Vec<DiscoveredWriterData>,
     enabled: bool,
-    ignored_participants: HashSet<InstanceHandle>,
-    ignored_publications: HashSet<InstanceHandle>,
-    ignored_subcriptions: HashSet<InstanceHandle>,
-    _ignored_topic_list: HashSet<InstanceHandle>,
+    ignored_participants: Vec<InstanceHandle>,
+    ignored_publications: Vec<InstanceHandle>,
+    ignored_subcriptions: Vec<InstanceHandle>,
+    _ignored_topic_list: Vec<InstanceHandle>,
     listener: Option<Actor<DomainParticipantListenerActor>>,
     listener_mask: Vec<StatusKind>,
     status_condition: Actor<StatusConditionActor>,
@@ -86,10 +83,10 @@ impl DomainParticipantEntity {
             discovered_reader_list: Vec::new(),
             discovered_writer_list: Vec::new(),
             enabled: false,
-            ignored_participants: HashSet::new(),
-            ignored_publications: HashSet::new(),
-            ignored_subcriptions: HashSet::new(),
-            _ignored_topic_list: HashSet::new(),
+            ignored_participants: Vec::new(),
+            ignored_publications: Vec::new(),
+            ignored_subcriptions: Vec::new(),
+            _ignored_topic_list: Vec::new(),
             listener,
             listener_mask,
             status_condition,
@@ -158,15 +155,21 @@ impl DomainParticipantEntity {
     }
 
     pub fn ignore_participant(&mut self, handle: InstanceHandle) {
-        self.ignored_participants.insert(handle);
+        if !self.ignored_participants.contains(&handle) {
+            self.ignored_participants.push(handle);
+        }
     }
 
     pub fn ignore_subscription(&mut self, handle: InstanceHandle) {
-        self.ignored_subcriptions.insert(handle);
+        if !self.ignored_subcriptions.contains(&handle) {
+            self.ignored_subcriptions.push(handle);
+        }
     }
 
     pub fn ignore_publication(&mut self, handle: InstanceHandle) {
-        self.ignored_publications.insert(handle);
+        if !self.ignored_publications.contains(&handle) {
+            self.ignored_publications.push(handle);
+        }
     }
 
     pub fn get_default_topic_qos(&self) -> &TopicQos {

--- a/dds/src/implementation/domain_participant_factory/domain_participant_factory_actor.rs
+++ b/dds/src/implementation/domain_participant_factory/domain_participant_factory_actor.rs
@@ -248,7 +248,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
             }
         }
 
-        let mut topic_list = HashMap::new();
+        let mut topic_list = Vec::new();
         let spdp_topic_participant_handle = instance_handle_counter.generate_new_instance_handle();
 
         let mut spdp_topic_participant = TopicEntity::new(
@@ -263,7 +263,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         );
         spdp_topic_participant.enable();
 
-        topic_list.insert(DCPS_PARTICIPANT.to_owned(), spdp_topic_participant);
+        topic_list.push(spdp_topic_participant);
 
         let sedp_topic_topics_handle = instance_handle_counter.generate_new_instance_handle();
         let mut sedp_topic_topics = TopicEntity::new(
@@ -278,7 +278,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         );
         sedp_topic_topics.enable();
 
-        topic_list.insert(DCPS_TOPIC.to_owned(), sedp_topic_topics);
+        topic_list.push(sedp_topic_topics);
 
         let sedp_topic_publications_handle = instance_handle_counter.generate_new_instance_handle();
         let mut sedp_topic_publications = TopicEntity::new(
@@ -292,7 +292,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
             Arc::new(DiscoveredWriterData::get_type()),
         );
         sedp_topic_publications.enable();
-        topic_list.insert(DCPS_PUBLICATION.to_owned(), sedp_topic_publications);
+        topic_list.push(sedp_topic_publications);
 
         let sedp_topic_subscriptions_handle =
             instance_handle_counter.generate_new_instance_handle();
@@ -307,7 +307,7 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
             Arc::new(DiscoveredReaderData::get_type()),
         );
         sedp_topic_subscriptions.enable();
-        topic_list.insert(DCPS_SUBSCRIPTION.to_owned(), sedp_topic_subscriptions);
+        topic_list.push(sedp_topic_subscriptions);
 
         let spdp_writer_qos = DataWriterQos {
             durability: DurabilityQosPolicy {
@@ -345,9 +345,9 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         let mut dcps_participant_reader = DataReaderEntity::new(
             instance_handle_counter.generate_new_instance_handle(),
             spdp_reader_qos,
-            topic_list[DCPS_PARTICIPANT].topic_name().to_owned(),
-            topic_list[DCPS_PARTICIPANT].type_name().to_owned(),
-            topic_list[DCPS_PARTICIPANT].type_support().clone(),
+            DCPS_PARTICIPANT.to_owned(),
+            "SpdpDiscoveredParticipantData".to_string(),
+            Arc::new(SpdpDiscoveredParticipantData::get_type()),
             Actor::spawn(StatusConditionActor::default(), &listener_executor.handle()),
             None,
             Vec::new(),
@@ -364,9 +364,9 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         let mut dcps_topic_reader = DataReaderEntity::new(
             instance_handle_counter.generate_new_instance_handle(),
             sedp_data_reader_qos(),
-            topic_list[DCPS_TOPIC].topic_name().to_owned(),
-            topic_list[DCPS_TOPIC].type_name().to_owned(),
-            topic_list[DCPS_TOPIC].type_support().clone(),
+            DCPS_TOPIC.to_owned(),
+            "DiscoveredTopicData".to_string(),
+            Arc::new(DiscoveredTopicData::get_type()),
             Actor::spawn(StatusConditionActor::default(), &listener_executor.handle()),
             None,
             Vec::new(),
@@ -383,9 +383,9 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         let mut dcps_publication_reader = DataReaderEntity::new(
             instance_handle_counter.generate_new_instance_handle(),
             sedp_data_reader_qos(),
-            topic_list[DCPS_PUBLICATION].topic_name().to_owned(),
-            topic_list[DCPS_PUBLICATION].type_name().to_owned(),
-            topic_list[DCPS_PUBLICATION].type_support().clone(),
+            DCPS_PUBLICATION.to_owned(),
+            "DiscoveredWriterData".to_string(),
+            Arc::new(DiscoveredWriterData::get_type()),
             Actor::spawn(StatusConditionActor::default(), &listener_executor.handle()),
             None,
             Vec::new(),
@@ -402,9 +402,9 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         let mut dcps_subscription_reader = DataReaderEntity::new(
             instance_handle_counter.generate_new_instance_handle(),
             sedp_data_reader_qos(),
-            topic_list[DCPS_SUBSCRIPTION].topic_name().to_owned(),
-            topic_list[DCPS_SUBSCRIPTION].type_name().to_owned(),
-            topic_list[DCPS_SUBSCRIPTION].type_support().clone(),
+            DCPS_SUBSCRIPTION.to_owned(),
+            "DiscoveredReaderData".to_string(),
+            Arc::new(DiscoveredReaderData::get_type()),
             Actor::spawn(StatusConditionActor::default(), &listener_executor.handle()),
             None,
             Vec::new(),
@@ -433,9 +433,9 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         let mut dcps_participant_writer = DataWriterEntity::new(
             instance_handle_counter.generate_new_instance_handle(),
             TransportWriterKind::Stateless(dcps_participant_transport_writer),
-            topic_list[DCPS_PARTICIPANT].topic_name().to_owned(),
-            topic_list[DCPS_PARTICIPANT].type_name().to_owned(),
-            topic_list[DCPS_PARTICIPANT].type_support().clone(),
+            DCPS_PARTICIPANT.to_owned(),
+            "SpdpDiscoveredParticipantData".to_string(),
+            Arc::new(SpdpDiscoveredParticipantData::get_type()),
             Actor::spawn(StatusConditionActor::default(), &listener_executor.handle()),
             None,
             vec![],
@@ -450,9 +450,9 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         let mut dcps_topics_writer = DataWriterEntity::new(
             instance_handle_counter.generate_new_instance_handle(),
             TransportWriterKind::Stateful(dcps_topics_transport_writer),
-            topic_list[DCPS_TOPIC].topic_name().to_owned(),
-            topic_list[DCPS_TOPIC].type_name().to_owned(),
-            topic_list[DCPS_TOPIC].type_support().clone(),
+            DCPS_TOPIC.to_owned(),
+            "DiscoveredTopicData".to_string(),
+            Arc::new(DiscoveredTopicData::get_type()),
             Actor::spawn(StatusConditionActor::default(), &listener_executor.handle()),
             None,
             vec![],
@@ -466,9 +466,9 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         let mut dcps_publications_writer = DataWriterEntity::new(
             instance_handle_counter.generate_new_instance_handle(),
             TransportWriterKind::Stateful(dcps_publications_transport_writer),
-            topic_list[DCPS_PUBLICATION].topic_name().to_owned(),
-            topic_list[DCPS_PUBLICATION].type_name().to_owned(),
-            topic_list[DCPS_PUBLICATION].type_support().clone(),
+            DCPS_PUBLICATION.to_owned(),
+            "DiscoveredWriterData".to_string(),
+            Arc::new(DiscoveredWriterData::get_type()),
             Actor::spawn(StatusConditionActor::default(), &listener_executor.handle()),
             None,
             vec![],
@@ -483,9 +483,9 @@ impl MailHandler<CreateParticipant> for DomainParticipantFactoryActor {
         let mut dcps_subscriptions_writer = DataWriterEntity::new(
             instance_handle_counter.generate_new_instance_handle(),
             TransportWriterKind::Stateful(dcps_subscriptions_transport_writer),
-            topic_list[DCPS_SUBSCRIPTION].topic_name().to_owned(),
-            topic_list[DCPS_SUBSCRIPTION].type_name().to_owned(),
-            topic_list[DCPS_SUBSCRIPTION].type_support().clone(),
+            DCPS_SUBSCRIPTION.to_owned(),
+            "DiscoveredReaderData".to_string(),
+            Arc::new(DiscoveredReaderData::get_type()),
             Actor::spawn(StatusConditionActor::default(), &listener_executor.handle()),
             None,
             vec![],


### PR DESCRIPTION
This is a refactor removing the Hash related types from the entities. After this change only the DataReader entity will contain hash maps.