### PR TITLE
Update/fix pypi pipeline

### DIFF
--- a/.github/workflows/pypi_deploy.yml
+++ b/.github/workflows/pypi_deploy.yml
@@ -9,6 +9,11 @@ on:
   release:
     types: published
   workflow_dispatch:
+    inputs:
+      force_publish:
+        description: Force publishing
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -167,7 +172,7 @@ jobs:
         with:
           subject-path: 'wheels-*/*'
       - name: Publish to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ startsWith(github.ref, 'refs/tags/') || inputs.force_publish }}
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi_deploy.yml
+++ b/.github/workflows/pypi_deploy.yml
@@ -19,17 +19,17 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: x86_64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: x86
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: aarch64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: armv7
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: s390x
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
@@ -54,13 +54,13 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: x86_64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: x86
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: aarch64
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             target: armv7
     steps:
       - uses: actions/checkout@v4
@@ -112,9 +112,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-26
+          - runner: macos-latest
             target: x86_64
-          - runner: macos-26
+          - runner: macos-latest
             target: aarch64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pypi_deploy.yml
+++ b/.github/workflows/pypi_deploy.yml
@@ -112,9 +112,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
+          - runner: macos-26
             target: x86_64
-          - runner: macos-14
+          - runner: macos-26
             target: aarch64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The macos runner macos-13 got removed by GitHub letting this workflow fail. The runners are all updated to use the latest. A force publish manual override is added to be able to retrospectively run this workflow and publish to PyPi.