### PR TITLE
Fix: Remove printing of Failed to join multicast group

### DIFF
--- a/dds/src/rtps_udp_transport/udp_transport.rs
+++ b/dds/src/rtps_udp_transport/udp_transport.rs
@@ -38,6 +38,7 @@ use std::{
         mpsc::{Sender, channel},
     },
 };
+use tracing::info;
 
 const MAX_DATAGRAM_SIZE: usize = 65507;
 
@@ -84,7 +85,7 @@ fn get_multicast_socket(
             Addr::V4(a) => {
                 let r = socket.join_multicast_v4(&addr, &a.ip);
                 if let Err(e) = r {
-                    println!(
+                    info!(
                         "Failed to join multicast group on address {} with error {}",
                         a.ip, e
                     )


### PR DESCRIPTION
As pointed out on #407 we are currently printing an information message when failing to join multicast group. This is irrelevant for the user since it only means no multicast data will arrive from that interface. Instead of printing out the error we now put it out as information tracing to avoid creating noise for the user.