### PR TITLE
Create interface for simpler transport option configuration

### DIFF
--- a/dds/examples/transport_configuration.rs
+++ b/dds/examples/transport_configuration.rs
@@ -1,0 +1,9 @@
+use dust_dds::domain::domain_participant_factory::DomainParticipantFactory;
+
+fn main() {
+    let participant_factory = DomainParticipantFactory::get_instance();
+    let mut transport = participant_factory.get_mut_transport();
+    transport.set_interface_name(Some(String::from("Wi-Fi")));
+    transport.set_fragment_size(500).unwrap();
+    transport.set_udp_receive_buffer_size(Some(10000));
+}

--- a/dds/src/dcps/dcps_domain_participant/status_condition_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/status_condition_methods.rs
@@ -8,12 +8,11 @@ use crate::{
         status::StatusKind,
     },
     runtime::DdsRuntime,
-    transport::interface::TransportParticipantFactory,
 };
 
 use alloc::vec::Vec;
 
-impl<R: DdsRuntime, T: TransportParticipantFactory> DcpsParticipantFactory<R, T> {
+impl<R: DdsRuntime> DcpsParticipantFactory<R> {
     pub fn get_status_condition_enabled_statuses(
         &mut self,
         entity: StatusConditionEntity,

--- a/dds/src/dcps/dcps_mail.rs
+++ b/dds/src/dcps/dcps_mail.rs
@@ -33,6 +33,7 @@ use crate::{
         },
         time::{Duration, Time},
     },
+    transport::{interface::RtpsTransportParticipant, types::GuidPrefix},
     xtypes::dynamic_type::{DynamicData, DynamicType},
 };
 use alloc::vec::Vec;
@@ -53,11 +54,13 @@ pub enum DcpsMail {
 
 pub enum ParticipantFactoryMail {
     CreateParticipant {
+        guid_prefix: GuidPrefix,
         domain_id: DomainId,
         qos: QosKind<DomainParticipantQos>,
         dcps_listener: Option<DcpsDomainParticipantListener>,
         status_kind: Vec<StatusKind>,
         reply_sender: OneshotSender<DdsResult<InstanceHandle>>,
+        transport_participant: RtpsTransportParticipant,
     },
     DeleteParticipant {
         participant_handle: InstanceHandle,

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -9,23 +9,26 @@ use crate::{
         dcps_participant_factory::DcpsParticipantFactory,
     },
     runtime::DdsRuntime,
-    transport::interface::TransportParticipantFactory,
 };
 
-impl<R: DdsRuntime, T: TransportParticipantFactory> DcpsParticipantFactory<R, T> {
+impl<R: DdsRuntime> DcpsParticipantFactory<R> {
     pub fn handle(&mut self, message: DcpsMail) {
         match message {
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::CreateParticipant {
+                guid_prefix,
                 domain_id,
                 qos,
                 dcps_listener,
                 status_kind,
                 reply_sender,
+                transport_participant,
             }) => reply_sender.send(self.create_participant(
+                guid_prefix,
                 domain_id,
                 qos,
                 dcps_listener,
                 status_kind,
+                transport_participant,
             )),
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::DeleteParticipant {
                 participant_handle,

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -13,92 +13,45 @@ use crate::{
         status::StatusKind,
     },
     runtime::{DdsRuntime, Spawner, Timer},
-    transport::{
-        interface::{TransportDataReceiver, TransportParticipantFactory},
-        types::{ENTITYID_PARTICIPANT, Guid, GuidPrefix},
-    },
+    transport::{interface::RtpsTransportParticipant, types::GuidPrefix},
 };
 use alloc::{borrow::ToOwned, string::String, vec::Vec};
 
-pub struct DcpsParticipantFactory<R: DdsRuntime, T> {
+pub struct DcpsParticipantFactory<R: DdsRuntime> {
     domain_participant_list: Vec<DcpsDomainParticipant<R>>,
     qos: DomainParticipantFactoryQos,
     default_participant_qos: DomainParticipantQos,
     configuration: DustDdsConfiguration,
     runtime: R,
-    transport: T,
-    entity_counter: u32,
-    app_id: [u8; 4],
-    host_id: [u8; 4],
     dcps_sender: DcpsSender,
 }
 
-impl<R: DdsRuntime, T: TransportParticipantFactory> DcpsParticipantFactory<R, T> {
-    pub fn new(
-        app_id: [u8; 4],
-        host_id: [u8; 4],
-        runtime: R,
-        transport: T,
-        dcps_sender: DcpsSender,
-    ) -> Self {
+impl<R: DdsRuntime> DcpsParticipantFactory<R> {
+    pub fn new(runtime: R, dcps_sender: DcpsSender) -> Self {
         Self {
             domain_participant_list: Default::default(),
             qos: Default::default(),
             default_participant_qos: Default::default(),
             configuration: Default::default(),
             runtime,
-            transport,
-            entity_counter: 0,
-            app_id,
-            host_id,
             dcps_sender,
         }
-    }
-
-    fn get_unique_participant_id(&mut self) -> u32 {
-        let id = self.entity_counter;
-        self.entity_counter += 1;
-        id
-    }
-
-    fn create_new_guid_prefix(&mut self) -> GuidPrefix {
-        let instance_id = self.get_unique_participant_id().to_ne_bytes();
-
-        [
-            self.host_id[0],
-            self.host_id[1],
-            self.host_id[2],
-            self.host_id[3], // Host ID
-            self.app_id[0],
-            self.app_id[1],
-            self.app_id[2],
-            self.app_id[3], // App ID
-            instance_id[0],
-            instance_id[1],
-            instance_id[2],
-            instance_id[3], // Instance ID
-        ]
     }
 
     #[allow(clippy::too_many_arguments)]
     pub fn create_participant(
         &mut self,
+        guid_prefix: GuidPrefix,
         domain_id: DomainId,
         qos: QosKind<DomainParticipantQos>,
         dcps_listener: Option<DcpsDomainParticipantListener>,
         status_kind: Vec<StatusKind>,
+        transport_participant: RtpsTransportParticipant,
     ) -> DdsResult<InstanceHandle> {
         let domain_participant_qos = match qos {
             QosKind::Default => self.default_participant_qos.clone(),
             QosKind::Specific(q) => q,
         };
-
-        let guid_prefix = self.create_new_guid_prefix();
-        let participant_handle = InstanceHandle::from(Guid::new(guid_prefix, ENTITYID_PARTICIPANT));
-        let transport = self.transport.create_participant(
-            domain_id,
-            TransportDataReceiver::new(participant_handle, self.dcps_sender),
-        );
 
         let clock_handle = self.runtime.clock();
         let mut timer_handle = self.runtime.timer();
@@ -113,7 +66,7 @@ impl<R: DdsRuntime, T: TransportParticipantFactory> DcpsParticipantFactory<R, T>
             domain_participant_qos,
             listener_sender,
             status_kind,
-            transport,
+            transport_participant,
             self.dcps_sender,
             clock_handle,
             timer_handle.clone(),

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -1,3 +1,5 @@
+use core::ops::DerefMut;
+
 use super::domain_participant::DomainParticipant;
 use crate::{
     configuration::DustDdsConfiguration,
@@ -130,6 +132,13 @@ impl DomainParticipantFactory {
     /// Get the current configuration of the [`DomainParticipantFactory`] singleton
     pub fn get_configuration(&self) -> DdsResult<DustDdsConfiguration> {
         block_on(self.participant_factory_async.get_configuration())
+    }
+
+    /// Get a mutable reference to the transport object
+    pub fn get_mut_transport(
+        &self,
+    ) -> impl DerefMut<Target = RtpsUdpTransportParticipantFactory> + '_ {
+        block_on(self.participant_factory_async.get_mut_transport())
     }
 }
 

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -9,6 +9,7 @@ use crate::{
         qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
         status::StatusKind,
     },
+    rtps_udp_transport::udp_transport::RtpsUdpTransportParticipantFactory,
     std_runtime::executor::block_on,
 };
 use tracing::warn;
@@ -17,12 +18,17 @@ use tracing::warn;
 /// [`DomainParticipantFactory`] itself has no factory. It is a pre-existing singleton object that can be accessed by means of the
 /// [`DomainParticipantFactory::get_instance`] operation.
 pub struct DomainParticipantFactory {
-    participant_factory_async: &'static DomainParticipantFactoryAsync,
+    participant_factory_async:
+        &'static DomainParticipantFactoryAsync<RtpsUdpTransportParticipantFactory>,
 }
 
 impl DomainParticipantFactory {
     /// Construct a new ['DomainParticipantFactory'] from an existing ['DomainParticipantFactoryAsync'] static reference
-    pub fn new(participant_factory_async: &'static DomainParticipantFactoryAsync) -> Self {
+    pub fn new(
+        participant_factory_async: &'static DomainParticipantFactoryAsync<
+            RtpsUdpTransportParticipantFactory,
+        >,
+    ) -> Self {
         Self {
             participant_factory_async,
         }
@@ -136,28 +142,6 @@ impl DomainParticipantFactory {
             std::sync::OnceLock::new();
         PARTICIPANT_FACTORY.get_or_init(|| DomainParticipantFactory {
             participant_factory_async: DomainParticipantFactoryAsync::get_instance(),
-        })
-    }
-
-    #[doc(hidden)]
-    pub fn get_custom_instance<
-        R: crate::runtime::DdsRuntime,
-        T: crate::transport::interface::TransportParticipantFactory,
-    >(
-        runtime: R,
-        app_id: [u8; 4],
-        host_id: [u8; 4],
-        transport: T,
-    ) -> &'static Self {
-        static PARTICIPANT_FACTORY_ASYNC: std::sync::OnceLock<DomainParticipantFactoryAsync> =
-            std::sync::OnceLock::new();
-
-        static PARTICIPANT_FACTORY: std::sync::OnceLock<DomainParticipantFactory> =
-            std::sync::OnceLock::new();
-        PARTICIPANT_FACTORY.get_or_init(|| DomainParticipantFactory {
-            participant_factory_async: PARTICIPANT_FACTORY_ASYNC.get_or_init(|| {
-                DomainParticipantFactoryAsync::new(runtime, app_id, host_id, transport)
-            }),
         })
     }
 }

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -1,3 +1,7 @@
+use core::ops::DerefMut;
+
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+
 use super::domain_participant::DomainParticipantAsync;
 use crate::{
     dcps::{
@@ -56,7 +60,7 @@ pub struct DomainParticipantFactoryAsync<T: TransportParticipantFactory> {
     entity_counter: core::sync::atomic::AtomicU32,
     app_id: [u8; 4],
     host_id: [u8; 4],
-    transport: T,
+    transport: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, T>,
 }
 
 impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
@@ -70,7 +74,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
     ) -> DdsResult<DomainParticipantAsync> {
         let guid_prefix = self.create_new_guid_prefix();
         let participant_handle = InstanceHandle::from(Guid::new(guid_prefix, ENTITYID_PARTICIPANT));
-        let transport_participant = self.transport.create_participant(
+        let transport_participant = self.transport.lock().await.create_participant(
             domain_id,
             TransportDataReceiver::new(participant_handle, self.dcps_sender),
         );
@@ -191,6 +195,11 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             .await;
         reply_receiver.await
     }
+
+    /// Get a mutable reference to the transport object
+    pub async fn get_mut_transport(&self) -> impl DerefMut<Target = T> + '_ {
+        self.transport.lock().await
+    }
 }
 
 #[cfg(feature = "std")]
@@ -267,7 +276,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             app_id,
             host_id,
             entity_counter: core::sync::atomic::AtomicU32::new(0),
-            transport,
+            transport: Mutex::new(transport),
         }
     }
 

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -11,11 +11,15 @@ use crate::{
     infrastructure::{
         domain::DomainId,
         error::DdsResult,
+        instance::InstanceHandle,
         qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
         status::StatusKind,
     },
     runtime::{DdsRuntime, Spawner},
-    transport::interface::TransportParticipantFactory,
+    transport::{
+        interface::{TransportDataReceiver, TransportParticipantFactory},
+        types::{ENTITYID_PARTICIPANT, Guid, GuidPrefix},
+    },
 };
 
 const DCPS_CHANNEL_SIZE: usize = 256;
@@ -47,11 +51,15 @@ pub type DcpsReceiver = embassy_sync::channel::Receiver<
 /// Unlike the sync version, the [`DomainParticipantFactoryAsync`] is not a singleton and can be created by means of
 /// a constructor by passing a DDS runtime. This allows the factory
 /// to spin tasks on an existing runtime which can be shared with other things outside Dust DDS.
-pub struct DomainParticipantFactoryAsync {
+pub struct DomainParticipantFactoryAsync<T: TransportParticipantFactory> {
     dcps_sender: DcpsSender,
+    entity_counter: core::sync::atomic::AtomicU32,
+    app_id: [u8; 4],
+    host_id: [u8; 4],
+    transport: T,
 }
 
-impl DomainParticipantFactoryAsync {
+impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
     /// Async version of [`create_participant`](crate::domain::domain_participant_factory::DomainParticipantFactory::create_participant).
     pub async fn create_participant(
         &self,
@@ -60,17 +68,26 @@ impl DomainParticipantFactoryAsync {
         a_listener: Option<impl DomainParticipantListener + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<DomainParticipantAsync> {
+        let guid_prefix = self.create_new_guid_prefix();
+        let participant_handle = InstanceHandle::from(Guid::new(guid_prefix, ENTITYID_PARTICIPANT));
+        let transport_participant = self.transport.create_participant(
+            domain_id,
+            TransportDataReceiver::new(participant_handle, self.dcps_sender),
+        );
+
         let status_kind = mask.to_vec();
         let dcps_listener = a_listener.map(DcpsDomainParticipantListener::new);
         let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
             .send(DcpsMail::ParticipantFactory(
                 ParticipantFactoryMail::CreateParticipant {
+                    guid_prefix,
                     domain_id,
                     qos,
                     dcps_listener,
                     status_kind,
                     reply_sender,
+                    transport_participant,
                 },
             ))
             .await;
@@ -177,17 +194,25 @@ impl DomainParticipantFactoryAsync {
 }
 
 #[cfg(feature = "std")]
-impl DomainParticipantFactoryAsync {
+impl
+    DomainParticipantFactoryAsync<
+        crate::rtps_udp_transport::udp_transport::RtpsUdpTransportParticipantFactory,
+    >
+{
     /// This operation returns the [`DomainParticipantFactoryAsync`] singleton. The operation is idempotent, that is, it can be called multiple
     /// times without side-effects and it will return the same [`DomainParticipantFactoryAsync`] instance.
     #[tracing::instrument]
-    pub fn get_instance() -> &'static DomainParticipantFactoryAsync {
+    pub fn get_instance() -> &'static Self {
         use core::net::IpAddr;
         use network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig};
         use std::sync::OnceLock;
         use tracing::warn;
 
-        static PARTICIPANT_FACTORY_ASYNC: OnceLock<DomainParticipantFactoryAsync> = OnceLock::new();
+        static PARTICIPANT_FACTORY_ASYNC: OnceLock<
+            DomainParticipantFactoryAsync<
+                crate::rtps_udp_transport::udp_transport::RtpsUdpTransportParticipantFactory,
+            >,
+        > = OnceLock::new();
         PARTICIPANT_FACTORY_ASYNC.get_or_init(|| {
 
             let executor = crate::std_runtime::executor::Executor::new();
@@ -219,23 +244,15 @@ impl DomainParticipantFactoryAsync {
     }
 }
 
-impl DomainParticipantFactoryAsync {
+impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
     #[doc(hidden)]
-    pub fn new<R: DdsRuntime, T: TransportParticipantFactory>(
-        runtime: R,
-        app_id: [u8; 4],
-        host_id: [u8; 4],
-        transport: T,
-    ) -> DomainParticipantFactoryAsync {
+    pub fn new<R: DdsRuntime>(runtime: R, app_id: [u8; 4], host_id: [u8; 4], transport: T) -> Self {
         static DCPS_CHANNEL: DcpsChannel = DcpsChannel::new();
         let spawner_handle = runtime.spawner();
 
         let mut domain_participant_factory =
             crate::dcps::dcps_participant_factory::DcpsParticipantFactory::new(
-                app_id,
-                host_id,
                 runtime,
-                transport,
                 DCPS_CHANNEL.sender(),
             );
         let dcps_receiver = DCPS_CHANNEL.receiver();
@@ -245,8 +262,38 @@ impl DomainParticipantFactoryAsync {
                 domain_participant_factory.handle(m);
             }
         });
-        DomainParticipantFactoryAsync {
+        Self {
             dcps_sender: DCPS_CHANNEL.sender(),
+            app_id,
+            host_id,
+            entity_counter: core::sync::atomic::AtomicU32::new(0),
+            transport,
         }
+    }
+
+    fn get_unique_participant_id(&self) -> u32 {
+        let id = self
+            .entity_counter
+            .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        id
+    }
+
+    fn create_new_guid_prefix(&self) -> GuidPrefix {
+        let instance_id = self.get_unique_participant_id().to_ne_bytes();
+
+        [
+            self.host_id[0],
+            self.host_id[1],
+            self.host_id[2],
+            self.host_id[3], // Host ID
+            self.app_id[0],
+            self.app_id[1],
+            self.app_id[2],
+            self.app_id[3], // App ID
+            instance_id[0],
+            instance_id[1],
+            instance_id[2],
+            instance_id[3], // Instance ID
+        ]
     }
 }

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -280,15 +280,11 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         }
     }
 
-    fn get_unique_participant_id(&self) -> u32 {
-        let id = self
-            .entity_counter
-            .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-        id
-    }
-
     fn create_new_guid_prefix(&self) -> GuidPrefix {
-        let instance_id = self.get_unique_participant_id().to_ne_bytes();
+        let instance_id = self
+            .entity_counter
+            .fetch_add(1, core::sync::atomic::Ordering::Relaxed)
+            .to_ne_bytes();
 
         [
             self.host_id[0],

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -20,7 +20,11 @@ use core::cmp::max;
 fn total_fragments_expected(data_frag_submessage: &DataFragSubmessage) -> u32 {
     let data_size = data_frag_submessage.data_size();
     let fragment_size = data_frag_submessage.fragment_size() as u32;
-    let total_fragments_correction = if data_size % fragment_size == 0 { 0 } else { 1 };
+    let total_fragments_correction = if data_size.is_multiple_of(fragment_size) {
+        0
+    } else {
+        1
+    };
     data_size / fragment_size + total_fragments_correction
 }
 

--- a/dds/src/rtps_udp_transport/udp_transport.rs
+++ b/dds/src/rtps_udp_transport/udp_transport.rs
@@ -151,7 +151,7 @@ impl Default for RtpsUdpTransportParticipantFactory {
 
 impl TransportParticipantFactory for RtpsUdpTransportParticipantFactory {
     fn create_participant(
-        &mut self,
+        &self,
         domain_id: i32,
         data_channel_sender: TransportDataReceiver,
     ) -> RtpsTransportParticipant {

--- a/dds/src/rtps_udp_transport/udp_transport.rs
+++ b/dds/src/rtps_udp_transport/udp_transport.rs
@@ -1,4 +1,5 @@
 use crate::{
+    infrastructure::error::{DdsError, DdsResult},
     std_runtime::{self},
     transport::{
         interface::{
@@ -78,74 +79,59 @@ fn get_multicast_socket(
     Ok(socket.into())
 }
 
-pub struct RtpsUdpTransportParticipantFactoryBuilder {
-    interface_name: Option<String>,
-    fragment_size: usize,
-    udp_receive_buffer_size: Option<usize>,
-}
-
-impl Default for RtpsUdpTransportParticipantFactoryBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl RtpsUdpTransportParticipantFactoryBuilder {
-    /// Construct a transport factory builder with all the default options.
-    pub fn new() -> Self {
-        Self {
-            interface_name: None,
-            fragment_size: 1344,
-            udp_receive_buffer_size: None,
-        }
-    }
-
-    /// Set the network interface name to use for discovery
-    pub fn interface_name(mut self, interface_name: Option<String>) -> Self {
-        self.interface_name = interface_name;
-        self
-    }
-
-    /// Set the maximum size for the data fragments. Types with serialized data above this size will be transmitted as fragments.
-    pub fn fragment_size(mut self, fragment_size: usize) -> Self {
-        self.fragment_size = fragment_size;
-        self
-    }
-
-    /// Set the value of the SO_RCVBUF option on the UDP socket. [`None`] corresponds to the OS default
-    pub fn udp_receive_buffer_size(mut self, udp_receive_buffer_size: Option<usize>) -> Self {
-        self.udp_receive_buffer_size = udp_receive_buffer_size;
-        self
-    }
-
-    /// Build a new participant factory
-    pub fn build(self) -> Result<RtpsUdpTransportParticipantFactory, String> {
-        let fragment_size_range = 8..=65000;
-        if !fragment_size_range.contains(&self.fragment_size) {
-            Err(format!(
-                "Interface size out of range. Value must be between in {fragment_size_range:?}",
-            ))
-        } else {
-            Ok(RtpsUdpTransportParticipantFactory {
-                interface_name: self.interface_name,
-                fragment_size: self.fragment_size,
-                udp_receive_buffer_size: self.udp_receive_buffer_size,
-            })
-        }
-    }
-}
-
 pub struct RtpsUdpTransportParticipantFactory {
     interface_name: Option<String>,
     fragment_size: usize,
     udp_receive_buffer_size: Option<usize>,
 }
 
+impl RtpsUdpTransportParticipantFactory {
+    /// Set the name of the specific interface to use or None for communicating
+    /// through all available interfaces
+    pub fn set_interface_name(&mut self, interface_name: Option<String>) {
+        self.interface_name = interface_name;
+    }
+
+    /// Set the value of the SO_RCVBUF option on the UDP socket. [`None`] corresponds to the OS default
+    pub fn set_udp_receive_buffer_size(&mut self, udp_receive_buffer_size: Option<usize>) {
+        self.udp_receive_buffer_size = udp_receive_buffer_size;
+    }
+
+    /// Set the fragment size in a range between 8 to 65000. This value is the maximum size of the payload
+    /// transmitted in a single RTPS data submessage. Sizes larger than this value will be transmitted in
+    /// separate message using RTPS data fragments
+    pub fn set_fragment_size(&mut self, fragment_size: usize) -> DdsResult<()> {
+        let fragment_size_range = 8..=65000;
+        if !fragment_size_range.contains(&self.fragment_size) {
+            return Err(DdsError::BadParameter);
+        }
+        self.fragment_size = fragment_size;
+        Ok(())
+    }
+
+    /// Get the value of the currently configured interface name
+    pub fn interface_name(&self) -> Option<&String> {
+        self.interface_name.as_ref()
+    }
+
+    /// Get the value of the currently configured fragment size
+    pub fn fragment_size(&self) -> usize {
+        self.fragment_size
+    }
+
+    /// Get the value of the currently configured buffer size
+    pub fn udp_receive_buffer_size(&self) -> Option<usize> {
+        self.udp_receive_buffer_size
+    }
+}
+
 impl Default for RtpsUdpTransportParticipantFactory {
     fn default() -> Self {
-        RtpsUdpTransportParticipantFactoryBuilder::new()
-            .build()
-            .expect("Default configuration should work")
+        Self {
+            interface_name: None,
+            fragment_size: 1344,
+            udp_receive_buffer_size: None,
+        }
     }
 }
 

--- a/dds/src/transport/interface.rs
+++ b/dds/src/transport/interface.rs
@@ -43,7 +43,7 @@ pub struct RtpsTransportParticipant {
 }
 pub trait TransportParticipantFactory: Send + 'static {
     fn create_participant(
-        &mut self,
+        &self,
         domain_id: i32,
         data_receiver: TransportDataReceiver,
     ) -> RtpsTransportParticipant;


### PR DESCRIPTION
Create an interface to enable transport configuration without having to go through the very clumsy way with the builder that is currently implemented. This new interface allows getting a mutable reference to the transport from the domain participant factory and then call the available setter methods on it. For the time being this allows configuring the name of the interface to use, the fragment size and the SO_RECVBUF OS option.

In terms of implementation this is achieved by moving the Transport generic T to the DomainParticipantAsync object which is part of the user facing API. This still doesn't propagate to the remaining objects so the change is fairly well contained. An additional advantage of this is that it reduces the number of generics in the internals which might help later in using a different RPC like architecture instead of the actor if we ever get to it.