### PR TITLE
Remove runtime generic from internal domain participant implementation

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -169,7 +169,6 @@ pub struct DcpsDomainParticipant<R: DdsRuntime> {
     publisher_counter: u8,
     subscriber_counter: u8,
     domain_participant: DomainParticipantEntity,
-    clock_handle: R::ClockHandle,
     timer_handle: R::TimerHandle,
     spawner_handle: R::SpawnerHandle,
     dcps_sender: DcpsSender,
@@ -189,7 +188,6 @@ where
         status_kind: Vec<StatusKind>,
         transport: RtpsTransportParticipant,
         dcps_sender: DcpsSender,
-        clock_handle: R::ClockHandle,
         timer_handle: R::TimerHandle,
         spawner_handle: R::SpawnerHandle,
     ) -> Self {
@@ -600,7 +598,6 @@ where
             publisher_counter: 0,
             subscriber_counter: 0,
             domain_participant,
-            clock_handle,
             timer_handle,
             spawner_handle,
             dcps_sender,
@@ -726,8 +723,8 @@ where
         &self.domain_participant.builtin_subscriber.status_condition
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn announce_participant(&mut self) {
+    #[tracing::instrument(skip(self, clock))]
+    pub fn announce_participant(&mut self, clock: &impl Clock) {
         if self.domain_participant.enabled {
             let builtin_topic_key = *self.domain_participant.instance_handle.as_ref();
             let guid = Guid::from(builtin_topic_key);
@@ -779,22 +776,23 @@ where
                 )
                 .into(),
             );
-            let timestamp = self.get_current_time();
+            let timestamp = self.get_current_time(clock);
             let (reply_sender, _) = oneshot();
             self.write_w_timestamp(
                 self.domain_participant.builtin_publisher.instance_handle,
                 data_writer_handle,
                 spdp_discovered_participant_data.create_dynamic_sample(),
                 timestamp,
+                clock,
                 reply_sender,
             );
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn announce_deleted_participant(&mut self) {
+    #[tracing::instrument(skip(self, clock))]
+    pub fn announce_deleted_participant(&mut self, clock: &impl Clock) {
         if self.domain_participant.enabled {
-            let timestamp = self.get_current_time();
+            let timestamp = self.get_current_time(clock);
             if let Some(dw) = self
                 .domain_participant
                 .builtin_publisher
@@ -818,18 +816,19 @@ where
                     dynamic_data,
                     timestamp,
                     self.transport.message_writer.as_ref(),
-                    &self.clock_handle,
+                    clock,
                 )
                 .ok();
             }
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     fn announce_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
+        clock: &impl Clock,
     ) {
         let Some(publisher) = self
             .domain_participant
@@ -899,20 +898,21 @@ where
             )
             .into(),
         );
-        let timestamp = self.get_current_time();
+        let timestamp = self.get_current_time(clock);
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
             self.domain_participant.builtin_publisher.instance_handle,
             data_writer_handle,
             discovered_writer_data.create_dynamic_sample(),
             timestamp,
+            clock,
             reply_sender,
         );
     }
 
-    #[tracing::instrument(skip(self, data_writer))]
-    fn announce_deleted_data_writer(&mut self, data_writer: DataWriterEntity) {
-        let timestamp = self.get_current_time();
+    #[tracing::instrument(skip(self, data_writer, clock))]
+    fn announce_deleted_data_writer(&mut self, data_writer: DataWriterEntity, clock: &impl Clock) {
+        let timestamp = self.get_current_time(clock);
         if let Some(dw) = self
             .domain_participant
             .builtin_publisher
@@ -935,17 +935,18 @@ where
                 dynamic_data,
                 timestamp,
                 self.transport.message_writer.as_ref(),
-                &self.clock_handle,
+                clock,
             )
             .ok();
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     fn announce_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
+        clock: &impl Clock,
     ) {
         let Some(subscriber) = self
             .domain_participant
@@ -1027,20 +1028,21 @@ where
             )
             .into(),
         );
-        let timestamp = self.get_current_time();
+        let timestamp = self.get_current_time(clock);
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
             self.domain_participant.builtin_publisher.instance_handle,
             data_writer_handle,
             discovered_reader_data.create_dynamic_sample(),
             timestamp,
+            clock,
             reply_sender,
         );
     }
 
-    #[tracing::instrument(skip(self, data_reader))]
-    fn announce_deleted_data_reader(&mut self, data_reader: DataReaderEntity) {
-        let timestamp = self.get_current_time();
+    #[tracing::instrument(skip(self, data_reader, clock))]
+    fn announce_deleted_data_reader(&mut self, data_reader: DataReaderEntity, clock: &impl Clock) {
+        let timestamp = self.get_current_time(clock);
         if let Some(dw) = self
             .domain_participant
             .builtin_publisher
@@ -1062,14 +1064,14 @@ where
                 dynamic_data,
                 timestamp,
                 self.transport.message_writer.as_ref(),
-                &self.clock_handle,
+                clock,
             )
             .ok();
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    fn announce_topic(&mut self, topic_name: String) {
+    #[tracing::instrument(skip(self, clock))]
+    fn announce_topic(&mut self, topic_name: String, clock: &impl Clock) {
         let Some(TopicDescriptionKind::Topic(topic)) = self
             .domain_participant
             .topic_description_list
@@ -1109,13 +1111,14 @@ where
             )
             .into(),
         );
-        let timestamp = self.get_current_time();
+        let timestamp = self.get_current_time(clock);
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
             self.domain_participant.builtin_publisher.instance_handle,
             data_writer_handle,
             discovered_topic_data.create_dynamic_sample(),
             timestamp,
+            clock,
             reply_sender,
         );
     }
@@ -1987,37 +1990,43 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     fn add_cache_change(
         &mut self,
         cache_change: CacheChange,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
+        clock: &impl Clock,
     ) {
         let reader_guid = Guid::from(<[u8; 16]>::from(data_reader_handle));
         match reader_guid.entity_id() {
             ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER => {
-                self.add_builtin_participants_detector_cache_change(cache_change)
+                self.add_builtin_participants_detector_cache_change(cache_change, clock)
             }
             ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR => {
-                self.add_builtin_publications_detector_cache_change(cache_change)
+                self.add_builtin_publications_detector_cache_change(cache_change, clock)
             }
             ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR => {
-                self.add_builtin_subscriptions_detector_cache_change(cache_change)
+                self.add_builtin_subscriptions_detector_cache_change(cache_change, clock)
             }
             ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR => {
-                self.add_builtin_topics_detector_cache_change(cache_change)
+                self.add_builtin_topics_detector_cache_change(cache_change, clock)
             }
             _ => self.add_user_defined_cache_change(
                 cache_change,
                 subscriber_handle,
                 data_reader_handle,
+                clock,
             ),
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn add_builtin_participants_detector_cache_change(&mut self, cache_change: CacheChange) {
+    #[tracing::instrument(skip(self, clock))]
+    pub fn add_builtin_participants_detector_cache_change(
+        &mut self,
+        cache_change: CacheChange,
+        clock: &impl Clock,
+    ) {
         let spdp_type_support =
             if let Some(TopicDescriptionKind::Topic(discovered_participant_data_type)) = self
                 .domain_participant
@@ -2038,7 +2047,7 @@ where
                     let discovered_participant_data =
                         SpdpDiscoveredParticipantData::create_sample(dynamic_data);
 
-                    self.add_discovered_participant(discovered_participant_data);
+                    self.add_discovered_participant(discovered_participant_data, clock);
                 }
             }
             ChangeKind::NotAliveDisposed | ChangeKind::NotAliveDisposedUnregistered => {
@@ -2058,7 +2067,7 @@ where
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (), // Do nothing,
         }
 
-        let reception_timestamp = self.get_current_time();
+        let reception_timestamp = self.get_current_time(clock);
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2072,8 +2081,12 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn add_builtin_publications_detector_cache_change(&mut self, cache_change: CacheChange) {
+    #[tracing::instrument(skip(self, clock))]
+    pub fn add_builtin_publications_detector_cache_change(
+        &mut self,
+        cache_change: CacheChange,
+        clock: &impl Clock,
+    ) {
         let sedp_writer_type_support =
             if let Some(TopicDescriptionKind::Topic(discovered_participant_data_type)) = self
                 .domain_participant
@@ -2172,7 +2185,7 @@ where
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (),
         }
 
-        let reception_timestamp = self.get_current_time();
+        let reception_timestamp = self.get_current_time(clock);
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2186,8 +2199,12 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn add_builtin_subscriptions_detector_cache_change(&mut self, cache_change: CacheChange) {
+    #[tracing::instrument(skip(self, clock))]
+    pub fn add_builtin_subscriptions_detector_cache_change(
+        &mut self,
+        cache_change: CacheChange,
+        clock: &impl Clock,
+    ) {
         let sedp_reader_type_support =
             if let Some(TopicDescriptionKind::Topic(discovered_participant_data_type)) = self
                 .domain_participant
@@ -2317,7 +2334,7 @@ where
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (),
         }
 
-        let reception_timestamp = self.get_current_time();
+        let reception_timestamp = self.get_current_time(clock);
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2331,8 +2348,12 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn add_builtin_topics_detector_cache_change(&mut self, cache_change: CacheChange) {
+    #[tracing::instrument(skip(self, clock))]
+    pub fn add_builtin_topics_detector_cache_change(
+        &mut self,
+        cache_change: CacheChange,
+        clock: &impl Clock,
+    ) {
         let sedp_topic_type_support =
             if let Some(TopicDescriptionKind::Topic(discovered_participant_data_type)) = self
                 .domain_participant
@@ -2380,7 +2401,7 @@ where
             | ChangeKind::NotAliveDisposedUnregistered => (),
         }
 
-        let reception_timestamp = self.get_current_time();
+        let reception_timestamp = self.get_current_time(clock);
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2394,14 +2415,15 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn add_user_defined_cache_change(
         &mut self,
         cache_change: CacheChange,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
+        clock: &impl Clock,
     ) {
-        let reception_timestamp = self.get_current_time();
+        let reception_timestamp = self.get_current_time(clock);
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
@@ -2808,14 +2830,15 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn offered_deadline_missed(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         change_instance_handle: InstanceHandle,
+        clock: &impl Clock,
     ) {
-        let current_time = self.get_current_time();
+        let current_time = self.get_current_time(clock);
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
@@ -2963,14 +2986,15 @@ where
             .add_communication_state(StatusKind::OfferedDeadlineMissed);
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn requested_deadline_missed(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         change_instance_handle: InstanceHandle,
+        clock: &impl Clock,
     ) {
-        let current_time = self.get_current_time();
+        let current_time = self.get_current_time(clock);
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
@@ -3109,10 +3133,11 @@ where
             .add_communication_state(StatusKind::RequestedDeadlineMissed);
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     fn add_discovered_participant(
         &mut self,
         discovered_participant_data: SpdpDiscoveredParticipantData,
+        clock: &impl Clock,
     ) {
         // Check that the domainId of the discovered participant equals the local one.
         // If it is not equal then there the local endpoints are not configured to
@@ -3155,7 +3180,7 @@ where
             self.add_matched_topics_detector(&discovered_participant_data);
             self.add_matched_topics_announcer(&discovered_participant_data);
 
-            self.announce_participant();
+            self.announce_participant(clock);
 
             self.domain_participant
                 .add_discovered_participant(discovered_participant_data);
@@ -3624,18 +3649,22 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, data_message))]
-    pub fn handle_data(&mut self, data_message: Arc<[u8]>) {
+    #[tracing::instrument(skip(self, data_message, clock))]
+    pub fn handle_data(&mut self, data_message: Arc<[u8]>, clock: &impl Clock) {
         if let Ok(rtps_message) = RtpsMessageRead::try_from(data_message.as_ref()) {
             let mut message_receiver = MessageReceiver::new(&rtps_message);
 
             while let Some(submessage) = message_receiver.next() {
                 match submessage {
                     RtpsSubmessageReadKind::Data(data_submessage) => {
-                        self.handle_data_submessage(&message_receiver, data_submessage);
+                        self.handle_data_submessage(&message_receiver, data_submessage, clock);
                     }
                     RtpsSubmessageReadKind::DataFrag(data_frag_submessage) => {
-                        self.handle_data_frag_submessage(&message_receiver, data_frag_submessage);
+                        self.handle_data_frag_submessage(
+                            &message_receiver,
+                            data_frag_submessage,
+                            clock,
+                        );
                     }
                     RtpsSubmessageReadKind::Gap(gap_submessage) => {
                         self.handle_gap_submessage(&message_receiver, gap_submessage);
@@ -3693,7 +3722,7 @@ where
                                             ack_nack_submessage,
                                             message_receiver.source_guid_prefix(),
                                             self.transport.message_writer.as_ref(),
-                                            &self.clock_handle,
+                                            clock,
                                         )
                                         .is_some()
                                         {
@@ -3751,6 +3780,7 @@ where
         &mut self,
         message_receiver: &MessageReceiver<'_>,
         data_submessage: &DataSubmessage,
+        clock: &impl Clock,
     ) {
         for subscriber in self
             .domain_participant
@@ -3790,6 +3820,7 @@ where
                                                 change,
                                                 subscriber_handle,
                                                 reader_handle,
+                                                clock,
                                             );
                                         }
                                     }
@@ -3810,6 +3841,7 @@ where
                                                 change,
                                                 subscriber_handle,
                                                 reader_handle,
+                                                clock,
                                             );
                                         }
                                     }
@@ -3834,6 +3866,7 @@ where
                                     change,
                                     subscriber_handle,
                                     reader_handle,
+                                    clock,
                                 );
                             }
                         }
@@ -3935,6 +3968,7 @@ where
         &mut self,
         message_receiver: &MessageReceiver<'_>,
         data_frag_submessage: &DataFragSubmessage,
+        clock: &impl Clock,
     ) {
         for subscriber in self
             .domain_participant
@@ -3974,8 +4008,11 @@ where
                             {
                                 writer_proxy.delete_data_fragments(data_submessage.writer_sn());
 
-                                return self
-                                    .handle_data_submessage(message_receiver, &data_submessage);
+                                return self.handle_data_submessage(
+                                    message_receiver,
+                                    &data_submessage,
+                                    clock,
+                                );
                             }
                         };
                     }
@@ -3985,7 +4022,7 @@ where
         }
     }
 
-    pub fn poke(&mut self) {
+    pub fn poke(&mut self, clock: &impl Clock) {
         for publisher in self
             .domain_participant
             .user_defined_publisher_list
@@ -3996,8 +4033,9 @@ where
         {
             for dw in &mut publisher.data_writer_list {
                 match &mut dw.transport_writer {
-                    RtpsWriterKind::Stateful(writer) => writer
-                        .write_message(self.transport.message_writer.as_ref(), &self.clock_handle),
+                    RtpsWriterKind::Stateful(writer) => {
+                        writer.write_message(self.transport.message_writer.as_ref(), clock)
+                    }
                     RtpsWriterKind::Stateless(_writer) => {}
                 }
             }

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -161,7 +161,7 @@ fn poll_timeout<T>(
     })
 }
 
-pub struct DcpsDomainParticipant<R: DdsRuntime> {
+pub struct DcpsDomainParticipant {
     transport: RtpsTransportParticipant,
     topic_counter: u16,
     reader_counter: u16,
@@ -169,14 +169,10 @@ pub struct DcpsDomainParticipant<R: DdsRuntime> {
     publisher_counter: u8,
     subscriber_counter: u8,
     domain_participant: DomainParticipantEntity,
-    spawner_handle: R::SpawnerHandle,
     dcps_sender: DcpsSender,
 }
 
-impl<R> DcpsDomainParticipant<R>
-where
-    R: DdsRuntime,
-{
+impl DcpsDomainParticipant {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         domain_id: DomainId,
@@ -187,7 +183,6 @@ where
         status_kind: Vec<StatusKind>,
         transport: RtpsTransportParticipant,
         dcps_sender: DcpsSender,
-        spawner_handle: R::SpawnerHandle,
     ) -> Self {
         let guid = Guid::new(guid_prefix, ENTITYID_PARTICIPANT);
 
@@ -596,7 +591,6 @@ where
             publisher_counter: 0,
             subscriber_counter: 0,
             domain_participant,
-            spawner_handle,
             dcps_sender,
         }
     }
@@ -720,8 +714,8 @@ where
         &self.domain_participant.builtin_subscriber.status_condition
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
-    pub fn announce_participant(&mut self, clock: &impl Clock, timer: impl Timer) {
+    #[tracing::instrument(skip(self, runtime))]
+    pub fn announce_participant(&mut self, runtime: &impl DdsRuntime) {
         if self.domain_participant.enabled {
             let builtin_topic_key = *self.domain_participant.instance_handle.as_ref();
             let guid = Guid::from(builtin_topic_key);
@@ -773,24 +767,23 @@ where
                 )
                 .into(),
             );
-            let timestamp = self.get_current_time(clock);
+            let timestamp = self.get_current_time(runtime);
             let (reply_sender, _) = oneshot();
             self.write_w_timestamp(
                 self.domain_participant.builtin_publisher.instance_handle,
                 data_writer_handle,
                 spdp_discovered_participant_data.create_dynamic_sample(),
                 timestamp,
-                clock,
-                timer,
+                runtime,
                 reply_sender,
             );
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
-    pub fn announce_deleted_participant(&mut self, clock: &impl Clock) {
+    #[tracing::instrument(skip(self, runtime))]
+    pub fn announce_deleted_participant(&mut self, runtime: &impl DdsRuntime) {
         if self.domain_participant.enabled {
-            let timestamp = self.get_current_time(clock);
+            let timestamp = self.get_current_time(runtime);
             if let Some(dw) = self
                 .domain_participant
                 .builtin_publisher
@@ -814,20 +807,19 @@ where
                     dynamic_data,
                     timestamp,
                     self.transport.message_writer.as_ref(),
-                    clock,
+                    runtime,
                 )
                 .ok();
             }
         }
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     fn announce_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) {
         let Some(publisher) = self
             .domain_participant
@@ -897,22 +889,25 @@ where
             )
             .into(),
         );
-        let timestamp = self.get_current_time(clock);
+        let timestamp = self.get_current_time(runtime);
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
             self.domain_participant.builtin_publisher.instance_handle,
             data_writer_handle,
             discovered_writer_data.create_dynamic_sample(),
             timestamp,
-            clock,
-            timer,
+            runtime,
             reply_sender,
         );
     }
 
-    #[tracing::instrument(skip(self, data_writer, clock))]
-    fn announce_deleted_data_writer(&mut self, data_writer: DataWriterEntity, clock: &impl Clock) {
-        let timestamp = self.get_current_time(clock);
+    #[tracing::instrument(skip(self, data_writer, runtime))]
+    fn announce_deleted_data_writer(
+        &mut self,
+        data_writer: DataWriterEntity,
+        runtime: &impl DdsRuntime,
+    ) {
+        let timestamp = self.get_current_time(runtime);
         if let Some(dw) = self
             .domain_participant
             .builtin_publisher
@@ -935,19 +930,18 @@ where
                 dynamic_data,
                 timestamp,
                 self.transport.message_writer.as_ref(),
-                clock,
+                runtime,
             )
             .ok();
         }
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     fn announce_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) {
         let Some(subscriber) = self
             .domain_participant
@@ -1029,22 +1023,25 @@ where
             )
             .into(),
         );
-        let timestamp = self.get_current_time(clock);
+        let timestamp = self.get_current_time(runtime);
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
             self.domain_participant.builtin_publisher.instance_handle,
             data_writer_handle,
             discovered_reader_data.create_dynamic_sample(),
             timestamp,
-            clock,
-            timer,
+            runtime,
             reply_sender,
         );
     }
 
-    #[tracing::instrument(skip(self, data_reader, clock))]
-    fn announce_deleted_data_reader(&mut self, data_reader: DataReaderEntity, clock: &impl Clock) {
-        let timestamp = self.get_current_time(clock);
+    #[tracing::instrument(skip(self, data_reader, runtime))]
+    fn announce_deleted_data_reader(
+        &mut self,
+        data_reader: DataReaderEntity,
+        runtime: &impl DdsRuntime,
+    ) {
+        let timestamp = self.get_current_time(runtime);
         if let Some(dw) = self
             .domain_participant
             .builtin_publisher
@@ -1066,14 +1063,14 @@ where
                 dynamic_data,
                 timestamp,
                 self.transport.message_writer.as_ref(),
-                clock,
+                runtime,
             )
             .ok();
         }
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
-    fn announce_topic(&mut self, topic_name: String, clock: &impl Clock, timer: impl Timer) {
+    #[tracing::instrument(skip(self, runtime))]
+    fn announce_topic(&mut self, topic_name: String, runtime: &impl DdsRuntime) {
         let Some(TopicDescriptionKind::Topic(topic)) = self
             .domain_participant
             .topic_description_list
@@ -1113,15 +1110,14 @@ where
             )
             .into(),
         );
-        let timestamp = self.get_current_time(clock);
+        let timestamp = self.get_current_time(runtime);
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
             self.domain_participant.builtin_publisher.instance_handle,
             data_writer_handle,
             discovered_topic_data.create_dynamic_sample(),
             timestamp,
-            clock,
-            timer,
+            runtime,
             reply_sender,
         );
     }
@@ -1993,45 +1989,42 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     fn add_cache_change(
         &mut self,
         cache_change: CacheChange,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) {
         let reader_guid = Guid::from(<[u8; 16]>::from(data_reader_handle));
         match reader_guid.entity_id() {
             ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER => {
-                self.add_builtin_participants_detector_cache_change(cache_change, clock, timer)
+                self.add_builtin_participants_detector_cache_change(cache_change, runtime)
             }
             ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR => {
-                self.add_builtin_publications_detector_cache_change(cache_change, clock)
+                self.add_builtin_publications_detector_cache_change(cache_change, runtime)
             }
             ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR => {
-                self.add_builtin_subscriptions_detector_cache_change(cache_change, clock)
+                self.add_builtin_subscriptions_detector_cache_change(cache_change, runtime)
             }
             ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR => {
-                self.add_builtin_topics_detector_cache_change(cache_change, clock)
+                self.add_builtin_topics_detector_cache_change(cache_change, runtime)
             }
             _ => self.add_user_defined_cache_change(
                 cache_change,
                 subscriber_handle,
                 data_reader_handle,
-                clock,
-                timer,
+                runtime,
             ),
         }
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_participants_detector_cache_change(
         &mut self,
         cache_change: CacheChange,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) {
         let spdp_type_support =
             if let Some(TopicDescriptionKind::Topic(discovered_participant_data_type)) = self
@@ -2053,7 +2046,7 @@ where
                     let discovered_participant_data =
                         SpdpDiscoveredParticipantData::create_sample(dynamic_data);
 
-                    self.add_discovered_participant(discovered_participant_data, clock, timer);
+                    self.add_discovered_participant(discovered_participant_data, runtime);
                 }
             }
             ChangeKind::NotAliveDisposed | ChangeKind::NotAliveDisposedUnregistered => {
@@ -2073,7 +2066,7 @@ where
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (), // Do nothing,
         }
 
-        let reception_timestamp = self.get_current_time(clock);
+        let reception_timestamp = self.get_current_time(runtime);
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2087,11 +2080,11 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_publications_detector_cache_change(
         &mut self,
         cache_change: CacheChange,
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) {
         let sedp_writer_type_support =
             if let Some(TopicDescriptionKind::Topic(discovered_participant_data_type)) = self
@@ -2191,7 +2184,7 @@ where
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (),
         }
 
-        let reception_timestamp = self.get_current_time(clock);
+        let reception_timestamp = self.get_current_time(runtime);
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2205,11 +2198,11 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_subscriptions_detector_cache_change(
         &mut self,
         cache_change: CacheChange,
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) {
         let sedp_reader_type_support =
             if let Some(TopicDescriptionKind::Topic(discovered_participant_data_type)) = self
@@ -2340,7 +2333,7 @@ where
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (),
         }
 
-        let reception_timestamp = self.get_current_time(clock);
+        let reception_timestamp = self.get_current_time(runtime);
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2354,11 +2347,11 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_topics_detector_cache_change(
         &mut self,
         cache_change: CacheChange,
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) {
         let sedp_topic_type_support =
             if let Some(TopicDescriptionKind::Topic(discovered_participant_data_type)) = self
@@ -2407,7 +2400,7 @@ where
             | ChangeKind::NotAliveDisposedUnregistered => (),
         }
 
-        let reception_timestamp = self.get_current_time(clock);
+        let reception_timestamp = self.get_current_time(runtime);
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2421,16 +2414,15 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn add_user_defined_cache_change(
         &mut self,
         cache_change: CacheChange,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
-        clock: &impl Clock,
-        mut timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) {
-        let reception_timestamp = self.get_current_time(clock);
+        let reception_timestamp = self.get_current_time(runtime);
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
@@ -2587,9 +2579,10 @@ where
                     {
                         let dcps_sender = self.dcps_sender;
 
-                        self.spawner_handle.spawn(async move {
+                        let mut timer_handle = runtime.timer();
+                        runtime.spawner().spawn(async move {
                             loop {
-                                timer.delay(deadline_missed_period.into()).await;
+                                timer_handle.delay(deadline_missed_period.into()).await;
                                 dcps_sender
                                     .send(DcpsMail::Event(
                                         EventServiceMail::RequestedDeadlineMissed {
@@ -2836,15 +2829,15 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn offered_deadline_missed(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         change_instance_handle: InstanceHandle,
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) {
-        let current_time = self.get_current_time(clock);
+        let current_time = self.get_current_time(runtime);
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
@@ -2992,15 +2985,15 @@ where
             .add_communication_state(StatusKind::OfferedDeadlineMissed);
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn requested_deadline_missed(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         change_instance_handle: InstanceHandle,
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) {
-        let current_time = self.get_current_time(clock);
+        let current_time = self.get_current_time(runtime);
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
@@ -3139,12 +3132,11 @@ where
             .add_communication_state(StatusKind::RequestedDeadlineMissed);
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     fn add_discovered_participant(
         &mut self,
         discovered_participant_data: SpdpDiscoveredParticipantData,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) {
         // Check that the domainId of the discovered participant equals the local one.
         // If it is not equal then there the local endpoints are not configured to
@@ -3187,7 +3179,7 @@ where
             self.add_matched_topics_detector(&discovered_participant_data);
             self.add_matched_topics_announcer(&discovered_participant_data);
 
-            self.announce_participant(clock, timer);
+            self.announce_participant(runtime);
 
             self.domain_participant
                 .add_discovered_participant(discovered_participant_data);
@@ -3656,27 +3648,21 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, data_message, clock, timer))]
-    pub fn handle_data(&mut self, data_message: Arc<[u8]>, clock: &impl Clock, timer: impl Timer) {
+    #[tracing::instrument(skip(self, data_message, runtime))]
+    pub fn handle_data(&mut self, data_message: Arc<[u8]>, runtime: &impl DdsRuntime) {
         if let Ok(rtps_message) = RtpsMessageRead::try_from(data_message.as_ref()) {
             let mut message_receiver = MessageReceiver::new(&rtps_message);
 
             while let Some(submessage) = message_receiver.next() {
                 match submessage {
                     RtpsSubmessageReadKind::Data(data_submessage) => {
-                        self.handle_data_submessage(
-                            &message_receiver,
-                            data_submessage,
-                            clock,
-                            timer.clone(),
-                        );
+                        self.handle_data_submessage(&message_receiver, data_submessage, runtime);
                     }
                     RtpsSubmessageReadKind::DataFrag(data_frag_submessage) => {
                         self.handle_data_frag_submessage(
                             &message_receiver,
                             data_frag_submessage,
-                            clock,
-                            timer.clone(),
+                            runtime,
                         );
                     }
                     RtpsSubmessageReadKind::Gap(gap_submessage) => {
@@ -3735,7 +3721,7 @@ where
                                             ack_nack_submessage,
                                             message_receiver.source_guid_prefix(),
                                             self.transport.message_writer.as_ref(),
-                                            clock,
+                                            &runtime.clock(),
                                         )
                                         .is_some()
                                         {
@@ -3793,8 +3779,7 @@ where
         &mut self,
         message_receiver: &MessageReceiver<'_>,
         data_submessage: &DataSubmessage,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) {
         for subscriber in self
             .domain_participant
@@ -3834,8 +3819,7 @@ where
                                                 change,
                                                 subscriber_handle,
                                                 reader_handle,
-                                                clock,
-                                                timer,
+                                                runtime,
                                             );
                                         }
                                     }
@@ -3856,8 +3840,7 @@ where
                                                 change,
                                                 subscriber_handle,
                                                 reader_handle,
-                                                clock,
-                                                timer,
+                                                runtime,
                                             );
                                         }
                                     }
@@ -3882,8 +3865,7 @@ where
                                     change,
                                     subscriber_handle,
                                     reader_handle,
-                                    clock,
-                                    timer,
+                                    runtime,
                                 );
                             }
                         }
@@ -3985,8 +3967,7 @@ where
         &mut self,
         message_receiver: &MessageReceiver<'_>,
         data_frag_submessage: &DataFragSubmessage,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) {
         for subscriber in self
             .domain_participant
@@ -4029,8 +4010,7 @@ where
                                 return self.handle_data_submessage(
                                     message_receiver,
                                     &data_submessage,
-                                    clock,
-                                    timer,
+                                    runtime,
                                 );
                             }
                         };
@@ -4631,10 +4611,12 @@ impl RtpsWriterKind {
         &mut self,
         cache_change: CacheChange,
         message_writer: &(impl WriteMessage + ?Sized),
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) {
         match self {
-            RtpsWriterKind::Stateful(w) => w.add_change(cache_change, message_writer, clock),
+            RtpsWriterKind::Stateful(w) => {
+                w.add_change(cache_change, message_writer, &runtime.clock())
+            }
             RtpsWriterKind::Stateless(w) => w.add_change(cache_change, message_writer),
         }
     }
@@ -4729,7 +4711,7 @@ impl DataWriterEntity {
         mut dynamic_data: DynamicData,
         timestamp: Time,
         message_writer: &(impl WriteMessage + ?Sized),
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         if !self.enabled {
             return Err(DdsError::NotEnabled);
@@ -4781,7 +4763,7 @@ impl DataWriterEntity {
             data_value: serialized_key.into(),
         };
         self.transport_writer
-            .add_change(cache_change, message_writer, clock);
+            .add_change(cache_change, message_writer, runtime);
 
         Ok(())
     }
@@ -4791,7 +4773,7 @@ impl DataWriterEntity {
         mut dynamic_data: DynamicData,
         timestamp: Time,
         message_writer: &(impl WriteMessage + ?Sized),
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         if !self.enabled {
             return Err(DdsError::NotEnabled);
@@ -4852,7 +4834,7 @@ impl DataWriterEntity {
             data_value: serialized_key.into(),
         };
         self.transport_writer
-            .add_change(cache_change, message_writer, clock);
+            .add_change(cache_change, message_writer, runtime);
         Ok(())
     }
 

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -169,7 +169,6 @@ pub struct DcpsDomainParticipant<R: DdsRuntime> {
     publisher_counter: u8,
     subscriber_counter: u8,
     domain_participant: DomainParticipantEntity,
-    timer_handle: R::TimerHandle,
     spawner_handle: R::SpawnerHandle,
     dcps_sender: DcpsSender,
 }
@@ -188,7 +187,6 @@ where
         status_kind: Vec<StatusKind>,
         transport: RtpsTransportParticipant,
         dcps_sender: DcpsSender,
-        timer_handle: R::TimerHandle,
         spawner_handle: R::SpawnerHandle,
     ) -> Self {
         let guid = Guid::new(guid_prefix, ENTITYID_PARTICIPANT);
@@ -598,7 +596,6 @@ where
             publisher_counter: 0,
             subscriber_counter: 0,
             domain_participant,
-            timer_handle,
             spawner_handle,
             dcps_sender,
         }
@@ -723,8 +720,8 @@ where
         &self.domain_participant.builtin_subscriber.status_condition
     }
 
-    #[tracing::instrument(skip(self, clock))]
-    pub fn announce_participant(&mut self, clock: &impl Clock) {
+    #[tracing::instrument(skip(self, clock, timer))]
+    pub fn announce_participant(&mut self, clock: &impl Clock, timer: impl Timer) {
         if self.domain_participant.enabled {
             let builtin_topic_key = *self.domain_participant.instance_handle.as_ref();
             let guid = Guid::from(builtin_topic_key);
@@ -784,6 +781,7 @@ where
                 spdp_discovered_participant_data.create_dynamic_sample(),
                 timestamp,
                 clock,
+                timer,
                 reply_sender,
             );
         }
@@ -823,12 +821,13 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     fn announce_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         clock: &impl Clock,
+        timer: impl Timer,
     ) {
         let Some(publisher) = self
             .domain_participant
@@ -906,6 +905,7 @@ where
             discovered_writer_data.create_dynamic_sample(),
             timestamp,
             clock,
+            timer,
             reply_sender,
         );
     }
@@ -941,12 +941,13 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     fn announce_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         clock: &impl Clock,
+        timer: impl Timer,
     ) {
         let Some(subscriber) = self
             .domain_participant
@@ -1036,6 +1037,7 @@ where
             discovered_reader_data.create_dynamic_sample(),
             timestamp,
             clock,
+            timer,
             reply_sender,
         );
     }
@@ -1070,8 +1072,8 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
-    fn announce_topic(&mut self, topic_name: String, clock: &impl Clock) {
+    #[tracing::instrument(skip(self, clock, timer))]
+    fn announce_topic(&mut self, topic_name: String, clock: &impl Clock, timer: impl Timer) {
         let Some(TopicDescriptionKind::Topic(topic)) = self
             .domain_participant
             .topic_description_list
@@ -1119,6 +1121,7 @@ where
             discovered_topic_data.create_dynamic_sample(),
             timestamp,
             clock,
+            timer,
             reply_sender,
         );
     }
@@ -1990,18 +1993,19 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     fn add_cache_change(
         &mut self,
         cache_change: CacheChange,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         clock: &impl Clock,
+        timer: impl Timer,
     ) {
         let reader_guid = Guid::from(<[u8; 16]>::from(data_reader_handle));
         match reader_guid.entity_id() {
             ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER => {
-                self.add_builtin_participants_detector_cache_change(cache_change, clock)
+                self.add_builtin_participants_detector_cache_change(cache_change, clock, timer)
             }
             ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR => {
                 self.add_builtin_publications_detector_cache_change(cache_change, clock)
@@ -2017,15 +2021,17 @@ where
                 subscriber_handle,
                 data_reader_handle,
                 clock,
+                timer,
             ),
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     pub fn add_builtin_participants_detector_cache_change(
         &mut self,
         cache_change: CacheChange,
         clock: &impl Clock,
+        timer: impl Timer,
     ) {
         let spdp_type_support =
             if let Some(TopicDescriptionKind::Topic(discovered_participant_data_type)) = self
@@ -2047,7 +2053,7 @@ where
                     let discovered_participant_data =
                         SpdpDiscoveredParticipantData::create_sample(dynamic_data);
 
-                    self.add_discovered_participant(discovered_participant_data, clock);
+                    self.add_discovered_participant(discovered_participant_data, clock, timer);
                 }
             }
             ChangeKind::NotAliveDisposed | ChangeKind::NotAliveDisposedUnregistered => {
@@ -2415,13 +2421,14 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     pub fn add_user_defined_cache_change(
         &mut self,
         cache_change: CacheChange,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         clock: &impl Clock,
+        mut timer: impl Timer,
     ) {
         let reception_timestamp = self.get_current_time(clock);
         let Some(subscriber) = self
@@ -2578,12 +2585,11 @@ where
                     if let DurationKind::Finite(deadline_missed_period) =
                         data_reader.qos.deadline.period
                     {
-                        let mut timer_handle = self.timer_handle.clone();
                         let dcps_sender = self.dcps_sender;
 
                         self.spawner_handle.spawn(async move {
                             loop {
-                                timer_handle.delay(deadline_missed_period.into()).await;
+                                timer.delay(deadline_missed_period.into()).await;
                                 dcps_sender
                                     .send(DcpsMail::Event(
                                         EventServiceMail::RequestedDeadlineMissed {
@@ -3133,11 +3139,12 @@ where
             .add_communication_state(StatusKind::RequestedDeadlineMissed);
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     fn add_discovered_participant(
         &mut self,
         discovered_participant_data: SpdpDiscoveredParticipantData,
         clock: &impl Clock,
+        timer: impl Timer,
     ) {
         // Check that the domainId of the discovered participant equals the local one.
         // If it is not equal then there the local endpoints are not configured to
@@ -3180,7 +3187,7 @@ where
             self.add_matched_topics_detector(&discovered_participant_data);
             self.add_matched_topics_announcer(&discovered_participant_data);
 
-            self.announce_participant(clock);
+            self.announce_participant(clock, timer);
 
             self.domain_participant
                 .add_discovered_participant(discovered_participant_data);
@@ -3649,21 +3656,27 @@ where
         }
     }
 
-    #[tracing::instrument(skip(self, data_message, clock))]
-    pub fn handle_data(&mut self, data_message: Arc<[u8]>, clock: &impl Clock) {
+    #[tracing::instrument(skip(self, data_message, clock, timer))]
+    pub fn handle_data(&mut self, data_message: Arc<[u8]>, clock: &impl Clock, timer: impl Timer) {
         if let Ok(rtps_message) = RtpsMessageRead::try_from(data_message.as_ref()) {
             let mut message_receiver = MessageReceiver::new(&rtps_message);
 
             while let Some(submessage) = message_receiver.next() {
                 match submessage {
                     RtpsSubmessageReadKind::Data(data_submessage) => {
-                        self.handle_data_submessage(&message_receiver, data_submessage, clock);
+                        self.handle_data_submessage(
+                            &message_receiver,
+                            data_submessage,
+                            clock,
+                            timer.clone(),
+                        );
                     }
                     RtpsSubmessageReadKind::DataFrag(data_frag_submessage) => {
                         self.handle_data_frag_submessage(
                             &message_receiver,
                             data_frag_submessage,
                             clock,
+                            timer.clone(),
                         );
                     }
                     RtpsSubmessageReadKind::Gap(gap_submessage) => {
@@ -3781,6 +3794,7 @@ where
         message_receiver: &MessageReceiver<'_>,
         data_submessage: &DataSubmessage,
         clock: &impl Clock,
+        timer: impl Timer,
     ) {
         for subscriber in self
             .domain_participant
@@ -3821,6 +3835,7 @@ where
                                                 subscriber_handle,
                                                 reader_handle,
                                                 clock,
+                                                timer,
                                             );
                                         }
                                     }
@@ -3842,6 +3857,7 @@ where
                                                 subscriber_handle,
                                                 reader_handle,
                                                 clock,
+                                                timer,
                                             );
                                         }
                                     }
@@ -3867,6 +3883,7 @@ where
                                     subscriber_handle,
                                     reader_handle,
                                     clock,
+                                    timer,
                                 );
                             }
                         }
@@ -3969,6 +3986,7 @@ where
         message_receiver: &MessageReceiver<'_>,
         data_frag_submessage: &DataFragSubmessage,
         clock: &impl Clock,
+        timer: impl Timer,
     ) {
         for subscriber in self
             .domain_participant
@@ -4012,6 +4030,7 @@ where
                                     message_receiver,
                                     &data_submessage,
                                     clock,
+                                    timer,
                                 );
                             }
                         };

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -219,7 +219,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, dcps_listener, type_support))]
+    #[tracing::instrument(skip(self, dcps_listener, type_support, clock))]
     pub fn create_topic(
         &mut self,
         topic_name: String,
@@ -228,6 +228,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         dcps_listener: Option<DcpsTopicListener>,
         mask: Vec<StatusKind>,
         type_support: &'static dyn DynamicType,
+        clock: &impl Clock,
     ) -> DdsResult<InstanceHandle> {
         if self
             .domain_participant
@@ -289,7 +290,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                 .entity_factory
                 .autoenable_created_entities
         {
-            self.enable_topic(topic_name)?;
+            self.enable_topic(topic_name, clock)?;
         }
 
         Ok(topic_handle)
@@ -551,8 +552,8 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn delete_participant_contained_entities(&mut self) -> DdsResult<()> {
+    #[tracing::instrument(skip(self, clock))]
+    pub fn delete_participant_contained_entities(&mut self, clock: &impl Clock) -> DdsResult<()> {
         let deleted_publisher_list: Vec<PublisherEntity> = self
             .domain_participant
             .user_defined_publisher_list
@@ -560,7 +561,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .collect();
         for mut publisher in deleted_publisher_list {
             for data_writer in publisher.data_writer_list.drain(..) {
-                self.announce_deleted_data_writer(data_writer);
+                self.announce_deleted_data_writer(data_writer, clock);
             }
         }
 
@@ -571,7 +572,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .collect();
         for mut subscriber in deleted_subscriber_list {
             for data_reader in subscriber.data_reader_list.drain(..) {
-                self.announce_deleted_data_reader(data_reader);
+                self.announce_deleted_data_reader(data_reader, clock);
             }
         }
 
@@ -691,15 +692,16 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(handle.clone())
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn get_current_time(&mut self) -> Time {
-        self.clock_handle.now()
+    #[tracing::instrument(skip(self, clock))]
+    pub fn get_current_time(&mut self, clock: &impl Clock) -> Time {
+        clock.now()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn set_domain_participant_qos(
         &mut self,
         qos: QosKind<DomainParticipantQos>,
+        clock: &impl Clock,
     ) -> DdsResult<()> {
         let qos = match qos {
             QosKind::Default => DomainParticipantQos::default(),
@@ -708,7 +710,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
 
         self.domain_participant.qos = qos;
         if self.domain_participant.enabled {
-            self.announce_participant();
+            self.announce_participant(clock);
         }
         Ok(())
     }
@@ -731,8 +733,8 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn enable_domain_participant(&mut self) -> DdsResult<()> {
+    #[tracing::instrument(skip(self, clock))]
+    pub fn enable_domain_participant(&mut self, clock: &impl Clock) -> DdsResult<()> {
         if !self.domain_participant.enabled {
             for t in &mut self.domain_participant.topic_description_list {
                 if let TopicDescriptionKind::Topic(t) = t {
@@ -750,7 +752,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             self.domain_participant.builtin_subscriber.enabled = true;
             self.domain_participant.enabled = true;
 
-            self.announce_participant();
+            self.announce_participant(clock);
         }
 
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -26,7 +26,7 @@ use crate::{
         status::StatusKind,
         time::Time,
     },
-    runtime::{Clock, DdsRuntime},
+    runtime::{Clock, DdsRuntime, Timer},
     transport::types::{USER_DEFINED_READER_GROUP, USER_DEFINED_TOPIC, USER_DEFINED_WRITER_GROUP},
     xtypes::dynamic_type::DynamicType,
 };
@@ -219,7 +219,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, dcps_listener, type_support, clock))]
+    #[tracing::instrument(skip(self, dcps_listener, type_support, clock, timer))]
     pub fn create_topic(
         &mut self,
         topic_name: String,
@@ -229,6 +229,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         mask: Vec<StatusKind>,
         type_support: &'static dyn DynamicType,
         clock: &impl Clock,
+        timer: impl Timer,
     ) -> DdsResult<InstanceHandle> {
         if self
             .domain_participant
@@ -290,7 +291,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                 .entity_factory
                 .autoenable_created_entities
         {
-            self.enable_topic(topic_name, clock)?;
+            self.enable_topic(topic_name, clock, timer)?;
         }
 
         Ok(topic_handle)
@@ -697,11 +698,12 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         clock.now()
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     pub fn set_domain_participant_qos(
         &mut self,
         qos: QosKind<DomainParticipantQos>,
         clock: &impl Clock,
+        timer: impl Timer,
     ) -> DdsResult<()> {
         let qos = match qos {
             QosKind::Default => DomainParticipantQos::default(),
@@ -710,7 +712,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
 
         self.domain_participant.qos = qos;
         if self.domain_participant.enabled {
-            self.announce_participant(clock);
+            self.announce_participant(clock, timer);
         }
         Ok(())
     }
@@ -733,8 +735,12 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, clock))]
-    pub fn enable_domain_participant(&mut self, clock: &impl Clock) -> DdsResult<()> {
+    #[tracing::instrument(skip(self, clock, timer))]
+    pub fn enable_domain_participant(
+        &mut self,
+        clock: &impl Clock,
+        timer: impl Timer,
+    ) -> DdsResult<()> {
         if !self.domain_participant.enabled {
             for t in &mut self.domain_participant.topic_description_list {
                 if let TopicDescriptionKind::Topic(t) = t {
@@ -752,7 +758,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             self.domain_participant.builtin_subscriber.enabled = true;
             self.domain_participant.enabled = true;
 
-            self.announce_participant(clock);
+            self.announce_participant(clock, timer);
         }
 
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -26,18 +26,19 @@ use crate::{
         status::StatusKind,
         time::Time,
     },
-    runtime::{Clock, DdsRuntime, Timer},
+    runtime::{Clock, DdsRuntime},
     transport::types::{USER_DEFINED_READER_GROUP, USER_DEFINED_TOPIC, USER_DEFINED_WRITER_GROUP},
     xtypes::dynamic_type::DynamicType,
 };
 
-impl<R: DdsRuntime> DcpsDomainParticipant<R> {
-    #[tracing::instrument(skip(self, dcps_listener))]
+impl DcpsDomainParticipant {
+    #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn create_user_defined_publisher(
         &mut self,
         qos: QosKind<PublisherQos>,
         dcps_listener: Option<DcpsPublisherListener>,
         mask: Vec<StatusKind>,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<InstanceHandle> {
         let publisher_qos = match qos {
             QosKind::Default => self.domain_participant.default_publisher_qos.clone(),
@@ -64,7 +65,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         ]);
         self.publisher_counter += 1;
         let data_writer_list = Default::default();
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         let mut publisher = PublisherEntity::new(
             publisher_qos,
             publisher_handle,
@@ -122,12 +123,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, dcps_listener))]
+    #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn create_user_defined_subscriber(
         &mut self,
         qos: QosKind<SubscriberQos>,
         dcps_listener: Option<DcpsSubscriberListener>,
         mask: Vec<StatusKind>,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<InstanceHandle> {
         let subscriber_qos = match qos {
             QosKind::Default => self.domain_participant.default_subscriber_qos.clone(),
@@ -156,7 +158,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         let listener_mask = mask.to_vec();
         let data_reader_list = Default::default();
 
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         let mut subscriber = SubscriberEntity::new(
             subscriber_handle,
             subscriber_qos,
@@ -219,7 +221,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, dcps_listener, type_support, clock, timer))]
+    #[tracing::instrument(skip(self, dcps_listener, type_support, runtime))]
     pub fn create_topic(
         &mut self,
         topic_name: String,
@@ -228,8 +230,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         dcps_listener: Option<DcpsTopicListener>,
         mask: Vec<StatusKind>,
         type_support: &'static dyn DynamicType,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<InstanceHandle> {
         if self
             .domain_participant
@@ -268,7 +269,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             USER_DEFINED_TOPIC,
         ]);
         self.topic_counter += 1;
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         let topic = TopicEntity::new(
             qos,
             type_name,
@@ -291,7 +292,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                 .entity_factory
                 .autoenable_created_entities
         {
-            self.enable_topic(topic_name, clock, timer)?;
+            self.enable_topic(topic_name, runtime)?;
         }
 
         Ok(topic_handle)
@@ -553,8 +554,11 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, clock))]
-    pub fn delete_participant_contained_entities(&mut self, clock: &impl Clock) -> DdsResult<()> {
+    #[tracing::instrument(skip(self, runtime))]
+    pub fn delete_participant_contained_entities(
+        &mut self,
+        runtime: &impl DdsRuntime,
+    ) -> DdsResult<()> {
         let deleted_publisher_list: Vec<PublisherEntity> = self
             .domain_participant
             .user_defined_publisher_list
@@ -562,7 +566,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .collect();
         for mut publisher in deleted_publisher_list {
             for data_writer in publisher.data_writer_list.drain(..) {
-                self.announce_deleted_data_writer(data_writer, clock);
+                self.announce_deleted_data_writer(data_writer, runtime);
             }
         }
 
@@ -573,7 +577,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .collect();
         for mut subscriber in deleted_subscriber_list {
             for data_reader in subscriber.data_reader_list.drain(..) {
-                self.announce_deleted_data_reader(data_reader, clock);
+                self.announce_deleted_data_reader(data_reader, runtime);
             }
         }
 
@@ -693,17 +697,16 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(handle.clone())
     }
 
-    #[tracing::instrument(skip(self, clock))]
-    pub fn get_current_time(&mut self, clock: &impl Clock) -> Time {
-        clock.now()
+    #[tracing::instrument(skip(self, runtime))]
+    pub fn get_current_time(&mut self, runtime: &impl DdsRuntime) -> Time {
+        runtime.clock().now()
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn set_domain_participant_qos(
         &mut self,
         qos: QosKind<DomainParticipantQos>,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let qos = match qos {
             QosKind::Default => DomainParticipantQos::default(),
@@ -712,7 +715,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
 
         self.domain_participant.qos = qos;
         if self.domain_participant.enabled {
-            self.announce_participant(clock, timer);
+            self.announce_participant(runtime);
         }
         Ok(())
     }
@@ -722,25 +725,22 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(self.domain_participant.qos.clone())
     }
 
-    #[tracing::instrument(skip(self, dcps_listener))]
+    #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn set_domain_participant_listener(
         &mut self,
         dcps_listener: Option<DcpsDomainParticipantListener>,
         status_kind: Vec<StatusKind>,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         self.domain_participant.listener_sender = listener_sender;
         self.domain_participant.listener_mask = status_kind;
 
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
-    pub fn enable_domain_participant(
-        &mut self,
-        clock: &impl Clock,
-        timer: impl Timer,
-    ) -> DdsResult<()> {
+    #[tracing::instrument(skip(self, runtime))]
+    pub fn enable_domain_participant(&mut self, runtime: &impl DdsRuntime) -> DdsResult<()> {
         if !self.domain_participant.enabled {
             for t in &mut self.domain_participant.topic_description_list {
                 if let TopicDescriptionKind::Topic(t) = t {
@@ -758,7 +758,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             self.domain_participant.builtin_subscriber.enabled = true;
             self.domain_participant.enabled = true;
 
-            self.announce_participant(clock, timer);
+            self.announce_participant(runtime);
         }
 
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
@@ -17,15 +17,15 @@ use crate::{
         status::StatusKind,
     },
     rtps::stateful_writer::RtpsStatefulWriter,
-    runtime::{Clock, DdsRuntime, Timer},
+    runtime::DdsRuntime,
     transport::types::{
         EntityId, Guid, TopicKind, USER_DEFINED_WRITER_NO_KEY, USER_DEFINED_WRITER_WITH_KEY,
     },
 };
 
-impl<R: DdsRuntime> DcpsDomainParticipant<R> {
+impl DcpsDomainParticipant {
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, dcps_listener, clock, timer))]
+    #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn create_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
@@ -33,8 +33,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         qos: QosKind<DataWriterQos>,
         dcps_listener: Option<DcpsDataWriterListener>,
         mask: Vec<StatusKind>,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<InstanceHandle> {
         let Some(TopicDescriptionKind::Topic(topic)) = self
             .domain_participant
@@ -107,7 +106,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             Guid::new(guid.prefix(), entity_id),
             self.transport.fragment_size,
         );
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         let data_writer = DataWriterEntity::new(
             writer_handle,
             RtpsWriterKind::Stateful(transport_writer),
@@ -123,18 +122,18 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         publisher.data_writer_list.push(data_writer);
 
         if publisher.enabled && publisher.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_writer(publisher_handle, writer_handle, clock, timer)?;
+            self.enable_data_writer(publisher_handle, writer_handle, runtime)?;
         }
 
         Ok(data_writer_handle)
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn delete_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
         datawriter_handle: InstanceHandle,
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -151,7 +150,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .position(|x| x.instance_handle == datawriter_handle)
         {
             let data_writer = publisher.data_writer_list.remove(index);
-            self.announce_deleted_data_writer(data_writer, clock);
+            self.announce_deleted_data_writer(data_writer, runtime);
             Ok(())
         } else {
             Err(DdsError::AlreadyDeleted)
@@ -238,12 +237,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(publisher.qos.clone())
     }
 
-    #[tracing::instrument(skip(self, dcps_listener))]
+    #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn set_publisher_listener(
         &mut self,
         publisher_handle: InstanceHandle,
         dcps_listener: Option<DcpsPublisherListener>,
         mask: Vec<StatusKind>,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -253,7 +253,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         else {
             return Err(DdsError::AlreadyDeleted);
         };
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         publisher.listener_sender = listener_sender;
         publisher.listener_mask = mask;
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
@@ -17,7 +17,7 @@ use crate::{
         status::StatusKind,
     },
     rtps::stateful_writer::RtpsStatefulWriter,
-    runtime::DdsRuntime,
+    runtime::{Clock, DdsRuntime},
     transport::types::{
         EntityId, Guid, TopicKind, USER_DEFINED_WRITER_NO_KEY, USER_DEFINED_WRITER_WITH_KEY,
     },
@@ -25,7 +25,7 @@ use crate::{
 
 impl<R: DdsRuntime> DcpsDomainParticipant<R> {
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, dcps_listener))]
+    #[tracing::instrument(skip(self, dcps_listener, clock))]
     pub fn create_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
@@ -33,6 +33,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         qos: QosKind<DataWriterQos>,
         dcps_listener: Option<DcpsDataWriterListener>,
         mask: Vec<StatusKind>,
+        clock: &impl Clock,
     ) -> DdsResult<InstanceHandle> {
         let Some(TopicDescriptionKind::Topic(topic)) = self
             .domain_participant
@@ -121,17 +122,18 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         publisher.data_writer_list.push(data_writer);
 
         if publisher.enabled && publisher.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_writer(publisher_handle, writer_handle)?;
+            self.enable_data_writer(publisher_handle, writer_handle, clock)?;
         }
 
         Ok(data_writer_handle)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn delete_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
         datawriter_handle: InstanceHandle,
+        clock: &impl Clock,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -148,7 +150,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .position(|x| x.instance_handle == datawriter_handle)
         {
             let data_writer = publisher.data_writer_list.remove(index);
-            self.announce_deleted_data_writer(data_writer);
+            self.announce_deleted_data_writer(data_writer, clock);
             Ok(())
         } else {
             Err(DdsError::AlreadyDeleted)

--- a/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
@@ -17,7 +17,7 @@ use crate::{
         status::StatusKind,
     },
     rtps::stateful_writer::RtpsStatefulWriter,
-    runtime::{Clock, DdsRuntime},
+    runtime::{Clock, DdsRuntime, Timer},
     transport::types::{
         EntityId, Guid, TopicKind, USER_DEFINED_WRITER_NO_KEY, USER_DEFINED_WRITER_WITH_KEY,
     },
@@ -25,7 +25,7 @@ use crate::{
 
 impl<R: DdsRuntime> DcpsDomainParticipant<R> {
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, dcps_listener, clock))]
+    #[tracing::instrument(skip(self, dcps_listener, clock, timer))]
     pub fn create_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
@@ -34,6 +34,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         dcps_listener: Option<DcpsDataWriterListener>,
         mask: Vec<StatusKind>,
         clock: &impl Clock,
+        timer: impl Timer,
     ) -> DdsResult<InstanceHandle> {
         let Some(TopicDescriptionKind::Topic(topic)) = self
             .domain_participant
@@ -122,7 +123,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         publisher.data_writer_list.push(data_writer);
 
         if publisher.enabled && publisher.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_writer(publisher_handle, writer_handle, clock)?;
+            self.enable_data_writer(publisher_handle, writer_handle, clock, timer)?;
         }
 
         Ok(data_writer_handle)

--- a/dds/src/dcps/dcps_domain_participant/reader_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/reader_methods.rs
@@ -18,7 +18,7 @@ use crate::{
         status::{StatusKind, SubscriptionMatchedStatus},
         time::Duration,
     },
-    runtime::{Clock, DdsRuntime},
+    runtime::{Clock, DdsRuntime, Timer},
     xtypes::dynamic_type::DynamicData,
 };
 
@@ -207,13 +207,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         max_wait: Duration,
+        timer: impl Timer,
     ) -> Pin<Box<dyn Future<Output = DdsResult<()>> + Send>> {
         let participant_handle = self.domain_participant.instance_handle;
-        let timer_handle = self.timer_handle.clone();
         let dcps_sender = self.dcps_sender;
         Box::pin(async move {
             poll_timeout(
-                timer_handle,
+                timer,
                 max_wait.into(),
                 Box::pin(async move {
                     loop {
@@ -304,13 +304,14 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(data_reader.get_matched_publications())
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     pub fn set_data_reader_qos(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         qos: QosKind<DataReaderQos>,
         clock: &impl Clock,
+        timer: impl Timer,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -340,7 +341,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         data_reader.qos = qos;
 
         if data_reader.enabled {
-            self.announce_data_reader(subscriber_handle, data_reader_handle, clock);
+            self.announce_data_reader(subscriber_handle, data_reader_handle, clock, timer);
         }
         Ok(())
     }
@@ -441,12 +442,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         }
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     pub fn enable_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         clock: &impl Clock,
+        timer: impl Timer,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -476,7 +478,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                 );
             }
 
-            self.announce_data_reader(subscriber_handle, data_reader_handle, clock);
+            self.announce_data_reader(subscriber_handle, data_reader_handle, clock, timer);
         }
         Ok(())
     }

--- a/dds/src/dcps/dcps_domain_participant/reader_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/reader_methods.rs
@@ -18,7 +18,7 @@ use crate::{
         status::{StatusKind, SubscriptionMatchedStatus},
         time::Duration,
     },
-    runtime::DdsRuntime,
+    runtime::{Clock, DdsRuntime},
     xtypes::dynamic_type::DynamicData,
 };
 
@@ -304,12 +304,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(data_reader.get_matched_publications())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn set_data_reader_qos(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         qos: QosKind<DataReaderQos>,
+        clock: &impl Clock,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -339,7 +340,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         data_reader.qos = qos;
 
         if data_reader.enabled {
-            self.announce_data_reader(subscriber_handle, data_reader_handle);
+            self.announce_data_reader(subscriber_handle, data_reader_handle, clock);
         }
         Ok(())
     }
@@ -440,11 +441,12 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn enable_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
+        clock: &impl Clock,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -474,7 +476,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                 );
             }
 
-            self.announce_data_reader(subscriber_handle, data_reader_handle);
+            self.announce_data_reader(subscriber_handle, data_reader_handle, clock);
         }
         Ok(())
     }

--- a/dds/src/dcps/dcps_domain_participant/reader_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/reader_methods.rs
@@ -18,11 +18,11 @@ use crate::{
         status::{StatusKind, SubscriptionMatchedStatus},
         time::Duration,
     },
-    runtime::{Clock, DdsRuntime, Timer},
+    runtime::{DdsRuntime, Timer},
     xtypes::dynamic_type::DynamicData,
 };
 
-impl<R: DdsRuntime> DcpsDomainParticipant<R> {
+impl DcpsDomainParticipant {
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     #[tracing::instrument(skip(self))]
     pub fn read(
@@ -304,14 +304,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(data_reader.get_matched_publications())
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn set_data_reader_qos(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         qos: QosKind<DataReaderQos>,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -341,7 +340,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         data_reader.qos = qos;
 
         if data_reader.enabled {
-            self.announce_data_reader(subscriber_handle, data_reader_handle, clock, timer);
+            self.announce_data_reader(subscriber_handle, data_reader_handle, runtime);
         }
         Ok(())
     }
@@ -371,13 +370,14 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(data_reader.qos.clone())
     }
 
-    #[tracing::instrument(skip(self, dcps_listener))]
+    #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn set_data_reader_listener(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         dcps_listener: Option<DcpsDataReaderListener>,
         listener_mask: Vec<StatusKind>,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -394,7 +394,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         else {
             return Err(DdsError::AlreadyDeleted);
         };
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         data_reader.listener_sender = listener_sender;
         data_reader.listener_mask = listener_mask;
         Ok(())
@@ -442,13 +442,12 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         }
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn enable_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -478,7 +477,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                 );
             }
 
-            self.announce_data_reader(subscriber_handle, data_reader_handle, clock, timer);
+            self.announce_data_reader(subscriber_handle, data_reader_handle, runtime);
         }
         Ok(())
     }

--- a/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
@@ -19,7 +19,7 @@ use crate::{
         status::StatusKind,
     },
     rtps::stateful_reader::RtpsStatefulReader,
-    runtime::DdsRuntime,
+    runtime::{Clock, DdsRuntime},
     transport::types::{
         EntityId, Guid, ReliabilityKind, TopicKind, USER_DEFINED_READER_NO_KEY,
         USER_DEFINED_READER_WITH_KEY,
@@ -28,7 +28,7 @@ use crate::{
 
 impl<R: DdsRuntime> DcpsDomainParticipant<R> {
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, dcps_listener))]
+    #[tracing::instrument(skip(self, dcps_listener, clock))]
     pub fn create_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
@@ -36,6 +36,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         qos: QosKind<DataReaderQos>,
         dcps_listener: Option<DcpsDataReaderListener>,
         mask: Vec<StatusKind>,
+        clock: &impl Clock,
     ) -> DdsResult<InstanceHandle> {
         let Some(topic) = self
             .domain_participant
@@ -143,16 +144,17 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         subscriber.data_reader_list.push(data_reader);
 
         if subscriber.enabled && subscriber.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_reader(subscriber_handle, data_reader_handle)?;
+            self.enable_data_reader(subscriber_handle, data_reader_handle, clock)?;
         }
         Ok(data_reader_handle)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn delete_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
         datareader_handle: InstanceHandle,
+        clock: &impl Clock,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -169,7 +171,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .position(|x| x.instance_handle == datareader_handle)
         {
             let data_reader = subscriber.data_reader_list.remove(index);
-            self.announce_deleted_data_reader(data_reader);
+            self.announce_deleted_data_reader(data_reader, clock);
         } else {
             return Err(DdsError::AlreadyDeleted);
         };

--- a/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
@@ -19,16 +19,16 @@ use crate::{
         status::StatusKind,
     },
     rtps::stateful_reader::RtpsStatefulReader,
-    runtime::{Clock, DdsRuntime, Timer},
+    runtime::DdsRuntime,
     transport::types::{
         EntityId, Guid, ReliabilityKind, TopicKind, USER_DEFINED_READER_NO_KEY,
         USER_DEFINED_READER_WITH_KEY,
     },
 };
 
-impl<R: DdsRuntime> DcpsDomainParticipant<R> {
+impl DcpsDomainParticipant {
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, dcps_listener, clock, timer))]
+    #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn create_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
@@ -36,8 +36,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         qos: QosKind<DataReaderQos>,
         dcps_listener: Option<DcpsDataReaderListener>,
         mask: Vec<StatusKind>,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<InstanceHandle> {
         let Some(topic) = self
             .domain_participant
@@ -129,7 +128,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             RtpsReaderKind::Stateful(RtpsStatefulReader::new(guid, reliablity_kind));
 
         let listener_mask = mask.to_vec();
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         let data_reader = DataReaderEntity::new(
             reader_handle,
             qos,
@@ -145,17 +144,17 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         subscriber.data_reader_list.push(data_reader);
 
         if subscriber.enabled && subscriber.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_reader(subscriber_handle, data_reader_handle, clock, timer)?;
+            self.enable_data_reader(subscriber_handle, data_reader_handle, runtime)?;
         }
         Ok(data_reader_handle)
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn delete_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
         datareader_handle: InstanceHandle,
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -172,7 +171,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .position(|x| x.instance_handle == datareader_handle)
         {
             let data_reader = subscriber.data_reader_list.remove(index);
-            self.announce_deleted_data_reader(data_reader, clock);
+            self.announce_deleted_data_reader(data_reader, runtime);
         } else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -303,12 +302,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(subscriber.qos.clone())
     }
 
-    #[tracing::instrument(skip(self, listener_sender_task))]
+    #[tracing::instrument(skip(self, listener_sender_task, runtime))]
     pub fn set_subscriber_listener(
         &mut self,
         subscriber_handle: InstanceHandle,
         listener_sender_task: Option<DcpsSubscriberListener>,
         mask: Vec<StatusKind>,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -319,7 +319,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             return Err(DdsError::AlreadyDeleted);
         };
 
-        let listener_sender = listener_sender_task.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = listener_sender_task.map(|l| l.spawn(&runtime.spawner()));
         subscriber.listener_sender = listener_sender;
         subscriber.listener_mask = mask;
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
@@ -19,7 +19,7 @@ use crate::{
         status::StatusKind,
     },
     rtps::stateful_reader::RtpsStatefulReader,
-    runtime::{Clock, DdsRuntime},
+    runtime::{Clock, DdsRuntime, Timer},
     transport::types::{
         EntityId, Guid, ReliabilityKind, TopicKind, USER_DEFINED_READER_NO_KEY,
         USER_DEFINED_READER_WITH_KEY,
@@ -28,7 +28,7 @@ use crate::{
 
 impl<R: DdsRuntime> DcpsDomainParticipant<R> {
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, dcps_listener, clock))]
+    #[tracing::instrument(skip(self, dcps_listener, clock, timer))]
     pub fn create_data_reader(
         &mut self,
         subscriber_handle: InstanceHandle,
@@ -37,6 +37,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         dcps_listener: Option<DcpsDataReaderListener>,
         mask: Vec<StatusKind>,
         clock: &impl Clock,
+        timer: impl Timer,
     ) -> DdsResult<InstanceHandle> {
         let Some(topic) = self
             .domain_participant
@@ -144,7 +145,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         subscriber.data_reader_list.push(data_reader);
 
         if subscriber.enabled && subscriber.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_reader(subscriber_handle, data_reader_handle, clock)?;
+            self.enable_data_reader(subscriber_handle, data_reader_handle, clock, timer)?;
         }
         Ok(data_reader_handle)
     }

--- a/dds/src/dcps/dcps_domain_participant/topic_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/topic_methods.rs
@@ -7,7 +7,7 @@ use crate::{
         qos::{QosKind, TopicQos},
         status::{InconsistentTopicStatus, StatusKind},
     },
-    runtime::{Clock, DdsRuntime},
+    runtime::{Clock, DdsRuntime, Timer},
     xtypes::dynamic_type::DynamicType,
 };
 
@@ -85,8 +85,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(topic.qos.clone())
     }
 
-    #[tracing::instrument(skip(self, clock))]
-    pub fn enable_topic(&mut self, topic_name: String, clock: &impl Clock) -> DdsResult<()> {
+    #[tracing::instrument(skip(self, clock, timer))]
+    pub fn enable_topic(
+        &mut self,
+        topic_name: String,
+        clock: &impl Clock,
+        timer: impl Timer,
+    ) -> DdsResult<()> {
         let Some(TopicDescriptionKind::Topic(topic)) = self
             .domain_participant
             .topic_description_list
@@ -98,7 +103,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
 
         if !topic.enabled {
             topic.enabled = true;
-            self.announce_topic(topic_name, clock);
+            self.announce_topic(topic_name, clock, timer);
         }
 
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/topic_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/topic_methods.rs
@@ -7,11 +7,11 @@ use crate::{
         qos::{QosKind, TopicQos},
         status::{InconsistentTopicStatus, StatusKind},
     },
-    runtime::{Clock, DdsRuntime, Timer},
+    runtime::DdsRuntime,
     xtypes::dynamic_type::DynamicType,
 };
 
-impl<R: DdsRuntime> DcpsDomainParticipant<R> {
+impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_inconsistent_topic_status(
         &mut self,
@@ -85,13 +85,8 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(topic.qos.clone())
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
-    pub fn enable_topic(
-        &mut self,
-        topic_name: String,
-        clock: &impl Clock,
-        timer: impl Timer,
-    ) -> DdsResult<()> {
+    #[tracing::instrument(skip(self, runtime))]
+    pub fn enable_topic(&mut self, topic_name: String, runtime: &impl DdsRuntime) -> DdsResult<()> {
         let Some(TopicDescriptionKind::Topic(topic)) = self
             .domain_participant
             .topic_description_list
@@ -103,7 +98,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
 
         if !topic.enabled {
             topic.enabled = true;
-            self.announce_topic(topic_name, clock, timer);
+            self.announce_topic(topic_name, runtime);
         }
 
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/topic_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/topic_methods.rs
@@ -7,7 +7,7 @@ use crate::{
         qos::{QosKind, TopicQos},
         status::{InconsistentTopicStatus, StatusKind},
     },
-    runtime::DdsRuntime,
+    runtime::{Clock, DdsRuntime},
     xtypes::dynamic_type::DynamicType,
 };
 
@@ -85,8 +85,8 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(topic.qos.clone())
     }
 
-    #[tracing::instrument(skip(self))]
-    pub fn enable_topic(&mut self, topic_name: String) -> DdsResult<()> {
+    #[tracing::instrument(skip(self, clock))]
+    pub fn enable_topic(&mut self, topic_name: String, clock: &impl Clock) -> DdsResult<()> {
         let Some(TopicDescriptionKind::Topic(topic)) = self
             .domain_participant
             .topic_description_list
@@ -98,7 +98,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
 
         if !topic.enabled {
             topic.enabled = true;
-            self.announce_topic(topic_name);
+            self.announce_topic(topic_name, clock);
         }
 
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -20,12 +20,12 @@ use crate::{
         status::{OfferedDeadlineMissedStatus, PublicationMatchedStatus, StatusKind},
         time::{Duration, DurationKind, Time},
     },
-    runtime::{Clock, DdsRuntime, Either, Spawner, Timer, select_future},
+    runtime::{DdsRuntime, Either, Spawner, Timer, select_future},
     transport::types::{CacheChange, ChangeKind},
     xtypes::dynamic_type::DynamicData,
 };
 
-impl<R: DdsRuntime> DcpsDomainParticipant<R> {
+impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_publication_matched_status(
         &mut self,
@@ -56,13 +56,14 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(status)
     }
 
-    #[tracing::instrument(skip(self, dcps_listener))]
+    #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn set_listener_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dcps_listener: Option<DcpsDataWriterListener>,
         listener_mask: Vec<StatusKind>,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -80,7 +81,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             return Ok(());
         };
 
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&self.spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         data_writer.listener_sender = listener_sender;
         data_writer.listener_mask = listener_mask;
 
@@ -170,14 +171,14 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .cloned()
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn unregister_instance(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData,
         timestamp: Time,
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -199,7 +200,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             dynamic_data,
             timestamp,
             self.transport.message_writer.as_ref(),
-            clock,
+            runtime,
         )
     }
 
@@ -245,18 +246,17 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, reply_sender, clock, timer))]
+    #[tracing::instrument(skip(self, reply_sender, runtime))]
     pub fn write_w_timestamp(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData,
         timestamp: Time,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
         reply_sender: OneshotSender<DdsResult<()>>,
     ) {
-        let now = self.get_current_time(clock);
+        let now = self.get_current_time(runtime);
         let Some(publisher) = core::iter::once(&mut self.domain_participant.builtin_publisher)
             .chain(&mut self.domain_participant.user_defined_publisher_list)
             .find(|x| x.instance_handle == publisher_handle)
@@ -391,8 +391,8 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                                     let participant_handle =
                                         self.domain_participant.instance_handle;
                                     let dcps_sender = self.dcps_sender;
-                                    let mut timer_handle = timer.clone();
-                                    self.spawner_handle.spawn(async move {
+                                    let mut timer_handle = runtime.timer();
+                                    runtime.spawner().spawn(async move {
                                         if let DurationKind::Finite(t) = max_blocking_time {
                                             let max_blocking_time_wait =
                                                 timer_handle.delay(t.into());
@@ -501,8 +501,8 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         let dcps_sender_clone = self.dcps_sender;
         let participant_handle = self.domain_participant.instance_handle;
         if let DurationKind::Finite(deadline_missed_period) = data_writer.qos.deadline.period {
-            let mut timer_handle = timer.clone();
-            self.spawner_handle.spawn(async move {
+            let mut timer_handle = runtime.timer();
+            runtime.spawner().spawn(async move {
                 loop {
                     timer_handle.delay(deadline_missed_period.into()).await;
                     dcps_sender_clone
@@ -527,8 +527,8 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             }
 
             let dcps_sender_clone = self.dcps_sender;
-            let mut timer_handle = timer.clone();
-            self.spawner_handle.spawn(async move {
+            let mut timer_handle = runtime.timer();
+            runtime.spawner().spawn(async move {
                 timer_handle.delay(sleep_duration.into()).await;
                 dcps_sender_clone
                     .send(DcpsMail::Message(MessageServiceMail::RemoveWriterChange {
@@ -544,20 +544,20 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         data_writer.transport_writer.add_change(
             change,
             self.transport.message_writer.as_ref(),
-            clock,
+            runtime,
         );
 
         reply_sender.send(Ok(()));
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn dispose_w_timestamp(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData,
         timestamp: Time,
-        clock: &impl Clock,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -579,7 +579,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             dynamic_data,
             timestamp,
             self.transport.message_writer.as_ref(),
-            clock,
+            runtime,
         )
     }
 
@@ -608,13 +608,12 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(data_writer.get_offered_deadline_missed_status())
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn enable_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -644,19 +643,18 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                 );
             }
 
-            self.announce_data_writer(publisher_handle, data_writer_handle, clock, timer);
+            self.announce_data_writer(publisher_handle, data_writer_handle, runtime);
         }
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, clock, timer))]
+    #[tracing::instrument(skip(self, runtime))]
     pub fn set_data_writer_qos(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         qos: QosKind<DataWriterQos>,
-        clock: &impl Clock,
-        timer: impl Timer,
+        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -685,7 +683,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         data_writer.qos = qos;
 
         if data_writer.enabled {
-            self.announce_data_writer(publisher_handle, data_writer_handle, clock, timer);
+            self.announce_data_writer(publisher_handle, data_writer_handle, runtime);
         }
         Ok(())
     }

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -244,7 +244,8 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .then_some(instance_handle))
     }
 
-    #[tracing::instrument(skip(self, reply_sender, clock))]
+    #[allow(clippy::too_many_arguments)]
+    #[tracing::instrument(skip(self, reply_sender, clock, timer))]
     pub fn write_w_timestamp(
         &mut self,
         publisher_handle: InstanceHandle,
@@ -252,6 +253,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         dynamic_data: DynamicData,
         timestamp: Time,
         clock: &impl Clock,
+        timer: impl Timer,
         reply_sender: OneshotSender<DdsResult<()>>,
     ) {
         let now = self.get_current_time(clock);
@@ -378,7 +380,6 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                                         ))));
                                         return;
                                     }
-                                    let mut timer_handle = self.timer_handle.clone();
                                     let max_blocking_time =
                                         data_writer.qos.reliability.max_blocking_time;
                                     let (
@@ -390,6 +391,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                                     let participant_handle =
                                         self.domain_participant.instance_handle;
                                     let dcps_sender = self.dcps_sender;
+                                    let mut timer_handle = timer.clone();
                                     self.spawner_handle.spawn(async move {
                                         if let DurationKind::Finite(t) = max_blocking_time {
                                             let max_blocking_time_wait =
@@ -499,7 +501,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         let dcps_sender_clone = self.dcps_sender;
         let participant_handle = self.domain_participant.instance_handle;
         if let DurationKind::Finite(deadline_missed_period) = data_writer.qos.deadline.period {
-            let mut timer_handle = self.timer_handle.clone();
+            let mut timer_handle = timer.clone();
             self.spawner_handle.spawn(async move {
                 loop {
                     timer_handle.delay(deadline_missed_period.into()).await;
@@ -519,13 +521,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
 
         if let DurationKind::Finite(lifespan_duration) = data_writer.qos.lifespan.duration {
             let sleep_duration = timestamp - now + lifespan_duration;
-            let mut timer_handle = self.timer_handle.clone();
             if sleep_duration <= Duration::new(0, 0) {
                 reply_sender.send(Ok(()));
                 return;
             }
 
             let dcps_sender_clone = self.dcps_sender;
+            let mut timer_handle = timer.clone();
             self.spawner_handle.spawn(async move {
                 timer_handle.delay(sleep_duration.into()).await;
                 dcps_sender_clone
@@ -606,12 +608,13 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(data_writer.get_offered_deadline_missed_status())
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     pub fn enable_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         clock: &impl Clock,
+        timer: impl Timer,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -641,18 +644,19 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                 );
             }
 
-            self.announce_data_writer(publisher_handle, data_writer_handle, clock);
+            self.announce_data_writer(publisher_handle, data_writer_handle, clock, timer);
         }
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, clock))]
+    #[tracing::instrument(skip(self, clock, timer))]
     pub fn set_data_writer_qos(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         qos: QosKind<DataWriterQos>,
         clock: &impl Clock,
+        timer: impl Timer,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -681,7 +685,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         data_writer.qos = qos;
 
         if data_writer.enabled {
-            self.announce_data_writer(publisher_handle, data_writer_handle, clock);
+            self.announce_data_writer(publisher_handle, data_writer_handle, clock, timer);
         }
         Ok(())
     }

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -20,7 +20,7 @@ use crate::{
         status::{OfferedDeadlineMissedStatus, PublicationMatchedStatus, StatusKind},
         time::{Duration, DurationKind, Time},
     },
-    runtime::{DdsRuntime, Either, Spawner, Timer, select_future},
+    runtime::{Clock, DdsRuntime, Either, Spawner, Timer, select_future},
     transport::types::{CacheChange, ChangeKind},
     xtypes::dynamic_type::DynamicData,
 };
@@ -170,13 +170,14 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .cloned()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn unregister_instance(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData,
         timestamp: Time,
+        clock: &impl Clock,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -198,7 +199,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             dynamic_data,
             timestamp,
             self.transport.message_writer.as_ref(),
-            &self.clock_handle,
+            clock,
         )
     }
 
@@ -243,16 +244,17 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             .then_some(instance_handle))
     }
 
-    #[tracing::instrument(skip(self, reply_sender))]
+    #[tracing::instrument(skip(self, reply_sender, clock))]
     pub fn write_w_timestamp(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData,
         timestamp: Time,
+        clock: &impl Clock,
         reply_sender: OneshotSender<DdsResult<()>>,
     ) {
-        let now = self.get_current_time();
+        let now = self.get_current_time(clock);
         let Some(publisher) = core::iter::once(&mut self.domain_participant.builtin_publisher)
             .chain(&mut self.domain_participant.user_defined_publisher_list)
             .find(|x| x.instance_handle == publisher_handle)
@@ -540,19 +542,20 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         data_writer.transport_writer.add_change(
             change,
             self.transport.message_writer.as_ref(),
-            &self.clock_handle,
+            clock,
         );
 
         reply_sender.send(Ok(()));
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn dispose_w_timestamp(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData,
         timestamp: Time,
+        clock: &impl Clock,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -574,7 +577,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
             dynamic_data,
             timestamp,
             self.transport.message_writer.as_ref(),
-            &self.clock_handle,
+            clock,
         )
     }
 
@@ -603,11 +606,12 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         Ok(data_writer.get_offered_deadline_missed_status())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn enable_data_writer(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
+        clock: &impl Clock,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -637,17 +641,18 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
                 );
             }
 
-            self.announce_data_writer(publisher_handle, data_writer_handle);
+            self.announce_data_writer(publisher_handle, data_writer_handle, clock);
         }
         Ok(())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, clock))]
     pub fn set_data_writer_qos(
         &mut self,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         qos: QosKind<DataWriterQos>,
+        clock: &impl Clock,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -676,7 +681,7 @@ impl<R: DdsRuntime> DcpsDomainParticipant<R> {
         data_writer.qos = qos;
 
         if data_writer.enabled {
-            self.announce_data_writer(publisher_handle, data_writer_handle);
+            self.announce_data_writer(publisher_handle, data_writer_handle, clock);
         }
         Ok(())
     }

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -8,6 +8,7 @@ use crate::{
         },
         dcps_participant_factory::DcpsParticipantFactory,
     },
+    infrastructure::error::DdsError,
     runtime::DdsRuntime,
 };
 
@@ -96,7 +97,12 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 mask,
                 type_support,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
                 Ok(p) => reply_sender.send(p.create_topic(
                     topic_name,
                     type_name,
@@ -104,6 +110,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     dcps_listener,
                     mask,
                     type_support,
+                    &self.runtime.clock(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -186,8 +193,14 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             DcpsMail::Participant(ParticipantServiceMail::DeleteContainedEntities {
                 participant_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
-                Ok(p) => reply_sender.send(p.delete_participant_contained_entities()),
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
+                Ok(p) => reply_sender
+                    .send(p.delete_participant_contained_entities(&self.runtime.clock())),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::SetDefaultPublisherQos {
@@ -239,8 +252,11 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
-                    .map(|p| p.get_current_time()),
+                self.domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                    .map(|p| p.get_current_time(&self.runtime.clock())),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredParticipants {
                 participant_handle,
@@ -277,8 +293,15 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 qos,
 
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
-                Ok(p) => reply_sender.send(p.set_domain_participant_qos(qos)),
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
+                Ok(p) => {
+                    reply_sender.send(p.set_domain_participant_qos(qos, &self.runtime.clock()))
+                }
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::GetQos {
@@ -301,8 +324,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
 
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
-                Ok(p) => reply_sender.send(p.enable_domain_participant()),
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
+                Ok(p) => reply_sender.send(p.enable_domain_participant(&self.runtime.clock())),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::GetInconsistentTopicStatus {
@@ -335,8 +363,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 topic_name,
 
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
-                Ok(p) => reply_sender.send(p.enable_topic(topic_name)),
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
+                Ok(p) => reply_sender.send(p.enable_topic(topic_name, &self.runtime.clock())),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::GetTypeSupport {
@@ -355,13 +388,19 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dcps_listener,
                 mask,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
                 Ok(p) => reply_sender.send(p.create_data_writer(
                     publisher_handle,
                     topic_name,
                     qos,
                     dcps_listener,
                     mask,
+                    &self.runtime.clock(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -370,10 +409,17 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 datawriter_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
-                Ok(p) => {
-                    reply_sender.send(p.delete_data_writer(publisher_handle, datawriter_handle))
-                }
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
+                Ok(p) => reply_sender.send(p.delete_data_writer(
+                    publisher_handle,
+                    datawriter_handle,
+                    &self.runtime.clock(),
+                )),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Publisher(PublisherServiceMail::GetDefaultDataWriterQos {
@@ -484,12 +530,18 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dynamic_data,
                 timestamp,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
                 Ok(p) => reply_sender.send(p.unregister_instance(
                     publisher_handle,
                     data_writer_handle,
                     dynamic_data,
                     timestamp,
+                    &self.runtime.clock(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -509,12 +561,18 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dynamic_data,
                 timestamp,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
                 Ok(p) => p.write_w_timestamp(
                     publisher_handle,
                     data_writer_handle,
                     dynamic_data,
                     timestamp,
+                    &self.runtime.clock(),
                     reply_sender,
                 ),
                 Err(e) => reply_sender.send(Err(e)),
@@ -527,12 +585,18 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dynamic_data,
                 timestamp,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
                 Ok(p) => reply_sender.send(p.dispose_w_timestamp(
                     publisher_handle,
                     data_writer_handle,
                     dynamic_data,
                     timestamp,
+                    &self.runtime.clock(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -552,10 +616,17 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 data_writer_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
-                Ok(p) => {
-                    reply_sender.send(p.enable_data_writer(publisher_handle, data_writer_handle))
-                }
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
+                Ok(p) => reply_sender.send(p.enable_data_writer(
+                    publisher_handle,
+                    data_writer_handle,
+                    &self.runtime.clock(),
+                )),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::SetDataWriterQos {
@@ -563,13 +634,18 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 data_writer_handle,
                 qos,
-
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
                 Ok(p) => reply_sender.send(p.set_data_writer_qos(
                     publisher_handle,
                     data_writer_handle,
                     qos,
+                    &self.runtime.clock(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -581,13 +657,19 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dcps_listener,
                 mask,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
                 Ok(p) => reply_sender.send(p.create_data_reader(
                     subscriber_handle,
                     topic_name,
                     qos,
                     dcps_listener,
                     mask,
+                    &self.runtime.clock(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -596,10 +678,17 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 datareader_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
-                Ok(p) => {
-                    reply_sender.send(p.delete_data_reader(subscriber_handle, datareader_handle))
-                }
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
+                Ok(p) => reply_sender.send(p.delete_data_reader(
+                    subscriber_handle,
+                    datareader_handle,
+                    &self.runtime.clock(),
+                )),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Subscriber(SubscriberServiceMail::LookupDataReader {
@@ -749,10 +838,17 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 data_reader_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
-                Ok(p) => {
-                    reply_sender.send(p.enable_data_reader(subscriber_handle, data_reader_handle))
-                }
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
+                Ok(p) => reply_sender.send(p.enable_data_reader(
+                    subscriber_handle,
+                    data_reader_handle,
+                    &self.runtime.clock(),
+                )),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Reader(ReaderServiceMail::GetSubscriptionMatchedStatus {
@@ -812,11 +908,17 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_reader_handle,
                 qos,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
                 Ok(p) => reply_sender.send(p.set_data_reader_qos(
                     subscriber_handle,
                     data_reader_handle,
                     qos,
+                    &self.runtime.clock(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -897,13 +999,23 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 data_message,
             }) => {
-                if let Ok(p) = self.find_participant(participant_handle) {
-                    p.handle_data(data_message);
+                if let Ok(p) = self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    p.handle_data(data_message, &self.runtime.clock());
                 }
             }
             DcpsMail::Message(MessageServiceMail::Poke { participant_handle }) => {
-                if let Ok(p) = self.find_participant(participant_handle) {
-                    p.poke()
+                if let Ok(p) = self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    p.poke(&self.runtime.clock())
                 }
             }
             DcpsMail::Event(EventServiceMail::OfferedDeadlineMissed {
@@ -912,11 +1024,17 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_writer_handle,
                 change_instance_handle,
             }) => {
-                if let Ok(p) = self.find_participant(participant_handle) {
+                if let Ok(p) = self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
                     p.offered_deadline_missed(
                         publisher_handle,
                         data_writer_handle,
                         change_instance_handle,
+                        &self.runtime.clock(),
                     )
                 }
             }
@@ -926,19 +1044,30 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_reader_handle,
                 change_instance_handle,
             }) => {
-                if let Ok(p) = self.find_participant(participant_handle) {
+                if let Ok(p) = self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
                     p.requested_deadline_missed(
                         subscriber_handle,
                         data_reader_handle,
                         change_instance_handle,
+                        &self.runtime.clock(),
                     )
                 }
             }
             DcpsMail::Discovery(DiscoveryServiceMail::AnnounceParticipant {
                 participant_handle,
             }) => {
-                if let Ok(p) = self.find_participant(participant_handle) {
-                    p.announce_participant()
+                if let Ok(p) = self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    p.announce_participant(&self.runtime.clock())
                 }
             }
         }

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -111,6 +111,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     mask,
                     type_support,
                     &self.runtime.clock(),
+                    self.runtime.timer(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -299,9 +300,11 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => {
-                    reply_sender.send(p.set_domain_participant_qos(qos, &self.runtime.clock()))
-                }
+                Ok(p) => reply_sender.send(p.set_domain_participant_qos(
+                    qos,
+                    &self.runtime.clock(),
+                    self.runtime.timer(),
+                )),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::GetQos {
@@ -330,7 +333,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.enable_domain_participant(&self.runtime.clock())),
+                Ok(p) => reply_sender
+                    .send(p.enable_domain_participant(&self.runtime.clock(), self.runtime.timer())),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::GetInconsistentTopicStatus {
@@ -369,7 +373,11 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.enable_topic(topic_name, &self.runtime.clock())),
+                Ok(p) => reply_sender.send(p.enable_topic(
+                    topic_name,
+                    &self.runtime.clock(),
+                    self.runtime.timer(),
+                )),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::GetTypeSupport {
@@ -401,6 +409,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     dcps_listener,
                     mask,
                     &self.runtime.clock(),
+                    self.runtime.timer(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -573,6 +582,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     dynamic_data,
                     timestamp,
                     &self.runtime.clock(),
+                    self.runtime.timer(),
                     reply_sender,
                 ),
                 Err(e) => reply_sender.send(Err(e)),
@@ -626,6 +636,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     publisher_handle,
                     data_writer_handle,
                     &self.runtime.clock(),
+                    self.runtime.timer(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -646,6 +657,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     data_writer_handle,
                     qos,
                     &self.runtime.clock(),
+                    self.runtime.timer(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -670,6 +682,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     dcps_listener,
                     mask,
                     &self.runtime.clock(),
+                    self.runtime.timer(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -848,6 +861,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     subscriber_handle,
                     data_reader_handle,
                     &self.runtime.clock(),
+                    self.runtime.timer(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -867,9 +881,20 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_reader_handle,
                 max_wait,
                 reply_sender,
-            }) => reply_sender.send(self.find_participant(participant_handle).map(|p| {
-                p.wait_for_historical_data(subscriber_handle, data_reader_handle, max_wait)
-            })),
+            }) => reply_sender.send(
+                self.domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                    .map(|p| {
+                        p.wait_for_historical_data(
+                            subscriber_handle,
+                            data_reader_handle,
+                            max_wait,
+                            self.runtime.timer(),
+                        )
+                    }),
+            ),
             DcpsMail::Reader(ReaderServiceMail::GetMatchedPublicationData {
                 participant_handle,
                 subscriber_handle,
@@ -919,6 +944,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     data_reader_handle,
                     qos,
                     &self.runtime.clock(),
+                    self.runtime.timer(),
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -1005,7 +1031,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .find(|x| x.get_instance_handle() == participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
-                    p.handle_data(data_message, &self.runtime.clock());
+                    p.handle_data(data_message, &self.runtime.clock(), self.runtime.timer());
                 }
             }
             DcpsMail::Message(MessageServiceMail::Poke { participant_handle }) => {
@@ -1067,7 +1093,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .find(|x| x.get_instance_handle() == participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
-                    p.announce_participant(&self.runtime.clock())
+                    p.announce_participant(&self.runtime.clock(), self.runtime.timer())
                 }
             }
         }

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -59,8 +59,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 mask,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
-                    .and_then(|p| p.create_user_defined_publisher(qos, dcps_listener, mask)),
+                self.domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                    .and_then(|p| {
+                        p.create_user_defined_publisher(qos, dcps_listener, mask, &self.runtime)
+                    }),
             ),
             DcpsMail::Participant(ParticipantServiceMail::DeleteUserDefinedPublisher {
                 participant_handle,
@@ -77,8 +82,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 mask,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
-                    .and_then(|p| p.create_user_defined_subscriber(qos, dcps_listener, mask)),
+                self.domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                    .and_then(|p| {
+                        p.create_user_defined_subscriber(qos, dcps_listener, mask, &self.runtime)
+                    }),
             ),
             DcpsMail::Participant(ParticipantServiceMail::DeleteUserDefinedSubscriber {
                 participant_handle,
@@ -110,8 +120,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     dcps_listener,
                     mask,
                     type_support,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -200,8 +209,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender
-                    .send(p.delete_participant_contained_entities(&self.runtime.clock())),
+                Ok(p) => reply_sender.send(p.delete_participant_contained_entities(&self.runtime)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::SetDefaultPublisherQos {
@@ -257,7 +265,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
-                    .map(|p| p.get_current_time(&self.runtime.clock())),
+                    .map(|p| p.get_current_time(&self.runtime)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredParticipants {
                 participant_handle,
@@ -300,11 +308,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.set_domain_participant_qos(
-                    qos,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
-                )),
+                Ok(p) => reply_sender.send(p.set_domain_participant_qos(qos, &self.runtime)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::GetQos {
@@ -320,8 +324,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 status_kind,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
-                    .and_then(|p| p.set_domain_participant_listener(dcps_listener, status_kind)),
+                self.domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                    .and_then(|p| {
+                        p.set_domain_participant_listener(dcps_listener, status_kind, &self.runtime)
+                    }),
             ),
             DcpsMail::Participant(ParticipantServiceMail::Enable {
                 participant_handle,
@@ -333,8 +342,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender
-                    .send(p.enable_domain_participant(&self.runtime.clock(), self.runtime.timer())),
+                Ok(p) => reply_sender.send(p.enable_domain_participant(&self.runtime)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::GetInconsistentTopicStatus {
@@ -373,11 +381,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.enable_topic(
-                    topic_name,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
-                )),
+                Ok(p) => reply_sender.send(p.enable_topic(topic_name, &self.runtime)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::GetTypeSupport {
@@ -408,8 +412,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     qos,
                     dcps_listener,
                     mask,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -427,7 +430,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.delete_data_writer(
                     publisher_handle,
                     datawriter_handle,
-                    &self.runtime.clock(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -472,8 +475,18 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 mask,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
-                    .and_then(|p| p.set_publisher_listener(publisher_handle, dcps_listener, mask)),
+                self.domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                    .and_then(|p| {
+                        p.set_publisher_listener(
+                            publisher_handle,
+                            dcps_listener,
+                            mask,
+                            &self.runtime,
+                        )
+                    }),
             ),
             DcpsMail::Writer(WriterServiceMail::SetListener {
                 participant_handle,
@@ -482,14 +495,21 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dcps_listener,
                 listener_mask,
                 reply_sender,
-            }) => reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
-                p.set_listener_data_writer(
-                    publisher_handle,
-                    data_writer_handle,
-                    dcps_listener,
-                    listener_mask,
-                )
-            })),
+            }) => reply_sender.send(
+                self.domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                    .and_then(|p| {
+                        p.set_listener_data_writer(
+                            publisher_handle,
+                            data_writer_handle,
+                            dcps_listener,
+                            listener_mask,
+                            &self.runtime,
+                        )
+                    }),
+            ),
             DcpsMail::Writer(WriterServiceMail::GetDataWriterQos {
                 participant_handle,
                 publisher_handle,
@@ -550,7 +570,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     data_writer_handle,
                     dynamic_data,
                     timestamp,
-                    &self.runtime.clock(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -581,8 +601,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     data_writer_handle,
                     dynamic_data,
                     timestamp,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
+                    &self.runtime,
                     reply_sender,
                 ),
                 Err(e) => reply_sender.send(Err(e)),
@@ -606,7 +625,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     data_writer_handle,
                     dynamic_data,
                     timestamp,
-                    &self.runtime.clock(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -635,8 +654,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.enable_data_writer(
                     publisher_handle,
                     data_writer_handle,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -656,8 +674,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     publisher_handle,
                     data_writer_handle,
                     qos,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -681,8 +698,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     qos,
                     dcps_listener,
                     mask,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -700,7 +716,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.delete_data_reader(
                     subscriber_handle,
                     datareader_handle,
-                    &self.runtime.clock(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -753,11 +769,20 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dcps_listener,
                 mask,
                 reply_sender,
-            }) => {
-                reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
-                    p.set_subscriber_listener(subscriber_handle, dcps_listener, mask)
-                }))
-            }
+            }) => reply_sender.send(
+                self.domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                    .and_then(|p| {
+                        p.set_subscriber_listener(
+                            subscriber_handle,
+                            dcps_listener,
+                            mask,
+                            &self.runtime,
+                        )
+                    }),
+            ),
             DcpsMail::Reader(ReaderServiceMail::Read {
                 participant_handle,
                 subscriber_handle,
@@ -860,8 +885,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.enable_data_reader(
                     subscriber_handle,
                     data_reader_handle,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -943,8 +967,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     subscriber_handle,
                     data_reader_handle,
                     qos,
-                    &self.runtime.clock(),
-                    self.runtime.timer(),
+                    &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -955,14 +978,21 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dcps_listener,
                 listener_mask,
                 reply_sender,
-            }) => reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
-                p.set_data_reader_listener(
-                    subscriber_handle,
-                    data_reader_handle,
-                    dcps_listener,
-                    listener_mask,
-                )
-            })),
+            }) => reply_sender.send(
+                self.domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                    .and_then(|p| {
+                        p.set_data_reader_listener(
+                            subscriber_handle,
+                            data_reader_handle,
+                            dcps_listener,
+                            listener_mask,
+                            &self.runtime,
+                        )
+                    }),
+            ),
             DcpsMail::Message(MessageServiceMail::RemoveWriterChange {
                 participant_handle,
                 publisher_handle,
@@ -1031,7 +1061,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .find(|x| x.get_instance_handle() == participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
-                    p.handle_data(data_message, &self.runtime.clock(), self.runtime.timer());
+                    p.handle_data(data_message, &self.runtime);
                 }
             }
             DcpsMail::Message(MessageServiceMail::Poke { participant_handle }) => {
@@ -1060,7 +1090,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                         publisher_handle,
                         data_writer_handle,
                         change_instance_handle,
-                        &self.runtime.clock(),
+                        &self.runtime,
                     )
                 }
             }
@@ -1080,7 +1110,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                         subscriber_handle,
                         data_reader_handle,
                         change_instance_handle,
-                        &self.runtime.clock(),
+                        &self.runtime,
                     )
                 }
             }
@@ -1093,7 +1123,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .find(|x| x.get_instance_handle() == participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
-                    p.announce_participant(&self.runtime.clock(), self.runtime.timer())
+                    p.announce_participant(&self.runtime)
                 }
             }
         }

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -53,7 +53,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             QosKind::Specific(q) => q,
         };
 
-        let mut timer_handle = self.runtime.timer();
         let spawner_handle = self.runtime.spawner();
 
         let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&spawner_handle));
@@ -67,7 +66,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             status_kind,
             transport_participant,
             self.dcps_sender,
-            timer_handle.clone(),
             spawner_handle.clone(),
         );
         let participant_handle = dcps_participant.get_instance_handle();
@@ -76,7 +74,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
 
         // Start the regular participant announcement task
         let dcps_sender_clone = self.dcps_sender;
-        let mut timer_handle_clone = timer_handle.clone();
+        let mut timer_handle = self.runtime.timer().clone();
 
         spawner_handle.spawn(async move {
             loop {
@@ -86,14 +84,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     ))
                     .await;
 
-                timer_handle_clone
-                    .delay(participant_announcement_interval)
-                    .await;
+                timer_handle.delay(participant_announcement_interval).await;
             }
         });
 
         // Start regular message writing
         let dcps_sender_clone = self.dcps_sender;
+        let mut timer_handle = self.runtime.timer();
         spawner_handle.spawn(async move {
             loop {
                 dcps_sender_clone
@@ -109,7 +106,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         });
 
         if self.qos.entity_factory.autoenable_created_entities {
-            dcps_participant.enable_domain_participant(&self.runtime.clock())?;
+            dcps_participant
+                .enable_domain_participant(&self.runtime.clock(), self.runtime.timer())?;
         }
 
         self.domain_participant_list.push(dcps_participant);

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -18,7 +18,7 @@ use crate::{
 use alloc::{string::String, vec::Vec};
 
 pub struct DcpsParticipantFactory<R: DdsRuntime> {
-    pub domain_participant_list: Vec<DcpsDomainParticipant<R>>,
+    pub domain_participant_list: Vec<DcpsDomainParticipant>,
     pub qos: DomainParticipantFactoryQos,
     pub default_participant_qos: DomainParticipantQos,
     pub runtime: R,
@@ -55,9 +55,9 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
 
         let spawner_handle = self.runtime.spawner();
 
-        let listener_sender = dcps_listener.map(|l| l.spawn::<R>(&spawner_handle));
+        let listener_sender = dcps_listener.map(|l| l.spawn(&self.runtime.spawner()));
 
-        let mut dcps_participant: DcpsDomainParticipant<R> = DcpsDomainParticipant::new(
+        let mut dcps_participant = DcpsDomainParticipant::new(
             domain_id,
             domain_tag,
             guid_prefix,
@@ -66,7 +66,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             status_kind,
             transport_participant,
             self.dcps_sender,
-            spawner_handle.clone(),
         );
         let participant_handle = dcps_participant.get_instance_handle();
 
@@ -106,8 +105,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         });
 
         if self.qos.entity_factory.autoenable_created_entities {
-            dcps_participant
-                .enable_domain_participant(&self.runtime.clock(), self.runtime.timer())?;
+            dcps_participant.enable_domain_participant(&self.runtime)?;
         }
 
         self.domain_participant_list.push(dcps_participant);
@@ -127,14 +125,14 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             )));
         }
         let mut participant = self.domain_participant_list.remove(index);
-        participant.announce_deleted_participant(&self.runtime.clock());
+        participant.announce_deleted_participant(&self.runtime);
         Ok(())
     }
 
     pub fn find_participant(
         &mut self,
         participant_handle: InstanceHandle,
-    ) -> DdsResult<&mut DcpsDomainParticipant<R>> {
+    ) -> DdsResult<&mut DcpsDomainParticipant> {
         self.domain_participant_list
             .iter_mut()
             .find(|x| x.get_instance_handle() == participant_handle)

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -18,11 +18,11 @@ use crate::{
 use alloc::{string::String, vec::Vec};
 
 pub struct DcpsParticipantFactory<R: DdsRuntime> {
-    domain_participant_list: Vec<DcpsDomainParticipant<R>>,
-    qos: DomainParticipantFactoryQos,
-    default_participant_qos: DomainParticipantQos,
-    runtime: R,
-    dcps_sender: DcpsSender,
+    pub domain_participant_list: Vec<DcpsDomainParticipant<R>>,
+    pub qos: DomainParticipantFactoryQos,
+    pub default_participant_qos: DomainParticipantQos,
+    pub runtime: R,
+    pub dcps_sender: DcpsSender,
 }
 
 impl<R: DdsRuntime> DcpsParticipantFactory<R> {
@@ -53,7 +53,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             QosKind::Specific(q) => q,
         };
 
-        let clock_handle = self.runtime.clock();
         let mut timer_handle = self.runtime.timer();
         let spawner_handle = self.runtime.spawner();
 
@@ -68,7 +67,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             status_kind,
             transport_participant,
             self.dcps_sender,
-            clock_handle,
             timer_handle.clone(),
             spawner_handle.clone(),
         );
@@ -111,7 +109,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         });
 
         if self.qos.entity_factory.autoenable_created_entities {
-            dcps_participant.enable_domain_participant()?;
+            dcps_participant.enable_domain_participant(&self.runtime.clock())?;
         }
 
         self.domain_participant_list.push(dcps_participant);
@@ -131,7 +129,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             )));
         }
         let mut participant = self.domain_participant_list.remove(index);
-        participant.announce_deleted_participant();
+        participant.announce_deleted_participant(&self.runtime.clock());
         Ok(())
     }
 

--- a/dds/src/dcps/listeners/data_reader_listener.rs
+++ b/dds/src/dcps/listeners/data_reader_listener.rs
@@ -7,7 +7,7 @@ use tracing::span;
 use crate::{
     dcps::channels::mpsc::{MpscSender, mpsc_channel},
     dds_async::data_reader_listener::DataReaderListener,
-    runtime::{DdsRuntime, Spawner},
+    runtime::Spawner,
 };
 
 use super::domain_participant_listener::ListenerMail;
@@ -80,10 +80,7 @@ impl DcpsDataReaderListener {
         Self { sender, task }
     }
 
-    pub fn spawn<R: DdsRuntime>(
-        self,
-        spawner_handle: &R::SpawnerHandle,
-    ) -> MpscSender<ListenerMail> {
+    pub fn spawn(self, spawner_handle: &impl Spawner) -> MpscSender<ListenerMail> {
         spawner_handle.spawn(self.task);
         self.sender
     }

--- a/dds/src/dcps/listeners/data_writer_listener.rs
+++ b/dds/src/dcps/listeners/data_writer_listener.rs
@@ -5,7 +5,7 @@ use alloc::boxed::Box;
 use crate::{
     dcps::channels::mpsc::{MpscSender, mpsc_channel},
     dds_async::data_writer_listener::DataWriterListener,
-    runtime::{DdsRuntime, Spawner},
+    runtime::Spawner,
 };
 
 use super::domain_participant_listener::ListenerMail;
@@ -72,10 +72,7 @@ impl DcpsDataWriterListener {
         Self { sender, task }
     }
 
-    pub fn spawn<R: DdsRuntime>(
-        self,
-        spawner_handle: &R::SpawnerHandle,
-    ) -> MpscSender<ListenerMail> {
+    pub fn spawn(self, spawner_handle: &impl Spawner) -> MpscSender<ListenerMail> {
         spawner_handle.spawn(self.task);
         self.sender
     }

--- a/dds/src/dcps/listeners/domain_participant_listener.rs
+++ b/dds/src/dcps/listeners/domain_participant_listener.rs
@@ -13,7 +13,7 @@ use crate::{
         RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus, SampleRejectedStatus,
         SubscriptionMatchedStatus,
     },
-    runtime::{DdsRuntime, Spawner},
+    runtime::Spawner,
 };
 
 pub struct DcpsDomainParticipantListener {
@@ -68,10 +68,7 @@ impl DcpsDomainParticipantListener {
         Self { sender, task }
     }
 
-    pub fn spawn<R: DdsRuntime>(
-        self,
-        spawner_handle: &R::SpawnerHandle,
-    ) -> MpscSender<ListenerMail> {
+    pub fn spawn(self, spawner_handle: &impl Spawner) -> MpscSender<ListenerMail> {
         spawner_handle.spawn(self.task);
         self.sender
     }

--- a/dds/src/dcps/listeners/publisher_listener.rs
+++ b/dds/src/dcps/listeners/publisher_listener.rs
@@ -5,7 +5,7 @@ use alloc::boxed::Box;
 use crate::{
     dcps::channels::mpsc::{MpscSender, mpsc_channel},
     dds_async::publisher_listener::PublisherListener,
-    runtime::{DdsRuntime, Spawner},
+    runtime::Spawner,
 };
 
 use super::domain_participant_listener::ListenerMail;
@@ -70,10 +70,7 @@ impl DcpsPublisherListener {
         Self { sender, task }
     }
 
-    pub fn spawn<R: DdsRuntime>(
-        self,
-        spawner_handle: &R::SpawnerHandle,
-    ) -> MpscSender<ListenerMail> {
+    pub fn spawn(self, spawner_handle: &impl Spawner) -> MpscSender<ListenerMail> {
         spawner_handle.spawn(self.task);
         self.sender
     }

--- a/dds/src/dcps/listeners/subscriber_listener.rs
+++ b/dds/src/dcps/listeners/subscriber_listener.rs
@@ -5,7 +5,7 @@ use alloc::boxed::Box;
 use crate::{
     dcps::channels::mpsc::{MpscSender, mpsc_channel},
     dds_async::subscriber_listener::SubscriberListener,
-    runtime::{DdsRuntime, Spawner},
+    runtime::Spawner,
 };
 
 use super::domain_participant_listener::ListenerMail;
@@ -67,7 +67,7 @@ impl DcpsSubscriberListener {
         Self { sender, task }
     }
 
-    pub fn spawn<R: DdsRuntime>(self, spawner: &R::SpawnerHandle) -> MpscSender<ListenerMail> {
+    pub fn spawn(self, spawner: &impl Spawner) -> MpscSender<ListenerMail> {
         spawner.spawn(self.task);
         self.sender
     }

--- a/dds/src/dcps/listeners/topic_listener.rs
+++ b/dds/src/dcps/listeners/topic_listener.rs
@@ -5,7 +5,7 @@ use alloc::boxed::Box;
 use crate::{
     dcps::channels::mpsc::{MpscSender, mpsc_channel},
     dds_async::topic_listener::TopicListener,
-    runtime::{DdsRuntime, Spawner},
+    runtime::Spawner,
 };
 
 use super::domain_participant_listener::ListenerMail;
@@ -23,7 +23,7 @@ impl DcpsTopicListener {
         Self { sender, task }
     }
 
-    pub fn spawn<R: DdsRuntime>(self, spawner: &R::SpawnerHandle) -> MpscSender<ListenerMail> {
+    pub fn spawn(self, spawner: &impl Spawner) -> MpscSender<ListenerMail> {
         spawner.spawn(self.task);
         self.sender
     }

--- a/dds/src/runtime.rs
+++ b/dds/src/runtime.rs
@@ -8,7 +8,7 @@ pub trait Clock {
 }
 
 /// Provides delay/sleep functionality in an asynchronous context.
-pub trait Timer {
+pub trait Timer: Clone + Send + Sync + 'static {
     /// Creates a future that completes after the specified duration has elapsed.
     ///
     /// # Arguments
@@ -17,7 +17,7 @@ pub trait Timer {
 }
 
 /// Provides task spawning capabilities for asynchronous execution.
-pub trait Spawner {
+pub trait Spawner: Clone + Send + Sync + 'static {
     /// Spawns a new asynchronous task.
     ///
     /// # Arguments


### PR DESCRIPTION
Remove runtime generic from internal domain participant implementation to simplify the code structure.