### PR TITLE
Reduce binary size by replace internal method arguments by references

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -225,7 +225,6 @@ impl DcpsDomainParticipant {
 
         let mut data_reader_list = Vec::with_capacity(4);
 
-        // Create shared type information Arcs to avoid multiple allocations
         let spdp_participant_type = SpdpDiscoveredParticipantData::TYPE;
         let discovered_topic_type = DiscoveredTopicData::TYPE;
         let discovered_writer_type = DiscoveredWriterData::TYPE;
@@ -615,23 +614,23 @@ impl DcpsDomainParticipant {
 
     fn get_data_reader_async<Foo>(
         &self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
     ) -> DdsResult<DataReaderAsync<Foo>> {
         let data_reader = self
             .domain_participant
             .user_defined_subscriber_list
             .iter()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
             .ok_or(DdsError::AlreadyDeleted)?
             .data_reader_list
             .iter()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
             .ok_or(DdsError::AlreadyDeleted)?;
 
         Ok(DataReaderAsync::new(
-            data_reader_handle,
-            self.get_subscriber_async(subscriber_handle)?,
+            *data_reader_handle,
+            self.get_subscriber_async(*subscriber_handle)?,
             self.get_topic_description_async(data_reader.topic_name.clone())?,
         ))
     }
@@ -768,11 +767,12 @@ impl DcpsDomainParticipant {
                 .into(),
             );
             let timestamp = self.get_current_time(runtime);
+            let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
             let (reply_sender, _) = oneshot();
             self.write_w_timestamp(
-                self.domain_participant.builtin_publisher.instance_handle,
-                data_writer_handle,
-                spdp_discovered_participant_data.create_dynamic_sample(),
+                &publisher_handle,
+                &data_writer_handle,
+                &spdp_discovered_participant_data.create_dynamic_sample(),
                 timestamp,
                 runtime,
                 reply_sender,
@@ -890,11 +890,12 @@ impl DcpsDomainParticipant {
             .into(),
         );
         let timestamp = self.get_current_time(runtime);
+        let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
-            self.domain_participant.builtin_publisher.instance_handle,
-            data_writer_handle,
-            discovered_writer_data.create_dynamic_sample(),
+            &publisher_handle,
+            &data_writer_handle,
+            &discovered_writer_data.create_dynamic_sample(),
             timestamp,
             runtime,
             reply_sender,
@@ -939,22 +940,22 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     fn announce_data_reader(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return;
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return;
         };
@@ -1024,11 +1025,12 @@ impl DcpsDomainParticipant {
             .into(),
         );
         let timestamp = self.get_current_time(runtime);
+        let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
-            self.domain_participant.builtin_publisher.instance_handle,
-            data_writer_handle,
-            discovered_reader_data.create_dynamic_sample(),
+            &publisher_handle,
+            &data_writer_handle,
+            &discovered_reader_data.create_dynamic_sample(),
             timestamp,
             runtime,
             reply_sender,
@@ -1111,11 +1113,12 @@ impl DcpsDomainParticipant {
             .into(),
         );
         let timestamp = self.get_current_time(runtime);
+        let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
-            self.domain_participant.builtin_publisher.instance_handle,
-            data_writer_handle,
-            discovered_topic_data.create_dynamic_sample(),
+            &publisher_handle,
+            &data_writer_handle,
+            &discovered_topic_data.create_dynamic_sample(),
             timestamp,
             runtime,
             reply_sender,
@@ -1561,9 +1564,9 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     fn add_discovered_writer(
         &mut self,
-        discovered_writer_data: DiscoveredWriterData,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        discovered_writer_data: &DiscoveredWriterData,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
     ) {
         let default_unicast_locator_list = if let Some(p) = self
             .domain_participant
@@ -1599,7 +1602,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return;
         };
@@ -1650,7 +1653,7 @@ impl DcpsDomainParticipant {
             let Some(data_reader) = subscriber
                 .data_reader_list
                 .iter_mut()
-                .find(|x| x.instance_handle == data_reader_handle)
+                .find(|x| &x.instance_handle == data_reader_handle)
             else {
                 return;
             };
@@ -1700,7 +1703,10 @@ impl DcpsDomainParticipant {
                     {
                         default_unicast_locator_list
                     } else {
-                        discovered_writer_data.writer_proxy.unicast_locator_list
+                        discovered_writer_data
+                            .writer_proxy
+                            .unicast_locator_list
+                            .clone()
                     };
                     let multicast_locator_list = if discovered_writer_data
                         .writer_proxy
@@ -1709,7 +1715,10 @@ impl DcpsDomainParticipant {
                     {
                         default_multicast_locator_list
                     } else {
-                        discovered_writer_data.writer_proxy.multicast_locator_list
+                        discovered_writer_data
+                            .writer_proxy
+                            .multicast_locator_list
+                            .clone()
                     };
                     let reliability_kind = match data_reader.qos.reliability.kind {
                         ReliabilityQosPolicyKind::BestEffort => ReliabilityKind::BestEffort,
@@ -1748,14 +1757,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -1777,14 +1786,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -1807,14 +1816,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -1829,14 +1838,14 @@ impl DcpsDomainParticipant {
                         .domain_participant
                         .user_defined_subscriber_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == subscriber_handle)
+                        .find(|x| &x.instance_handle == subscriber_handle)
                     else {
                         return;
                     };
                     let Some(data_reader) = subscriber
                         .data_reader_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == data_reader_handle)
+                        .find(|x| &x.instance_handle == data_reader_handle)
                     else {
                         return;
                     };
@@ -1865,14 +1874,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -1893,14 +1902,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -1923,14 +1932,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -1945,14 +1954,14 @@ impl DcpsDomainParticipant {
                         .domain_participant
                         .user_defined_subscriber_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == subscriber_handle)
+                        .find(|x| &x.instance_handle == subscriber_handle)
                     else {
                         return;
                     };
                     let Some(data_reader) = subscriber
                         .data_reader_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == data_reader_handle)
+                        .find(|x| &x.instance_handle == data_reader_handle)
                     else {
                         return;
                     };
@@ -2151,9 +2160,9 @@ impl DcpsDomainParticipant {
                     }
                     for (subscriber_handle, data_reader_handle) in handle_list {
                         self.add_discovered_writer(
-                            discovered_writer_data.clone(),
-                            subscriber_handle,
-                            data_reader_handle,
+                            &discovered_writer_data,
+                            &subscriber_handle,
+                            &data_reader_handle,
                         );
                     }
                 }
@@ -2639,7 +2648,7 @@ impl DcpsDomainParticipant {
                         }
                     } else if data_reader_on_data_available_active {
                         let Ok(the_reader) =
-                            self.get_data_reader_async(*subscriber_handle, *data_reader_handle)
+                            self.get_data_reader_async(subscriber_handle, data_reader_handle)
                         else {
                             return;
                         };
@@ -2702,7 +2711,7 @@ impl DcpsDomainParticipant {
                     {
                         let status = data_reader.get_sample_rejected_status();
                         let Ok(the_reader) =
-                            self.get_data_reader_async(*subscriber_handle, *data_reader_handle)
+                            self.get_data_reader_async(subscriber_handle, data_reader_handle)
                         else {
                             return;
                         };
@@ -2731,7 +2740,7 @@ impl DcpsDomainParticipant {
                         .contains(&StatusKind::SampleRejected)
                     {
                         let Ok(the_reader) =
-                            self.get_data_reader_async(*subscriber_handle, *data_reader_handle)
+                            self.get_data_reader_async(subscriber_handle, data_reader_handle)
                         else {
                             return;
                         };
@@ -2762,7 +2771,7 @@ impl DcpsDomainParticipant {
                         .contains(&StatusKind::SampleRejected)
                     {
                         let Ok(the_reader) =
-                            self.get_data_reader_async(*subscriber_handle, *data_reader_handle)
+                            self.get_data_reader_async(subscriber_handle, data_reader_handle)
                         else {
                             return;
                         };
@@ -2996,9 +3005,9 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn requested_deadline_missed(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
-        change_instance_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
+        change_instance_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) {
         let current_time = self.get_current_time(runtime);
@@ -3006,14 +3015,14 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return;
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return;
         };
@@ -3029,7 +3038,7 @@ impl DcpsDomainParticipant {
         }
 
         data_reader.remove_instance_ownership(&change_instance_handle);
-        data_reader.increment_requested_deadline_missed_status(change_instance_handle);
+        data_reader.increment_requested_deadline_missed_status(*change_instance_handle);
 
         if data_reader
             .listener_mask
@@ -3044,14 +3053,14 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .user_defined_subscriber_list
                 .iter_mut()
-                .find(|x| x.instance_handle == subscriber_handle)
+                .find(|x| &x.instance_handle == subscriber_handle)
             else {
                 return;
             };
             let Some(data_reader) = subscriber
                 .data_reader_list
                 .iter_mut()
-                .find(|x| x.instance_handle == data_reader_handle)
+                .find(|x| &x.instance_handle == data_reader_handle)
             else {
                 return;
             };
@@ -3072,14 +3081,14 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .user_defined_subscriber_list
                 .iter_mut()
-                .find(|x| x.instance_handle == subscriber_handle)
+                .find(|x| &x.instance_handle == subscriber_handle)
             else {
                 return;
             };
             let Some(data_reader) = subscriber
                 .data_reader_list
                 .iter_mut()
-                .find(|x| x.instance_handle == data_reader_handle)
+                .find(|x| &x.instance_handle == data_reader_handle)
             else {
                 return;
             };
@@ -3102,14 +3111,14 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .user_defined_subscriber_list
                 .iter_mut()
-                .find(|x| x.instance_handle == subscriber_handle)
+                .find(|x| &x.instance_handle == subscriber_handle)
             else {
                 return;
             };
             let Some(data_reader) = subscriber
                 .data_reader_list
                 .iter_mut()
-                .find(|x| x.instance_handle == data_reader_handle)
+                .find(|x| &x.instance_handle == data_reader_handle)
             else {
                 return;
             };
@@ -3123,14 +3132,14 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return;
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return;
         };
@@ -3657,8 +3666,8 @@ impl DcpsDomainParticipant {
     }
 
     #[tracing::instrument(skip(self, data_message, runtime))]
-    pub fn handle_data(&mut self, data_message: Arc<[u8]>, runtime: &impl DdsRuntime) {
-        if let Ok(rtps_message) = RtpsMessageRead::try_from(data_message.as_ref()) {
+    pub fn handle_data(&mut self, data_message: &[u8], runtime: &impl DdsRuntime) {
+        if let Ok(rtps_message) = RtpsMessageRead::try_from(data_message) {
             let mut message_receiver = MessageReceiver::new(&rtps_message);
 
             while let Some(submessage) = message_receiver.next() {
@@ -5010,8 +5019,8 @@ impl InstanceState {
         self.view_state = ViewStateKind::NotNew;
     }
 
-    fn handle(&self) -> InstanceHandle {
-        self.handle
+    fn handle(&self) -> &InstanceHandle {
+        &self.handle
     }
 }
 
@@ -5115,7 +5124,7 @@ impl DataReaderEntity {
         sample_states: &[SampleStateKind],
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
-        specific_instance_handle: Option<InstanceHandle>,
+        specific_instance_handle: &Option<InstanceHandle>,
     ) -> DdsResult<Vec<IndexedSample>> {
         if let Some(h) = specific_instance_handle {
             if !self.instances.iter().any(|x| x.handle() == h) {
@@ -5128,7 +5137,7 @@ impl DataReaderEntity {
         let mut instances_in_collection = Vec::<InstanceState>::new();
         for (index, cache_change) in self.sample_list.iter().enumerate() {
             if let Some(h) = specific_instance_handle {
-                if cache_change.instance_handle != h {
+                if &cache_change.instance_handle != h {
                     continue;
                 }
             };
@@ -5150,14 +5159,14 @@ impl DataReaderEntity {
 
             if !instances_in_collection
                 .iter()
-                .any(|x| x.handle() == cache_change.instance_handle)
+                .any(|x| x.handle() == &cache_change.instance_handle)
             {
                 instances_in_collection.push(InstanceState::new(cache_change.instance_handle));
             }
 
             let instance_from_collection = instances_in_collection
                 .iter_mut()
-                .find(|x| x.handle() == cache_change.instance_handle)
+                .find(|x| x.handle() == &cache_change.instance_handle)
                 .expect("Instance must exist");
             instance_from_collection.update_state(cache_change.kind);
             let sample_state = cache_change.sample_state;
@@ -5210,7 +5219,7 @@ impl DataReaderEntity {
                     |IndexedSample {
                          sample: (_, sample_info),
                          ..
-                     }| sample_info.instance_handle == handle,
+                     }| &sample_info.instance_handle == handle,
                 )
                 .map(
                     |IndexedSample {
@@ -5227,7 +5236,7 @@ impl DataReaderEntity {
                     |IndexedSample {
                          sample: (_, sample_info),
                          ..
-                     }| sample_info.instance_handle == handle,
+                     }| &sample_info.instance_handle == handle,
                 )
                 .count();
 
@@ -5238,7 +5247,7 @@ impl DataReaderEntity {
                 |IndexedSample {
                      sample: (_, sample_info),
                      ..
-                 }| sample_info.instance_handle == handle,
+                 }| &sample_info.instance_handle == handle,
             ) {
                 sample_info.generation_rank = sample_info.absolute_generation_rank
                     - most_recent_sample_absolute_generation_rank;
@@ -5261,15 +5270,19 @@ impl DataReaderEntity {
         }
     }
 
-    fn next_instance(&mut self, previous_handle: Option<InstanceHandle>) -> Option<InstanceHandle> {
+    fn next_instance(
+        &mut self,
+        previous_handle: &Option<InstanceHandle>,
+    ) -> Option<InstanceHandle> {
         match previous_handle {
             Some(p) => self
                 .instances
                 .iter()
                 .map(|x| x.handle())
-                .filter(|&h| h > p)
-                .min(),
-            None => self.instances.iter().map(|x| x.handle()).min(),
+                .filter(|&h| h > &p)
+                .min()
+                .cloned(),
+            None => self.instances.iter().map(|x| x.handle()).min().cloned(),
         }
     }
 
@@ -5395,7 +5408,7 @@ impl DataReaderEntity {
                 match self
                     .instances
                     .iter_mut()
-                    .find(|x| x.handle() == instance_handle)
+                    .find(|x| x.handle() == &instance_handle)
                 {
                     Some(x) => x.update_state(cache_change.kind),
                     None => {
@@ -5412,7 +5425,7 @@ impl DataReaderEntity {
                 match self
                     .instances
                     .iter_mut()
-                    .find(|x| x.handle() == instance_handle)
+                    .find(|x| x.handle() == &instance_handle)
                 {
                     Some(instance) => {
                         instance.update_state(cache_change.kind);
@@ -5427,7 +5440,7 @@ impl DataReaderEntity {
         let instance = self
             .instances
             .iter()
-            .find(|x| x.handle() == instance_handle)
+            .find(|x| x.handle() == &instance_handle)
             .expect("Sample with handle must exist");
         Ok(ReaderSample {
             kind: cache_change.kind,
@@ -5611,7 +5624,7 @@ impl DataReaderEntity {
                 match self
                     .instances
                     .iter_mut()
-                    .find(|x| x.handle() == sample.instance_handle)
+                    .find(|x| x.handle() == &sample.instance_handle)
                 {
                     Some(x) => x.update_state(sample.kind),
                     None => {
@@ -5628,7 +5641,7 @@ impl DataReaderEntity {
                 match self
                     .instances
                     .iter_mut()
-                    .find(|x| x.handle() == sample.instance_handle)
+                    .find(|x| x.handle() == &sample.instance_handle)
                 {
                     Some(instance) => {
                         instance.update_state(sample.kind);
@@ -5825,7 +5838,7 @@ impl DataReaderEntity {
         sample_states: &[SampleStateKind],
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
-        specific_instance_handle: Option<InstanceHandle>,
+        specific_instance_handle: &Option<InstanceHandle>,
     ) -> DdsResult<SampleList> {
         if !self.enabled {
             return Err(DdsError::NotEnabled);
@@ -5860,10 +5873,10 @@ impl DataReaderEntity {
     fn take(
         &mut self,
         max_samples: i32,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
-        specific_instance_handle: Option<InstanceHandle>,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
+        specific_instance_handle: &Option<InstanceHandle>,
     ) -> DdsResult<SampleList> {
         if !self.enabled {
             return Err(DdsError::NotEnabled);
@@ -5871,9 +5884,9 @@ impl DataReaderEntity {
 
         let indexed_sample_list = self.create_indexed_sample_collection(
             max_samples,
-            &sample_states,
-            &view_states,
-            &instance_states,
+            sample_states,
+            view_states,
+            instance_states,
             specific_instance_handle,
         )?;
 
@@ -5898,10 +5911,10 @@ impl DataReaderEntity {
     fn take_next_instance(
         &mut self,
         max_samples: i32,
-        previous_handle: Option<InstanceHandle>,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
+        previous_handle: &Option<InstanceHandle>,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
     ) -> DdsResult<SampleList> {
         if !self.enabled {
             return Err(DdsError::NotEnabled);
@@ -5913,7 +5926,7 @@ impl DataReaderEntity {
                 sample_states,
                 view_states,
                 instance_states,
-                Some(next_handle),
+                &Some(next_handle),
             ),
             None => Err(DdsError::NoData),
         }
@@ -5922,7 +5935,7 @@ impl DataReaderEntity {
     fn read_next_instance(
         &mut self,
         max_samples: i32,
-        previous_handle: Option<InstanceHandle>,
+        previous_handle: &Option<InstanceHandle>,
         sample_states: &[SampleStateKind],
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
@@ -5937,7 +5950,7 @@ impl DataReaderEntity {
                 sample_states,
                 view_states,
                 instance_states,
-                Some(next_handle),
+                &Some(next_handle),
             ),
             None => Err(DdsError::NoData),
         }

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -765,7 +765,7 @@ impl DcpsDomainParticipant {
                 )
                 .into(),
             );
-            let timestamp = self.get_current_time(runtime);
+            let timestamp = runtime.clock().now();
             let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
             let (reply_sender, _) = oneshot();
             self.write_w_timestamp(
@@ -782,7 +782,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn announce_deleted_participant(&mut self, runtime: &impl DdsRuntime) {
         if self.domain_participant.enabled {
-            let timestamp = self.get_current_time(runtime);
+            let timestamp = runtime.clock().now();
             if let Some(dw) = self
                 .domain_participant
                 .builtin_publisher
@@ -888,7 +888,7 @@ impl DcpsDomainParticipant {
             )
             .into(),
         );
-        let timestamp = self.get_current_time(runtime);
+        let timestamp = runtime.clock().now();
         let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
@@ -907,7 +907,7 @@ impl DcpsDomainParticipant {
         data_writer: DataWriterEntity,
         runtime: &impl DdsRuntime,
     ) {
-        let timestamp = self.get_current_time(runtime);
+        let timestamp = runtime.clock().now();
         if let Some(dw) = self
             .domain_participant
             .builtin_publisher
@@ -1023,7 +1023,7 @@ impl DcpsDomainParticipant {
             )
             .into(),
         );
-        let timestamp = self.get_current_time(runtime);
+        let timestamp = runtime.clock().now();
         let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
@@ -1042,7 +1042,7 @@ impl DcpsDomainParticipant {
         data_reader: DataReaderEntity,
         runtime: &impl DdsRuntime,
     ) {
-        let timestamp = self.get_current_time(runtime);
+        let timestamp = runtime.clock().now();
         if let Some(dw) = self
             .domain_participant
             .builtin_publisher
@@ -1111,7 +1111,7 @@ impl DcpsDomainParticipant {
             )
             .into(),
         );
-        let timestamp = self.get_current_time(runtime);
+        let timestamp = runtime.clock().now();
         let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
         let (reply_sender, _) = oneshot();
         self.write_w_timestamp(
@@ -2078,7 +2078,7 @@ impl DcpsDomainParticipant {
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (), // Do nothing,
         }
 
-        let reception_timestamp = self.get_current_time(runtime);
+        let reception_timestamp = runtime.clock().now();
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2195,7 +2195,7 @@ impl DcpsDomainParticipant {
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (),
         }
 
-        let reception_timestamp = self.get_current_time(runtime);
+        let reception_timestamp = runtime.clock().now();
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2343,7 +2343,7 @@ impl DcpsDomainParticipant {
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (),
         }
 
-        let reception_timestamp = self.get_current_time(runtime);
+        let reception_timestamp = runtime.clock().now();
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2409,7 +2409,7 @@ impl DcpsDomainParticipant {
             | ChangeKind::NotAliveDisposedUnregistered => (),
         }
 
-        let reception_timestamp = self.get_current_time(runtime);
+        let reception_timestamp = runtime.clock().now();
         if let Some(reader) = self
             .domain_participant
             .builtin_subscriber
@@ -2430,7 +2430,7 @@ impl DcpsDomainParticipant {
         data_reader_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) {
-        let reception_timestamp = self.get_current_time(runtime);
+        let reception_timestamp = runtime.clock().now();
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
@@ -2847,7 +2847,7 @@ impl DcpsDomainParticipant {
         change_instance_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) {
-        let current_time = self.get_current_time(runtime);
+        let current_time = runtime.clock().now();
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
@@ -3003,7 +3003,7 @@ impl DcpsDomainParticipant {
         change_instance_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) {
-        let current_time = self.get_current_time(runtime);
+        let current_time = runtime.clock().now();
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
@@ -3197,7 +3197,6 @@ impl DcpsDomainParticipant {
     }
 
     /// Remove discovered [domain participant](SpdpDiscoveredParticipantData) with the speficied [handle](InstanceHandle).
-    #[tracing::instrument(skip(self))]
     fn remove_discovered_participant(&mut self, handle: &InstanceHandle) {
         self.domain_participant
             .discovered_participant_list

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -645,23 +645,23 @@ impl DcpsDomainParticipant {
 
     fn get_data_writer_async<Foo>(
         &self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
     ) -> DdsResult<DataWriterAsync<Foo>> {
         let data_writer = self
             .domain_participant
             .user_defined_publisher_list
             .iter()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
             .ok_or(DdsError::AlreadyDeleted)?
             .data_writer_list
             .iter()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
             .ok_or(DdsError::AlreadyDeleted)?;
 
         Ok(DataWriterAsync::new(
-            data_writer_handle,
-            self.get_publisher_async(publisher_handle)?,
+            *data_writer_handle,
+            self.get_publisher_async(*publisher_handle)?,
             self.get_topic_description_async(data_writer.topic_name.clone())?,
         ))
     }
@@ -706,8 +706,8 @@ impl DcpsDomainParticipant {
         }
     }
 
-    pub fn get_instance_handle(&self) -> InstanceHandle {
-        self.domain_participant.instance_handle
+    pub fn get_instance_handle(&self) -> &InstanceHandle {
+        &self.domain_participant.instance_handle
     }
 
     pub fn get_builtin_subscriber_status_condition(&self) -> &DcpsStatusCondition {
@@ -817,22 +817,22 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     fn announce_data_writer(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return;
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return;
         };
@@ -1125,9 +1125,9 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     fn add_discovered_reader(
         &mut self,
-        discovered_reader_data: DiscoveredReaderData,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        discovered_reader_data: &DiscoveredReaderData,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
     ) {
         let default_unicast_locator_list = if let Some(p) = self
             .domain_participant
@@ -1163,7 +1163,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return;
         };
@@ -1215,7 +1215,7 @@ impl DcpsDomainParticipant {
             let Some(data_writer) = publisher
                 .data_writer_list
                 .iter_mut()
-                .find(|x| x.instance_handle == data_writer_handle)
+                .find(|x| &x.instance_handle == data_writer_handle)
             else {
                 return;
             };
@@ -1244,7 +1244,10 @@ impl DcpsDomainParticipant {
                     {
                         default_unicast_locator_list
                     } else {
-                        discovered_reader_data.reader_proxy.unicast_locator_list
+                        discovered_reader_data
+                            .reader_proxy
+                            .unicast_locator_list
+                            .clone()
                     };
                     let multicast_locator_list = if discovered_reader_data
                         .reader_proxy
@@ -1253,7 +1256,10 @@ impl DcpsDomainParticipant {
                     {
                         default_multicast_locator_list
                     } else {
-                        discovered_reader_data.reader_proxy.multicast_locator_list
+                        discovered_reader_data
+                            .reader_proxy
+                            .multicast_locator_list
+                            .clone()
                     };
                     let reliability_kind = match discovered_reader_data
                         .dds_subscription_data
@@ -1302,14 +1308,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_publisher_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == publisher_handle)
+                            .find(|x| &x.instance_handle == publisher_handle)
                         else {
                             return;
                         };
                         let Some(data_writer) = publisher
                             .data_writer_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_writer_handle)
+                            .find(|x| &x.instance_handle == data_writer_handle)
                         else {
                             return;
                         };
@@ -1330,14 +1336,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_publisher_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == publisher_handle)
+                            .find(|x| &x.instance_handle == publisher_handle)
                         else {
                             return;
                         };
                         let Some(data_writer) = publisher
                             .data_writer_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_writer_handle)
+                            .find(|x| &x.instance_handle == data_writer_handle)
                         else {
                             return;
                         };
@@ -1360,14 +1366,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_publisher_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == publisher_handle)
+                            .find(|x| &x.instance_handle == publisher_handle)
                         else {
                             return;
                         };
                         let Some(data_writer) = publisher
                             .data_writer_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_writer_handle)
+                            .find(|x| &x.instance_handle == data_writer_handle)
                         else {
                             return;
                         };
@@ -1382,14 +1388,14 @@ impl DcpsDomainParticipant {
                         .domain_participant
                         .user_defined_publisher_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == publisher_handle)
+                        .find(|x| &x.instance_handle == publisher_handle)
                     else {
                         return;
                     };
                     let Some(data_writer) = publisher
                         .data_writer_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == data_writer_handle)
+                        .find(|x| &x.instance_handle == data_writer_handle)
                     else {
                         return;
                     };
@@ -1418,14 +1424,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_publisher_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == publisher_handle)
+                            .find(|x| &x.instance_handle == publisher_handle)
                         else {
                             return;
                         };
                         let Some(data_writer) = publisher
                             .data_writer_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_writer_handle)
+                            .find(|x| &x.instance_handle == data_writer_handle)
                         else {
                             return;
                         };
@@ -1446,14 +1452,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_publisher_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == publisher_handle)
+                            .find(|x| &x.instance_handle == publisher_handle)
                         else {
                             return;
                         };
                         let Some(data_writer) = publisher
                             .data_writer_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_writer_handle)
+                            .find(|x| &x.instance_handle == data_writer_handle)
                         else {
                             return;
                         };
@@ -1476,14 +1482,14 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_publisher_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == publisher_handle)
+                            .find(|x| &x.instance_handle == publisher_handle)
                         else {
                             return;
                         };
                         let Some(data_writer) = publisher
                             .data_writer_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_writer_handle)
+                            .find(|x| &x.instance_handle == data_writer_handle)
                         else {
                             return;
                         };
@@ -1498,14 +1504,14 @@ impl DcpsDomainParticipant {
                         .domain_participant
                         .user_defined_publisher_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == publisher_handle)
+                        .find(|x| &x.instance_handle == publisher_handle)
                     else {
                         return;
                     };
                     let Some(data_writer) = publisher
                         .data_writer_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == data_writer_handle)
+                        .find(|x| &x.instance_handle == data_writer_handle)
                     else {
                         return;
                     };
@@ -1992,12 +1998,12 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     fn add_cache_change(
         &mut self,
-        cache_change: CacheChange,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        cache_change: &CacheChange,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) {
-        let reader_guid = Guid::from(<[u8; 16]>::from(data_reader_handle));
+        let reader_guid = Guid::from(<[u8; 16]>::from(*data_reader_handle));
         match reader_guid.entity_id() {
             ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER => {
                 self.add_builtin_participants_detector_cache_change(cache_change, runtime)
@@ -2023,7 +2029,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_participants_detector_cache_change(
         &mut self,
-        cache_change: CacheChange,
+        cache_change: &CacheChange,
         runtime: &impl DdsRuntime,
     ) {
         let spdp_type_support =
@@ -2061,7 +2067,7 @@ impl DcpsDomainParticipant {
                     return;
                 };
 
-                self.remove_discovered_participant(discovered_participant_handle);
+                self.remove_discovered_participant(&discovered_participant_handle);
             }
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (), // Do nothing,
         }
@@ -2083,7 +2089,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_publications_detector_cache_change(
         &mut self,
-        cache_change: CacheChange,
+        cache_change: &CacheChange,
         runtime: &impl DdsRuntime,
     ) {
         let sedp_writer_type_support =
@@ -2201,7 +2207,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_subscriptions_detector_cache_change(
         &mut self,
-        cache_change: CacheChange,
+        cache_change: &CacheChange,
         runtime: &impl DdsRuntime,
     ) {
         let sedp_reader_type_support =
@@ -2293,9 +2299,9 @@ impl DcpsDomainParticipant {
                     }
                     for (publisher_handle, data_writer_handle) in handle_list {
                         self.add_discovered_reader(
-                            discovered_reader_data.clone(),
-                            publisher_handle,
-                            data_writer_handle,
+                            &discovered_reader_data,
+                            &publisher_handle,
+                            &data_writer_handle,
                         );
                     }
                 }
@@ -2350,7 +2356,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_topics_detector_cache_change(
         &mut self,
-        cache_change: CacheChange,
+        cache_change: &CacheChange,
         runtime: &impl DdsRuntime,
     ) {
         let sedp_topic_type_support =
@@ -2417,9 +2423,9 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn add_user_defined_cache_change(
         &mut self,
-        cache_change: CacheChange,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        cache_change: &CacheChange,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) {
         let reception_timestamp = self.get_current_time(runtime);
@@ -2427,7 +2433,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return;
         };
@@ -2435,7 +2441,7 @@ impl DcpsDomainParticipant {
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return;
         };
@@ -2580,6 +2586,8 @@ impl DcpsDomainParticipant {
                         let dcps_sender = self.dcps_sender;
 
                         let mut timer_handle = runtime.timer();
+                        let subscriber_handle = *subscriber_handle;
+                        let data_reader_handle = *data_reader_handle;
                         runtime.spawner().spawn(async move {
                             loop {
                                 timer_handle.delay(deadline_missed_period.into()).await;
@@ -2604,7 +2612,7 @@ impl DcpsDomainParticipant {
                         .domain_participant
                         .user_defined_subscriber_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == subscriber_handle)
+                        .find(|x| &x.instance_handle == subscriber_handle)
                     else {
                         return;
                     };
@@ -2613,7 +2621,7 @@ impl DcpsDomainParticipant {
                         .listener_mask
                         .contains(&StatusKind::DataOnReaders)
                     {
-                        let Ok(the_subscriber) = self.get_subscriber_async(subscriber_handle)
+                        let Ok(the_subscriber) = self.get_subscriber_async(*subscriber_handle)
                         else {
                             return;
                         };
@@ -2621,7 +2629,7 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
@@ -2631,7 +2639,7 @@ impl DcpsDomainParticipant {
                         }
                     } else if data_reader_on_data_available_active {
                         let Ok(the_reader) =
-                            self.get_data_reader_async(subscriber_handle, data_reader_handle)
+                            self.get_data_reader_async(*subscriber_handle, *data_reader_handle)
                         else {
                             return;
                         };
@@ -2639,7 +2647,7 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
@@ -2647,7 +2655,7 @@ impl DcpsDomainParticipant {
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -2661,7 +2669,7 @@ impl DcpsDomainParticipant {
                         .domain_participant
                         .user_defined_subscriber_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == subscriber_handle)
+                        .find(|x| &x.instance_handle == subscriber_handle)
                     else {
                         return;
                     };
@@ -2672,7 +2680,7 @@ impl DcpsDomainParticipant {
                     let Some(data_reader) = subscriber
                         .data_reader_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == data_reader_handle)
+                        .find(|x| &x.instance_handle == data_reader_handle)
                     else {
                         return;
                     };
@@ -2694,7 +2702,7 @@ impl DcpsDomainParticipant {
                     {
                         let status = data_reader.get_sample_rejected_status();
                         let Ok(the_reader) =
-                            self.get_data_reader_async(subscriber_handle, data_reader_handle)
+                            self.get_data_reader_async(*subscriber_handle, *data_reader_handle)
                         else {
                             return;
                         };
@@ -2702,7 +2710,7 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
@@ -2710,7 +2718,7 @@ impl DcpsDomainParticipant {
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -2723,7 +2731,7 @@ impl DcpsDomainParticipant {
                         .contains(&StatusKind::SampleRejected)
                     {
                         let Ok(the_reader) =
-                            self.get_data_reader_async(subscriber_handle, data_reader_handle)
+                            self.get_data_reader_async(*subscriber_handle, *data_reader_handle)
                         else {
                             return;
                         };
@@ -2731,7 +2739,7 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
@@ -2739,7 +2747,7 @@ impl DcpsDomainParticipant {
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -2754,7 +2762,7 @@ impl DcpsDomainParticipant {
                         .contains(&StatusKind::SampleRejected)
                     {
                         let Ok(the_reader) =
-                            self.get_data_reader_async(subscriber_handle, data_reader_handle)
+                            self.get_data_reader_async(*subscriber_handle, *data_reader_handle)
                         else {
                             return;
                         };
@@ -2762,7 +2770,7 @@ impl DcpsDomainParticipant {
                             .domain_participant
                             .user_defined_subscriber_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == subscriber_handle)
+                            .find(|x| &x.instance_handle == subscriber_handle)
                         else {
                             return;
                         };
@@ -2770,7 +2778,7 @@ impl DcpsDomainParticipant {
                         let Some(data_reader) = subscriber
                             .data_reader_list
                             .iter_mut()
-                            .find(|x| x.instance_handle == data_reader_handle)
+                            .find(|x| &x.instance_handle == data_reader_handle)
                         else {
                             return;
                         };
@@ -2785,7 +2793,7 @@ impl DcpsDomainParticipant {
                         .domain_participant
                         .user_defined_subscriber_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == subscriber_handle)
+                        .find(|x| &x.instance_handle == subscriber_handle)
                     else {
                         return;
                     };
@@ -2793,7 +2801,7 @@ impl DcpsDomainParticipant {
                     let Some(data_reader) = subscriber
                         .data_reader_list
                         .iter_mut()
-                        .find(|x| x.instance_handle == data_reader_handle)
+                        .find(|x| &x.instance_handle == data_reader_handle)
                     else {
                         return;
                     };
@@ -2832,9 +2840,9 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn offered_deadline_missed(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
-        change_instance_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
+        change_instance_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) {
         let current_time = self.get_current_time(runtime);
@@ -2842,14 +2850,14 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return;
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return;
         };
@@ -2869,7 +2877,7 @@ impl DcpsDomainParticipant {
 
         data_writer
             .offered_deadline_missed_status
-            .last_instance_handle = change_instance_handle;
+            .last_instance_handle = *change_instance_handle;
         data_writer.offered_deadline_missed_status.total_count += 1;
         data_writer
             .offered_deadline_missed_status
@@ -2889,14 +2897,14 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .user_defined_publisher_list
                 .iter_mut()
-                .find(|x| x.instance_handle == publisher_handle)
+                .find(|x| &x.instance_handle == publisher_handle)
             else {
                 return;
             };
             let Some(data_writer) = publisher
                 .data_writer_list
                 .iter_mut()
-                .find(|x| x.instance_handle == data_writer_handle)
+                .find(|x| &x.instance_handle == data_writer_handle)
             else {
                 return;
             };
@@ -2917,14 +2925,14 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .user_defined_publisher_list
                 .iter_mut()
-                .find(|x| x.instance_handle == publisher_handle)
+                .find(|x| &x.instance_handle == publisher_handle)
             else {
                 return;
             };
             let Some(data_writer) = publisher
                 .data_writer_list
                 .iter_mut()
-                .find(|x| x.instance_handle == data_writer_handle)
+                .find(|x| &x.instance_handle == data_writer_handle)
             else {
                 return;
             };
@@ -2947,14 +2955,14 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .user_defined_publisher_list
                 .iter_mut()
-                .find(|x| x.instance_handle == publisher_handle)
+                .find(|x| &x.instance_handle == publisher_handle)
             else {
                 return;
             };
             let Some(data_writer) = publisher
                 .data_writer_list
                 .iter_mut()
-                .find(|x| x.instance_handle == data_writer_handle)
+                .find(|x| &x.instance_handle == data_writer_handle)
             else {
                 return;
             };
@@ -2969,14 +2977,14 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return;
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return;
         };
@@ -3188,14 +3196,14 @@ impl DcpsDomainParticipant {
 
     /// Remove discovered [domain participant](SpdpDiscoveredParticipantData) with the speficied [handle](InstanceHandle).
     #[tracing::instrument(skip(self))]
-    fn remove_discovered_participant(&mut self, handle: InstanceHandle) {
+    fn remove_discovered_participant(&mut self, handle: &InstanceHandle) {
         self.domain_participant
             .discovered_participant_list
             .retain(|domain_participant| {
-                domain_participant.dds_participant_data.key.value != handle
+                &domain_participant.dds_participant_data.key.value != handle
             });
 
-        let prefix = Guid::from(<[u8; 16]>::from(handle)).prefix();
+        let prefix = Guid::from(<[u8; 16]>::from(*handle)).prefix();
 
         for subscriber in &mut self.domain_participant.user_defined_subscriber_list {
             for data_reader in &mut subscriber.data_reader_list {
@@ -3816,9 +3824,9 @@ impl DcpsDomainParticipant {
                                             let subscriber_handle = subscriber.instance_handle;
                                             let reader_handle = dr.instance_handle;
                                             return self.add_cache_change(
-                                                change,
-                                                subscriber_handle,
-                                                reader_handle,
+                                                &change,
+                                                &subscriber_handle,
+                                                &reader_handle,
                                                 runtime,
                                             );
                                         }
@@ -3837,9 +3845,9 @@ impl DcpsDomainParticipant {
                                             let subscriber_handle = subscriber.instance_handle;
                                             let reader_handle = dr.instance_handle;
                                             return self.add_cache_change(
-                                                change,
-                                                subscriber_handle,
-                                                reader_handle,
+                                                &change,
+                                                &subscriber_handle,
+                                                &reader_handle,
                                                 runtime,
                                             );
                                         }
@@ -3862,9 +3870,9 @@ impl DcpsDomainParticipant {
                                 let subscriber_handle = subscriber.instance_handle;
                                 let reader_handle = dr.instance_handle;
                                 return self.add_cache_change(
-                                    change,
-                                    subscriber_handle,
-                                    reader_handle,
+                                    &change,
+                                    &subscriber_handle,
+                                    &reader_handle,
                                     runtime,
                                 );
                             }
@@ -4917,10 +4925,10 @@ impl DataWriterEntity {
         status
     }
 
-    fn get_instance_write_time(&self, instance_handle: InstanceHandle) -> Option<Time> {
+    fn get_instance_write_time(&self, instance_handle: &InstanceHandle) -> Option<Time> {
         self.instance_publication_time
             .iter()
-            .find(|x| x.instance == instance_handle)
+            .find(|x| &x.instance == instance_handle)
             .map(|x| x.last_write_time)
     }
 
@@ -5267,7 +5275,7 @@ impl DataReaderEntity {
 
     fn convert_cache_change_to_sample(
         &mut self,
-        cache_change: CacheChange,
+        cache_change: &CacheChange,
         reception_timestamp: Time,
     ) -> DdsResult<ReaderSample> {
         struct KeyHolder<'a> {
@@ -5436,7 +5444,7 @@ impl DataReaderEntity {
 
     fn add_reader_change(
         &mut self,
-        cache_change: CacheChange,
+        cache_change: &CacheChange,
         reception_timestamp: Time,
     ) -> DdsResult<AddChangeResult> {
         let sample = self.convert_cache_change_to_sample(cache_change, reception_timestamp)?;

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -2003,7 +2003,6 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
     fn add_cache_change(
         &mut self,
         cache_change: &CacheChange,
@@ -2034,7 +2033,6 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_participants_detector_cache_change(
         &mut self,
         cache_change: &CacheChange,
@@ -2094,7 +2092,6 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_publications_detector_cache_change(
         &mut self,
         cache_change: &CacheChange,
@@ -2212,7 +2209,6 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_subscriptions_detector_cache_change(
         &mut self,
         cache_change: &CacheChange,
@@ -2361,7 +2357,6 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
     pub fn add_builtin_topics_detector_cache_change(
         &mut self,
         cache_change: &CacheChange,
@@ -2428,7 +2423,6 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
     pub fn add_user_defined_cache_change(
         &mut self,
         cache_change: &CacheChange,

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -107,7 +107,6 @@ use alloc::{
     boxed::Box,
     collections::{BTreeSet, VecDeque},
     string::{String, ToString},
-    sync::Arc,
     vec,
     vec::Vec,
 };
@@ -3028,7 +3027,7 @@ impl DcpsDomainParticipant {
         };
 
         if let DurationKind::Finite(deadline) = data_reader.qos.deadline.period {
-            if let Some(t) = data_reader.get_instance_received_time(&change_instance_handle) {
+            if let Some(t) = data_reader.get_instance_received_time(change_instance_handle) {
                 if current_time - t < deadline {
                     return;
                 }
@@ -3037,7 +3036,7 @@ impl DcpsDomainParticipant {
             }
         }
 
-        data_reader.remove_instance_ownership(&change_instance_handle);
+        data_reader.remove_instance_ownership(change_instance_handle);
         data_reader.increment_requested_deadline_missed_status(*change_instance_handle);
 
         if data_reader
@@ -5279,7 +5278,7 @@ impl DataReaderEntity {
                 .instances
                 .iter()
                 .map(|x| x.handle())
-                .filter(|&h| h > &p)
+                .filter(|&h| h > p)
                 .min()
                 .cloned(),
             None => self.instances.iter().map(|x| x.handle()).min().cloned(),

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -535,22 +535,22 @@ impl DcpsDomainParticipant {
     }
 
     #[tracing::instrument(skip(self))]
-    pub fn ignore_publication(&mut self, handle: InstanceHandle) -> DdsResult<()> {
+    pub fn ignore_publication(&mut self, handle: &InstanceHandle) -> DdsResult<()> {
         if !self.domain_participant.enabled {
             return Err(DdsError::NotEnabled);
         }
 
-        self.domain_participant.ignored_publications.insert(handle);
+        self.domain_participant.ignored_publications.insert(*handle);
         Ok(())
     }
 
     #[tracing::instrument(skip(self))]
-    pub fn ignore_subscription(&mut self, handle: InstanceHandle) -> DdsResult<()> {
+    pub fn ignore_subscription(&mut self, handle: &InstanceHandle) -> DdsResult<()> {
         if !self.domain_participant.enabled {
             return Err(DdsError::NotEnabled);
         }
 
-        self.domain_participant.ignored_subscriptions.insert(handle);
+        self.domain_participant.ignored_subscriptions.insert(*handle);
         Ok(())
     }
 

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -210,10 +210,7 @@ impl DcpsDomainParticipant {
                 "Subscriber still contains data readers".to_string(),
             ));
         }
-        let Some(_) = self
-            .domain_participant
-            .remove_subscriber(subscriber_handle)
-        else {
+        let Some(_) = self.domain_participant.remove_subscriber(subscriber_handle) else {
             return Err(DdsError::AlreadyDeleted);
         };
 
@@ -550,7 +547,9 @@ impl DcpsDomainParticipant {
             return Err(DdsError::NotEnabled);
         }
 
-        self.domain_participant.ignored_subscriptions.insert(*handle);
+        self.domain_participant
+            .ignored_subscriptions
+            .insert(*handle);
         Ok(())
     }
 

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -116,7 +116,7 @@ impl DcpsDomainParticipant {
                 "Publisher still contains data writers".to_string(),
             ));
         }
-        let Some(_) = self.domain_participant.remove_publisher(&publisher_handle) else {
+        let Some(_) = self.domain_participant.remove_publisher(publisher_handle) else {
             return Err(DdsError::AlreadyDeleted);
         };
 
@@ -212,7 +212,7 @@ impl DcpsDomainParticipant {
         }
         let Some(_) = self
             .domain_participant
-            .remove_subscriber(&subscriber_handle)
+            .remove_subscriber(subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -24,9 +24,8 @@ use crate::{
         instance::InstanceHandle,
         qos::{DomainParticipantQos, PublisherQos, QosKind, SubscriberQos, TopicQos},
         status::StatusKind,
-        time::Time,
     },
-    runtime::{Clock, DdsRuntime},
+    runtime::DdsRuntime,
     transport::types::{USER_DEFINED_READER_GROUP, USER_DEFINED_TOPIC, USER_DEFINED_WRITER_GROUP},
     xtypes::dynamic_type::DynamicType,
 };
@@ -694,11 +693,6 @@ impl DcpsDomainParticipant {
         };
 
         Ok(handle.clone())
-    }
-
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn get_current_time(&mut self, runtime: &impl DdsRuntime) -> Time {
-        runtime.clock().now()
     }
 
     #[tracing::instrument(skip(self, runtime))]

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -94,10 +94,10 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn delete_user_defined_publisher(
         &mut self,
-        participant_handle: InstanceHandle,
-        publisher_handle: InstanceHandle,
+        participant_handle: &InstanceHandle,
+        publisher_handle: &InstanceHandle,
     ) -> DdsResult<()> {
-        if participant_handle != self.domain_participant.instance_handle {
+        if participant_handle != &self.domain_participant.instance_handle {
             return Err(DdsError::PreconditionNotMet(
                 "Publisher can only be deleted from its parent participant".to_string(),
             ));
@@ -106,7 +106,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -187,10 +187,10 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn delete_user_defined_subscriber(
         &mut self,
-        participant_handle: InstanceHandle,
-        subscriber_handle: InstanceHandle,
+        participant_handle: &InstanceHandle,
+        subscriber_handle: &InstanceHandle,
     ) -> DdsResult<()> {
-        if self.domain_participant.instance_handle != participant_handle {
+        if &self.domain_participant.instance_handle != participant_handle {
             return Err(DdsError::PreconditionNotMet(
                 "Subscriber can only be deleted from its parent participant".to_string(),
             ));
@@ -200,7 +200,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -301,10 +301,10 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn delete_user_defined_topic(
         &mut self,
-        participant_handle: InstanceHandle,
+        participant_handle: &InstanceHandle,
         topic_name: String,
     ) -> DdsResult<()> {
-        if self.domain_participant.instance_handle != participant_handle {
+        if &self.domain_participant.instance_handle != participant_handle {
             return Err(DdsError::PreconditionNotMet(
                 "Topic can only be deleted from its parent participant".to_string(),
             ));
@@ -353,7 +353,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn create_content_filtered_topic(
         &mut self,
-        participant_handle: InstanceHandle,
+        participant_handle: &InstanceHandle,
         name: String,
         related_topic_name: String,
         filter_expression: String,
@@ -406,7 +406,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn delete_content_filtered_topic(
         &mut self,
-        participant_handle: InstanceHandle,
+        participant_handle: &InstanceHandle,
         name: String,
     ) -> DdsResult<()> {
         Ok(())
@@ -516,14 +516,14 @@ impl DcpsDomainParticipant {
 
     /// Ignore participant with the specified [`handle`](InstanceHandle).
     #[tracing::instrument(skip(self))]
-    pub fn ignore_participant(&mut self, handle: InstanceHandle) -> DdsResult<()> {
+    pub fn ignore_participant(&mut self, handle: &InstanceHandle) -> DdsResult<()> {
         // Check enabled
         if !self.domain_participant.enabled {
             return Err(DdsError::NotEnabled);
         }
 
         // Add to ignored participants
-        if !self.domain_participant.ignored_participants.insert(handle) {
+        if !self.domain_participant.ignored_participants.insert(*handle) {
             // Already ignored
             return Ok(());
         }
@@ -657,13 +657,13 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_discovered_participant_data(
         &mut self,
-        participant_handle: InstanceHandle,
+        participant_handle: &InstanceHandle,
     ) -> DdsResult<ParticipantBuiltinTopicData> {
         let Some(handle) = self
             .domain_participant
             .discovered_participant_list
             .iter()
-            .find(|p| &p.dds_participant_data.key().value == participant_handle.as_ref())
+            .find(|p| &p.dds_participant_data.key().value == participant_handle)
         else {
             return Err(DdsError::BadParameter);
         };
@@ -683,11 +683,11 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_discovered_topic_data(
         &mut self,
-        topic_handle: InstanceHandle,
+        topic_handle: &InstanceHandle,
     ) -> DdsResult<TopicBuiltinTopicData> {
         let Some(handle) = self
             .domain_participant
-            .get_discovered_topic_data(&topic_handle)
+            .get_discovered_topic_data(topic_handle)
         else {
             return Err(DdsError::PreconditionNotMet(String::from(
                 "Topic with this handle not discovered",

--- a/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
@@ -28,7 +28,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn create_data_writer(
         &mut self,
-        publisher_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
         topic_name: String,
         qos: QosKind<DataWriterQos>,
         dcps_listener: Option<DcpsDataWriterListener>,
@@ -52,7 +52,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -122,7 +122,7 @@ impl DcpsDomainParticipant {
         publisher.data_writer_list.push(data_writer);
 
         if publisher.enabled && publisher.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_writer(publisher_handle, writer_handle, runtime)?;
+            self.enable_data_writer(publisher_handle, &writer_handle, runtime)?;
         }
 
         Ok(data_writer_handle)

--- a/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
@@ -131,15 +131,15 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn delete_data_writer(
         &mut self,
-        publisher_handle: InstanceHandle,
-        datawriter_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        datawriter_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -147,7 +147,7 @@ impl DcpsDomainParticipant {
         if let Some(index) = publisher
             .data_writer_list
             .iter()
-            .position(|x| x.instance_handle == datawriter_handle)
+            .position(|x| &x.instance_handle == datawriter_handle)
         {
             let data_writer = publisher.data_writer_list.remove(index);
             self.announce_deleted_data_writer(data_writer, runtime);
@@ -160,13 +160,13 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_default_datawriter_qos(
         &mut self,
-        publisher_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
     ) -> DdsResult<DataWriterQos> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -176,14 +176,14 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn set_default_datawriter_qos(
         &mut self,
-        publisher_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
         qos: QosKind<DataWriterQos>,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -200,7 +200,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn set_publisher_qos(
         &mut self,
-        publisher_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
         qos: QosKind<PublisherQos>,
     ) -> DdsResult<()> {
         let qos = match qos {
@@ -211,7 +211,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -223,13 +223,13 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_publisher_qos(
         &mut self,
-        publisher_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
     ) -> DdsResult<PublisherQos> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -240,7 +240,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn set_publisher_listener(
         &mut self,
-        publisher_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
         dcps_listener: Option<DcpsPublisherListener>,
         mask: Vec<StatusKind>,
         runtime: &impl DdsRuntime,
@@ -249,7 +249,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };

--- a/dds/src/dcps/dcps_domain_participant/reader_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/reader_methods.rs
@@ -131,9 +131,9 @@ impl DcpsDomainParticipant {
         data_reader.read_next_instance(
             max_samples,
             previous_handle,
-            &sample_states,
-            &view_states,
-            &instance_states,
+            sample_states,
+            view_states,
+            instance_states,
         )
     }
 

--- a/dds/src/dcps/dcps_domain_participant/reader_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/reader_methods.rs
@@ -27,21 +27,21 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn read(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         max_samples: i32,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
-        specific_instance_handle: Option<InstanceHandle>,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
+        specific_instance_handle: &Option<InstanceHandle>,
     ) -> DdsResult<Vec<(Option<DynamicData>, SampleInfo)>> {
-        let subscriber = if subscriber_handle == self.domain_participant.instance_handle {
+        let subscriber = if subscriber_handle == &self.domain_participant.instance_handle {
             Some(&mut self.domain_participant.builtin_subscriber)
         } else {
             self.domain_participant
                 .user_defined_subscriber_list
                 .iter_mut()
-                .find(|x| x.instance_handle == subscriber_handle)
+                .find(|x| &x.instance_handle == subscriber_handle)
         };
 
         let Some(subscriber) = subscriber else {
@@ -51,16 +51,16 @@ impl DcpsDomainParticipant {
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
 
         data_reader.read(
             max_samples,
-            &sample_states,
-            &view_states,
-            &instance_states,
+            sample_states,
+            view_states,
+            instance_states,
             specific_instance_handle,
         )
     }
@@ -69,26 +69,26 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn take(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         max_samples: i32,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
-        specific_instance_handle: Option<InstanceHandle>,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
+        specific_instance_handle: &Option<InstanceHandle>,
     ) -> DdsResult<Vec<(Option<DynamicData>, SampleInfo)>> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -105,26 +105,26 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn read_next_instance(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         max_samples: i32,
-        previous_handle: Option<InstanceHandle>,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
+        previous_handle: &Option<InstanceHandle>,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<(Option<DynamicData>, SampleInfo)>> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -141,26 +141,26 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn take_next_instance(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         max_samples: i32,
-        previous_handle: Option<InstanceHandle>,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
+        previous_handle: &Option<InstanceHandle>,
+        sample_states: &[SampleStateKind],
+        view_states: &[ViewStateKind],
+        instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<(Option<DynamicData>, SampleInfo)>> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -176,21 +176,21 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_subscription_matched_status(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
     ) -> DdsResult<SubscriptionMatchedStatus> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -248,22 +248,22 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_matched_publication_data(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
-        publication_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
+        publication_handle: &InstanceHandle,
     ) -> DdsResult<PublicationBuiltinTopicData> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -282,21 +282,21 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_matched_publications(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
     ) -> DdsResult<Vec<InstanceHandle>> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -307,8 +307,8 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn set_data_reader_qos(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         qos: QosKind<DataReaderQos>,
         runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
@@ -316,7 +316,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -327,7 +327,7 @@ impl DcpsDomainParticipant {
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -348,14 +348,14 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_data_reader_qos(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
     ) -> DdsResult<DataReaderQos> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -363,7 +363,7 @@ impl DcpsDomainParticipant {
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -373,8 +373,8 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn set_data_reader_listener(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         dcps_listener: Option<DcpsDataReaderListener>,
         listener_mask: Vec<StatusKind>,
         runtime: &impl DdsRuntime,
@@ -383,14 +383,14 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -403,14 +403,14 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn is_historical_data_received(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
     ) -> DdsResult<bool> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -418,7 +418,7 @@ impl DcpsDomainParticipant {
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -445,22 +445,22 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn enable_data_reader(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        data_reader_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_reader) = subscriber
             .data_reader_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
+            .find(|x| &x.instance_handle == data_reader_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -471,7 +471,7 @@ impl DcpsDomainParticipant {
                 self.domain_participant.discovered_writer_list.to_vec();
             for discovered_writer_data in discovered_writer_list {
                 self.add_discovered_writer(
-                    discovered_writer_data,
+                    &discovered_writer_data,
                     subscriber_handle,
                     data_reader_handle,
                 );

--- a/dds/src/dcps/dcps_domain_participant/status_condition_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/status_condition_methods.rs
@@ -22,7 +22,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 subscriber_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 let s = dp
                     .domain_participant
                     .user_defined_subscriber_list
@@ -38,7 +38,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 topic_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for t in dp.domain_participant.topic_description_list.iter_mut() {
                     match t {
                         super::TopicDescriptionKind::Topic(topic_entity) => {
@@ -56,7 +56,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 writer_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for p in dp
                     .domain_participant
                     .user_defined_publisher_list
@@ -79,7 +79,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 reader_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for s in dp
                     .domain_participant
                     .user_defined_subscriber_list
@@ -112,7 +112,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 subscriber_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 let s = dp
                     .domain_participant
                     .user_defined_subscriber_list
@@ -129,7 +129,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 topic_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for t in dp.domain_participant.topic_description_list.iter_mut() {
                     match t {
                         super::TopicDescriptionKind::Topic(topic_entity) => {
@@ -150,7 +150,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 writer_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for p in dp
                     .domain_participant
                     .user_defined_publisher_list
@@ -174,7 +174,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 reader_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for s in dp
                     .domain_participant
                     .user_defined_subscriber_list
@@ -207,7 +207,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 subscriber_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 let s = dp
                     .domain_participant
                     .user_defined_subscriber_list
@@ -223,7 +223,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 topic_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for t in dp.domain_participant.topic_description_list.iter_mut() {
                     match t {
                         super::TopicDescriptionKind::Topic(topic_entity) => {
@@ -241,7 +241,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 writer_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for p in dp
                     .domain_participant
                     .user_defined_publisher_list
@@ -264,7 +264,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 reader_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for s in dp
                     .domain_participant
                     .user_defined_subscriber_list
@@ -297,7 +297,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 subscriber_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 let s = dp
                     .domain_participant
                     .user_defined_subscriber_list
@@ -315,7 +315,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 topic_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for t in dp.domain_participant.topic_description_list.iter_mut() {
                     match t {
                         super::TopicDescriptionKind::Topic(topic_entity) => {
@@ -336,7 +336,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 writer_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for p in dp
                     .domain_participant
                     .user_defined_publisher_list
@@ -361,7 +361,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 reader_handle,
             } => {
-                let dp = self.find_participant(participant_handle)?;
+                let dp = self.find_participant(&participant_handle)?;
                 for s in dp
                     .domain_participant
                     .user_defined_subscriber_list

--- a/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
@@ -31,7 +31,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn create_data_reader(
         &mut self,
-        subscriber_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
         topic_name: String,
         qos: QosKind<DataReaderQos>,
         dcps_listener: Option<DcpsDataReaderListener>,
@@ -70,7 +70,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -144,7 +144,7 @@ impl DcpsDomainParticipant {
         subscriber.data_reader_list.push(data_reader);
 
         if subscriber.enabled && subscriber.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_reader(subscriber_handle, data_reader_handle, runtime)?;
+            self.enable_data_reader(subscriber_handle, &data_reader_handle, runtime)?;
         }
         Ok(data_reader_handle)
     }
@@ -152,15 +152,15 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn delete_data_reader(
         &mut self,
-        subscriber_handle: InstanceHandle,
-        datareader_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
+        datareader_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x: &&mut SubscriberEntity| x.instance_handle == subscriber_handle)
+            .find(|x: &&mut SubscriberEntity| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -168,7 +168,7 @@ impl DcpsDomainParticipant {
         if let Some(index) = subscriber
             .data_reader_list
             .iter()
-            .position(|x| x.instance_handle == datareader_handle)
+            .position(|x| &x.instance_handle == datareader_handle)
         {
             let data_reader = subscriber.data_reader_list.remove(index);
             self.announce_deleted_data_reader(data_reader, runtime);
@@ -181,7 +181,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn lookup_data_reader(
         &mut self,
-        subscriber_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
         topic_name: String,
     ) -> DdsResult<Option<InstanceHandle>> {
         if !self
@@ -194,7 +194,7 @@ impl DcpsDomainParticipant {
         }
 
         // Built-in subscriber is identified by the handle of the participant itself
-        if self.domain_participant.instance_handle == subscriber_handle {
+        if &self.domain_participant.instance_handle == subscriber_handle {
             Ok(self
                 .domain_participant
                 .builtin_subscriber
@@ -207,7 +207,7 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .user_defined_subscriber_list
                 .iter_mut()
-                .find(|x| x.instance_handle == subscriber_handle)
+                .find(|x| &x.instance_handle == subscriber_handle)
             else {
                 return Err(DdsError::AlreadyDeleted);
             };
@@ -221,14 +221,14 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn set_default_data_reader_qos(
         &mut self,
-        subscriber_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
         qos: QosKind<DataReaderQos>,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -244,13 +244,13 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_default_data_reader_qos(
         &mut self,
-        subscriber_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
     ) -> DdsResult<DataReaderQos> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -261,7 +261,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn set_subscriber_qos(
         &mut self,
-        subscriber_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
         qos: QosKind<SubscriberQos>,
     ) -> DdsResult<()> {
         let qos = match qos {
@@ -273,7 +273,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -288,13 +288,13 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_subscriber_qos(
         &mut self,
-        subscriber_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
     ) -> DdsResult<SubscriberQos> {
         let Some(subscriber) = self
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -305,7 +305,7 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, listener_sender_task, runtime))]
     pub fn set_subscriber_listener(
         &mut self,
-        subscriber_handle: InstanceHandle,
+        subscriber_handle: &InstanceHandle,
         listener_sender_task: Option<DcpsSubscriberListener>,
         mask: Vec<StatusKind>,
         runtime: &impl DdsRuntime,
@@ -314,7 +314,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_subscriber_list
             .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
+            .find(|x| &x.instance_handle == subscriber_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -59,8 +59,8 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, dcps_listener, runtime))]
     pub fn set_listener_data_writer(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
         dcps_listener: Option<DcpsDataWriterListener>,
         listener_mask: Vec<StatusKind>,
         runtime: &impl DdsRuntime,
@@ -69,14 +69,14 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Ok(());
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Ok(());
         };
@@ -91,21 +91,21 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_data_writer_qos(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
     ) -> DdsResult<DataWriterQos> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -116,21 +116,21 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_matched_subscriptions(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
     ) -> DdsResult<Vec<InstanceHandle>> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -144,22 +144,22 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_matched_subscription_data(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
-        subscription_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
+        subscription_handle: &InstanceHandle,
     ) -> DdsResult<SubscriptionBuiltinTopicData> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -174,8 +174,8 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn unregister_instance(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
         dynamic_data: DynamicData,
         timestamp: Time,
         runtime: &impl DdsRuntime,
@@ -184,14 +184,14 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -207,22 +207,22 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn lookup_instance(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
-        dynamic_data: DynamicData,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
+        dynamic_data: &DynamicData,
     ) -> DdsResult<Option<InstanceHandle>> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -231,13 +231,15 @@ impl DcpsDomainParticipant {
             return Err(DdsError::NotEnabled);
         }
 
-        let instance_handle =
-            match get_instance_handle_from_dynamic_data(data_writer.type_support, dynamic_data) {
-                Ok(k) => k,
-                Err(e) => {
-                    return Err(e.into());
-                }
-            };
+        let instance_handle = match get_instance_handle_from_dynamic_data(
+            data_writer.type_support,
+            dynamic_data.clone(),
+        ) {
+            Ok(k) => k,
+            Err(e) => {
+                return Err(e.into());
+            }
+        };
 
         Ok(data_writer
             .registered_instance_list
@@ -249,9 +251,9 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, reply_sender, runtime))]
     pub fn write_w_timestamp(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
-        dynamic_data: DynamicData,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
+        dynamic_data: &DynamicData,
         timestamp: Time,
         runtime: &impl DdsRuntime,
         reply_sender: OneshotSender<DdsResult<()>>,
@@ -259,7 +261,7 @@ impl DcpsDomainParticipant {
         let now = self.get_current_time(runtime);
         let Some(publisher) = core::iter::once(&mut self.domain_participant.builtin_publisher)
             .chain(&mut self.domain_participant.user_defined_publisher_list)
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             reply_sender.send(Err(DdsError::AlreadyDeleted));
             return;
@@ -267,7 +269,7 @@ impl DcpsDomainParticipant {
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             reply_sender.send(Err(DdsError::AlreadyDeleted));
             return;
@@ -392,6 +394,9 @@ impl DcpsDomainParticipant {
                                         self.domain_participant.instance_handle;
                                     let dcps_sender = self.dcps_sender;
                                     let mut timer_handle = runtime.timer();
+                                    let publisher_handle = *publisher_handle;
+                                    let data_writer_handle = *data_writer_handle;
+                                    let dynamic_data = dynamic_data.clone();
                                     runtime.spawner().spawn(async move {
                                         if let DurationKind::Finite(t) = max_blocking_time {
                                             let max_blocking_time_wait =
@@ -502,6 +507,8 @@ impl DcpsDomainParticipant {
         let participant_handle = self.domain_participant.instance_handle;
         if let DurationKind::Finite(deadline_missed_period) = data_writer.qos.deadline.period {
             let mut timer_handle = runtime.timer();
+            let publisher_handle = *publisher_handle;
+            let data_writer_handle = *data_writer_handle;
             runtime.spawner().spawn(async move {
                 loop {
                     timer_handle.delay(deadline_missed_period.into()).await;
@@ -528,6 +535,8 @@ impl DcpsDomainParticipant {
 
             let dcps_sender_clone = self.dcps_sender;
             let mut timer_handle = runtime.timer();
+            let publisher_handle = *publisher_handle;
+            let data_writer_handle = *data_writer_handle;
             runtime.spawner().spawn(async move {
                 timer_handle.delay(sleep_duration.into()).await;
                 dcps_sender_clone
@@ -553,8 +562,8 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn dispose_w_timestamp(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
         dynamic_data: DynamicData,
         timestamp: Time,
         runtime: &impl DdsRuntime,
@@ -563,14 +572,14 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -586,21 +595,21 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_offered_deadline_missed_status(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
     ) -> DdsResult<OfferedDeadlineMissedStatus> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -694,15 +703,15 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, notify_sender))]
     pub fn notify_acknowledgments(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
         notify_sender: OneshotSender<DdsResult<()>>,
     ) {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return notify_sender.send(Err(DdsError::AlreadyDeleted));
         };
@@ -710,7 +719,7 @@ impl DcpsDomainParticipant {
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return notify_sender.send(Err(DdsError::AlreadyDeleted));
         };

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -355,7 +355,7 @@ impl DcpsDomainParticipant {
 
         let serialized_data = match serialize(
             data_writer.type_support,
-            &dynamic_data,
+            dynamic_data,
             &data_writer.qos.representation,
         ) {
             Ok(s) => s,

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -20,7 +20,7 @@ use crate::{
         status::{OfferedDeadlineMissedStatus, PublicationMatchedStatus, StatusKind},
         time::{Duration, DurationKind, Time},
     },
-    runtime::{DdsRuntime, Either, Spawner, Timer, select_future},
+    runtime::{Clock, DdsRuntime, Either, Spawner, Timer, select_future},
     transport::types::{CacheChange, ChangeKind},
     xtypes::dynamic_type::DynamicData,
 };
@@ -258,7 +258,7 @@ impl DcpsDomainParticipant {
         runtime: &impl DdsRuntime,
         reply_sender: OneshotSender<DdsResult<()>>,
     ) {
-        let now = self.get_current_time(runtime);
+        let now = runtime.clock().now();
         let Some(publisher) = core::iter::once(&mut self.domain_participant.builtin_publisher)
             .chain(&mut self.domain_participant.user_defined_publisher_list)
             .find(|x| &x.instance_handle == publisher_handle)

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -29,21 +29,21 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn get_publication_matched_status(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
     ) -> DdsResult<PublicationMatchedStatus> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -611,22 +611,22 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn enable_data_writer(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
         runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -637,7 +637,7 @@ impl DcpsDomainParticipant {
                 self.domain_participant.discovered_reader_list.to_vec();
             for discovered_reader_data in discovered_reader_list {
                 self.add_discovered_reader(
-                    discovered_reader_data,
+                    &discovered_reader_data,
                     publisher_handle,
                     data_writer_handle,
                 );
@@ -651,8 +651,8 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, runtime))]
     pub fn set_data_writer_qos(
         &mut self,
-        publisher_handle: InstanceHandle,
-        data_writer_handle: InstanceHandle,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
         qos: QosKind<DataWriterQos>,
         runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
@@ -660,7 +660,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .user_defined_publisher_list
             .iter_mut()
-            .find(|x| x.instance_handle == publisher_handle)
+            .find(|x| &x.instance_handle == publisher_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -671,7 +671,7 @@ impl DcpsDomainParticipant {
         let Some(data_writer) = publisher
             .data_writer_list
             .iter_mut()
-            .find(|x| x.instance_handle == data_writer_handle)
+            .find(|x| &x.instance_handle == data_writer_handle)
         else {
             return Err(DdsError::AlreadyDeleted);
         };

--- a/dds/src/dcps/dcps_mail.rs
+++ b/dds/src/dcps/dcps_mail.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, string::String, sync::Arc};
+use alloc::{boxed::Box, string::String};
 use core::pin::Pin;
 
 use crate::{
@@ -602,7 +602,7 @@ pub enum MessageServiceMail {
     },
     HandleData {
         participant_handle: InstanceHandle,
-        data_message: Arc<[u8]>,
+        data_message: Vec<u8>,
     },
     Poke {
         participant_handle: InstanceHandle,

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -9,7 +9,7 @@ use crate::{
         dcps_participant_factory::DcpsParticipantFactory,
     },
     infrastructure::error::DdsError,
-    runtime::DdsRuntime,
+    runtime::{Clock, DdsRuntime},
 };
 
 impl<R: DdsRuntime> DcpsParticipantFactory<R> {
@@ -265,7 +265,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
-                    .map(|p| p.get_current_time(&self.runtime)),
+                    .map(|_| self.runtime.clock().now()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredParticipants {
                 participant_handle,

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -38,7 +38,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::DeleteParticipant {
                 participant_handle,
                 reply_sender,
-            }) => reply_sender.send(self.delete_participant(participant_handle)),
+            }) => reply_sender.send(self.delete_participant(&participant_handle)),
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::SetDefaultParticipantQos {
                 qos,
                 reply_sender,
@@ -61,7 +61,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => reply_sender.send(
                 self.domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.create_user_defined_publisher(qos, dcps_listener, mask, &self.runtime)
@@ -72,8 +72,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 parent_participant_handle,
                 publisher_handle,
                 reply_sender,
-            }) => reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
-                p.delete_user_defined_publisher(parent_participant_handle, publisher_handle)
+            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
+                p.delete_user_defined_publisher(&parent_participant_handle, &publisher_handle)
             })),
             DcpsMail::Participant(ParticipantServiceMail::CreateUserDefinedSubscriber {
                 participant_handle,
@@ -84,7 +84,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => reply_sender.send(
                 self.domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.create_user_defined_subscriber(qos, dcps_listener, mask, &self.runtime)
@@ -95,8 +95,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 parent_participant_handle,
                 subscriber_handle,
                 reply_sender,
-            }) => reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
-                p.delete_user_defined_subscriber(parent_participant_handle, subscriber_handle)
+            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
+                p.delete_user_defined_subscriber(&parent_participant_handle, &subscriber_handle)
             })),
             DcpsMail::Participant(ParticipantServiceMail::CreateTopic {
                 participant_handle,
@@ -110,7 +110,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.create_topic(
@@ -130,8 +130,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 topic_name,
                 reply_sender,
             }) => {
-                reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
-                    p.delete_user_defined_topic(parent_participant_handle, topic_name)
+                reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
+                    p.delete_user_defined_topic(&parent_participant_handle, topic_name)
                 }))
             }
             DcpsMail::Participant(ParticipantServiceMail::CreateContentFilteredTopic {
@@ -141,9 +141,9 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 filter_expression,
                 expression_parameters,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.create_content_filtered_topic(
-                    participant_handle,
+                    &participant_handle,
                     name,
                     related_topic_name,
                     filter_expression,
@@ -156,8 +156,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 name,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
-                    .and_then(|p| p.delete_content_filtered_topic(participant_handle, name)),
+                self.find_participant(&participant_handle)
+                    .and_then(|p| p.delete_content_filtered_topic(&participant_handle, name)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::FindTopic {
                 participant_handle,
@@ -165,7 +165,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 type_support,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.find_topic(topic_name, type_support)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::LookupTopicdescription {
@@ -173,15 +173,15 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 topic_name,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.lookup_topicdescription(topic_name)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::IgnoreParticipant {
                 participant_handle,
                 handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
-                Ok(p) => reply_sender.send(p.ignore_participant(handle)),
+            }) => match self.find_participant(&participant_handle) {
+                Ok(p) => reply_sender.send(p.ignore_participant(&handle)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::IgnoreSubscription {
@@ -189,7 +189,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.ignore_subscription(handle)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::IgnorePublication {
@@ -197,7 +197,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.ignore_publication(handle)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::DeleteContainedEntities {
@@ -206,7 +206,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.delete_participant_contained_entities(&self.runtime)),
@@ -217,14 +217,14 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 qos,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.set_default_publisher_qos(qos)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDefaultPublisherQos {
                 participant_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_default_publisher_qos()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::SetDefaultSubscriberQos {
@@ -232,14 +232,14 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 qos,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.set_default_subscriber_qos(qos)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDefaultSubscriberQos {
                 participant_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_default_subscriber_qos()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::SetDefaultTopicQos {
@@ -247,14 +247,14 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 qos,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.set_default_topic_qos(qos)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDefaultTopicQos {
                 participant_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_default_topic_qos()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetCurrentTime {
@@ -263,7 +263,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => reply_sender.send(
                 self.domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                     .map(|p| p.get_current_time(&self.runtime)),
             ),
@@ -271,22 +271,23 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_discovered_participants()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredParticipantData {
                 participant_handle,
                 discovered_participant_handle,
                 reply_sender,
-            }) => reply_sender
-                .send(self.find_participant(participant_handle).and_then(|p| {
-                    p.get_discovered_participant_data(discovered_participant_handle)
-                })),
+            }) => {
+                reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
+                    p.get_discovered_participant_data(&discovered_participant_handle)
+                }))
+            }
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredTopics {
                 participant_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_discovered_topics()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredTopicData {
@@ -294,8 +295,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 topic_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
-                    .and_then(|p| p.get_discovered_topic_data(topic_handle)),
+                self.find_participant(&participant_handle)
+                    .and_then(|p| p.get_discovered_topic_data(&topic_handle)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::SetQos {
                 participant_handle,
@@ -305,7 +306,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.set_domain_participant_qos(qos, &self.runtime)),
@@ -315,7 +316,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_domain_participant_qos()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::SetListener {
@@ -326,7 +327,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => reply_sender.send(
                 self.domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.set_domain_participant_listener(dcps_listener, status_kind, &self.runtime)
@@ -339,7 +340,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.enable_domain_participant(&self.runtime)),
@@ -349,7 +350,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 topic_name,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.get_inconsistent_topic_status(topic_name)),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -359,7 +360,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 topic_qos,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.set_topic_qos(topic_name, topic_qos)),
             ),
             DcpsMail::Topic(TopicServiceMail::GetQos {
@@ -367,7 +368,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 topic_name,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_topic_qos(topic_name)),
             ),
             DcpsMail::Topic(TopicServiceMail::Enable {
@@ -378,7 +379,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.enable_topic(topic_name, &self.runtime)),
@@ -389,7 +390,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 topic_name,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_type_support(topic_name)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::CreateDataWriter {
@@ -403,11 +404,11 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.create_data_writer(
-                    publisher_handle,
+                    &publisher_handle,
                     topic_name,
                     qos,
                     dcps_listener,
@@ -424,7 +425,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.delete_data_writer(
@@ -439,7 +440,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_default_datawriter_qos(publisher_handle)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::SetDefaultDataWriterQos {
@@ -448,7 +449,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 qos,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.set_default_datawriter_qos(publisher_handle, qos)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::GetPublisherQos {
@@ -456,7 +457,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_publisher_qos(publisher_handle)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::SetPublisherQos {
@@ -465,7 +466,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 qos,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.set_publisher_qos(publisher_handle, qos)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::SetPublisherListener {
@@ -477,7 +478,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => reply_sender.send(
                 self.domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.set_publisher_listener(
@@ -498,7 +499,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => reply_sender.send(
                 self.domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.set_listener_data_writer(
@@ -516,7 +517,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_writer_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_data_writer_qos(publisher_handle, data_writer_handle)),
             ),
             DcpsMail::Writer(WriterServiceMail::GetMatchedSubscriptions {
@@ -525,7 +526,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_writer_handle,
                 reply_sender,
             }) => {
-                reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
+                reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
                     p.get_matched_subscriptions(publisher_handle, data_writer_handle)
                 }))
             }
@@ -535,7 +536,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_writer_handle,
                 subscription_handle,
                 reply_sender,
-            }) => reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
+            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
                 p.get_matched_subscription_data(
                     publisher_handle,
                     data_writer_handle,
@@ -547,9 +548,9 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 data_writer_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender
-                    .send(p.get_publication_matched_status(publisher_handle, data_writer_handle)),
+                    .send(p.get_publication_matched_status(&publisher_handle, &data_writer_handle)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::UnregisterInstance {
@@ -562,7 +563,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.unregister_instance(
@@ -580,7 +581,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_writer_handle,
                 dynamic_data,
                 reply_sender,
-            }) => reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
+            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
                 p.lookup_instance(publisher_handle, data_writer_handle, dynamic_data)
             })),
             DcpsMail::Writer(WriterServiceMail::WriteWTimestamp {
@@ -593,7 +594,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => p.write_w_timestamp(
@@ -617,7 +618,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.dispose_w_timestamp(
@@ -634,7 +635,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 data_writer_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(
                     p.get_offered_deadline_missed_status(publisher_handle, data_writer_handle),
                 ),
@@ -648,12 +649,12 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.enable_data_writer(
-                    publisher_handle,
-                    data_writer_handle,
+                    &publisher_handle,
+                    &data_writer_handle,
                     &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
@@ -667,12 +668,12 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.set_data_writer_qos(
-                    publisher_handle,
-                    data_writer_handle,
+                    &publisher_handle,
+                    &data_writer_handle,
                     qos,
                     &self.runtime,
                 )),
@@ -689,7 +690,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.create_data_reader(
@@ -710,7 +711,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.delete_data_reader(
@@ -726,7 +727,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 topic_name,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.lookup_data_reader(subscriber_handle, topic_name)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::SetDefaultDataReaderQos {
@@ -735,7 +736,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 qos,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.set_default_data_reader_qos(subscriber_handle, qos)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::GetDefaultDataReaderQos {
@@ -743,7 +744,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_default_data_reader_qos(subscriber_handle)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::SetQos {
@@ -752,7 +753,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 qos,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.set_subscriber_qos(subscriber_handle, qos)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::GetSubscriberQos {
@@ -760,7 +761,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_subscriber_qos(subscriber_handle)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::SetListener {
@@ -772,7 +773,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => reply_sender.send(
                 self.domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.set_subscriber_listener(
@@ -793,7 +794,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 instance_states,
                 specific_instance_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.read(
                     subscriber_handle,
                     data_reader_handle,
@@ -815,7 +816,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 instance_states,
                 specific_instance_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.take(
                     subscriber_handle,
                     data_reader_handle,
@@ -837,7 +838,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 view_states,
                 instance_states,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.read_next_instance(
                     subscriber_handle,
                     data_reader_handle,
@@ -859,7 +860,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 view_states,
                 instance_states,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.take_next_instance(
                     subscriber_handle,
                     data_reader_handle,
@@ -879,7 +880,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.enable_data_reader(
@@ -894,7 +895,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 data_reader_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender
                     .send(p.get_subscription_matched_status(subscriber_handle, data_reader_handle)),
                 Err(e) => reply_sender.send(Err(e)),
@@ -908,7 +909,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => reply_sender.send(
                 self.domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                     .map(|p| {
                         p.wait_for_historical_data(
@@ -925,7 +926,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_reader_handle,
                 publication_handle,
                 reply_sender,
-            }) => reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
+            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
                 p.get_matched_publication_data(
                     subscriber_handle,
                     data_reader_handle,
@@ -938,7 +939,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_reader_handle,
                 reply_sender,
             }) => {
-                reply_sender.send(self.find_participant(participant_handle).and_then(|p| {
+                reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
                     p.get_matched_publications(subscriber_handle, data_reader_handle)
                 }))
             }
@@ -948,7 +949,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_reader_handle,
                 reply_sender,
             }) => reply_sender.send(
-                self.find_participant(participant_handle)
+                self.find_participant(&participant_handle)
                     .and_then(|p| p.get_data_reader_qos(subscriber_handle, data_reader_handle)),
             ),
             DcpsMail::Reader(ReaderServiceMail::SetQos {
@@ -960,7 +961,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => match self
                 .domain_participant_list
                 .iter_mut()
-                .find(|x| x.get_instance_handle() == participant_handle)
+                .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.set_data_reader_qos(
@@ -981,7 +982,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }) => reply_sender.send(
                 self.domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.set_data_reader_listener(
@@ -999,7 +1000,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_writer_handle,
                 sequence_number,
             }) => {
-                if let Ok(p) = self.find_participant(participant_handle) {
+                if let Ok(p) = self.find_participant(&participant_handle) {
                     p.remove_writer_change(publisher_handle, data_writer_handle, sequence_number)
                 }
             }
@@ -1034,7 +1035,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 publisher_handle,
                 data_writer_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => {
                     p.notify_acknowledgments(publisher_handle, data_writer_handle, reply_sender)
                 }
@@ -1046,7 +1047,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 data_reader_handle,
                 reply_sender,
-            }) => match self.find_participant(participant_handle) {
+            }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender
                     .send(p.is_historical_data_received(subscriber_handle, data_reader_handle)),
                 Err(e) => reply_sender.send(Err(e)),
@@ -1058,7 +1059,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 if let Ok(p) = self
                     .domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
                     p.handle_data(data_message, &self.runtime);
@@ -1068,7 +1069,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 if let Ok(p) = self
                     .domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
                     p.poke(&self.runtime.clock())
@@ -1083,13 +1084,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 if let Ok(p) = self
                     .domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
                     p.offered_deadline_missed(
-                        publisher_handle,
-                        data_writer_handle,
-                        change_instance_handle,
+                        &publisher_handle,
+                        &data_writer_handle,
+                        &change_instance_handle,
                         &self.runtime,
                     )
                 }
@@ -1103,7 +1104,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 if let Ok(p) = self
                     .domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
                     p.requested_deadline_missed(
@@ -1120,7 +1121,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 if let Ok(p) = self
                     .domain_participant_list
                     .iter_mut()
-                    .find(|x| x.get_instance_handle() == participant_handle)
+                    .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
                     p.announce_participant(&self.runtime)

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -190,7 +190,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.ignore_subscription(handle)),
+                    .and_then(|p| p.ignore_subscription(&handle)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::IgnorePublication {
                 participant_handle,
@@ -198,7 +198,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.ignore_publication(handle)),
+                    .and_then(|p| p.ignore_publication(&handle)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::DeleteContainedEntities {
                 participant_handle,
@@ -429,8 +429,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.delete_data_writer(
-                    publisher_handle,
-                    datawriter_handle,
+                    &publisher_handle,
+                    &datawriter_handle,
                     &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
@@ -441,7 +441,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_default_datawriter_qos(publisher_handle)),
+                    .and_then(|p| p.get_default_datawriter_qos(&publisher_handle)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::SetDefaultDataWriterQos {
                 participant_handle,
@@ -450,7 +450,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_default_datawriter_qos(publisher_handle, qos)),
+                    .and_then(|p| p.set_default_datawriter_qos(&publisher_handle, qos)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::GetPublisherQos {
                 participant_handle,
@@ -458,7 +458,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_publisher_qos(publisher_handle)),
+                    .and_then(|p| p.get_publisher_qos(&publisher_handle)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::SetPublisherQos {
                 participant_handle,
@@ -467,7 +467,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_publisher_qos(publisher_handle, qos)),
+                    .and_then(|p| p.set_publisher_qos(&publisher_handle, qos)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::SetPublisherListener {
                 participant_handle,
@@ -482,7 +482,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.set_publisher_listener(
-                            publisher_handle,
+                            &publisher_handle,
                             dcps_listener,
                             mask,
                             &self.runtime,
@@ -503,8 +503,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.set_listener_data_writer(
-                            publisher_handle,
-                            data_writer_handle,
+                            &publisher_handle,
+                            &data_writer_handle,
                             dcps_listener,
                             listener_mask,
                             &self.runtime,
@@ -518,7 +518,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_data_writer_qos(publisher_handle, data_writer_handle)),
+                    .and_then(|p| p.get_data_writer_qos(&publisher_handle, &data_writer_handle)),
             ),
             DcpsMail::Writer(WriterServiceMail::GetMatchedSubscriptions {
                 participant_handle,
@@ -527,7 +527,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => {
                 reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
-                    p.get_matched_subscriptions(publisher_handle, data_writer_handle)
+                    p.get_matched_subscriptions(&publisher_handle, &data_writer_handle)
                 }))
             }
             DcpsMail::Writer(WriterServiceMail::GetMatchedSubscriptionData {
@@ -538,9 +538,9 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
                 p.get_matched_subscription_data(
-                    publisher_handle,
-                    data_writer_handle,
-                    subscription_handle,
+                    &publisher_handle,
+                    &data_writer_handle,
+                    &subscription_handle,
                 )
             })),
             DcpsMail::Writer(WriterServiceMail::GetPublicationMatchedStatus {
@@ -567,8 +567,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.unregister_instance(
-                    publisher_handle,
-                    data_writer_handle,
+                    &publisher_handle,
+                    &data_writer_handle,
                     dynamic_data,
                     timestamp,
                     &self.runtime,
@@ -582,7 +582,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dynamic_data,
                 reply_sender,
             }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
-                p.lookup_instance(publisher_handle, data_writer_handle, dynamic_data)
+                p.lookup_instance(&publisher_handle, &data_writer_handle, &dynamic_data)
             })),
             DcpsMail::Writer(WriterServiceMail::WriteWTimestamp {
                 participant_handle,
@@ -598,9 +598,9 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => p.write_w_timestamp(
-                    publisher_handle,
-                    data_writer_handle,
-                    dynamic_data,
+                    &publisher_handle,
+                    &data_writer_handle,
+                    &dynamic_data,
                     timestamp,
                     &self.runtime,
                     reply_sender,
@@ -622,8 +622,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.dispose_w_timestamp(
-                    publisher_handle,
-                    data_writer_handle,
+                    &publisher_handle,
+                    &data_writer_handle,
                     dynamic_data,
                     timestamp,
                     &self.runtime,
@@ -637,7 +637,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(
-                    p.get_offered_deadline_missed_status(publisher_handle, data_writer_handle),
+                    p.get_offered_deadline_missed_status(&publisher_handle, &data_writer_handle),
                 ),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -694,7 +694,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.create_data_reader(
-                    subscriber_handle,
+                    &subscriber_handle,
                     topic_name,
                     qos,
                     dcps_listener,
@@ -715,8 +715,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.delete_data_reader(
-                    subscriber_handle,
-                    datareader_handle,
+                    &subscriber_handle,
+                    &datareader_handle,
                     &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
@@ -728,7 +728,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.lookup_data_reader(subscriber_handle, topic_name)),
+                    .and_then(|p| p.lookup_data_reader(&subscriber_handle, topic_name)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::SetDefaultDataReaderQos {
                 participant_handle,
@@ -737,7 +737,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_default_data_reader_qos(subscriber_handle, qos)),
+                    .and_then(|p| p.set_default_data_reader_qos(&subscriber_handle, qos)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::GetDefaultDataReaderQos {
                 participant_handle,
@@ -745,7 +745,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_default_data_reader_qos(subscriber_handle)),
+                    .and_then(|p| p.get_default_data_reader_qos(&subscriber_handle)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::SetQos {
                 participant_handle,
@@ -754,7 +754,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_subscriber_qos(subscriber_handle, qos)),
+                    .and_then(|p| p.set_subscriber_qos(&subscriber_handle, qos)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::GetSubscriberQos {
                 participant_handle,
@@ -762,7 +762,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_subscriber_qos(subscriber_handle)),
+                    .and_then(|p| p.get_subscriber_qos(&subscriber_handle)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::SetListener {
                 participant_handle,
@@ -777,7 +777,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.set_subscriber_listener(
-                            subscriber_handle,
+                            &subscriber_handle,
                             dcps_listener,
                             mask,
                             &self.runtime,
@@ -796,13 +796,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.read(
-                    subscriber_handle,
-                    data_reader_handle,
+                    &subscriber_handle,
+                    &data_reader_handle,
                     max_samples,
-                    sample_states,
-                    view_states,
-                    instance_states,
-                    specific_instance_handle,
+                    &sample_states,
+                    &view_states,
+                    &instance_states,
+                    &specific_instance_handle,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -818,13 +818,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.take(
-                    subscriber_handle,
-                    data_reader_handle,
+                    &subscriber_handle,
+                    &data_reader_handle,
                     max_samples,
-                    sample_states,
-                    view_states,
-                    instance_states,
-                    specific_instance_handle,
+                    &sample_states,
+                    &view_states,
+                    &instance_states,
+                    &specific_instance_handle,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -840,13 +840,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.read_next_instance(
-                    subscriber_handle,
-                    data_reader_handle,
+                    &subscriber_handle,
+                    &data_reader_handle,
                     max_samples,
-                    previous_handle,
-                    sample_states,
-                    view_states,
-                    instance_states,
+                    &previous_handle,
+                    &sample_states,
+                    &view_states,
+                    &instance_states,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -862,13 +862,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender.send(p.take_next_instance(
-                    subscriber_handle,
-                    data_reader_handle,
+                    &subscriber_handle,
+                    &data_reader_handle,
                     max_samples,
-                    previous_handle,
-                    sample_states,
-                    view_states,
-                    instance_states,
+                    &previous_handle,
+                    &sample_states,
+                    &view_states,
+                    &instance_states,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -884,8 +884,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.enable_data_reader(
-                    subscriber_handle,
-                    data_reader_handle,
+                    &subscriber_handle,
+                    &data_reader_handle,
                     &self.runtime,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
@@ -896,8 +896,9 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_reader_handle,
                 reply_sender,
             }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender
-                    .send(p.get_subscription_matched_status(subscriber_handle, data_reader_handle)),
+                Ok(p) => reply_sender.send(
+                    p.get_subscription_matched_status(&subscriber_handle, &data_reader_handle),
+                ),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Reader(ReaderServiceMail::WaitForHistoricalData {
@@ -928,9 +929,9 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
                 p.get_matched_publication_data(
-                    subscriber_handle,
-                    data_reader_handle,
-                    publication_handle,
+                    &subscriber_handle,
+                    &data_reader_handle,
+                    &publication_handle,
                 )
             })),
             DcpsMail::Reader(ReaderServiceMail::GetMatchedPublications {
@@ -940,7 +941,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => {
                 reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
-                    p.get_matched_publications(subscriber_handle, data_reader_handle)
+                    p.get_matched_publications(&subscriber_handle, &data_reader_handle)
                 }))
             }
             DcpsMail::Reader(ReaderServiceMail::GetQos {
@@ -950,7 +951,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => reply_sender.send(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_data_reader_qos(subscriber_handle, data_reader_handle)),
+                    .and_then(|p| p.get_data_reader_qos(&subscriber_handle, &data_reader_handle)),
             ),
             DcpsMail::Reader(ReaderServiceMail::SetQos {
                 participant_handle,
@@ -965,8 +966,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => reply_sender.send(p.set_data_reader_qos(
-                    subscriber_handle,
-                    data_reader_handle,
+                    &subscriber_handle,
+                    &data_reader_handle,
                     qos,
                     &self.runtime,
                 )),
@@ -986,8 +987,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .ok_or(DdsError::AlreadyDeleted)
                     .and_then(|p| {
                         p.set_data_reader_listener(
-                            subscriber_handle,
-                            data_reader_handle,
+                            &subscriber_handle,
+                            &data_reader_handle,
                             dcps_listener,
                             listener_mask,
                             &self.runtime,
@@ -1037,7 +1038,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => match self.find_participant(&participant_handle) {
                 Ok(p) => {
-                    p.notify_acknowledgments(publisher_handle, data_writer_handle, reply_sender)
+                    p.notify_acknowledgments(&publisher_handle, &data_writer_handle, reply_sender)
                 }
 
                 Err(e) => reply_sender.send(Err(e)),
@@ -1049,7 +1050,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 reply_sender,
             }) => match self.find_participant(&participant_handle) {
                 Ok(p) => reply_sender
-                    .send(p.is_historical_data_received(subscriber_handle, data_reader_handle)),
+                    .send(p.is_historical_data_received(&subscriber_handle, &data_reader_handle)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Message(MessageServiceMail::HandleData {
@@ -1062,7 +1063,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
                 {
-                    p.handle_data(data_message, &self.runtime);
+                    p.handle_data(data_message.as_slice(), &self.runtime);
                 }
             }
             DcpsMail::Message(MessageServiceMail::Poke { participant_handle }) => {
@@ -1108,9 +1109,9 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .ok_or(DdsError::AlreadyDeleted)
                 {
                     p.requested_deadline_missed(
-                        subscriber_handle,
-                        data_reader_handle,
-                        change_instance_handle,
+                        &subscriber_handle,
+                        &data_reader_handle,
+                        &change_instance_handle,
                         &self.runtime,
                     )
                 }

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -67,7 +67,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             transport_participant,
             self.dcps_sender,
         );
-        let participant_handle = dcps_participant.get_instance_handle();
+        let participant_handle = *dcps_participant.get_instance_handle();
 
         //****** Spawn the participant actor and tasks **********//
 
@@ -113,7 +113,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         Ok(participant_handle)
     }
 
-    pub fn delete_participant(&mut self, participant_handle: InstanceHandle) -> DdsResult<()> {
+    pub fn delete_participant(&mut self, participant_handle: &InstanceHandle) -> DdsResult<()> {
         let index = self
             .domain_participant_list
             .iter()
@@ -131,7 +131,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
 
     pub fn find_participant(
         &mut self,
-        participant_handle: InstanceHandle,
+        participant_handle: &InstanceHandle,
     ) -> DdsResult<&mut DcpsDomainParticipant> {
         self.domain_participant_list
             .iter_mut()

--- a/dds/src/rtps_udp_transport/udp_transport.rs
+++ b/dds/src/rtps_udp_transport/udp_transport.rs
@@ -233,7 +233,7 @@ impl TransportParticipantFactory for RtpsUdpTransportParticipantFactory {
                     if let Ok(size) = metatraffic_multicast_socket.recv(&mut buf) {
                         if size > 0 {
                             std_runtime::executor::block_on(
-                                data_channel_sender_clone.receive_message(Arc::from(&buf[..size])),
+                                data_channel_sender_clone.receive_message(buf[..size].to_vec()),
                             );
                         }
                     }
@@ -250,7 +250,7 @@ impl TransportParticipantFactory for RtpsUdpTransportParticipantFactory {
                     if let Ok(size) = metatraffic_unicast_socket.recv(&mut buf) {
                         if size > 0 {
                             std_runtime::executor::block_on(
-                                data_channel_sender_clone.receive_message(Arc::from(&buf[..size])),
+                                data_channel_sender_clone.receive_message(buf[..size].to_vec()),
                             )
                         }
                     }
@@ -267,7 +267,7 @@ impl TransportParticipantFactory for RtpsUdpTransportParticipantFactory {
                     if let Ok(size) = default_unicast_socket.recv(&mut buf) {
                         if size > 0 {
                             std_runtime::executor::block_on(
-                                data_channel_sender_clone.receive_message(Arc::from(&buf[..size])),
+                                data_channel_sender_clone.receive_message(buf[..size].to_vec()),
                             )
                         }
                     }

--- a/dds/src/transport/interface.rs
+++ b/dds/src/transport/interface.rs
@@ -4,7 +4,7 @@ use crate::{
     infrastructure::instance::InstanceHandle,
     transport::types::Locator,
 };
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 
 pub trait WriteMessage {
     fn write_message(&self, buf: &[u8], locators: &[Locator]);
@@ -23,7 +23,7 @@ impl TransportDataReceiver {
         }
     }
 
-    pub async fn receive_message(&self, data_message: Arc<[u8]>) {
+    pub async fn receive_message(&self, data_message: Vec<u8>) {
         self.dcps_sender
             .send(DcpsMail::Message(MessageServiceMail::HandleData {
                 participant_handle: self.participant_handle,


### PR DESCRIPTION
Use references instead of move for internal methods except for the explicit case where moves are needed for object ownership. This reduces the binary size from 817.8KiB to about 799.9KiB.