### PR TITLE
Move to latest version of 1.y.z of network-interface to ensure freebsd compatibility

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -21,7 +21,7 @@ dust_dds_derive = { version = "0.13", path = "../dds_derive" }
 md5 = { version = "0.7.0", default-features = false, optional = true } # Chose this crate over other possibilities since it doesn't have any other dependencies
 
 socket2 = { version = "0.5", features = ["all"], optional = true }
-network-interface = { version = "1.1.1", optional = true }
+network-interface = { version = "1.1.4", optional = true }
 
 tracing = { version = "0.1", default-features = false, features = ["attributes"], optional = true }
 async-lock = { version = "3.4.0", optional = true }


### PR DESCRIPTION
Move to latest version of 1.y.z of network-interface to ensure freebsd compatibility