### PR TITLE
Use async for RTPS message writer trait

### DIFF
--- a/dds/src/dcps/domain_participant_actor.rs
+++ b/dds/src/dcps/domain_participant_actor.rs
@@ -1581,7 +1581,7 @@ where
                 timeout.into(),
                 Box::pin(async move {
                     loop {
-                        let (reply_sender, mut reply_receiver) = R::oneshot();
+                        let (reply_sender, reply_receiver) = R::oneshot();
                         participant_address
                             .send(DomainParticipantMail::Message(
                                 MessageServiceMail::AreAllChangesAcknowledged {
@@ -1888,7 +1888,7 @@ where
                 max_wait.into(),
                 Box::pin(async move {
                     loop {
-                        let (reply_sender, mut reply_receiver) = R::oneshot();
+                        let (reply_sender, reply_receiver) = R::oneshot();
                         participant_address
                             .send(DomainParticipantMail::Message(
                                 MessageServiceMail::IsHistoricalDataReceived {

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -1,7 +1,6 @@
 use super::domain_participant_listener::DomainParticipantListener;
 use crate::{
     builtin_topics::{ParticipantBuiltinTopicData, TopicBuiltinTopicData},
-    runtime::DdsRuntime,
     dds_async::domain_participant::DomainParticipantAsync,
     infrastructure::{
         domain::DomainId,
@@ -13,6 +12,7 @@ use crate::{
         type_support::TypeSupport,
     },
     publication::{publisher::Publisher, publisher_listener::PublisherListener},
+    runtime::DdsRuntime,
     subscription::{subscriber::Subscriber, subscriber_listener::SubscriberListener},
     topic_definition::{topic::Topic, topic_listener::TopicListener},
     xtypes::dynamic_type::DynamicType,
@@ -42,7 +42,8 @@ pub struct DomainParticipant<R: DdsRuntime> {
 }
 
 impl<R: DdsRuntime> DomainParticipant<R> {
-    pub(crate) fn new(participant_async: DomainParticipantAsync<R>) -> Self {
+    /// Construct a new ['DomainParticipant'] from an existing ['DomainParticipantAsync']
+    pub fn new(participant_async: DomainParticipantAsync<R>) -> Self {
         Self { participant_async }
     }
 

--- a/dds/src/dds/domain/domain_participant.rs
+++ b/dds/src/dds/domain/domain_participant.rs
@@ -1,6 +1,7 @@
 use super::domain_participant_listener::DomainParticipantListener;
 use crate::{
     builtin_topics::{ParticipantBuiltinTopicData, TopicBuiltinTopicData},
+    runtime::DdsRuntime,
     dds_async::domain_participant::DomainParticipantAsync,
     infrastructure::{
         domain::DomainId,
@@ -12,7 +13,6 @@ use crate::{
         type_support::TypeSupport,
     },
     publication::{publisher::Publisher, publisher_listener::PublisherListener},
-    runtime::DdsRuntime,
     subscription::{subscriber::Subscriber, subscriber_listener::SubscriberListener},
     topic_definition::{topic::Topic, topic_listener::TopicListener},
     xtypes::dynamic_type::DynamicType,
@@ -42,8 +42,7 @@ pub struct DomainParticipant<R: DdsRuntime> {
 }
 
 impl<R: DdsRuntime> DomainParticipant<R> {
-    /// Construct a new ['DomainParticipant'] from an existing ['DomainParticipantAsync']
-    pub fn new(participant_async: DomainParticipantAsync<R>) -> Self {
+    pub(crate) fn new(participant_async: DomainParticipantAsync<R>) -> Self {
         Self { participant_async }
     }
 

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -22,6 +22,13 @@ pub struct DomainParticipantFactory<R: DdsRuntime> {
 }
 
 impl<R: DdsRuntime> DomainParticipantFactory<R> {
+    /// Construct a new ['DomainParticipantFactory'] from an existing ['DomainParticipantFactoryAsync'] static reference
+    pub fn new(participant_factory_async: &'static DomainParticipantFactoryAsync<R>) -> Self {
+        Self {
+            participant_factory_async,
+        }
+    }
+
     /// This operation creates a new [`DomainParticipant`] object. The [`DomainParticipant`] signifies that the calling application intends
     /// to join the Domain identified by the `domain_id` argument.
     /// If the specified QoS policies are not consistent, the operation will fail and no [`DomainParticipant`] will be created.

--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -43,7 +43,7 @@ impl<R: DdsRuntime> StatusConditionAsync<R> {
     /// Async version of [`get_enabled_statuses`](crate::infrastructure::condition::StatusCondition::get_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn get_enabled_statuses(&self) -> DdsResult<Vec<StatusKind>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.address
             .send_actor_mail(StatusConditionMail::GetStatusConditionEnabledStatuses {
                 reply_sender,
@@ -74,7 +74,7 @@ impl<R: DdsRuntime> StatusConditionAsync<R> {
     /// Async version of [`get_trigger_value`](crate::infrastructure::condition::StatusCondition::get_trigger_value).
     #[tracing::instrument(skip(self))]
     pub async fn get_trigger_value(&self) -> DdsResult<bool> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.address
             .send_actor_mail(StatusConditionMail::GetStatusConditionTriggerValue { reply_sender })
             .await?;

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -91,7 +91,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(ReaderServiceMail::Read {
                 subscriber_handle: self.subscriber.get_instance_handle().await,
@@ -121,7 +121,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(ReaderServiceMail::Take {
                 subscriber_handle: self.subscriber.get_instance_handle().await,
@@ -145,7 +145,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
     /// Async version of [`read_next_sample`](crate::subscription::data_reader::DataReader::read_next_sample).
     #[tracing::instrument(skip(self))]
     pub async fn read_next_sample(&self) -> DdsResult<Sample<Foo>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(ReaderServiceMail::Read {
                 subscriber_handle: self.subscriber.get_instance_handle().await,
@@ -166,7 +166,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
     /// Async version of [`take_next_sample`](crate::subscription::data_reader::DataReader::take_next_sample).
     #[tracing::instrument(skip(self))]
     pub async fn take_next_sample(&self) -> DdsResult<Sample<Foo>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(ReaderServiceMail::Take {
                 subscriber_handle: self.subscriber.get_instance_handle().await,
@@ -194,7 +194,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(ReaderServiceMail::Read {
                 subscriber_handle: self.subscriber.get_instance_handle().await,
@@ -224,7 +224,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(ReaderServiceMail::Take {
                 subscriber_handle: self.subscriber.get_instance_handle().await,
@@ -255,7 +255,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(
                 ReaderServiceMail::ReadNextInstance {
@@ -287,7 +287,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(
                 ReaderServiceMail::TakeNextInstance {
@@ -364,7 +364,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
     /// Async version of [`get_subscription_matched_status`](crate::subscription::data_reader::DataReader::get_subscription_matched_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_subscription_matched_status(&self) -> DdsResult<SubscriptionMatchedStatus> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(
                 ReaderServiceMail::GetSubscriptionMatchedStatus {
@@ -392,7 +392,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
     /// Async version of [`wait_for_historical_data`](crate::subscription::data_reader::DataReader::wait_for_historical_data).
     #[tracing::instrument(skip(self))]
     pub async fn wait_for_historical_data(&self, max_wait: Duration) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(
                 ReaderServiceMail::WaitForHistoricalData {
@@ -413,7 +413,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
         &self,
         publication_handle: InstanceHandle,
     ) -> DdsResult<PublicationBuiltinTopicData> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(
                 ReaderServiceMail::GetMatchedPublicationData {
@@ -431,7 +431,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
     /// Async version of [`get_matched_publications`](crate::subscription::data_reader::DataReader::get_matched_publications).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_publications(&self) -> DdsResult<Vec<InstanceHandle>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(
                 ReaderServiceMail::GetMatchedPublications {
@@ -448,7 +448,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
 impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
     /// Async version of [`set_qos`](crate::subscription::data_reader::DataReader::set_qos).
     pub async fn set_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(ReaderServiceMail::SetQos {
                 subscriber_handle: self.subscriber.get_instance_handle().await,
@@ -463,7 +463,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
     /// Async version of [`get_qos`](crate::subscription::data_reader::DataReader::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DataReaderQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(ReaderServiceMail::GetQos {
                 subscriber_handle: self.subscriber.get_instance_handle().await,
@@ -492,7 +492,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
     /// Async version of [`enable`](crate::subscription::data_reader::DataReader::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Reader(ReaderServiceMail::Enable {
                 subscriber_handle: self.subscriber.get_instance_handle().await,
@@ -519,7 +519,7 @@ impl<R: DdsRuntime, Foo> DataReaderAsync<R, Foo> {
         a_listener: Option<impl DataReaderListener<R, Foo> + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let listener_sender = a_listener.map(|l| {
             DataReaderListenerActor::spawn(
                 l,

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -131,7 +131,7 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let serialized_data = instance.serialize_data()?;
         self.participant_address()
             .send(DomainParticipantMail::Writer(
@@ -160,7 +160,7 @@ where
     /// Async version of [`lookup_instance`](crate::publication::data_writer::DataWriter::lookup_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn lookup_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let serialized_data = instance.serialize_data()?;
         self.participant_address()
             .send(DomainParticipantMail::Writer(
@@ -194,7 +194,7 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let serialized_data = data.serialize_data()?;
         self.participant_address()
             .send(DomainParticipantMail::Writer(
@@ -230,7 +230,7 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let serialized_data = data.serialize_data()?;
         self.participant_address()
             .send(DomainParticipantMail::Writer(
@@ -265,7 +265,7 @@ impl<R: DdsRuntime, Foo> DataWriterAsync<R, Foo> {
             max_wait.into(),
             Box::pin(async move {
                 loop {
-                    let (reply_sender, mut reply_receiver) = R::oneshot();
+                    let (reply_sender, reply_receiver) = R::oneshot();
                     participant_address
                         .send(DomainParticipantMail::Message(
                             MessageServiceMail::AreAllChangesAcknowledged {
@@ -302,7 +302,7 @@ impl<R: DdsRuntime, Foo> DataWriterAsync<R, Foo> {
     pub async fn get_offered_deadline_missed_status(
         &self,
     ) -> DdsResult<OfferedDeadlineMissedStatus> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Writer(
                 WriterServiceMail::GetOfferedDeadlineMissedStatus {
@@ -326,7 +326,7 @@ impl<R: DdsRuntime, Foo> DataWriterAsync<R, Foo> {
     /// Async version of [`get_publication_matched_status`](crate::publication::data_writer::DataWriter::get_publication_matched_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_publication_matched_status(&self) -> DdsResult<PublicationMatchedStatus> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Writer(
                 WriterServiceMail::GetPublicationMatchedStatus {
@@ -363,7 +363,7 @@ impl<R: DdsRuntime, Foo> DataWriterAsync<R, Foo> {
         &self,
         subscription_handle: InstanceHandle,
     ) -> DdsResult<SubscriptionBuiltinTopicData> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Writer(
                 WriterServiceMail::GetMatchedSubscriptionData {
@@ -380,7 +380,7 @@ impl<R: DdsRuntime, Foo> DataWriterAsync<R, Foo> {
     /// Async version of [`get_matched_subscriptions`](crate::publication::data_writer::DataWriter::get_matched_subscriptions).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_subscriptions(&self) -> DdsResult<Vec<InstanceHandle>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Writer(
                 WriterServiceMail::GetMatchedSubscriptions {
@@ -398,7 +398,7 @@ impl<R: DdsRuntime, Foo> DataWriterAsync<R, Foo> {
     /// Async version of [`set_qos`](crate::publication::data_writer::DataWriter::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Writer(
                 WriterServiceMail::SetDataWriterQos {
@@ -415,7 +415,7 @@ impl<R: DdsRuntime, Foo> DataWriterAsync<R, Foo> {
     /// Async version of [`get_qos`](crate::publication::data_writer::DataWriter::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DataWriterQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Writer(
                 WriterServiceMail::GetDataWriterQos {
@@ -446,7 +446,7 @@ impl<R: DdsRuntime, Foo> DataWriterAsync<R, Foo> {
     /// Async version of [`enable`](crate::publication::data_writer::DataWriter::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Writer(
                 WriterServiceMail::EnableDataWriter {
@@ -474,7 +474,7 @@ impl<R: DdsRuntime, Foo> DataWriterAsync<R, Foo> {
         a_listener: Option<impl DataWriterListener<R, Foo> + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let listener_sender = a_listener.map(|l| {
             DataWriterListenerActor::spawn(
                 l,

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -104,7 +104,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
         a_listener: Option<impl PublisherListener<R> + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<PublisherAsync<R>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let listener_sender =
             a_listener.map(|l| PublisherListenerActor::spawn(l, self.spawner_handle()));
         self.participant_address
@@ -126,7 +126,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`delete_publisher`](crate::domain::domain_participant::DomainParticipant::delete_publisher).
     #[tracing::instrument(skip(self, a_publisher))]
     pub async fn delete_publisher(&self, a_publisher: &PublisherAsync<R>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::DeleteUserDefinedPublisher {
@@ -147,7 +147,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
         a_listener: Option<impl SubscriberListener<R> + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<SubscriberAsync<R>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let status_condition = Actor::spawn(StatusConditionActor::default(), &self.spawner_handle);
         let subscriber_status_condition_address = status_condition.address();
         let listener_sender =
@@ -173,7 +173,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`delete_subscriber`](crate::domain::domain_participant::DomainParticipant::delete_subscriber).
     #[tracing::instrument(skip(self, a_subscriber))]
     pub async fn delete_subscriber(&self, a_subscriber: &SubscriberAsync<R>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::DeleteUserDefinedSubscriber {
@@ -216,7 +216,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
         mask: &[StatusKind],
         dynamic_type_representation: Arc<dyn DynamicType + Send + Sync>,
     ) -> DdsResult<TopicAsync<R>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let status_condition = Actor::spawn(StatusConditionActor::default(), &self.spawner_handle);
         let topic_status_condition_address = status_condition.address();
         let listener_sender =
@@ -249,7 +249,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`delete_topic`](crate::domain::domain_participant::DomainParticipant::delete_topic).
     #[tracing::instrument(skip(self, a_topic))]
     pub async fn delete_topic(&self, a_topic: &TopicAsync<R>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::DeleteUserDefinedTopic {
@@ -282,7 +282,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
             timeout.into(),
             Box::pin(async move {
                 loop {
-                    let (reply_sender, mut reply_receiver) = R::oneshot();
+                    let (reply_sender, reply_receiver) = R::oneshot();
                     let status_condition =
                         Actor::spawn(StatusConditionActor::default(), &executor_handle);
 
@@ -320,7 +320,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
         &self,
         topic_name: &str,
     ) -> DdsResult<Option<TopicAsync<R>>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::LookupTopicdescription {
@@ -357,7 +357,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`ignore_participant`](crate::domain::domain_participant::DomainParticipant::ignore_participant).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_participant(&self, handle: InstanceHandle) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::IgnoreParticipant {
@@ -378,7 +378,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`ignore_publication`](crate::domain::domain_participant::DomainParticipant::ignore_publication).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_publication(&self, handle: InstanceHandle) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::IgnorePublication {
@@ -393,7 +393,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`ignore_subscription`](crate::domain::domain_participant::DomainParticipant::ignore_subscription).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_subscription(&self, handle: InstanceHandle) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::IgnoreSubscription {
@@ -414,7 +414,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`delete_contained_entities`](crate::domain::domain_participant::DomainParticipant::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::DeleteContainedEntities { reply_sender },
@@ -432,7 +432,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`set_default_publisher_qos`](crate::domain::domain_participant::DomainParticipant::set_default_publisher_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_publisher_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::SetDefaultPublisherQos { qos, reply_sender },
@@ -444,7 +444,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`get_default_publisher_qos`](crate::domain::domain_participant::DomainParticipant::get_default_publisher_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_publisher_qos(&self) -> DdsResult<PublisherQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::GetDefaultPublisherQos { reply_sender },
@@ -456,7 +456,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`set_default_subscriber_qos`](crate::domain::domain_participant::DomainParticipant::set_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_subscriber_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::SetDefaultSubscriberQos { qos, reply_sender },
@@ -468,7 +468,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`get_default_subscriber_qos`](crate::domain::domain_participant::DomainParticipant::get_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_subscriber_qos(&self) -> DdsResult<SubscriberQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::GetDefaultSubscriberQos { reply_sender },
@@ -480,7 +480,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`set_default_topic_qos`](crate::domain::domain_participant::DomainParticipant::set_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_topic_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::SetDefaultTopicQos { qos, reply_sender },
@@ -492,7 +492,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`get_default_topic_qos`](crate::domain::domain_participant::DomainParticipant::get_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_topic_qos(&self) -> DdsResult<TopicQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::GetDefaultTopicQos { reply_sender },
@@ -504,7 +504,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`get_discovered_participants`](crate::domain::domain_participant::DomainParticipant::get_discovered_participants).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_participants(&self) -> DdsResult<Vec<InstanceHandle>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::GetDiscoveredParticipants { reply_sender },
@@ -519,7 +519,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
         &self,
         participant_handle: InstanceHandle,
     ) -> DdsResult<ParticipantBuiltinTopicData> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::GetDiscoveredParticipantData {
@@ -534,7 +534,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`get_discovered_topics`](crate::domain::domain_participant::DomainParticipant::get_discovered_topics).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_topics(&self) -> DdsResult<Vec<InstanceHandle>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::GetDiscoveredTopics { reply_sender },
@@ -549,7 +549,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
         &self,
         topic_handle: InstanceHandle,
     ) -> DdsResult<TopicBuiltinTopicData> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::GetDiscoveredTopicData {
@@ -570,7 +570,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`get_current_time`](crate::domain::domain_participant::DomainParticipant::get_current_time).
     #[tracing::instrument(skip(self))]
     pub async fn get_current_time(&self) -> DdsResult<Time> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::GetCurrentTime { reply_sender },
@@ -584,7 +584,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`set_qos`](crate::domain::domain_participant::DomainParticipant::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<DomainParticipantQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::SetQos { qos, reply_sender },
@@ -596,7 +596,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`get_qos`](crate::domain::domain_participant::DomainParticipant::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::GetQos { reply_sender },
@@ -612,7 +612,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
         a_listener: Option<impl DomainParticipantListener<R> + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let listener_sender = a_listener
             .map(|l| DomainParticipantListenerActor::spawn::<R>(l, self.spawner_handle()));
         self.participant_address
@@ -636,7 +636,7 @@ impl<R: DdsRuntime> DomainParticipantAsync<R> {
     /// Async version of [`enable`](crate::domain::domain_participant::DomainParticipant::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address
             .send(DomainParticipantMail::Participant(
                 ParticipantServiceMail::Enable { reply_sender },

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -47,7 +47,7 @@ impl<R: DdsRuntime> DomainParticipantFactoryAsync<R> {
         let status_kind = mask.to_vec();
         let listener_sender =
             a_listener.map(|l| DomainParticipantListenerActor::spawn::<R>(l, &spawner_handle));
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.domain_participant_factory_actor
             .send_actor_mail(DomainParticipantFactoryMail::CreateParticipant {
                 domain_id,
@@ -82,7 +82,7 @@ impl<R: DdsRuntime> DomainParticipantFactoryAsync<R> {
         &self,
         participant: &DomainParticipantAsync<R>,
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         participant
             .participant_address()
             .send(DomainParticipantMail::Participant(
@@ -91,7 +91,7 @@ impl<R: DdsRuntime> DomainParticipantFactoryAsync<R> {
             .await?;
         let is_participant_empty = reply_receiver.receive().await?;
         if is_participant_empty {
-            let (reply_sender, mut reply_receiver) = R::oneshot();
+            let (reply_sender, reply_receiver) = R::oneshot();
             let handle = participant.get_instance_handle().await;
 
             self.domain_participant_factory_actor
@@ -128,7 +128,7 @@ impl<R: DdsRuntime> DomainParticipantFactoryAsync<R> {
         &self,
         qos: QosKind<DomainParticipantQos>,
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.domain_participant_factory_actor
             .send_actor_mail(DomainParticipantFactoryMail::SetDefaultParticipantQos {
                 qos,
@@ -140,7 +140,7 @@ impl<R: DdsRuntime> DomainParticipantFactoryAsync<R> {
 
     /// Async version of [`get_default_participant_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::get_default_participant_qos).
     pub async fn get_default_participant_qos(&self) -> DdsResult<DomainParticipantQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.domain_participant_factory_actor
             .send_actor_mail(DomainParticipantFactoryMail::GetDefaultParticipantQos {
                 reply_sender,
@@ -151,7 +151,7 @@ impl<R: DdsRuntime> DomainParticipantFactoryAsync<R> {
 
     /// Async version of [`set_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::set_qos).
     pub async fn set_qos(&self, qos: QosKind<DomainParticipantFactoryQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.domain_participant_factory_actor
             .send_actor_mail(DomainParticipantFactoryMail::SetQos { qos, reply_sender })
             .await;
@@ -160,7 +160,7 @@ impl<R: DdsRuntime> DomainParticipantFactoryAsync<R> {
 
     /// Async version of [`get_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::get_qos).
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantFactoryQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.domain_participant_factory_actor
             .send_actor_mail(DomainParticipantFactoryMail::GetQos { reply_sender })
             .await;
@@ -177,7 +177,7 @@ impl<R: DdsRuntime> DomainParticipantFactoryAsync<R> {
 
     /// Async version of [`get_configuration`](crate::domain::domain_participant_factory::DomainParticipantFactory::get_configuration).
     pub async fn get_configuration(&self) -> DdsResult<DustDdsConfiguration> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.domain_participant_factory_actor
             .send_actor_mail(DomainParticipantFactoryMail::GetConfiguration { reply_sender })
             .await;

--- a/dds/src/dds_async/publisher.rs
+++ b/dds/src/dds_async/publisher.rs
@@ -71,7 +71,7 @@ impl<R: DdsRuntime> PublisherAsync<R> {
         let writer_status_condition_address = status_condition.address();
         let listener_sender = a_listener
             .map(|l| DataWriterListenerActor::spawn(l, self.participant.spawner_handle()));
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Publisher(
                 PublisherServiceMail::CreateDataWriter {
@@ -102,7 +102,7 @@ impl<R: DdsRuntime> PublisherAsync<R> {
         &self,
         a_datawriter: &DataWriterAsync<R, Foo>,
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Publisher(
                 PublisherServiceMail::DeleteDataWriter {
@@ -169,7 +169,7 @@ impl<R: DdsRuntime> PublisherAsync<R> {
     /// Async version of [`set_default_datawriter_qos`](crate::publication::publisher::Publisher::set_default_datawriter_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_datawriter_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Publisher(
                 PublisherServiceMail::SetDefaultDataWriterQos {
@@ -185,7 +185,7 @@ impl<R: DdsRuntime> PublisherAsync<R> {
     /// Async version of [`get_default_datawriter_qos`](crate::publication::publisher::Publisher::get_default_datawriter_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_datawriter_qos(&self) -> DdsResult<DataWriterQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Publisher(
                 PublisherServiceMail::GetDefaultDataWriterQos {
@@ -212,7 +212,7 @@ impl<R: DdsRuntime> PublisherAsync<R> {
     /// Async version of [`set_qos`](crate::publication::publisher::Publisher::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Publisher(
                 PublisherServiceMail::SetPublisherQos {
@@ -228,7 +228,7 @@ impl<R: DdsRuntime> PublisherAsync<R> {
     /// Async version of [`get_qos`](crate::publication::publisher::Publisher::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<PublisherQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Publisher(
                 PublisherServiceMail::GetPublisherQos {
@@ -247,7 +247,7 @@ impl<R: DdsRuntime> PublisherAsync<R> {
         a_listener: Option<impl PublisherListener<R> + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let listener_sender =
             a_listener.map(|l| PublisherListenerActor::spawn(l, self.participant.spawner_handle()));
         self.participant_address()

--- a/dds/src/dds_async/subscriber.rs
+++ b/dds/src/dds_async/subscriber.rs
@@ -77,7 +77,7 @@ impl<R: DdsRuntime> SubscriberAsync<R> {
         let reader_status_condition_address = status_condition.address();
         let listener_sender = a_listener
             .map(|l| DataReaderListenerActor::spawn(l, self.participant.spawner_handle()));
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Subscriber(
                 SubscriberServiceMail::CreateDataReader {
@@ -108,7 +108,7 @@ impl<R: DdsRuntime> SubscriberAsync<R> {
         &self,
         a_datareader: &DataReaderAsync<R, Foo>,
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Subscriber(
                 SubscriberServiceMail::DeleteDataReader {
@@ -128,7 +128,7 @@ impl<R: DdsRuntime> SubscriberAsync<R> {
         topic_name: &str,
     ) -> DdsResult<Option<DataReaderAsync<R, Foo>>> {
         if let Some(topic) = self.participant.lookup_topicdescription(topic_name).await? {
-            let (reply_sender, mut reply_receiver) = R::oneshot();
+            let (reply_sender, reply_receiver) = R::oneshot();
             self.participant_address()
                 .send(DomainParticipantMail::Subscriber(
                     SubscriberServiceMail::LookupDataReader {
@@ -182,7 +182,7 @@ impl<R: DdsRuntime> SubscriberAsync<R> {
     /// Async version of [`set_default_datareader_qos`](crate::subscription::subscriber::Subscriber::set_default_datareader_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_datareader_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Subscriber(
                 SubscriberServiceMail::SetDefaultDataReaderQos {
@@ -199,7 +199,7 @@ impl<R: DdsRuntime> SubscriberAsync<R> {
     /// Async version of [`get_default_datareader_qos`](crate::subscription::subscriber::Subscriber::get_default_datareader_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_datareader_qos(&self) -> DdsResult<DataReaderQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Subscriber(
                 SubscriberServiceMail::GetDefaultDataReaderQos {
@@ -223,7 +223,7 @@ impl<R: DdsRuntime> SubscriberAsync<R> {
     /// Async version of [`set_qos`](crate::subscription::subscriber::Subscriber::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Subscriber(
                 SubscriberServiceMail::SetQos {
@@ -239,7 +239,7 @@ impl<R: DdsRuntime> SubscriberAsync<R> {
     /// Async version of [`get_qos`](crate::subscription::subscriber::Subscriber::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<SubscriberQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant_address()
             .send(DomainParticipantMail::Subscriber(
                 SubscriberServiceMail::GetSubscriberQos {
@@ -258,7 +258,7 @@ impl<R: DdsRuntime> SubscriberAsync<R> {
         a_listener: Option<impl SubscriberListener<R> + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         let listener_sender = a_listener
             .map(|l| SubscriberListenerActor::spawn(l, self.participant.spawner_handle()));
         self.participant_address()

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -60,7 +60,7 @@ impl<R: DdsRuntime> TopicAsync<R> {
     /// Async version of [`get_inconsistent_topic_status`](crate::topic_definition::topic::Topic::get_inconsistent_topic_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_inconsistent_topic_status(&self) -> DdsResult<InconsistentTopicStatus> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant
             .participant_address()
             .send(DomainParticipantMail::Topic(
@@ -98,7 +98,7 @@ impl<R: DdsRuntime> TopicAsync<R> {
     /// Async version of [`set_qos`](crate::topic_definition::topic::Topic::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant
             .participant_address()
             .send(DomainParticipantMail::Topic(TopicServiceMail::SetQos {
@@ -114,7 +114,7 @@ impl<R: DdsRuntime> TopicAsync<R> {
     /// Async version of [`get_qos`](crate::topic_definition::topic::Topic::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<TopicQos> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant
             .participant_address()
             .send(DomainParticipantMail::Topic(TopicServiceMail::GetQos {
@@ -144,7 +144,7 @@ impl<R: DdsRuntime> TopicAsync<R> {
     /// Async version of [`enable`](crate::topic_definition::topic::Topic::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant
             .participant_address()
             .send(DomainParticipantMail::Topic(TopicServiceMail::Enable {
@@ -176,7 +176,7 @@ impl<R: DdsRuntime> TopicAsync<R> {
     #[doc(hidden)]
     #[tracing::instrument(skip(self))]
     pub async fn get_type_support(&self) -> DdsResult<Arc<dyn DynamicType + Send + Sync>> {
-        let (reply_sender, mut reply_receiver) = R::oneshot();
+        let (reply_sender, reply_receiver) = R::oneshot();
         self.participant
             .participant_address()
             .send(DomainParticipantMail::Topic(

--- a/dds/src/rtps/message_sender.rs
+++ b/dds/src/rtps/message_sender.rs
@@ -1,7 +1,13 @@
+use core::future::Future;
+
 use crate::transport::types::{GuidPrefix, Locator};
 
 pub trait WriteMessage {
-    fn write_message(&self, datagram: &[u8], locator_list: &[Locator]);
+    fn write_message(
+        &self,
+        datagram: &[u8],
+        locator_list: &[Locator],
+    ) -> impl Future<Output = ()> + Send;
     fn guid_prefix(&self) -> GuidPrefix;
 }
 

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -294,7 +294,8 @@ async fn write_message_to_reader_proxy_best_effort(
                 message_writer.guid_prefix(),
             );
             message_writer
-                .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+                .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                .await;
 
             reader_proxy.set_highest_sent_seq_num(next_unsent_change_seq_num);
         } else if let Some(cache_change) = changes
@@ -362,7 +363,8 @@ async fn write_message_to_reader_proxy_best_effort(
                         message_writer.guid_prefix(),
                     );
                     message_writer
-                        .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+                        .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                        .await;
                 }
             } else {
                 let info_dst =
@@ -382,7 +384,8 @@ async fn write_message_to_reader_proxy_best_effort(
                     message_writer.guid_prefix(),
                 );
                 message_writer
-                    .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+                    .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                    .await;
             }
         } else {
             let gap_submessage = GapSubmessage::new(
@@ -396,7 +399,8 @@ async fn write_message_to_reader_proxy_best_effort(
                 message_writer.guid_prefix(),
             );
             message_writer
-                .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+                .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                .await;
         }
 
         reader_proxy.set_highest_sent_seq_num(next_unsent_change_seq_num);
@@ -441,7 +445,8 @@ async fn write_message_to_reader_proxy_reliable(
                     message_writer.guid_prefix(),
                 );
                 message_writer
-                    .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+                    .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                    .await;
             } else {
                 write_change_message_reader_proxy_reliable(
                     reader_proxy,
@@ -479,7 +484,8 @@ async fn write_message_to_reader_proxy_reliable(
                 message_writer.guid_prefix(),
             );
             message_writer
-                .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+                .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                .await;
         }
     } else if reader_proxy
         .heartbeat_machine()
@@ -497,7 +503,9 @@ async fn write_message_to_reader_proxy_reliable(
             &[&info_dst, &heartbeat_submessage],
             message_writer.guid_prefix(),
         );
-        message_writer.write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+        message_writer
+            .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+            .await;
     }
 
     // Middle-part of the state-machine - Figure 8.19 RTPS standard
@@ -604,7 +612,8 @@ async fn write_change_message_reader_proxy_reliable(
                         message_writer.guid_prefix(),
                     );
                     message_writer
-                        .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+                        .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                        .await;
                 }
             } else {
                 let info_dst =
@@ -630,7 +639,8 @@ async fn write_change_message_reader_proxy_reliable(
                     message_writer.guid_prefix(),
                 );
                 message_writer
-                    .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+                    .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                    .await;
             }
         }
         _ => {
@@ -649,7 +659,8 @@ async fn write_change_message_reader_proxy_reliable(
                 message_writer.guid_prefix(),
             );
             message_writer
-                .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list());
+                .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                .await;
         }
     }
 }

--- a/dds/src/rtps/stateless_writer.rs
+++ b/dds/src/rtps/stateless_writer.rs
@@ -53,7 +53,7 @@ impl RtpsStatelessWriter {
         &mut self.reader_locators
     }
 
-    pub fn behavior(&mut self, message_writer: &mut impl WriteMessage) {
+    pub async fn behavior(&mut self, message_writer: &mut impl WriteMessage) {
         for reader_locator in &mut self.reader_locators {
             while let Some(unsent_change_seq_num) =
                 reader_locator.next_unsent_change(self.changes.iter())
@@ -81,7 +81,8 @@ impl RtpsStatelessWriter {
                         message_writer.guid_prefix(),
                     );
                     message_writer
-                        .write_message(rtps_message.buffer(), &[reader_locator.locator()]);
+                        .write_message(rtps_message.buffer(), &[reader_locator.locator()])
+                        .await;
                 } else {
                     let gap_submessage = GapSubmessage::new(
                         ENTITYID_UNKNOWN,
@@ -94,7 +95,8 @@ impl RtpsStatelessWriter {
                         message_writer.guid_prefix(),
                     );
                     message_writer
-                        .write_message(rtps_message.buffer(), &[reader_locator.locator()]);
+                        .write_message(rtps_message.buffer(), &[reader_locator.locator()])
+                        .await;
                 }
                 reader_locator.set_highest_sent_change_sn(unsent_change_seq_num);
             }

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -265,7 +265,9 @@ impl RtpsWriterProxy {
                 &[&info_dst_submessage, &acknack_submessage],
                 message_writer.guid_prefix(),
             );
-            message_writer.write_message(rtps_message.buffer(), self.unicast_locator_list());
+            message_writer
+                .write_message(rtps_message.buffer(), self.unicast_locator_list())
+                .await;
 
             let mut missing_fragment_seq_num_list: Vec<SequenceNumber> =
                 self.frag_buffer.iter().map(|f| f.writer_sn()).collect();
@@ -310,7 +312,8 @@ impl RtpsWriterProxy {
                         message_writer.guid_prefix(),
                     );
                     message_writer
-                        .write_message(rtps_message.buffer(), self.unicast_locator_list());
+                        .write_message(rtps_message.buffer(), self.unicast_locator_list())
+                        .await;
                 }
             }
         }

--- a/dds/src/rtps_udp_transport/udp_transport.rs
+++ b/dds/src/rtps_udp_transport/udp_transport.rs
@@ -552,7 +552,7 @@ impl MessageWriter {
     }
 }
 impl WriteMessage for MessageWriter {
-    fn write_message(&self, datagram: &[u8], locator_list: &[Locator]) {
+    async fn write_message(&self, datagram: &[u8], locator_list: &[Locator]) {
         for &destination_locator in locator_list {
             if UdpLocator(destination_locator).is_multicast() {
                 let socket2: socket2::Socket = self.socket.try_clone().unwrap().into();
@@ -685,9 +685,7 @@ impl TransportParticipant for RtpsUdpTransportParticipant {
                 cache_change: CacheChange,
             ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
                 self.rtps_writer.add_change(cache_change);
-                self.rtps_writer.behavior(
-                    &mut self.message_writer,
-                );
+                self.rtps_writer.behavior(&mut self.message_writer);
                 Box::pin(async {})
             }
 

--- a/dds/src/rtps_udp_transport/udp_transport.rs
+++ b/dds/src/rtps_udp_transport/udp_transport.rs
@@ -685,8 +685,9 @@ impl TransportParticipant for RtpsUdpTransportParticipant {
                 cache_change: CacheChange,
             ) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
                 self.rtps_writer.add_change(cache_change);
-                self.rtps_writer.behavior(&mut self.message_writer);
-                Box::pin(async {})
+                Box::pin(async {
+                    self.rtps_writer.behavior(&mut self.message_writer).await;
+                })
             }
 
             fn remove_change(

--- a/dds/src/runtime.rs
+++ b/dds/src/runtime.rs
@@ -1,5 +1,5 @@
-use core::future::Future;
 use super::infrastructure::{error::DdsResult, time::Time};
+use core::future::Future;
 
 /// Represents a clock that provides the current time.
 pub trait Clock {
@@ -39,7 +39,7 @@ pub trait OneshotReceive<T> {
     /// Receives a value from the one-shot channel.
     ///
     /// Returns a future that resolves to the received value or an error.
-    fn receive(&mut self) -> impl Future<Output = DdsResult<T>> + Send;
+    fn receive(self) -> impl Future<Output = DdsResult<T>> + Send;
 }
 
 /// Represents the sending half of a multiple-producer channel.

--- a/dds/src/std_runtime/oneshot.rs
+++ b/dds/src/std_runtime/oneshot.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use crate::{
-    runtime::{OneshotReceive, OneshotSend},
     infrastructure::error::{DdsError, DdsResult},
+    runtime::{OneshotReceive, OneshotSend},
 };
 
 #[derive(Debug)]
@@ -102,7 +102,7 @@ impl<T> OneshotReceive<T> for OneshotReceiver<T>
 where
     T: Send,
 {
-    async fn receive(&mut self) -> DdsResult<T> {
+    async fn receive(self) -> DdsResult<T> {
         self.await
             .map_err(|_| DdsError::Error(String::from("Receive error")))
     }


### PR DESCRIPTION
Allow the RTPS WriteMessage trait to implement async. The rest of the changes remove some not necessary mut and make the oneshot receiver consuming