### PR TITLE
Fix enum values handled as instance

### DIFF
--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -432,14 +432,12 @@ fn enum_should_be_always_same_instance() {
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
-
     writer.write(UnKeyedData::On, None).unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
     let sample = reader
         .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
     assert_eq!(sample[0].data.as_ref().unwrap(), &UnKeyedData::On);
-
 
     writer.write(UnKeyedData::Off, None).unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();


### PR DESCRIPTION
Enum values were treated as different instances because is was treated as a structure with a keyed value. This PR makes every type that is not a structure a key-less type. 
Also, fix the runtime to support the select function