### PR TITLE
Simplify set Dust DDS configuration options

### DIFF
--- a/dds/examples/configuration.rs
+++ b/dds/examples/configuration.rs
@@ -21,9 +21,7 @@ fn main() {
         .build()
         .unwrap();
 
-    participant_factory
-        .set_configuration(configuration)
-        .unwrap();
+    *participant_factory.get_mut_configuration() = configuration;
 
     let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)

--- a/dds/examples/transport_configuration.rs
+++ b/dds/examples/transport_configuration.rs
@@ -1,9 +1,53 @@
-use dust_dds::domain::domain_participant_factory::DomainParticipantFactory;
+use dust_dds::{
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        listener::NO_LISTENER, qos::QosKind, status::NO_STATUS, type_support::DdsType,
+    },
+};
+
+#[derive(DdsType, Debug)]
+struct HelloWorldType {
+    #[dust_dds(key)]
+    id: u8,
+    msg: String,
+}
 
 fn main() {
     let participant_factory = DomainParticipantFactory::get_instance();
-    let mut transport = participant_factory.get_mut_transport();
-    transport.set_interface_name(Some(String::from("Wi-Fi")));
-    transport.set_fragment_size(500).unwrap();
-    transport.set_udp_receive_buffer_size(Some(10000));
+    participant_factory
+        .get_mut_transport()
+        .set_interface_name(Some(String::from("Wi-Fi")))
+        .set_fragment_size(500)
+        .unwrap()
+        .set_udp_receive_buffer_size(Some(10000));
+
+    let domain_id = 0;
+    let participant = participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<HelloWorldType>(
+            "HelloWorld",
+            "HelloWorldType",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let writer = publisher
+        .create_datawriter(&topic, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let hello_world = HelloWorldType {
+        id: 8,
+        msg: "Hello world!".to_string(),
+    };
+
+    writer.write(hello_world, None).unwrap();
 }

--- a/dds/src/dcps/dcps_mail.rs
+++ b/dds/src/dcps/dcps_mail.rs
@@ -17,7 +17,6 @@ use crate::{
         },
         status_condition::StatusConditionEntity,
     },
-    dds_async::configuration::DustDdsConfiguration,
     infrastructure::{
         domain::DomainId,
         error::DdsResult,
@@ -52,6 +51,7 @@ pub enum DcpsMail {
     Discovery(DiscoveryServiceMail),
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum ParticipantFactoryMail {
     CreateParticipant {
         guid_prefix: GuidPrefix,
@@ -61,6 +61,8 @@ pub enum ParticipantFactoryMail {
         status_kind: Vec<StatusKind>,
         reply_sender: OneshotSender<DdsResult<InstanceHandle>>,
         transport_participant: RtpsTransportParticipant,
+        domain_tag: String,
+        participant_announcement_interval: core::time::Duration,
     },
     DeleteParticipant {
         participant_handle: InstanceHandle,
@@ -79,12 +81,6 @@ pub enum ParticipantFactoryMail {
     },
     GetQos {
         reply_sender: OneshotSender<DomainParticipantFactoryQos>,
-    },
-    SetConfiguration {
-        configuration: DustDdsConfiguration,
-    },
-    GetConfiguration {
-        reply_sender: OneshotSender<DustDdsConfiguration>,
     },
 }
 

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -22,6 +22,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 status_kind,
                 reply_sender,
                 transport_participant,
+                domain_tag,
+                participant_announcement_interval,
             }) => reply_sender.send(self.create_participant(
                 guid_prefix,
                 domain_id,
@@ -29,6 +31,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dcps_listener,
                 status_kind,
                 transport_participant,
+                domain_tag,
+                participant_announcement_interval,
             )),
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::DeleteParticipant {
                 participant_handle,
@@ -47,12 +51,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::GetQos { reply_sender }) => {
                 reply_sender.send(self.get_qos())
             }
-            DcpsMail::ParticipantFactory(ParticipantFactoryMail::SetConfiguration {
-                configuration,
-            }) => self.set_configuration(configuration),
-            DcpsMail::ParticipantFactory(ParticipantFactoryMail::GetConfiguration {
-                reply_sender,
-            }) => reply_sender.send(self.get_configuration()),
             DcpsMail::Participant(ParticipantServiceMail::CreateUserDefinedPublisher {
                 qos,
                 participant_handle,

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -4,7 +4,7 @@ use crate::{
         dcps_mail::{DcpsMail, DiscoveryServiceMail, MessageServiceMail},
         listeners::domain_participant_listener::DcpsDomainParticipantListener,
     },
-    dds_async::{configuration::DustDdsConfiguration, domain_participant_factory::DcpsSender},
+    dds_async::domain_participant_factory::DcpsSender,
     infrastructure::{
         domain::DomainId,
         error::{DdsError, DdsResult},
@@ -15,13 +15,12 @@ use crate::{
     runtime::{DdsRuntime, Spawner, Timer},
     transport::{interface::RtpsTransportParticipant, types::GuidPrefix},
 };
-use alloc::{borrow::ToOwned, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 pub struct DcpsParticipantFactory<R: DdsRuntime> {
     domain_participant_list: Vec<DcpsDomainParticipant<R>>,
     qos: DomainParticipantFactoryQos,
     default_participant_qos: DomainParticipantQos,
-    configuration: DustDdsConfiguration,
     runtime: R,
     dcps_sender: DcpsSender,
 }
@@ -32,7 +31,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             domain_participant_list: Default::default(),
             qos: Default::default(),
             default_participant_qos: Default::default(),
-            configuration: Default::default(),
             runtime,
             dcps_sender,
         }
@@ -47,6 +45,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         dcps_listener: Option<DcpsDomainParticipantListener>,
         status_kind: Vec<StatusKind>,
         transport_participant: RtpsTransportParticipant,
+        domain_tag: String,
+        participant_announcement_interval: core::time::Duration,
     ) -> DdsResult<InstanceHandle> {
         let domain_participant_qos = match qos {
             QosKind::Default => self.default_participant_qos.clone(),
@@ -61,7 +61,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
 
         let mut dcps_participant: DcpsDomainParticipant<R> = DcpsDomainParticipant::new(
             domain_id,
-            self.configuration.domain_tag().to_owned(),
+            domain_tag,
             guid_prefix,
             domain_participant_qos,
             listener_sender,
@@ -79,8 +79,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         // Start the regular participant announcement task
         let dcps_sender_clone = self.dcps_sender;
         let mut timer_handle_clone = timer_handle.clone();
-        let participant_announcement_interval =
-            self.configuration.participant_announcement_interval();
 
         spawner_handle.spawn(async move {
             loop {
@@ -177,13 +175,5 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
 
     pub fn get_qos(&mut self) -> DomainParticipantFactoryQos {
         self.qos.clone()
-    }
-
-    pub fn set_configuration(&mut self, configuration: DustDdsConfiguration) {
-        self.configuration = configuration;
-    }
-
-    pub fn get_configuration(&mut self) -> DustDdsConfiguration {
-        self.configuration.clone()
     }
 }

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -121,24 +121,16 @@ impl DomainParticipantFactory {
 }
 
 impl DomainParticipantFactory {
-    /// Set the configuration of the [`DomainParticipantFactory`] singleton
-    pub fn set_configuration(&self, configuration: DustDdsConfiguration) -> DdsResult<()> {
-        block_on(
-            self.participant_factory_async
-                .set_configuration(configuration),
-        )
-    }
-
-    /// Get the current configuration of the [`DomainParticipantFactory`] singleton
-    pub fn get_configuration(&self) -> DdsResult<DustDdsConfiguration> {
-        block_on(self.participant_factory_async.get_configuration())
-    }
-
     /// Get a mutable reference to the transport object
     pub fn get_mut_transport(
         &self,
     ) -> impl DerefMut<Target = RtpsUdpTransportParticipantFactory> + '_ {
         block_on(self.participant_factory_async.get_mut_transport())
+    }
+
+    /// Get a mutable reference to the configuration object
+    pub fn get_mut_configuration(&self) -> impl DerefMut<Target = DustDdsConfiguration> + '_ {
+        block_on(self.participant_factory_async.get_mut_configuration())
     }
 }
 

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -1,5 +1,5 @@
-use core::ops::DerefMut;
 use alloc::borrow::ToOwned;
+use core::ops::DerefMut;
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
 

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -1,4 +1,5 @@
 use core::ops::DerefMut;
+use alloc::borrow::ToOwned;
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
 

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -61,6 +61,7 @@ pub struct DomainParticipantFactoryAsync<T: TransportParticipantFactory> {
     app_id: [u8; 4],
     host_id: [u8; 4],
     transport: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, T>,
+    configuration: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, DustDdsConfiguration>,
 }
 
 impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
@@ -72,6 +73,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         a_listener: Option<impl DomainParticipantListener + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<DomainParticipantAsync> {
+        let configuration = self.configuration.lock().await;
         let guid_prefix = self.create_new_guid_prefix();
         let participant_handle = InstanceHandle::from(Guid::new(guid_prefix, ENTITYID_PARTICIPANT));
         let transport_participant = self.transport.lock().await.create_participant(
@@ -79,6 +81,8 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             TransportDataReceiver::new(participant_handle, self.dcps_sender),
         );
 
+        let domain_tag = configuration.domain_tag().to_owned();
+        let participant_announcement_interval = configuration.participant_announcement_interval();
         let status_kind = mask.to_vec();
         let dcps_listener = a_listener.map(DcpsDomainParticipantListener::new);
         let (reply_sender, reply_receiver) = oneshot();
@@ -92,6 +96,8 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     status_kind,
                     reply_sender,
                     transport_participant,
+                    domain_tag,
+                    participant_announcement_interval,
                 },
             ))
             .await;
@@ -175,30 +181,14 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         reply_receiver.await
     }
 
-    /// Async version of [`set_configuration`](crate::domain::domain_participant_factory::DomainParticipantFactory::set_configuration).
-    pub async fn set_configuration(&self, configuration: DustDdsConfiguration) -> DdsResult<()> {
-        self.dcps_sender
-            .send(DcpsMail::ParticipantFactory(
-                ParticipantFactoryMail::SetConfiguration { configuration },
-            ))
-            .await;
-        Ok(())
-    }
-
-    /// Async version of [`get_configuration`](crate::domain::domain_participant_factory::DomainParticipantFactory::get_configuration).
-    pub async fn get_configuration(&self) -> DdsResult<DustDdsConfiguration> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender
-            .send(DcpsMail::ParticipantFactory(
-                ParticipantFactoryMail::GetConfiguration { reply_sender },
-            ))
-            .await;
-        reply_receiver.await
-    }
-
     /// Get a mutable reference to the transport object
     pub async fn get_mut_transport(&self) -> impl DerefMut<Target = T> + '_ {
         self.transport.lock().await
+    }
+
+    /// Get a mutable reference to the configuration object
+    pub async fn get_mut_configuration(&self) -> impl DerefMut<Target = DustDdsConfiguration> + '_ {
+        self.configuration.lock().await
     }
 }
 
@@ -248,14 +238,21 @@ impl
 
             let app_id = std::process::id().to_ne_bytes();
             let transport = crate::rtps_udp_transport::udp_transport::RtpsUdpTransportParticipantFactory::default();
-            Self::new(runtime, app_id, host_id, transport)
+            let configuration = Default::default();
+            Self::new(runtime, app_id, host_id, transport, configuration)
         })
     }
 }
 
 impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
     #[doc(hidden)]
-    pub fn new<R: DdsRuntime>(runtime: R, app_id: [u8; 4], host_id: [u8; 4], transport: T) -> Self {
+    pub fn new<R: DdsRuntime>(
+        runtime: R,
+        app_id: [u8; 4],
+        host_id: [u8; 4],
+        transport: T,
+        configuration: DustDdsConfiguration,
+    ) -> Self {
         static DCPS_CHANNEL: DcpsChannel = DcpsChannel::new();
         let spawner_handle = runtime.spawner();
 
@@ -277,6 +274,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             host_id,
             entity_counter: core::sync::atomic::AtomicU32::new(0),
             transport: Mutex::new(transport),
+            configuration: Mutex::new(configuration),
         }
     }
 

--- a/dds/src/rtps_udp_transport/udp_transport.rs
+++ b/dds/src/rtps_udp_transport/udp_transport.rs
@@ -88,25 +88,30 @@ pub struct RtpsUdpTransportParticipantFactory {
 impl RtpsUdpTransportParticipantFactory {
     /// Set the name of the specific interface to use or None for communicating
     /// through all available interfaces
-    pub fn set_interface_name(&mut self, interface_name: Option<String>) {
+    pub fn set_interface_name(&mut self, interface_name: Option<String>) -> &mut Self {
         self.interface_name = interface_name;
+        self
     }
 
     /// Set the value of the SO_RCVBUF option on the UDP socket. [`None`] corresponds to the OS default
-    pub fn set_udp_receive_buffer_size(&mut self, udp_receive_buffer_size: Option<usize>) {
+    pub fn set_udp_receive_buffer_size(
+        &mut self,
+        udp_receive_buffer_size: Option<usize>,
+    ) -> &mut Self {
         self.udp_receive_buffer_size = udp_receive_buffer_size;
+        self
     }
 
     /// Set the fragment size in a range between 8 to 65000. This value is the maximum size of the payload
     /// transmitted in a single RTPS data submessage. Sizes larger than this value will be transmitted in
     /// separate message using RTPS data fragments
-    pub fn set_fragment_size(&mut self, fragment_size: usize) -> DdsResult<()> {
+    pub fn set_fragment_size(&mut self, fragment_size: usize) -> DdsResult<&mut Self> {
         let fragment_size_range = 8..=65000;
         if !fragment_size_range.contains(&self.fragment_size) {
             return Err(DdsError::BadParameter);
         }
         self.fragment_size = fragment_size;
-        Ok(())
+        Ok(self)
     }
 
     /// Get the value of the currently configured interface name


### PR DESCRIPTION
Simplify the set Dust DDS configuration by providing a mutable getter on the API instead of having to send the set configuration message. This also improves the interface for the transport configuration to avoid potentially causing deadlocks