### PR TITLE
feat: custom discriminant on enum (union) variant

### DIFF
--- a/dds_derive/src/derive/enum_support.rs
+++ b/dds_derive/src/derive/enum_support.rs
@@ -26,14 +26,14 @@ impl Parse for VariantArgs {
                 if discriminant.is_some() {
                     return Err(syn::Error::new(
                         ident.span(),
-                        format!("argument `discriminant` already defined"),
+                        "Argument `discriminant` already defined",
                     ));
                 }
                 discriminant = Some(arg.value);
             } else {
                 return Err(syn::Error::new(
                     ident.span(),
-                    format!("unknown argument `{ident}`"),
+                    format!("Unknown argument `{ident}`"),
                 ));
             }
         }


### PR DESCRIPTION
Avoid explicit discriminants and prevent the following error: _`#[repr(inttype)]` must be specified for enums with explicit discriminants and non-unit variants_. Note that if the user sets an explicit discriminant, the error will still be displayed.

Support custom discriminant on enum (union) variant via `#[dust_dds(discriminant = EXPRESSION)]`:
```rust
#[derive(DdsType)]
enum Good {
    #[dust_dds(discriminant = 10)]
    a(u32),
    #[dust_dds(discriminant = 20)]
    b(MyStruct),
    #[dust_dds(discriminant = 30)]
    c(u8),
}

#[derive(DdsType)]
#[repr(u8)]
enum Bad {
    a(u32) = 10,
    b(MyStruct) = 20,
    c(u8) = 30,
}
```

Currently, the discriminant is an expression (allowing `const A: u8 = 10`), but we may change it to only allow a numerical literal.