### PR TITLE
Detect disconnected subscriber

### DIFF
--- a/dds/tests/detect_disconnected_subscriber.rs
+++ b/dds/tests/detect_disconnected_subscriber.rs
@@ -1,6 +1,7 @@
 use dust_dds::dds_async::data_writer::DataWriterAsync;
 use dust_dds::publication::data_writer_listener::DataWriterListener;
 use dust_dds::infrastructure::status::PublicationMatchedStatus;
+
 struct PubListener {
     label: String,
 }
@@ -21,22 +22,25 @@ impl<R: DdsRuntime, T: 'static> DataWriterListener<R, T> for PubListener {
         core::future::ready(())
     }
 }
+
 use dust_dds::{
-    domain::domain_participant_factory::DomainParticipantFactory, infrastructure::{
-        qos::{DataReaderQos, QosKind}, qos_policy::{DurabilityQosPolicy, DurabilityQosPolicyKind, ReliabilityQosPolicy, ReliabilityQosPolicyKind}, status::{StatusKind, NO_STATUS}, time::{Duration, DurationKind}, type_support::DdsType
-    }, listener::NO_LISTENER
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        qos::QosKind,
+        status::{StatusKind, NO_STATUS},
+        type_support::DdsType,
+    },
+    listener::NO_LISTENER,
 };
 use std::{
-    sync::mpsc::{sync_channel, SyncSender,},
+    sync::mpsc::{sync_channel, SyncSender},
     thread,
 };
-    
+
 use dust_dds::{
-    runtime::DdsRuntime,
     dds_async::data_reader::DataReaderAsync,
-    infrastructure::{
-        sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
-    },
+    infrastructure::sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+    runtime::DdsRuntime,
     subscription::data_reader_listener::DataReaderListener,
 };
 
@@ -68,6 +72,7 @@ impl<R: DdsRuntime> DataReaderListener<R, TestType> for Listener {
             }
         }
     }
+    
     async fn on_subscription_matched(
         &mut self,
         _the_reader: DataReaderAsync<R, TestType>,
@@ -99,7 +104,9 @@ fn run_publisher(domain_id: i32, topic_name: &str) {
         .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
         .unwrap();
 
-    let pub_listener = PubListener { label: "main".to_string() };
+    let pub_listener = PubListener {
+        label: "main".to_string(),
+    };
     let writer = publisher
         .create_datawriter(
             &topic,
@@ -114,10 +121,10 @@ fn run_publisher(domain_id: i32, topic_name: &str) {
             id: 3 + i,
             message: String::from("Test"),
         };
-    println!("\x1b[35m[Publisher]\x1b[0m Writing sample: {:?}", sample);
+        println!("\x1b[35m[Publisher]\x1b[0m Writing sample: {:?}", sample);
         let result = writer.write(&sample, None);
         assert!(result.is_ok());
-    println!("\x1b[35m[Publisher]\x1b[0m Sample written successfully.");
+        println!("\x1b[35m[Publisher]\x1b[0m Sample written successfully.");
 
         std::thread::sleep(std::time::Duration::from_millis(250));
     }
@@ -127,16 +134,20 @@ fn run_publisher(domain_id: i32, topic_name: &str) {
     println!("\x1b[35m[Publisher]\x1b[0m Datawriter deleted, exiting publisher.");
 }
 
-fn run_subscriber(domain_id: i32, topic_name: &str, label: &str) {
-    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+fn run_subscriber_with_reconnect(domain_id: i32, topic_name: &str) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    
     rt.block_on(async move {
-    println!("\x1b[32m[Subscriber-{label}]\x1b[0m Creating participant...");
+        println!("\x1b[32m[Subscriber]\x1b[0m Creating participant (once)...");
         let participant_factory = DomainParticipantFactory::get_instance();
         let participant = participant_factory
             .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
             .unwrap();
 
-    println!("\x1b[32m[Subscriber-{label}]\x1b[0m Creating topic...");
+        println!("\x1b[32m[Subscriber]\x1b[0m Creating topic (once)...");
         let topic = participant
             .create_topic::<TestType>(
                 topic_name,
@@ -147,48 +158,93 @@ fn run_subscriber(domain_id: i32, topic_name: &str, label: &str) {
             )
             .unwrap();
 
-    println!("\x1b[32m[Subscriber-{label}]\x1b[0m Creating subscriber...");
+        println!("\x1b[32m[Subscriber]\x1b[0m Creating subscriber (once)...");
         let subscriber = participant
             .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
             .unwrap();
 
-    let (sender, receiver) = sync_channel(0);
-    let listener = Listener { sender, label: label.to_string() };
+        // First connection
+        println!("\x1b[32m[Subscriber]\x1b[0m === FIRST CONNECTION ===");
+        {
+            let (sender, receiver) = sync_channel(0);
+            let listener = Listener {
+                sender,
+                label: "connection-1".to_string(),
+            };
 
-    println!("\x1b[32m[Subscriber-{label}]\x1b[0m Creating datareader with listener...");
-        let reader = subscriber
-            .create_datareader(
-                &topic,
-                QosKind::Default,
-                Some(listener),
-                &[StatusKind::DataAvailable, StatusKind::SubscriptionMatched],
-            )
-            .unwrap();
+            println!("\x1b[32m[Subscriber]\x1b[0m Creating datareader with listener...");
+            let reader = subscriber
+                .create_datareader(
+                    &topic,
+                    QosKind::Default,
+                    Some(listener),
+                    &[StatusKind::DataAvailable, StatusKind::SubscriptionMatched],
+                )
+                .unwrap();
 
+            println!("\x1b[32m[Subscriber]\x1b[0m Waiting for subscription match...");
+            let result = receiver.recv();
+            assert!(result.is_ok(), "{:?}", result.err());
+            println!("\x1b[32m[Subscriber]\x1b[0m Subscription matched! Waiting for data...");
 
-    println!("\x1b[32m[Subscriber-{label}]\x1b[0m Waiting for subscription match...");
-    let result = receiver.recv();
-    assert!(result.is_ok(), "{:?}", result.err());
-    println!("\x1b[32m[Subscriber-{label}]\x1b[0m Subscription matched! Waiting for data...");
+            // Wait for some data
+            std::thread::sleep(std::time::Duration::from_secs(2));
 
-    // Periodically log subscriber status every 4 seconds while waiting for data
-    let total_wait = 12; // seconds
-    let interval = 4; // seconds
-    for waited in (interval..=total_wait).step_by(interval) {
-        std::thread::sleep(std::time::Duration::from_secs(interval as u64));
-        println!("\x1b[32m[Subscriber-{label}]\x1b[0m Status: still waiting for data... ({}s elapsed)", waited);
-    }
+            // Simulate disconnect by deleting the datareader
+            println!("\x1b[32m[Subscriber]\x1b[0m Deleting datareader (simulating disconnect)...");
+            subscriber.delete_datareader(&reader).unwrap();
+            println!("\x1b[32m[Subscriber]\x1b[0m Datareader deleted.");
+        }
 
-    println!("\x1b[32m[Subscriber-{label}]\x1b[0m Sample read successfully");
+        // Wait a bit before reconnecting
+        std::thread::sleep(std::time::Duration::from_secs(2));
 
-        // Clean up
-        subscriber.delete_datareader(&reader).unwrap();
-    println!("\x1b[32m[Subscriber-{label}]\x1b[0m Datareader deleted, exiting subscriber.");
+        // Reconnect - create new datareader with same subscriber
+        println!("\x1b[32m[Subscriber]\x1b[0m === RECONNECTION ===");
+        {
+            let (sender, receiver) = sync_channel(0);
+            let listener = Listener {
+                sender,
+                label: "reconnect-1".to_string(),
+            };
+
+            println!("\x1b[32m[Subscriber]\x1b[0m Creating new datareader (reconnection)...");
+            let reader = subscriber
+                .create_datareader(
+                    &topic,
+                    QosKind::Default,
+                    Some(listener),
+                    &[StatusKind::DataAvailable, StatusKind::SubscriptionMatched],
+                )
+                .unwrap();
+
+            println!("\x1b[32m[Subscriber]\x1b[0m Waiting for subscription match...");
+            let result = receiver.recv();
+            assert!(result.is_ok(), "{:?}", result.err());
+            println!("\x1b[32m[Subscriber]\x1b[0m Subscription matched! Waiting for data...");
+
+            // Wait for data
+            let total_wait = 12; // seconds
+            let interval = 4; // seconds
+            for waited in (interval..=total_wait).step_by(interval) {
+                std::thread::sleep(std::time::Duration::from_secs(interval as u64));
+                println!(
+                    "\x1b[32m[Subscriber]\x1b[0m Status: still waiting for data... ({}s elapsed)",
+                    waited
+                );
+            }
+
+            println!("\x1b[32m[Subscriber]\x1b[0m Sample read successfully");
+
+            // Clean up
+            subscriber.delete_datareader(&reader).unwrap();
+            println!("\x1b[32m[Subscriber]\x1b[0m Datareader deleted, exiting subscriber.");
+        }
     });
 }
 
 #[test]
-fn test_publisher_subscriber_threads() {
+fn test_publisher_subscriber_reconnect() {
     let domain_id = 1;
     let topic_name = "TestTopic";
 
@@ -202,46 +258,19 @@ fn test_publisher_subscriber_threads() {
         }
     });
 
-    // Start subscriber thread (first connection)
-    let topic_name1 = topic_name.to_string();
-    let subscriber1 = thread::spawn(move || {
-        println!("\x1b[33m[Main]\x1b[0m Starting subscriber (first connection)...");
-        run_subscriber(domain_id, &topic_name1, "1");
-        println!("\x1b[33m[Main]\x1b[0m Subscriber (first connection) finished (simulating disconnect)");
+    // Start subscriber thread with reconnection logic
+    let subscriber_thread = thread::spawn({
+        let topic_name = topic_name.to_string();
+        move || {
+            println!("\x1b[33m[Main]\x1b[0m Starting subscriber thread...");
+            run_subscriber_with_reconnect(domain_id, &topic_name);
+            println!("\x1b[33m[Main]\x1b[0m Subscriber thread finished.");
+        }
     });
 
-    // Wait for the subscriber to process some data
-    std::thread::sleep(std::time::Duration::from_secs(2));
-
-    // Explicitly delete the subscriber thread (simulating sudden disconnect)
-    println!("\x1b[33m[Main]\x1b[0m Deleting subscriber thread (simulating disconnect)...");
-    subscriber1.join().unwrap();
-    println!("\x1b[33m[Main]\x1b[0m Subscriber thread deleted.");
-    std::thread::sleep(std::time::Duration::from_secs(2));
-
-    // Try to reconnect subscriber up to 3 times if it can't connect
-    let mut reconnect_attempts = 0;
-    let mut connected = false;
-    while reconnect_attempts < 3 && !connected {
-        reconnect_attempts += 1;
-        let topic_name2 = topic_name.to_string();
-        println!("\x1b[33m[Main]\x1b[0m Attempt {}: Starting subscriber (reconnection)...", reconnect_attempts);
-        let result = std::panic::catch_unwind(|| {
-            run_subscriber(domain_id, &topic_name2, &format!("reconnect-{}", reconnect_attempts));
-        });
-        match result {
-            Ok(_) => {
-                println!("\x1b[33m[Main]\x1b[0m Subscriber (reconnection) finished");
-                connected = true;
-            },
-            Err(_) => {
-                println!("\x1b[31m[Main]\x1b[0m Subscriber (reconnection) failed, will retry if attempts remain");
-                std::thread::sleep(std::time::Duration::from_secs(2));
-            }
-        }
-    }
-    if !connected {
-        println!("\x1b[31m[Main]\x1b[0m ERROR: Subscriber failed to reconnect after 3 attempts");
-    }
+    // Wait for both threads to complete
+    subscriber_thread.join().unwrap();
     publisher_thread.join().unwrap();
+    
+    println!("\x1b[33m[Main]\x1b[0m Test completed successfully!");
 }


### PR DESCRIPTION
I encountered the [issue](https://github.com/s2e-systems/dust-dds/issues/357) with a subscriber reconnecting to a topic. In this request, I provided my solution to this problem.

The file contains a test that creates two threads: one for the `publisher` and one for the `subscriber`.

They pass a structure [TestType](https://github.com/s2e-systems/dust-dds/compare/main...Parsifal22:dust-dds:main#diff-c1be8461f0a7f58de405ecca65eb526d41c6e276b35d62aa2cd63a03a38ed110R48-R51) to the topic with two fields: one `id: i32` and the other `Massage: String`.

After a `publisher` and `subscriber` connect to the same `topic`, the `publisher` [sends](https://github.com/s2e-systems/dust-dds/compare/main...Parsifal22:dust-dds:main) its messages to `topic`, and the subscriber reads them using a [DataReader](https://github.com/s2e-systems/dust-dds/compare/main...Parsifal22:dust-dds:main#diff-c1be8461f0a7f58de405ecca65eb526d41c6e276b35d62aa2cd63a03a38ed110R176-R181). After [2 seconds](https://github.com/s2e-systems/dust-dds/compare/main...Parsifal22:dust-dds:main#diff-c1be8461f0a7f58de405ecca65eb526d41c6e276b35d62aa2cd63a03a38ed110R191), the subscriber deletes the thread associated with the [DataReader](https://github.com/s2e-systems/dust-dds/compare/main...Parsifal22:dust-dds:main#diff-c1be8461f0a7f58de405ecca65eb526d41c6e276b35d62aa2cd63a03a38ed110R195), which it started at the very beginning, thereby simulating a disconnection from reading, and after [2 seconds](https://github.com/s2e-systems/dust-dds/compare/main...Parsifal22:dust-dds:main#diff-c1be8461f0a7f58de405ecca65eb526d41c6e276b35d62aa2cd63a03a38ed110R200), it starts it again, simulating a reconnection.

While running tests, I didn't encounter any issues related to Timeout error. 
I hope you find this material useful.

To check all the outputs for this test, you need to run:
`cargo test --test detect_disconnected_subscriber -- --show-output`

and you get this result:
<img width="937" height="373" alt="image" src="https://github.com/user-attachments/assets/7e3856cb-d0b6-41f8-abd3-d3ee24ccd13f" />


