### PR TITLE
feat: xtypes union

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -174,9 +174,9 @@ jobs:
           key: cargo-bloat-bin-v1-{{ arch }}
           paths:
             - ~/.cargo/bin/cargo-bloat
-      - run: 
+      - run:
           name: Check compilation time
-          command: cargo build --package dust_dds --timings --tests --examples      
+          command: cargo build --package dust_dds --timings --tests --examples
       - run:
           name: Check binary size hello_world_publisher
           command: cargo bloat -p dust_dds --example hello_world_publisher --release --wide -n 100 --filter dust_dds > hello_world_publisher_bloat.txt
@@ -304,6 +304,20 @@ jobs:
             cargo run --package dust_dds_interoperability --bin dust_dds_subscriber_nested &
             pid=$!
             build/cyclone_dds/CycloneDdsPublisherNested
+            wait $pid
+      - run:
+          name: Cyclone publisher union interoperability test
+          command: |
+            cargo run --package dust_dds_interoperability --bin dust_dds_subscriber_union &
+            pid=$!
+            build/cyclone_dds/CycloneDdsPublisherUnion
+            wait $pid
+      - run:
+          name: Cyclone subscriber union interoperability test
+          command: |
+            build/cyclone_dds/CycloneDdsSubscriberUnion &
+            pid=$!
+            cargo run --package dust_dds_interoperability --bin dust_dds_publisher_union
             wait $pid
 
   multi_machine_tests:

--- a/dds/src/xtypes/binding.rs
+++ b/dds/src/xtypes/binding.rs
@@ -10,6 +10,23 @@ pub trait XTypesBinding {
     const TYPE_INFORMATION: &'static dyn DynamicType;
 }
 
+impl XTypesBinding for () {
+    const TYPE_INFORMATION: &'static dyn DynamicType = &StaticTypeInformation {
+        descriptor: &TypeDescriptor {
+            kind: TypeKind::NONE,
+            name: "",
+            base_type: None,
+            discriminator_type: None,
+            bound: None,
+            element_type: None,
+            key_element_type: None,
+            extensibility_kind: ExtensibilityKind::Final,
+            is_nested: false,
+        },
+        member_list: &[],
+    };
+}
+
 impl XTypesBinding for u8 {
     const TYPE_INFORMATION: &'static dyn DynamicType = &StaticTypeInformation {
         descriptor: &TypeDescriptor {

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -1,7 +1,7 @@
 use crate::xtypes::{
     dynamic_type::{
         DynamicData, DynamicDataFactory, DynamicType, DynamicTypeMember, ExtensibilityKind,
-        TypeKind,
+        MemberId, TypeKind,
     },
     error::{XTypesError, XTypesResult},
     read_write::Read,
@@ -236,25 +236,8 @@ trait XTypesDeserialize {
                     }
                 }
             }
-            TypeKind::ENUM => {
-                let discriminator_type = dynamic_type
-                    .get_descriptor()
-                    .discriminator_type
-                    .as_ref()
-                    .ok_or(XTypesError::InvalidType)?;
-                match discriminator_type.get_kind() {
-                    TypeKind::INT8 => {
-                        let value = self.deserialize_primitive_type::<i8>()?;
-                        dynamic_data.set_int8_value(0, value)
-                    }
-                    TypeKind::INT32 => {
-                        let value = self.deserialize_primitive_type::<i32>()?;
-                        dynamic_data.set_int32_value(0, value)
-                    }
-                    d => panic!("Invalid discriminator {d:?}"),
-                }
-            }
-            //     TypeKind::UNION => todo!(),
+            TypeKind::UNION => self.deserialize_final_union(dynamic_type, dynamic_data),
+            TypeKind::ENUM => self.deserialize_enum(dynamic_type, dynamic_data),
             kind => {
                 debug!("Expected structure, enum or union. Got kind {kind:?} ");
                 Err(XTypesError::InvalidType)
@@ -288,6 +271,165 @@ trait XTypesDeserialize {
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()>;
 
+    fn deserialize_final_union(
+        &mut self,
+        dynamic_type: &dyn DynamicType,
+        dynamic_data: &mut DynamicData,
+    ) -> XTypesResult<()> {
+        // Discriminator
+        let discriminator_descriptor = dynamic_type
+            .get_descriptor()
+            .discriminator_type
+            .ok_or(XTypesError::InvalidType)?
+            .get_descriptor();
+
+        let variant_id = match discriminator_descriptor.kind {
+            TypeKind::NONE => Err(XTypesError::InvalidType),
+            TypeKind::BOOLEAN => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_boolean_value(0, discriminator)?;
+                Ok(discriminator.into())
+            }
+            TypeKind::BYTE => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_byte_value(0, discriminator)?;
+                Ok(discriminator.into())
+            }
+            TypeKind::INT16 => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_int16_value(0, discriminator)?;
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::INT32 => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_int32_value(0, discriminator)?;
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::INT64 => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_int64_value(0, discriminator)?;
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::UINT16 => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_uint16_value(0, discriminator)?;
+                Ok(discriminator.into())
+            }
+            TypeKind::UINT32 => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_uint32_value(0, discriminator)?;
+                Ok(discriminator)
+            }
+            TypeKind::UINT64 => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_uint64_value(0, discriminator)?;
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::FLOAT32 => Err(XTypesError::InvalidType),
+            TypeKind::FLOAT64 => Err(XTypesError::InvalidType),
+            TypeKind::FLOAT128 => Err(XTypesError::InvalidType),
+            TypeKind::INT8 => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_int8_value(0, discriminator)?;
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::UINT8 => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_uint8_value(0, discriminator)?;
+                Ok(discriminator.into())
+            }
+            TypeKind::CHAR8 => {
+                let discriminator = self.deserialize_primitive_type()?;
+                dynamic_data.set_char8_value(0, discriminator)?;
+                Ok(discriminator.into())
+            }
+            TypeKind::CHAR16 => Err(XTypesError::InvalidType),
+            TypeKind::STRING8 => Err(XTypesError::InvalidType),
+            TypeKind::STRING16 => Err(XTypesError::InvalidType),
+            TypeKind::ALIAS => Err(XTypesError::InvalidType),
+            TypeKind::ENUM => {
+                // Discriminator
+                let discriminator_kind = discriminator_descriptor
+                    .discriminator_type
+                    .ok_or(XTypesError::InvalidType)?
+                    .get_kind();
+
+                match discriminator_kind {
+                    TypeKind::INT8 => {
+                        let discriminator = self.deserialize_primitive_type()?;
+                        let mut dynamic_data_factory = DynamicDataFactory::create_data();
+                        dynamic_data_factory.set_int8_value(0, discriminator)?;
+                        dynamic_data.set_complex_value(0, dynamic_data_factory)?;
+                        discriminator
+                            .try_into()
+                            .map_err(|_| XTypesError::InvalidData)
+                    }
+                    TypeKind::INT16 => {
+                        let discriminator = self.deserialize_primitive_type()?;
+                        let mut dynamic_data_factory = DynamicDataFactory::create_data();
+                        dynamic_data_factory.set_int16_value(0, discriminator)?;
+                        dynamic_data.set_complex_value(0, dynamic_data_factory)?;
+                        discriminator
+                            .try_into()
+                            .map_err(|_| XTypesError::InvalidData)
+                    }
+                    TypeKind::INT32 => {
+                        let discriminator = self.deserialize_primitive_type()?;
+                        let mut dynamic_data_factory = DynamicDataFactory::create_data();
+                        dynamic_data_factory.set_int32_value(0, discriminator)?;
+                        dynamic_data.set_complex_value(0, dynamic_data_factory)?;
+                        discriminator
+                            .try_into()
+                            .map_err(|_| XTypesError::InvalidData)
+                    }
+                    _ => Err(XTypesError::InvalidType),
+                }
+            }
+            TypeKind::BITMASK => Err(XTypesError::InvalidType),
+            TypeKind::ANNOTATION => Err(XTypesError::InvalidType),
+            TypeKind::STRUCTURE => Err(XTypesError::InvalidType),
+            TypeKind::UNION => Err(XTypesError::InvalidType),
+            TypeKind::BITSET => Err(XTypesError::InvalidType),
+            TypeKind::SEQUENCE => Err(XTypesError::InvalidType),
+            TypeKind::ARRAY => Err(XTypesError::InvalidType),
+            TypeKind::MAP => Err(XTypesError::InvalidType),
+        }?;
+
+        // Variant
+        let variant_type = dynamic_type.get_member(variant_id)?;
+        self.deserialize_union_variant(variant_type, dynamic_data)
+    }
+
+    fn deserialize_enum(
+        &mut self,
+        dynamic_type: &dyn DynamicType,
+        dynamic_data: &mut DynamicData,
+    ) -> XTypesResult<()> {
+        // Discriminator
+        let discriminator_kind = dynamic_type
+            .get_descriptor()
+            .discriminator_type
+            .ok_or(XTypesError::InvalidType)?
+            .get_kind();
+
+        match discriminator_kind {
+            TypeKind::INT8 => dynamic_data.set_int8_value(0, self.deserialize_primitive_type()?),
+            TypeKind::INT16 => dynamic_data.set_int16_value(0, self.deserialize_primitive_type()?),
+            TypeKind::INT32 => dynamic_data.set_int32_value(0, self.deserialize_primitive_type()?),
+            _ => Err(XTypesError::InvalidType),
+        }
+    }
+
     fn deserialize_string(&mut self) -> Result<String, XTypesError> {
         let length = self.deserialize_primitive_type::<u32>()?;
         let mut values = Vec::with_capacity(length as usize);
@@ -300,146 +442,149 @@ trait XTypesDeserialize {
 
     fn deserialize_primitive_type<T: CdrPrimitiveTypeDeserialize>(&mut self) -> XTypesResult<T>;
 
-    fn deserialize_final_member(
+    fn deserialize_member_to_id(
         &mut self,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
+        member_id: MemberId,
     ) -> XTypesResult<()> {
         let member_descriptor = member.get_descriptor()?;
         match member_descriptor.r#type.get_kind() {
             TypeKind::NONE => todo!(),
             TypeKind::BOOLEAN => {
-                dynamic_data.set_boolean_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_boolean_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::BYTE => todo!(),
             TypeKind::INT16 => {
-                dynamic_data.set_int16_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_int16_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::INT32 => {
-                dynamic_data.set_int32_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_int32_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::INT64 => {
-                dynamic_data.set_int64_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_int64_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::UINT16 => {
-                dynamic_data.set_uint16_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_uint16_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::UINT32 => {
-                dynamic_data.set_uint32_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_uint32_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::UINT64 => {
-                dynamic_data.set_uint64_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_uint64_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::FLOAT32 => {
-                dynamic_data.set_float32_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_float32_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::FLOAT64 => {
-                dynamic_data.set_float64_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_float64_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::FLOAT128 => todo!(),
             TypeKind::INT8 => {
-                dynamic_data.set_int8_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_int8_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::UINT8 => {
-                dynamic_data.set_uint8_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_uint8_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::CHAR8 => {
-                dynamic_data.set_char8_value(member.get_id(), self.deserialize_primitive_type()?)
+                dynamic_data.set_char8_value(member_id, self.deserialize_primitive_type()?)
             }
             TypeKind::CHAR16 => todo!(),
             TypeKind::STRING8 => {
-                dynamic_data.set_string_value(member.get_id(), self.deserialize_string()?)
+                dynamic_data.set_string_value(member_id, self.deserialize_string()?)
             }
             TypeKind::STRING16 => todo!(),
             TypeKind::ALIAS => todo!(),
             TypeKind::ENUM => dynamic_data.set_complex_value(
-                member.get_id(),
+                member_id,
                 self.deserialize_complex_value(member_descriptor.r#type)?,
             ),
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
             TypeKind::STRUCTURE => dynamic_data.set_complex_value(
-                member.get_id(),
+                member_id,
                 self.deserialize_complex_value(member_descriptor.r#type)?,
             ),
-            TypeKind::UNION => todo!(),
+            TypeKind::UNION => dynamic_data.set_complex_value(
+                member_id,
+                self.deserialize_complex_value(member_descriptor.r#type)?,
+            ),
             TypeKind::BITSET => todo!(),
-            TypeKind::SEQUENCE => self.deserialize_sequence(member, dynamic_data),
-            TypeKind::ARRAY => self.deserialize_array(member, dynamic_data),
+            TypeKind::SEQUENCE => self.deserialize_sequence(member, dynamic_data, member_id),
+            TypeKind::ARRAY => self.deserialize_array(member, dynamic_data, member_id),
             TypeKind::MAP => todo!(),
         }
     }
 
-    fn deserialize_array(
+    #[inline]
+    fn deserialize_final_member(
         &mut self,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
-        let sequence_type = member
+        self.deserialize_member_to_id(member, dynamic_data, member.get_id())
+    }
+
+    #[inline]
+    fn deserialize_union_variant(
+        &mut self,
+        variant: &DynamicTypeMember,
+        dynamic_data: &mut DynamicData,
+    ) -> XTypesResult<()> {
+        // Skip if kind is none
+        if variant.get_descriptor()?.r#type.get_kind() == TypeKind::NONE {
+            return Ok(());
+        }
+        self.deserialize_member_to_id(variant, dynamic_data, 1)
+    }
+
+    fn deserialize_array(
+        &mut self,
+        array: &DynamicTypeMember,
+        dynamic_data: &mut DynamicData,
+        member_id: MemberId,
+    ) -> XTypesResult<()> {
+        let array_element_type = array
             .get_descriptor()?
             .r#type
             .get_descriptor()
             .element_type
-            .as_ref()
-            .expect("Sequence must have element type");
-        let bound = member
+            .expect("Array must have element type");
+        let length = array
             .get_descriptor()?
             .r#type
             .get_descriptor()
             .bound
             .ok_or(XTypesError::InvalidType)?;
-        match sequence_type.get_kind() {
+
+        match array_element_type.get_kind() {
             TypeKind::NONE => todo!(),
-            TypeKind::BOOLEAN => dynamic_data.set_boolean_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
+            TypeKind::BOOLEAN => dynamic_data
+                .set_boolean_values(member_id, self.deserialize_primitive_type_array(length)?),
             TypeKind::BYTE => todo!(),
-            TypeKind::INT16 => dynamic_data.set_int16_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
-            TypeKind::INT32 => dynamic_data.set_int32_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
-            TypeKind::INT64 => dynamic_data.set_int64_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
-            TypeKind::UINT16 => dynamic_data.set_uint16_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
-            TypeKind::UINT32 => dynamic_data.set_uint32_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
-            TypeKind::UINT64 => dynamic_data.set_uint64_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
-            TypeKind::FLOAT32 => dynamic_data.set_float32_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
-            TypeKind::FLOAT64 => dynamic_data.set_float64_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
+            TypeKind::INT16 => dynamic_data
+                .set_int16_values(member_id, self.deserialize_primitive_type_array(length)?),
+            TypeKind::INT32 => dynamic_data
+                .set_int32_values(member_id, self.deserialize_primitive_type_array(length)?),
+            TypeKind::INT64 => dynamic_data
+                .set_int64_values(member_id, self.deserialize_primitive_type_array(length)?),
+            TypeKind::UINT16 => dynamic_data
+                .set_uint16_values(member_id, self.deserialize_primitive_type_array(length)?),
+            TypeKind::UINT32 => dynamic_data
+                .set_uint32_values(member_id, self.deserialize_primitive_type_array(length)?),
+            TypeKind::UINT64 => dynamic_data
+                .set_uint64_values(member_id, self.deserialize_primitive_type_array(length)?),
+            TypeKind::FLOAT32 => dynamic_data
+                .set_float32_values(member_id, self.deserialize_primitive_type_array(length)?),
+            TypeKind::FLOAT64 => dynamic_data
+                .set_float64_values(member_id, self.deserialize_primitive_type_array(length)?),
             TypeKind::FLOAT128 => todo!(),
-            TypeKind::INT8 => dynamic_data.set_int8_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
-            TypeKind::UINT8 => dynamic_data.set_uint8_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
-            TypeKind::CHAR8 => dynamic_data.set_char8_values(
-                member.get_id(),
-                self.deserialize_primitive_type_array(bound)?,
-            ),
+            TypeKind::INT8 => dynamic_data
+                .set_int8_values(member_id, self.deserialize_primitive_type_array(length)?),
+            TypeKind::UINT8 => dynamic_data
+                .set_uint8_values(member_id, self.deserialize_primitive_type_array(length)?),
+            TypeKind::CHAR8 => dynamic_data
+                .set_char8_values(member_id, self.deserialize_primitive_type_array(length)?),
             TypeKind::CHAR16 => todo!(),
             TypeKind::STRING8 => todo!(),
             TypeKind::STRING16 => todo!(),
@@ -448,7 +593,8 @@ trait XTypesDeserialize {
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
             TypeKind::STRUCTURE => todo!(),
-            TypeKind::UNION => todo!(),
+            TypeKind::UNION => dynamic_data
+                .set_complex_values(member_id, self.deserialize_complex_array(array, length)?),
             TypeKind::BITSET => todo!(),
             TypeKind::SEQUENCE => todo!(),
             TypeKind::ARRAY => todo!(),
@@ -475,75 +621,89 @@ trait XTypesDeserialize {
     }
 
     fn deserialize_string_sequence(&mut self) -> XTypesResult<Vec<String>> {
-        let mut sequence_of_string = Vec::new();
         let length = self.deserialize_primitive_type::<u32>()?;
+        self.deserialize_string_array(length)
+    }
+
+    fn deserialize_string_array(&mut self, length: u32) -> XTypesResult<Vec<String>> {
+        let mut values = Vec::with_capacity(length as usize);
         for _ in 0..length {
-            sequence_of_string.push(self.deserialize_string()?);
+            values.push(self.deserialize_string()?);
         }
-        Ok(sequence_of_string)
+        Ok(values)
     }
 
     fn deserialize_complex_sequence(
         &mut self,
-        member: &DynamicTypeMember,
+        sequence: &DynamicTypeMember,
     ) -> XTypesResult<Vec<DynamicData>> {
-        let mut sequence_of_dynamic_data = Vec::new();
-        let element_type = member
+        let length = self.deserialize_primitive_type::<u32>()?;
+        self.deserialize_complex_array(sequence, length)
+    }
+
+    fn deserialize_complex_array(
+        &mut self,
+        array: &DynamicTypeMember,
+        length: u32,
+    ) -> XTypesResult<Vec<DynamicData>> {
+        let array_type = array
             .get_descriptor()?
             .r#type
             .get_descriptor()
             .element_type
             .expect("must have element type");
-        let length = self.deserialize_primitive_type::<u32>()?;
+        let mut values = Vec::with_capacity(length as usize);
         for _ in 0..length {
-            sequence_of_dynamic_data.push(self.deserialize_complex_value(element_type)?);
+            values.push(self.deserialize_complex_value(array_type)?);
         }
-        Ok(sequence_of_dynamic_data)
+        Ok(values)
     }
 
     fn deserialize_sequence(
         &mut self,
-        member: &DynamicTypeMember,
+        sequence: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
+        member_id: MemberId,
     ) -> XTypesResult<()> {
-        let sequence_type = member
+        let sequence_element_type = sequence
             .get_descriptor()?
             .r#type
             .get_descriptor()
             .element_type
-            .as_ref()
             .expect("Sequence must have element type");
-        match sequence_type.get_kind() {
+
+        match sequence_element_type.get_kind() {
             TypeKind::NONE => todo!(),
             TypeKind::BOOLEAN => dynamic_data
-                .set_boolean_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_boolean_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::BYTE => todo!(),
             TypeKind::INT16 => dynamic_data
-                .set_int16_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_int16_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::INT32 => dynamic_data
-                .set_int32_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_int32_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::INT64 => dynamic_data
-                .set_int64_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_int64_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::UINT16 => dynamic_data
-                .set_uint16_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_uint16_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::UINT32 => dynamic_data
-                .set_uint32_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_uint32_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::UINT64 => dynamic_data
-                .set_uint64_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_uint64_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::FLOAT32 => dynamic_data
-                .set_float32_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_float32_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::FLOAT64 => dynamic_data
-                .set_float64_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_float64_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::FLOAT128 => todo!(),
-            TypeKind::INT8 => dynamic_data
-                .set_int8_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+            TypeKind::INT8 => {
+                dynamic_data.set_int8_values(member_id, self.deserialize_primitive_type_sequence()?)
+            }
             TypeKind::UINT8 => dynamic_data
-                .set_uint8_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_uint8_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::CHAR8 => dynamic_data
-                .set_char8_values(member.get_id(), self.deserialize_primitive_type_sequence()?),
+                .set_char8_values(member_id, self.deserialize_primitive_type_sequence()?),
             TypeKind::CHAR16 => todo!(),
             TypeKind::STRING8 => {
-                dynamic_data.set_string_values(member.get_id(), self.deserialize_string_sequence()?)
+                dynamic_data.set_string_values(member_id, self.deserialize_string_sequence()?)
             }
             TypeKind::STRING16 => todo!(),
             TypeKind::ALIAS => todo!(),
@@ -551,8 +711,9 @@ trait XTypesDeserialize {
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
             TypeKind::STRUCTURE => dynamic_data
-                .set_complex_values(member.get_id(), self.deserialize_complex_sequence(member)?),
-            TypeKind::UNION => todo!(),
+                .set_complex_values(member_id, self.deserialize_complex_sequence(sequence)?),
+            TypeKind::UNION => dynamic_data
+                .set_complex_values(member_id, self.deserialize_complex_sequence(sequence)?),
             TypeKind::BITSET => todo!(),
             TypeKind::SEQUENCE => todo!(),
             TypeKind::ARRAY => todo!(),

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -1,6 +1,6 @@
 use super::dynamic_type::ExtensibilityKind;
 use crate::xtypes::{
-    dynamic_type::{DynamicData, DynamicType, TypeKind},
+    dynamic_type::{DynamicData, DynamicType, MemberId, TypeKind},
     error::{XTypesError, XTypesResult},
     read_write::Write,
 };
@@ -188,13 +188,11 @@ trait XTypesSerializer {
         dynamic_data: &DynamicData,
     ) -> XTypesResult<()> {
         match dynamic_type.get_kind() {
-            TypeKind::ENUM => {
-                self.serialize_enum(dynamic_type, dynamic_data)?;
-            }
-            TypeKind::STRUCTURE => self.serialize_complex(dynamic_type, dynamic_data)?,
+            TypeKind::ENUM => self.serialize_enum(dynamic_type, dynamic_data),
+            TypeKind::STRUCTURE => self.serialize_complex(dynamic_type, dynamic_data),
+            TypeKind::UNION => self.serialize_union(dynamic_type, dynamic_data),
             kind => unimplemented!("Should not reach for {kind:?}"),
         }
-        Ok(())
     }
 
     fn serialize_final_struct(
@@ -251,100 +249,311 @@ trait XTypesSerializer {
         self.serialize_primitive_type(&0u8);
     }
 
-    fn serialize_dynamic_data_member(
+    fn serialize_member_from_id(
         &mut self,
         dynamic_type: &dyn DynamicType,
-        v: &DynamicData,
-        member_id: u32,
+        dynamic_data: &DynamicData,
+        member_id: MemberId,
     ) -> Result<(), XTypesError> {
-        let member_descriptor = v.get_descriptor(dynamic_type, member_id)?;
-        match member_descriptor.r#type.get_kind() {
+        match dynamic_type.get_descriptor().kind {
             TypeKind::NONE => todo!(),
-            TypeKind::BOOLEAN => self.serialize_primitive_type(v.get_boolean_value(member_id)?),
+            TypeKind::BOOLEAN => {
+                self.serialize_primitive_type(dynamic_data.get_boolean_value(member_id)?)
+            }
             TypeKind::BYTE => todo!(),
-            TypeKind::INT16 => self.serialize_primitive_type(v.get_int16_value(member_id)?),
-            TypeKind::INT32 => self.serialize_primitive_type(v.get_int32_value(member_id)?),
-            TypeKind::INT64 => self.serialize_primitive_type(v.get_int64_value(member_id)?),
-            TypeKind::UINT16 => self.serialize_primitive_type(v.get_uint16_value(member_id)?),
-            TypeKind::UINT32 => self.serialize_primitive_type(v.get_uint32_value(member_id)?),
-            TypeKind::UINT64 => self.serialize_primitive_type(v.get_uint64_value(member_id)?),
-            TypeKind::FLOAT32 => self.serialize_primitive_type(v.get_float32_value(member_id)?),
-            TypeKind::FLOAT64 => self.serialize_primitive_type(v.get_float64_value(member_id)?),
+            TypeKind::INT16 => {
+                self.serialize_primitive_type(dynamic_data.get_int16_value(member_id)?)
+            }
+            TypeKind::INT32 => {
+                self.serialize_primitive_type(dynamic_data.get_int32_value(member_id)?)
+            }
+            TypeKind::INT64 => {
+                self.serialize_primitive_type(dynamic_data.get_int64_value(member_id)?)
+            }
+            TypeKind::UINT16 => {
+                self.serialize_primitive_type(dynamic_data.get_uint16_value(member_id)?)
+            }
+            TypeKind::UINT32 => {
+                self.serialize_primitive_type(dynamic_data.get_uint32_value(member_id)?)
+            }
+            TypeKind::UINT64 => {
+                self.serialize_primitive_type(dynamic_data.get_uint64_value(member_id)?)
+            }
+            TypeKind::FLOAT32 => {
+                self.serialize_primitive_type(dynamic_data.get_float32_value(member_id)?)
+            }
+            TypeKind::FLOAT64 => {
+                self.serialize_primitive_type(dynamic_data.get_float64_value(member_id)?)
+            }
             TypeKind::FLOAT128 => unimplemented!("not supported by Rust"),
-            TypeKind::INT8 => self.serialize_primitive_type(v.get_int8_value(member_id)?),
-            TypeKind::UINT8 => self.serialize_primitive_type(v.get_uint8_value(member_id)?),
-            TypeKind::CHAR8 => self.serialize_primitive_type(v.get_char8_value(member_id)?),
+            TypeKind::INT8 => {
+                self.serialize_primitive_type(dynamic_data.get_int8_value(member_id)?)
+            }
+            TypeKind::UINT8 => {
+                self.serialize_primitive_type(dynamic_data.get_uint8_value(member_id)?)
+            }
+            TypeKind::CHAR8 => {
+                self.serialize_primitive_type(dynamic_data.get_char8_value(member_id)?)
+            }
             TypeKind::CHAR16 => todo!(),
-            TypeKind::STRING8 => self.serialize_string(v.get_string_value(member_id)?),
+            TypeKind::STRING8 => self.serialize_string(dynamic_data.get_string_value(member_id)?),
             TypeKind::STRING16 => todo!(),
             TypeKind::ALIAS => todo!(),
             TypeKind::ENUM => {
-                self.serialize_enum(member_descriptor.r#type, v.get_complex_value(member_id)?)?
+                self.serialize_enum(dynamic_type, dynamic_data.get_complex_value(member_id)?)?
             }
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
             TypeKind::STRUCTURE => {
-                self.serialize_complex(member_descriptor.r#type, v.get_complex_value(member_id)?)?
+                self.serialize_complex(dynamic_type, dynamic_data.get_complex_value(member_id)?)?
             }
-            TypeKind::UNION => todo!(),
+            TypeKind::UNION => {
+                self.serialize_union(dynamic_type, dynamic_data.get_complex_value(member_id)?)?
+            }
             TypeKind::BITSET => todo!(),
-            TypeKind::SEQUENCE => self.serialize_sequence(dynamic_type, v, member_id)?,
-            TypeKind::ARRAY => self.serialize_array(dynamic_type, v, member_id)?,
+            TypeKind::SEQUENCE => self.serialize_sequence(dynamic_type, dynamic_data, member_id)?,
+            TypeKind::ARRAY => self.serialize_array(dynamic_type, dynamic_data, member_id)?,
             TypeKind::MAP => todo!(),
         }
         Ok(())
     }
 
-    fn serialize_sequence(
+    #[inline]
+    fn serialize_dynamic_data_member(
         &mut self,
         dynamic_type: &dyn DynamicType,
-        v: &DynamicData,
+        dynamic_data: &DynamicData,
         member_id: u32,
     ) -> Result<(), XTypesError> {
-        let member_descriptor = v.get_descriptor(dynamic_type, member_id)?;
-        let element_type = member_descriptor
-            .r#type
+        let member_dynamic_type = dynamic_type.get_member(member_id)?.get_descriptor()?.r#type;
+        self.serialize_member_from_id(member_dynamic_type, dynamic_data, member_id)
+    }
+
+    fn serialize_union(
+        &mut self,
+        dynamic_type: &dyn DynamicType,
+        dynamic_data: &DynamicData,
+    ) -> Result<(), XTypesError> {
+        // Discriminator
+        let discriminator_descriptor = dynamic_type
+            .get_descriptor()
+            .discriminator_type
+            .expect("union has discriminator type")
+            .get_descriptor();
+
+        let variant_id = match discriminator_descriptor.kind {
+            TypeKind::NONE => Err(XTypesError::InvalidType),
+            TypeKind::BOOLEAN => {
+                let discriminator = *dynamic_data.get_boolean_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                Ok(discriminator.into())
+            }
+            TypeKind::BYTE => {
+                let discriminator = *dynamic_data.get_uint8_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                Ok(discriminator.into())
+            }
+            TypeKind::INT16 => {
+                let discriminator = *dynamic_data.get_int16_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::INT32 => {
+                let discriminator = *dynamic_data.get_int32_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::INT64 => {
+                let discriminator = *dynamic_data.get_int64_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::UINT16 => {
+                let discriminator = *dynamic_data.get_uint16_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                Ok(discriminator.into())
+            }
+            TypeKind::UINT32 => {
+                let discriminator = *dynamic_data.get_uint32_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                Ok(discriminator)
+            }
+            TypeKind::UINT64 => {
+                let discriminator = *dynamic_data.get_uint64_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::FLOAT32 => Err(XTypesError::InvalidType),
+            TypeKind::FLOAT64 => Err(XTypesError::InvalidType),
+            TypeKind::FLOAT128 => Err(XTypesError::InvalidType),
+            TypeKind::INT8 => {
+                let discriminator = *dynamic_data.get_int8_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                discriminator
+                    .try_into()
+                    .map_err(|_| XTypesError::InvalidData)
+            }
+            TypeKind::UINT8 => {
+                let discriminator = *dynamic_data.get_uint8_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                Ok(discriminator.into())
+            }
+            TypeKind::CHAR8 => {
+                let discriminator = *dynamic_data.get_char8_value(0)?;
+                self.serialize_primitive_type(&discriminator);
+                Ok(discriminator.into())
+            }
+            TypeKind::CHAR16 => Err(XTypesError::InvalidType),
+            TypeKind::STRING8 => Err(XTypesError::InvalidType),
+            TypeKind::STRING16 => Err(XTypesError::InvalidType),
+            TypeKind::ALIAS => Err(XTypesError::InvalidType),
+            TypeKind::ENUM => {
+                // Discriminator
+                let discriminator_kind = discriminator_descriptor
+                    .discriminator_type
+                    .expect("enum has discriminator type")
+                    .get_kind();
+
+                match discriminator_kind {
+                    TypeKind::INT8 => {
+                        let discriminator =
+                            *dynamic_data.get_complex_value(0)?.get_int8_value(0)?;
+                        self.serialize_primitive_type(&discriminator);
+                        discriminator
+                            .try_into()
+                            .map_err(|_| XTypesError::InvalidData)
+                    }
+                    TypeKind::INT16 => {
+                        let discriminator =
+                            *dynamic_data.get_complex_value(0)?.get_int16_value(0)?;
+                        self.serialize_primitive_type(&discriminator);
+                        discriminator
+                            .try_into()
+                            .map_err(|_| XTypesError::InvalidData)
+                    }
+                    TypeKind::INT32 => {
+                        let discriminator =
+                            *dynamic_data.get_complex_value(0)?.get_int32_value(0)?;
+                        self.serialize_primitive_type(&discriminator);
+                        discriminator
+                            .try_into()
+                            .map_err(|_| XTypesError::InvalidData)
+                    }
+                    _ => Err(XTypesError::InvalidType),
+                }
+            }
+            TypeKind::BITMASK => Err(XTypesError::InvalidType),
+            TypeKind::ANNOTATION => Err(XTypesError::InvalidType),
+            TypeKind::STRUCTURE => Err(XTypesError::InvalidType),
+            TypeKind::UNION => Err(XTypesError::InvalidType),
+            TypeKind::BITSET => Err(XTypesError::InvalidType),
+            TypeKind::SEQUENCE => Err(XTypesError::InvalidType),
+            TypeKind::ARRAY => Err(XTypesError::InvalidType),
+            TypeKind::MAP => Err(XTypesError::InvalidType),
+        }?;
+
+        // Variant
+        let variant_dynamic_type = dynamic_type
+            .get_member(variant_id)?
+            .get_descriptor()?
+            .r#type;
+        // Skip if kind is none
+        if variant_dynamic_type.get_kind() == TypeKind::NONE {
+            return Ok(());
+        }
+        self.serialize_member_from_id(variant_dynamic_type, dynamic_data, 1)
+    }
+
+    fn serialize_sequence(
+        &mut self,
+        sequence_type: &dyn DynamicType,
+        sequence_data: &DynamicData,
+        member_id: MemberId,
+    ) -> Result<(), XTypesError> {
+        let sequence_element_type = sequence_type
             .get_descriptor()
             .element_type
-            .as_ref()
             .expect("sequence has element type");
-        match element_type.get_descriptor().kind {
+
+        match sequence_element_type.get_descriptor().kind {
             TypeKind::NONE => todo!(),
-            TypeKind::BOOLEAN => self.serialize_sequence_basic(v.get_boolean_values(member_id)?),
+            TypeKind::BOOLEAN => {
+                self.serialize_sequence_basic(sequence_data.get_boolean_values(member_id)?)
+            }
             TypeKind::BYTE => todo!(),
-            TypeKind::INT16 => self.serialize_sequence_basic(v.get_int16_values(member_id)?),
-            TypeKind::INT32 => self.serialize_sequence_basic(v.get_int32_values(member_id)?),
-            TypeKind::INT64 => self.serialize_sequence_basic(v.get_int64_values(member_id)?),
-            TypeKind::UINT16 => self.serialize_sequence_basic(v.get_uint16_values(member_id)?),
-            TypeKind::UINT32 => self.serialize_sequence_basic(v.get_uint32_values(member_id)?),
-            TypeKind::UINT64 => self.serialize_sequence_basic(v.get_uint64_values(member_id)?),
-            TypeKind::FLOAT32 => self.serialize_sequence_basic(v.get_float32_values(member_id)?),
-            TypeKind::FLOAT64 => self.serialize_sequence_basic(v.get_float64_values(member_id)?),
+            TypeKind::INT16 => {
+                self.serialize_sequence_basic(sequence_data.get_int16_values(member_id)?)
+            }
+            TypeKind::INT32 => {
+                self.serialize_sequence_basic(sequence_data.get_int32_values(member_id)?)
+            }
+            TypeKind::INT64 => {
+                self.serialize_sequence_basic(sequence_data.get_int64_values(member_id)?)
+            }
+            TypeKind::UINT16 => {
+                self.serialize_sequence_basic(sequence_data.get_uint16_values(member_id)?)
+            }
+            TypeKind::UINT32 => {
+                self.serialize_sequence_basic(sequence_data.get_uint32_values(member_id)?)
+            }
+            TypeKind::UINT64 => {
+                self.serialize_sequence_basic(sequence_data.get_uint64_values(member_id)?)
+            }
+            TypeKind::FLOAT32 => {
+                self.serialize_sequence_basic(sequence_data.get_float32_values(member_id)?)
+            }
+            TypeKind::FLOAT64 => {
+                self.serialize_sequence_basic(sequence_data.get_float64_values(member_id)?)
+            }
             TypeKind::FLOAT128 => todo!(),
-            TypeKind::INT8 => self.serialize_sequence_basic(v.get_int8_values(member_id)?),
-            TypeKind::UINT8 => self.serialize_sequence_basic(v.get_uint8_values(member_id)?),
+            TypeKind::INT8 => {
+                self.serialize_sequence_basic(sequence_data.get_int8_values(member_id)?)
+            }
+            TypeKind::UINT8 => {
+                self.serialize_sequence_basic(sequence_data.get_uint8_values(member_id)?)
+            }
             TypeKind::CHAR8 => todo!(),
             TypeKind::CHAR16 => todo!(),
             TypeKind::STRING8 => {
-                let list = v.get_string_values(member_id)?;
-                self.serialize_primitive_type(&(list.len() as u32));
-                for v in list {
-                    self.serialize_string(v);
+                let strings_data = sequence_data.get_string_values(member_id)?;
+                self.serialize_primitive_type(&(strings_data.len() as u32));
+                for string_data in strings_data {
+                    self.serialize_string(string_data);
                 }
             }
             TypeKind::STRING16 => todo!(),
             TypeKind::ALIAS => todo!(),
-            TypeKind::ENUM => todo!(),
+            TypeKind::ENUM => {
+                let enums_data = sequence_data.get_complex_values(member_id)?;
+                self.serialize_primitive_type(&(enums_data.len() as u32));
+                for enum_data in enums_data {
+                    self.serialize_enum(sequence_element_type, enum_data)?;
+                }
+            }
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
             TypeKind::STRUCTURE => {
-                let list = v.get_complex_values(member_id)?;
-                self.serialize_primitive_type(&(list.len() as u32));
-                for v in list {
-                    self.serialize_complex(dynamic_type, v)?;
+                let structures_data = sequence_data.get_complex_values(member_id)?;
+                self.serialize_primitive_type(&(structures_data.len() as u32));
+                for structure_data in structures_data {
+                    self.serialize_complex(sequence_element_type, structure_data)?;
                 }
             }
-            TypeKind::UNION => todo!(),
+            TypeKind::UNION => {
+                let unions_data = sequence_data.get_complex_values(member_id)?;
+                self.serialize_primitive_type(&(unions_data.len() as u32));
+                for union_data in unions_data {
+                    self.serialize_union(sequence_element_type, union_data)?;
+                }
+            }
             TypeKind::BITSET => todo!(),
             TypeKind::SEQUENCE => todo!(),
             TypeKind::ARRAY => todo!(),
@@ -356,50 +565,72 @@ trait XTypesSerializer {
 
     fn serialize_array(
         &mut self,
-        dynamic_type: &dyn DynamicType,
-        v: &DynamicData,
-        member_id: u32,
+        array_type: &dyn DynamicType,
+        array_data: &DynamicData,
+        member_id: MemberId,
     ) -> Result<(), XTypesError> {
-        let member_descriptor = v.get_descriptor(dynamic_type, member_id)?;
-        let element_type = member_descriptor
-            .r#type
+        let array_element_type = array_type
             .get_descriptor()
             .element_type
-            .as_ref()
             .expect("array has element type");
-        match element_type.get_descriptor().kind {
+
+        match array_element_type.get_descriptor().kind {
             TypeKind::NONE => todo!(),
-            TypeKind::BOOLEAN => todo!(),
+            TypeKind::BOOLEAN => {
+                self.serialize_array_basic(array_data.get_boolean_values(member_id)?)
+            }
             TypeKind::BYTE => todo!(),
-            TypeKind::INT16 => todo!(),
-            TypeKind::INT32 => todo!(),
-            TypeKind::INT64 => todo!(),
-            TypeKind::UINT16 => todo!(),
-            TypeKind::UINT32 => todo!(),
-            TypeKind::UINT64 => todo!(),
-            TypeKind::FLOAT32 => todo!(),
-            TypeKind::FLOAT64 => todo!(),
+            TypeKind::INT16 => self.serialize_array_basic(array_data.get_int16_values(member_id)?),
+            TypeKind::INT32 => self.serialize_array_basic(array_data.get_int32_values(member_id)?),
+            TypeKind::INT64 => self.serialize_array_basic(array_data.get_int64_values(member_id)?),
+            TypeKind::UINT16 => {
+                self.serialize_array_basic(array_data.get_uint16_values(member_id)?)
+            }
+            TypeKind::UINT32 => {
+                self.serialize_array_basic(array_data.get_uint32_values(member_id)?)
+            }
+            TypeKind::UINT64 => {
+                self.serialize_array_basic(array_data.get_uint64_values(member_id)?)
+            }
+            TypeKind::FLOAT32 => {
+                self.serialize_array_basic(array_data.get_float32_values(member_id)?)
+            }
+            TypeKind::FLOAT64 => {
+                self.serialize_array_basic(array_data.get_float64_values(member_id)?)
+            }
             TypeKind::FLOAT128 => todo!(),
-            TypeKind::INT8 => todo!(),
-            TypeKind::UINT8 => self.serialize_array_basic(v.get_uint8_values(member_id)?),
+            TypeKind::INT8 => self.serialize_array_basic(array_data.get_int8_values(member_id)?),
+            TypeKind::UINT8 => self.serialize_array_basic(array_data.get_uint8_values(member_id)?),
             TypeKind::CHAR8 => todo!(),
             TypeKind::CHAR16 => todo!(),
             TypeKind::STRING8 => {
-                for v in v.get_string_values(member_id)? {
-                    self.serialize_string(v);
+                let strings_data = array_data.get_string_values(member_id)?;
+                for string_data in strings_data {
+                    self.serialize_string(string_data);
                 }
             }
             TypeKind::STRING16 => todo!(),
             TypeKind::ALIAS => todo!(),
-            TypeKind::ENUM => todo!(),
+            TypeKind::ENUM => {
+                let enums_data = array_data.get_complex_values(member_id)?;
+                for enum_data in enums_data {
+                    self.serialize_enum(array_element_type, enum_data)?;
+                }
+            }
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
             TypeKind::STRUCTURE => {
-                for v in v.get_complex_values(member_id)? {
-                    self.serialize_complex(dynamic_type, v)?;
+                let structures_data = array_data.get_complex_values(member_id)?;
+                for structure_data in structures_data {
+                    self.serialize_complex(array_element_type, structure_data)?;
                 }
             }
-            TypeKind::UNION => todo!(),
+            TypeKind::UNION => {
+                let unions_data = array_data.get_complex_values(member_id)?;
+                for union_data in unions_data {
+                    self.serialize_union(array_element_type, union_data)?;
+                }
+            }
             TypeKind::BITSET => todo!(),
             TypeKind::SEQUENCE => todo!(),
             TypeKind::ARRAY => todo!(),
@@ -412,11 +643,30 @@ trait XTypesSerializer {
     fn serialize_enum(
         &mut self,
         dynamic_type: &dyn DynamicType,
-        v: &DynamicData,
+        dynamic_data: &DynamicData,
     ) -> Result<(), XTypesError> {
-        let _discriminator_type = dynamic_type.get_descriptor().discriminator_type.as_ref();
-        self.serialize_primitive_type(v.get_int32_value(0)?);
-        Ok(())
+        // Discriminator
+        let discriminator_kind = dynamic_type
+            .get_descriptor()
+            .discriminator_type
+            .expect("enum has discriminator type")
+            .get_kind();
+
+        match discriminator_kind {
+            TypeKind::INT8 => {
+                self.serialize_primitive_type(dynamic_data.get_int8_value(0)?);
+                Ok(())
+            }
+            TypeKind::INT16 => {
+                self.serialize_primitive_type(dynamic_data.get_int16_value(0)?);
+                Ok(())
+            }
+            TypeKind::INT32 => {
+                self.serialize_primitive_type(dynamic_data.get_int32_value(0)?);
+                Ok(())
+            }
+            _ => Err(XTypesError::InvalidType),
+        }
     }
 
     fn serialize_complex(

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -9,7 +9,7 @@ use dust_dds::{
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
         status::{NO_STATUS, StatusKind},
         time::{Duration, DurationKind},
-        type_support::DdsType,
+        type_support::{DdsType, TypeSupport},
     },
     wait_set::{Condition, WaitSet},
 };
@@ -297,16 +297,25 @@ fn nested_types_should_read_and_write() {
 
 #[ignore = "create_dynamic_sample not derived yet"]
 #[test]
-fn foo_xtypes_union_should_read_and_write() {
+fn union_should_read_and_write() {
     #[derive(Clone, Debug, PartialEq, DdsType)]
-    struct MyInnerType(u32);
+    struct VariantA(u32);
 
     #[derive(Clone, Debug, PartialEq, DdsType)]
-    #[repr(u8)]
+    struct VariantB {
+        a: u32,
+        b: i16,
+    }
+
+    #[derive(Clone, Debug, PartialEq, DdsType)]
+    #[dust_dds(discriminator = u8)]
     enum MyEnum {
-        _VariantA(MyInnerType) = 5,
-        VariantB { a: u32, b: i16 } = 6,
-        _VariantC = 7,
+        #[dust_dds(discriminator = 5)]
+        VariantA(VariantA),
+        #[dust_dds(discriminator = 10)]
+        VariantB(VariantB),
+        #[dust_dds(discriminator = 15)]
+        VariantC,
     }
 
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
@@ -318,7 +327,7 @@ fn foo_xtypes_union_should_read_and_write() {
     let topic = participant
         .create_topic::<MyEnum>(
             "MyEnumTopic",
-            "MyEnum",
+            MyEnum::TYPE_NAME,
             QosKind::Default,
             NO_LISTENER,
             NO_STATUS,
@@ -373,7 +382,7 @@ fn foo_xtypes_union_should_read_and_write() {
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
-    let data = MyEnum::VariantB { a: 10, b: -20 };
+    let data = MyEnum::VariantB(VariantB { a: 10, b: -20 });
 
     writer.write(data.clone(), None).unwrap();
 

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -295,7 +295,6 @@ fn nested_types_should_read_and_write() {
     assert_eq!(samples[0].data.as_ref().unwrap(), &data);
 }
 
-#[ignore = "create_dynamic_sample not derived yet"]
 #[test]
 fn union_should_read_and_write() {
     #[derive(Clone, Debug, PartialEq, DdsType)]

--- a/dds_derive/src/derive/attributes.rs
+++ b/dds_derive/src/derive/attributes.rs
@@ -1,4 +1,4 @@
-use syn::{Expr, Field};
+use syn::{Expr, Field, Variant, spanned::Spanned};
 
 pub struct FieldAttributes {
     pub key: bool,
@@ -41,4 +41,53 @@ pub fn get_field_attributes(field: &Field) -> syn::Result<FieldAttributes> {
         default_value,
         non_serialized,
     })
+}
+
+pub struct VariantAttributes {
+    pub discriminators: Vec<Expr>,
+}
+
+pub fn get_variant_attributes(variant: &Variant) -> syn::Result<VariantAttributes> {
+    let mut discriminators = None;
+
+    if let Some(xtypes_attribute) = variant
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("dust_dds"))
+    {
+        xtypes_attribute.parse_nested_meta(|meta| {
+            if meta.path.is_ident("discriminator") {
+                let value = meta.value()?;
+
+                discriminators = if value.peek(syn::token::Bracket) {
+                    let expr_array: syn::ExprArray = value.parse()?;
+                    if expr_array.elems.is_empty() {
+                        return Err(syn::Error::new(
+                            value.span(),
+                            "`discriminator` must contain at least one expression",
+                        ));
+                    }
+                    Some(expr_array.elems.into_iter().collect())
+                } else {
+                    Some(vec![value.parse()?])
+                };
+            } else {
+                return Err(syn::Error::new(
+                    meta.path.span(),
+                    format!("unknown attribute `{}`", meta.path.require_ident()?),
+                ));
+            }
+
+            Ok(())
+        })?;
+    }
+
+    let Some(discriminators) = discriminators else {
+        return Err(syn::Error::new(
+            variant.span(),
+            "`discriminator` is required",
+        ));
+    };
+
+    Ok(VariantAttributes { discriminators })
 }

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -1,31 +1,37 @@
 use crate::derive::{
-    attributes::get_field_attributes, enum_support::read_enum_variant_discriminant_mapping,
+    attributes::{get_field_attributes, get_variant_attributes},
+    enum_support::read_enum_variant_discriminant_mapping,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
+use std::borrow::Cow;
 use syn::{DataEnum, DeriveInput, Fields, Index, Result, spanned::Spanned};
 
 pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
-    let input_attributes = get_input_attributes(input)?;
     let ident = &input.ident;
 
-    let type_name = input_attributes.name.as_str();
-    let extensibility_kind = match input_attributes.extensibility {
-        Extensibility::Final => {
-            quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final}
-        }
-        Extensibility::Appendable => {
-            quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Appendable}
-        }
-        Extensibility::Mutable => {
-            quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Mutable}
-        }
-    };
-    let is_nested = input_attributes.is_nested;
-
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
-    let (get_type_quote, create_dynamic_sample_quote, create_sample_quote) = match &input.data {
+
+    let (type_name, get_type_quote, create_dynamic_sample_quote, create_sample_quote) = match &input
+        .data
+    {
         syn::Data::Struct(data_struct) => {
+            let struct_attributes = get_struct_or_enum_attributes(input)?;
+
+            let type_name = struct_attributes.name;
+            let extensibility_kind = match struct_attributes.extensibility {
+                Extensibility::Final => {
+                    quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final}
+                }
+                Extensibility::Appendable => {
+                    quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Appendable}
+                }
+                Extensibility::Mutable => {
+                    quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Mutable}
+                }
+            };
+            let is_nested = struct_attributes.is_nested;
+
             let struct_descriptor = quote! {
                 &dust_dds::xtypes::dynamic_type::TypeDescriptor {
                     kind: dust_dds::xtypes::dynamic_type::TypeKind::STRUCTURE,
@@ -48,7 +54,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 let field_attributes = get_field_attributes(field)?;
 
                 let index = field_index as u32;
-                let member_id = match input_attributes.extensibility {
+                let member_id = match struct_attributes.extensibility {
                     Extensibility::Final | Extensibility::Appendable => {
                         syn::parse_str(&field_index.to_string())
                     }
@@ -165,6 +171,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 quote! {Self{#(#member_sample_seq)*}}
             };
             Ok((
+                type_name,
                 get_type_quote,
                 create_dynamic_sample_quote,
                 create_sample_quote,
@@ -174,41 +181,175 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
             // Separate between Unions and Enumeration which are both
             // mapped as Rust enum types
             if is_enum_xtypes_union(data_enum) {
+                if data_enum.variants.len() > (u32::MAX as usize + 1) {
+                    return Err(syn::Error::new(
+                        input.span(),
+                        "Enum can hold at most `u32::MAX + 1` variants",
+                    ));
+                }
+
+                let union_attributes = get_union_attributes(input)?;
+
+                let union_name = union_attributes.name;
+                let discriminator_type = &union_attributes.discriminator;
+
                 let union_descriptor = quote! {
-                    &dust_dds::xtypes::dynamic_type::TypeDescriptor {
-                        kind: dust_dds::xtypes::dynamic_type::TypeKind::UNION,
-                        name: #type_name,
-                        base_type: None,
-                        discriminator_type: None,
-                        bound: None,
-                        element_type: None,
-                        key_element_type: None,
-                        extensibility_kind: #extensibility_kind,
-                        is_nested: #is_nested,
+                    &::dust_dds::xtypes::dynamic_type::TypeDescriptor {
+                        kind: ::dust_dds::xtypes::dynamic_type::TypeKind::UNION,
+                        name: #union_name,
+                        base_type: ::core::option::Option::None,
+                        discriminator_type: ::core::option::Option::Some(<#discriminator_type as ::dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION),
+                        bound: ::core::option::Option::None,
+                        element_type: ::core::option::Option::None,
+                        key_element_type: ::core::option::Option::None,
+                        extensibility_kind: ::dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final,
+                        is_nested: false,
                     }
                 };
+
+                let mut variant_list = Vec::new();
+                let mut variant_sample_seq = Vec::new();
+                let mut variant_dynamic_sample_seq = Vec::new();
+
+                for (variant_index, variant) in data_enum.variants.iter().enumerate() {
+                    let variant_attributes = get_variant_attributes(variant)?;
+
+                    let index = variant_index as u32;
+                    let variant_discriminators = variant_attributes.discriminators;
+                    let variant_discriminator = &variant_discriminators[0];
+                    let variant_ident = &variant.ident;
+                    let variant_name = variant_ident.to_string();
+                    let variant_ty = match &variant.fields {
+                        Fields::Named(_) => {
+                            return Err(syn::Error::new(
+                                variant.span(),
+                                "Enum variant must be unnamed or unit",
+                            ));
+                        }
+                        Fields::Unnamed(fields) => {
+                            if fields.unnamed.len() != 1 {
+                                return Err(syn::Error::new(
+                                    variant.span(),
+                                    "Enum variant must contain a single field",
+                                ));
+                            }
+
+                            let variant_ty = &fields.unnamed[0].ty;
+
+                            variant_sample_seq.push(quote! {
+                                #(#variant_discriminators)|* => Self::#variant_ident(<#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(src.remove_value(1).expect("Must exist")).expect("Must match"))
+                            });
+
+                            variant_dynamic_sample_seq.push(quote! {
+                                Self::#variant_ident(variant) => {
+                                    data.set_value(0u32, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#variant_discriminator));
+                                    data.set_value(1u32, <#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(variant));
+                                }
+                            });
+
+                            Cow::Borrowed(variant_ty)
+                        }
+                        Fields::Unit => {
+                            variant_sample_seq.push(quote! {
+                                #(#variant_discriminators)|* => Self::#variant_ident
+                            });
+
+                            variant_dynamic_sample_seq.push(quote! {
+                                Self::#variant_ident => {
+                                    data.set_value(0u32, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#variant_discriminator));
+                                }
+                            });
+
+                            Cow::Owned(syn::parse_quote!(()))
+                        }
+                    };
+
+                    for variant_discriminator in variant_discriminators {
+                        variant_list.push(
+                            quote! {
+                                ::dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+                                    descriptor: ::dust_dds::xtypes::dynamic_type::MemberDescriptor {
+                                        name: #variant_name,
+                                        id: const {
+                                            let id = (#variant_discriminator) as i64;
+                                            ::core::assert!(id >= 0, ::core::concat!("discriminator `", ::core::stringify!(#variant_discriminator), "` of `", ::core::stringify!(#ident), "::", ::core::stringify!(#variant_ident),"` must evaluate to a value `>= 0`"));
+                                            ::core::assert!(id <= (u32::MAX as i64), ::core::concat!("discriminator `", ::core::stringify!(#variant_discriminator), "` of `", ::core::stringify!(#ident), "::", ::core::stringify!(#variant_ident),"` must evaluate to a value `<= u32::MAX`"));
+                                            id as u32
+                                        },
+                                        r#type: <#variant_ty as ::dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION,
+                                        default_value: ::core::option::Option::None,
+                                        index: #index,
+                                        try_construct_kind: ::dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,
+                                        label: ::core::option::Option::None,
+                                        is_key: false,
+                                        is_optional: false,
+                                        is_must_understand: true,
+                                        is_shared: false,
+                                        is_default_label: false,
+                                    }
+                                }
+                            },
+                        );
+                    }
+                }
+
                 let get_type_quote = quote! {
-                    const r#TYPE: &'static dyn dust_dds::xtypes::dynamic_type::DynamicType =
-                        &dust_dds::xtypes::dynamic_type::StaticTypeInformation {
+                    const r#TYPE: &'static dyn ::dust_dds::xtypes::dynamic_type::DynamicType =
+                        &::dust_dds::xtypes::dynamic_type::StaticTypeInformation {
                             descriptor: #union_descriptor,
-                            member_list: &[]
+                            member_list: &[#(#variant_list,)*]
                         };
                 };
 
-                let create_dynamic_sample_quote = quote! {todo!()};
-                let create_sample_quote = quote! {
-                    todo!()
+                let create_dynamic_sample_quote = quote! {
+                    let mut data = ::dust_dds::xtypes::dynamic_type::DynamicDataFactory::create_data();
+
+                    match self {
+                        #(#variant_dynamic_sample_seq,)*
+                    }
+
+                    data
                 };
+
+                let create_sample_quote = quote! {
+                    let discriminator = <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
+                            src.remove_value(0).expect("Must exist")
+                        )
+                        .expect("Must match");
+
+                    match discriminator {
+                        #(#variant_sample_seq,)*
+                        _ => panic!("invalid discriminator"),
+                    }
+                };
+
                 Ok((
+                    union_name,
                     get_type_quote,
                     create_dynamic_sample_quote,
                     create_sample_quote,
                 ))
             } else {
+                let enum_attributes = get_struct_or_enum_attributes(input)?;
+
+                let type_name = enum_attributes.name;
+                let extensibility_kind = match enum_attributes.extensibility {
+                    Extensibility::Final => {
+                        quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final}
+                    }
+                    Extensibility::Appendable => {
+                        quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Appendable}
+                    }
+                    Extensibility::Mutable => {
+                        quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Mutable}
+                    }
+                };
+                let is_nested = enum_attributes.is_nested;
+                let discriminator_type =
+                    quote! {<i32 as ::dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION};
+
                 // Note: Mapping has to be done with a match self strategy because the enum might not be copy so casting it using e.g. "self as i64" would
                 // be consuming it.
-                let discriminator_type =
-                    quote! {<i32 as dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION};
                 let discriminator_dynamic_value =
                     quote! {data.set_int32_value(0, self as i32).unwrap();};
 
@@ -253,6 +394,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 };
 
                 Ok((
+                    type_name,
                     get_type_quote,
                     create_dynamic_sample_quote,
                     create_sample_quote,
@@ -289,13 +431,13 @@ enum Extensibility {
     Mutable,
 }
 
-struct InputAttributes {
+struct StructOrEnumAttributes {
     name: String,
     extensibility: Extensibility,
     is_nested: bool,
 }
 
-fn get_input_attributes(input: &DeriveInput) -> Result<InputAttributes> {
+fn get_struct_or_enum_attributes(input: &DeriveInput) -> Result<StructOrEnumAttributes> {
     let mut name = input.ident.to_string();
     let mut extensibility = Extensibility::Final;
     let mut is_nested = false;
@@ -331,16 +473,59 @@ fn get_input_attributes(input: &DeriveInput) -> Result<InputAttributes> {
             } else if meta.path.is_ident("nested") {
                 is_nested = true;
                 Ok(())
-            }
-            else {
-                Ok(())
+            } else {
+               Err(syn::Error::new(
+                    meta.path.span(),
+                    format!("unknown attribute `{}`", meta.path.require_ident()?),
+                ))
             }
         })?;
     }
-    Ok(InputAttributes {
+
+    Ok(StructOrEnumAttributes {
         name,
         extensibility,
         is_nested,
+    })
+}
+
+struct UnionAttributes {
+    name: String,
+    discriminator: syn::Type,
+}
+
+fn get_union_attributes(input: &DeriveInput) -> Result<UnionAttributes> {
+    let mut name = input.ident.to_string();
+    let mut discriminator = None;
+
+    if let Some(xtypes_attribute) = input
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("dust_dds"))
+    {
+        xtypes_attribute.parse_nested_meta(|meta| {
+            if meta.path.is_ident("name") {
+                name = meta.value()?.parse::<syn::LitStr>()?.value();
+                Ok(())
+            } else if meta.path.is_ident("discriminator") {
+                discriminator = Some(meta.value()?.parse()?);
+                Ok(())
+            } else {
+                Err(syn::Error::new(
+                    meta.path.span(),
+                    format!("unknown attribute `{}`", meta.path.require_ident()?),
+                ))
+            }
+        })?;
+    }
+
+    let Some(discriminator) = discriminator else {
+        return Err(syn::Error::new(input.span(), "`discriminator` is required"));
+    };
+
+    Ok(UnionAttributes {
+        name,
+        discriminator,
     })
 }
 

--- a/interoperability_tests/Cargo.toml
+++ b/interoperability_tests/Cargo.toml
@@ -60,3 +60,11 @@ path = "dust_dds_subscriber_nested.rs"
 [[bin]]
 name = "dust_dds_publisher_nested"
 path = "dust_dds_publisher_nested.rs"
+
+[[bin]]
+name = "dust_dds_subscriber_union"
+path = "dust_dds_subscriber_union.rs"
+
+[[bin]]
+name = "dust_dds_publisher_union"
+path = "dust_dds_publisher_union.rs"

--- a/interoperability_tests/Union.idl
+++ b/interoperability_tests/Union.idl
@@ -1,5 +1,5 @@
 module interoperability {
-	module test {
+    module test {
         enum VariantEnum {
             VARIANT_ENUM_X,
             VARIANT_ENUM_Y,
@@ -134,5 +134,5 @@ module interoperability {
             UnionType union_array[20];
             sequence<UnionType, 20> union_sequence;
         };
-	};
+    };
 };

--- a/interoperability_tests/Union.idl
+++ b/interoperability_tests/Union.idl
@@ -1,0 +1,138 @@
+module interoperability {
+	module test {
+        enum VariantEnum {
+            VARIANT_ENUM_X,
+            VARIANT_ENUM_Y,
+            VARIANT_ENUM_Z
+        };
+
+        struct VariantStructure {
+            uint8 x;
+            uint16 y;
+            uint32 z;
+        };
+
+        union VariantUnion switch (uint16) {
+            case 10:
+            case 20:
+            case 30:
+                uint8 x;
+            case 100:
+            case 200:
+            case 300:
+                uint16 y;
+            case 1000:
+            case 2000:
+            case 3000:
+                uint32 z;
+        };
+
+        enum UnionDiscriminator {
+            @value(0)
+            UNION_DISCRIMINATOR_NONE,
+            @value(1)
+            UNION_DISCRIMINATOR_BOOLEAN,
+            @value(2)
+            UNION_DISCRIMINATOR_BYTE,
+            @value(4)
+            UNION_DISCRIMINATOR_INT16,
+            @value(8)
+            UNION_DISCRIMINATOR_INT32,
+            @value(16)
+            UNION_DISCRIMINATOR_INT64,
+            @value(32)
+            UNION_DISCRIMINATOR_UINT16,
+            @value(64)
+            UNION_DISCRIMINATOR_UINT32,
+            @value(128)
+            UNION_DISCRIMINATOR_UINT64,
+            @value(256)
+            UNION_DISCRIMINATOR_FLOAT32,
+            @value(512)
+            UNION_DISCRIMINATOR_FLOAT64,
+            // @value(1024)
+            // UNION_DISCRIMINATOR_FLOAT128,
+            @value(2048)
+            UNION_DISCRIMINATOR_INT8,
+            @value(4096)
+            UNION_DISCRIMINATOR_UINT8,
+            @value(8192)
+            UNION_DISCRIMINATOR_CHAR8,
+            // @value(16384)
+            // UNION_DISCRIMINATOR_CHAR16,
+            @value(32768)
+            UNION_DISCRIMINATOR_STRING8,
+            // @value(65536)
+            // UNION_DISCRIMINATOR_STRING16,
+            // @value(131072)
+            // UNION_DISCRIMINATOR_ALIAS,
+            @value(262144)
+            UNION_DISCRIMINATOR_ENUM,
+            // @value(524288)
+            // UNION_DISCRIMINATOR_BITMASK,
+            // @value(1048576)
+            // UNION_DISCRIMINATOR_ANNOTATION,
+            @value(2097152)
+            UNION_DISCRIMINATOR_STRUCTURE,
+            @value(4194304)
+            UNION_DISCRIMINATOR_UNION,
+            // @value(8388608)
+            // UNION_DISCRIMINATOR_BITSET,
+            @value(16777216)
+            UNION_DISCRIMINATOR_SEQUENCE,
+            @value(33554432)
+            UNION_DISCRIMINATOR_ARRAY
+            // @value(67108864)
+            // UNION_DISCRIMINATOR_MAP
+        };
+
+        union UnionType switch (UnionDiscriminator) {
+            // case UNION_DISCRIMINATOR_NONE:
+            //    ;
+            case UNION_DISCRIMINATOR_BOOLEAN:
+                boolean v_boolean;
+            case UNION_DISCRIMINATOR_BYTE:
+                octet v_byte;
+            case UNION_DISCRIMINATOR_INT16:
+                int16 v_int16;
+            case UNION_DISCRIMINATOR_INT32:
+                int32 v_int32;
+            case UNION_DISCRIMINATOR_INT64:
+                int64 v_int64;
+            case UNION_DISCRIMINATOR_UINT16:
+                uint16 v_uint16;
+            case UNION_DISCRIMINATOR_UINT32:
+                uint32 v_uint32;
+            case UNION_DISCRIMINATOR_UINT64:
+                uint64 v_uint64;
+            case UNION_DISCRIMINATOR_FLOAT32:
+                float v_float32;
+            case UNION_DISCRIMINATOR_FLOAT64:
+                double v_float64;
+            case UNION_DISCRIMINATOR_INT8:
+                int8 v_int8;
+            case UNION_DISCRIMINATOR_UINT8:
+                uint8 v_uint8;
+            case UNION_DISCRIMINATOR_CHAR8:
+                char v_char8;
+            case UNION_DISCRIMINATOR_STRING8:
+                string v_string8;
+            case UNION_DISCRIMINATOR_ENUM:
+                VariantEnum v_enum;
+            case UNION_DISCRIMINATOR_STRUCTURE:
+                VariantStructure v_structure;
+            case UNION_DISCRIMINATOR_UNION:
+                VariantUnion v_union;
+            case UNION_DISCRIMINATOR_SEQUENCE:
+                sequence<string> v_sequence;
+            case UNION_DISCRIMINATOR_ARRAY:
+                double v_array[3];
+        };
+
+        struct UnionTypeWrapper {
+            UnionType union_type;
+            UnionType union_array[20];
+            sequence<UnionType, 20> union_sequence;
+        };
+	};
+};

--- a/interoperability_tests/cyclone_dds/CMakeLists.txt
+++ b/interoperability_tests/cyclone_dds/CMakeLists.txt
@@ -6,6 +6,7 @@ idlc_generate(TARGET HelloWorldGeneratedIdl FILES ../HelloWorld.idl)
 idlc_generate(TARGET BigDataGeneratedIdl FILES ../BigData.idl)
 idlc_generate(TARGET DisposeDataGeneratedIdl FILES ../DisposeData.idl)
 idlc_generate(TARGET NestedTypeGeneratedIdl FILES ../NestedType.idl)
+idlc_generate(TARGET UnionGeneratedIdl FILES ../Union.idl)
 
 add_executable(CycloneDdsSubscriber
   cyclone_dds_subscriber.c
@@ -71,4 +72,20 @@ add_executable(CycloneDdsSubscriberNested
 target_link_libraries(CycloneDdsSubscriberNested PRIVATE
   CycloneDDS::ddsc
   NestedTypeGeneratedIdl
+)
+
+add_executable(CycloneDdsPublisherUnion
+  cyclone_dds_publisher_union.c
+)
+target_link_libraries(CycloneDdsPublisherUnion PRIVATE
+  CycloneDDS::ddsc
+  UnionGeneratedIdl
+)
+
+add_executable(CycloneDdsSubscriberUnion
+  cyclone_dds_subscriber_union.c
+)
+target_link_libraries(CycloneDdsSubscriberUnion PRIVATE
+  CycloneDDS::ddsc
+  UnionGeneratedIdl
 )

--- a/interoperability_tests/cyclone_dds/cyclone_dds_publisher_union.c
+++ b/interoperability_tests/cyclone_dds/cyclone_dds_publisher_union.c
@@ -1,0 +1,247 @@
+#include <float.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "ddsc/dds.h"
+#include "Union.h"
+
+size_t random_value(size_t end);
+
+interoperability_test_VariantUnion variant_union_random();
+
+int main(int argc, char *argv[]) {
+	const char *topic_name = "Union";
+
+	const dds_entity_t participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL /*qos*/, NULL /*listener*/);
+	if (participant < 0) {
+		DDS_FATAL("dds_create_participant: %s\n", dds_strretcode(-participant));
+	}
+	const dds_entity_t topic = dds_create_topic(participant, &interoperability_test_UnionTypeWrapper_desc, topic_name, NULL /*qos*/, NULL /*listener*/);
+	if (topic < 0) {
+		DDS_FATAL("dds_create_topic: %s\n", dds_strretcode(-topic));
+	}
+	dds_qos_t *qos = dds_create_qos();
+	dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE, DDS_SECS(1));
+	dds_qset_durability(qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+
+	const dds_entity_t data_writer = dds_create_writer(participant, topic, qos, NULL /*listener*/);
+	if (data_writer < 0) {
+		DDS_FATAL("dds_create_writer: %s\n", dds_strretcode(-data_writer));
+	}
+
+	dds_return_t rc;
+
+	rc = dds_set_status_mask(data_writer, DDS_PUBLICATION_MATCHED_STATUS);
+	if (rc != DDS_RETCODE_OK) {
+		DDS_FATAL("dds_set_status_mask: %s\n", dds_strretcode(-rc));
+	}
+
+	dds_entity_t waitset = dds_create_waitset(participant);
+
+	rc = dds_waitset_attach(waitset, data_writer, data_writer);
+	if (rc != DDS_RETCODE_OK) {
+		DDS_FATAL("dds_waitset_attach: %s\n", dds_strretcode(-rc));
+	}
+
+	dds_attach_t wsresults[1];
+	const size_t wsresultsize = 1U;
+	rc = dds_waitset_wait(waitset, wsresults, wsresultsize, DDS_SECS(60));
+	if (rc == 0) {
+		DDS_FATAL("dds_waitset_wait: timeout");
+	}
+	if (rc != wsresultsize) {
+		DDS_FATAL("dds_waitset_wait: %s\n", dds_strretcode(-rc));
+	}
+
+    srand((unsigned int) time(NULL));
+
+	const interoperability_test_UnionType unions[] = {
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_NONE
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_BOOLEAN,
+			._u = {
+				.v_boolean = true
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_BYTE,
+			._u = {
+				.v_byte = UINT8_MAX / 2
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_INT16,
+			._u = {
+				.v_int16 = INT16_MAX / 2
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_INT32,
+			._u = {
+				.v_int32 = INT32_MAX / 2
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_INT64,
+			._u = {
+				.v_int64 = INT64_MAX / 2
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_UINT16,
+			._u = {
+				.v_uint16 = UINT16_MAX / 2
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_UINT32,
+			._u = {
+				.v_uint32 = UINT32_MAX / 2
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_UINT64,
+			._u = {
+				.v_uint64 = UINT64_MAX / 2
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_FLOAT32,
+			._u = {
+				.v_float32 = FLT_MAX / 2.0
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_FLOAT64,
+			._u = {
+				.v_float64 = DBL_MAX / 2.0
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_INT8,
+			._u = {
+				.v_int8 = INT8_MAX / 2
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_UINT8,
+			._u = {
+				.v_uint8 = UINT8_MAX / 2
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_CHAR8,
+			._u = {
+				.v_char8 = 'M'
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_STRING8,
+			._u = {
+				.v_string8 = "Hello World!"
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_ENUM,
+			._u = {
+				.v_enum = interoperability_test_VARIANT_ENUM_Y
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_STRUCTURE,
+			._u = {
+				.v_structure = {
+					.x = UINT8_MAX / 2,
+					.y = UINT16_MAX / 2,
+					.z = UINT32_MAX / 2
+				}
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_UNION,
+			._u = {
+				.v_union = variant_union_random()
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_SEQUENCE,
+			._u = {
+				.v_sequence = {
+					._maximum = 3,
+					._length = 3,
+					._buffer = (char *[]) {"Hello", "World", "!"},
+					._release = false
+				}
+			}
+		},
+		{
+			._d = interoperability_test_UNION_DISCRIMINATOR_ARRAY,
+			._u = {
+				.v_array = {-DBL_MAX, 3.14159265358979323846264338327950288, DBL_MAX}
+			}
+		}
+	};
+
+	interoperability_test_UnionTypeWrapper msg;
+	msg.union_type =  unions[random_value(sizeof(unions) / sizeof(unions[0]))];
+	memcpy(msg.union_array, unions, sizeof(unions));
+	msg.union_sequence._maximum = (uint32_t) (sizeof(unions) / sizeof(unions[0]));
+	msg.union_sequence._length = (uint32_t) (sizeof(unions) / sizeof(unions[0]));
+	msg.union_sequence._buffer = (interoperability_test_UnionType *) unions;
+	msg.union_sequence._release = false;
+
+	dds_write(data_writer, &msg);
+
+	rc = dds_wait_for_acks(data_writer, DDS_SECS(30));
+	if (rc != DDS_RETCODE_OK) {
+		DDS_FATAL("dds_wait_for_acks: %s\n", dds_strretcode(-rc));
+	}
+}
+
+size_t random_value(size_t end) {
+	return ((size_t) rand()) % end;
+}
+
+interoperability_test_VariantUnion variant_union_random() {
+	switch (random_value(3)) {
+		case 0: {
+			return (interoperability_test_VariantUnion) {
+				._d = (int32_t) (10 * random_value(3)),
+				._u = {
+					.x = UINT8_MAX / 2
+				}
+			};
+		}
+		case 1: {
+			return (interoperability_test_VariantUnion) {
+				._d = (int32_t) (100 * random_value(3)),
+				._u = {
+					.y = UINT16_MAX / 2
+				}
+			};
+		}
+		case 2: {
+			return (interoperability_test_VariantUnion) {
+				._d = (int32_t) (1000 * random_value(3)),
+				._u = {
+					.z = UINT32_MAX / 2
+				}
+			};
+		}
+		default: {
+			#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+				unreachable();
+			#elif defined(__GNUC__) || defined(__clang__)
+				__builtin_unreachable();
+			#elif defined(_MSC_VER)
+				__assume(false);
+			#else
+				assert(false);
+			#endif
+		}
+	}
+}

--- a/interoperability_tests/cyclone_dds/cyclone_dds_subscriber_union.c
+++ b/interoperability_tests/cyclone_dds/cyclone_dds_subscriber_union.c
@@ -1,0 +1,286 @@
+#include <float.h>
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "ddsc/dds.h"
+#include "Union.h"
+
+#define MAX_SAMPLES 1
+
+void union_checker(const interoperability_test_UnionType * union_type);
+
+int main(int argc, char *argv[]) {
+	const char *topic_name = "Union";
+
+	const dds_entity_t participant = dds_create_participant(DDS_DOMAIN_DEFAULT, NULL /*qos*/, NULL /*listener*/);
+	if (participant < 0) {
+		DDS_FATAL("dds_create_participant: %s\n", dds_strretcode(-participant));
+	}
+	const dds_entity_t topic = dds_create_topic(participant, &interoperability_test_UnionTypeWrapper_desc, topic_name, NULL /*qos*/, NULL /*listener*/);
+	if (topic < 0) {
+		DDS_FATAL("dds_create_topic: %s\n", dds_strretcode(-topic));
+	}
+	dds_qos_t *qos = dds_create_qos();
+	dds_qset_reliability(qos, DDS_RELIABILITY_RELIABLE, DDS_SECS(1));
+	dds_qset_durability(qos, DDS_DURABILITY_TRANSIENT_LOCAL);
+
+	const dds_entity_t data_reader = dds_create_reader(participant, topic, qos, NULL /*listener*/);
+	if (data_reader < 0) {
+		DDS_FATAL("dds_create_reader: %s\n", dds_strretcode(-data_reader));
+	}
+
+	dds_return_t rc;
+
+	rc = dds_set_status_mask(data_reader, DDS_SUBSCRIPTION_MATCHED_STATUS);
+	if (rc != DDS_RETCODE_OK) {
+		DDS_FATAL("dds_set_status_mask: %s\n", dds_strretcode(-rc));
+	}
+
+	dds_entity_t waitset = dds_create_waitset(participant);
+
+	rc = dds_waitset_attach(waitset, data_reader, data_reader);
+	if (rc != DDS_RETCODE_OK) {
+		DDS_FATAL("dds_waitset_attach: %s\n", dds_strretcode(-rc));
+	}
+
+	dds_attach_t wsresults[1];
+	const size_t wsresultsize = 1U;
+	rc = dds_waitset_wait(waitset, wsresults, wsresultsize, DDS_SECS(3660));
+	if (rc == 0) {
+		DDS_FATAL("dds_waitset_wait: timeout: Subscription not matched");
+	}
+	if (rc != wsresultsize) {
+		DDS_FATAL("dds_waitset_wait: %s\n", dds_strretcode(-rc));
+	}
+
+	rc = dds_set_status_mask(data_reader, DDS_DATA_AVAILABLE_STATUS);
+	if (rc != DDS_RETCODE_OK) {
+		DDS_FATAL("dds_set_status_mask: %s\n", dds_strretcode(-rc));
+	}
+	rc = dds_waitset_wait(waitset, wsresults, wsresultsize, DDS_SECS(30));
+	if (rc == 0) {
+		DDS_FATAL("dds_waitset_wait: timeout: No data received");
+	}
+	if (rc != wsresultsize) {
+		DDS_FATAL("dds_waitset_wait: %s\n", dds_strretcode(-rc));
+	}
+
+	void *samples[MAX_SAMPLES];
+	dds_sample_info_t infos[MAX_SAMPLES];
+	samples[0] = interoperability_test_UnionTypeWrapper__alloc();
+
+	rc = dds_read(data_reader, samples, infos, MAX_SAMPLES, MAX_SAMPLES);
+	if (rc < 0) {
+		DDS_FATAL("dds_read: %s\n", dds_strretcode(-rc));
+	}
+
+	if ((rc > 0) && (infos[0].valid_data)) {
+		const interoperability_test_UnionTypeWrapper *msg = (interoperability_test_UnionTypeWrapper *) samples[0];
+		const size_t length = 20;
+
+		assert(msg->union_sequence._maximum == length);
+		assert(msg->union_sequence._length == length);
+		printf("union: ");
+		union_checker(&msg->union_type);
+		printf("array: [\n");
+		for (size_t i = 0; i < length; ++i) {
+			printf("    ");
+			union_checker(&msg->union_array[i]);
+		}
+		printf("]\n");
+		printf("sequence: [\n");
+		for (size_t i = 0; i < length; ++i) {
+			printf("    ");
+			union_checker(&msg->union_sequence._buffer[i]);
+		}
+		printf("]\n");
+	}
+
+	// Sleep to allow sending acknowledgements
+	dds_sleepfor(DDS_SECS(2));
+}
+
+void union_checker(const interoperability_test_UnionType * union_type) {
+	printf("{ d: %d, v: ", union_type->_d);
+	switch (union_type->_d) {
+		case interoperability_test_UNION_DISCRIMINATOR_NONE: {
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_BOOLEAN: {
+			printf("%s", union_type->_u.v_boolean ? "true" : "false");
+			assert(union_type->_u.v_boolean);
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_BYTE: {
+			printf("%" PRIu8, union_type->_u.v_byte);
+			assert(union_type->_u.v_byte == (UINT8_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_INT16: {
+			printf("%" PRId16, union_type->_u.v_int16);
+			assert(union_type->_u.v_int16 == (INT16_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_INT32: {
+			printf("%" PRId32, union_type->_u.v_int32);
+			assert(union_type->_u.v_int32 == (INT32_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_INT64: {
+			printf("%" PRId64, union_type->_u.v_int64);
+			assert(union_type->_u.v_int64 == (INT64_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_UINT16: {
+			printf("%" PRIu16, union_type->_u.v_uint16);
+			assert(union_type->_u.v_uint16 == (UINT16_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_UINT32: {
+			printf("%" PRIu32, union_type->_u.v_uint32);
+			assert(union_type->_u.v_uint32 == (UINT32_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_UINT64: {
+			printf("%" PRIu64, union_type->_u.v_uint64);
+			assert(union_type->_u.v_uint64 == (UINT64_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_FLOAT32: {
+			printf("%e", union_type->_u.v_float32);
+			assert(union_type->_u.v_float32 == (FLT_MAX / 2.0));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_FLOAT64: {
+			printf("%e", union_type->_u.v_float64);
+			assert(union_type->_u.v_float64 == (DBL_MAX / 2.0));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_INT8: {
+			printf("%" PRId8, union_type->_u.v_int8);
+			assert(union_type->_u.v_int8 == (INT8_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_UINT8: {
+			printf("%" PRIu8, union_type->_u.v_uint8);
+			assert(union_type->_u.v_uint8 == (UINT8_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_CHAR8: {
+			printf("%c", union_type->_u.v_char8);
+			assert(union_type->_u.v_char8 == 'M');
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_STRING8: {
+			printf("\"%s\"", union_type->_u.v_string8);
+			assert(strcmp(union_type->_u.v_string8, "Hello World!") == 0);
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_ENUM: {
+			switch (union_type->_u.v_enum) {
+				case interoperability_test_VARIANT_ENUM_X: {
+					printf("X");
+					break;
+				}
+				case interoperability_test_VARIANT_ENUM_Y: {
+					printf("Y");
+					break;
+				}
+				case interoperability_test_VARIANT_ENUM_Z: {
+					printf("Z");
+					break;
+				}
+				default: {
+					DDS_FATAL("variant enum: %d", union_type->_u.v_enum);
+					break;
+				}
+			}
+			assert(union_type->_u.v_enum == interoperability_test_VARIANT_ENUM_Y);
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_STRUCTURE: {
+			const interoperability_test_VariantStructure* variant_structure = &union_type->_u.v_structure;
+			printf("{ x: %" PRIu8 ", y: %" PRIu16 ", z: %" PRIu32 " }", variant_structure->x, variant_structure->y, variant_structure->z);
+			assert(variant_structure->x == (UINT8_MAX / 2));
+			assert(variant_structure->y == (UINT16_MAX / 2));
+			assert(variant_structure->z == (UINT32_MAX / 2));
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_UNION: {
+			const interoperability_test_VariantUnion* variant_union = &union_type->_u.v_union;
+			switch (variant_union->_d) {
+				case 10:
+				case 20:
+				case 30: {
+					printf("{ x: %" PRIu8 " }", variant_union->_u.x);
+					assert(variant_union->_u.x == (UINT8_MAX / 2));
+					break;
+				}
+				case 100:
+				case 200:
+				case 300: {
+					printf("{ y: %" PRIu16 " }", variant_union->_u.y);
+					assert(variant_union->_u.y == (UINT16_MAX / 2));
+					break;
+				}
+				case 1000:
+				case 2000:
+				case 3000: {
+					printf("{ z: %" PRIu32 " }", variant_union->_u.z);
+					assert(variant_union->_u.z == (UINT32_MAX / 2));
+					break;
+				}
+				default: {
+					printf("variant union discriminator: %d\n", variant_union->_d);
+					assert(false);
+					break;
+				}
+			}
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_SEQUENCE: {
+			const dds_sequence_string* variant_sequence = &union_type->_u.v_sequence;
+
+			printf("[");
+			for(uint32_t i = 0; i < variant_sequence->_length; ++i) {
+				printf("\"%s\"", variant_sequence->_buffer[i]);
+				if (i < (variant_sequence->_length - 1)) {
+					printf(", ");
+				}
+			}
+			printf("]");
+			assert(variant_sequence->_maximum == 3);
+			assert(variant_sequence->_length == 3);
+			assert(strcmp(variant_sequence->_buffer[0], "Hello") == 0);
+			assert(strcmp(variant_sequence->_buffer[1], "World") == 0);
+			assert(strcmp(variant_sequence->_buffer[2], "!") == 0);
+			break;
+		}
+		case interoperability_test_UNION_DISCRIMINATOR_ARRAY: {
+			const double *variant_array = union_type->_u.v_array;
+			const uint32_t length = 3;
+
+			printf("[");
+			for (uint32_t i = 0; i < length; ++i) {
+				printf("%e", variant_array[i]);
+				if (i < (length - 1)) {
+					printf(", ");
+				}
+			}
+			printf("]");
+			assert(variant_array[0] == -DBL_MAX);
+			assert(variant_array[1] == 3.14159265358979323846264338327950288);
+			assert(variant_array[2] == DBL_MAX);
+			break;
+		}
+		default: {
+			printf("union discriminator: %d\n", union_type->_d);
+			assert(false);
+			break;
+		}
+	}
+
+	printf(" }\n");
+}

--- a/interoperability_tests/dust_dds_publisher_union.rs
+++ b/interoperability_tests/dust_dds_publisher_union.rs
@@ -1,0 +1,262 @@
+use crate::interoperability::test::{
+    UnionType, UnionTypeWrapper, VariantEnum, VariantStructure, VariantUnion,
+};
+use dust_dds::{
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        listener::NO_LISTENER,
+        qos::{DataWriterQos, QosKind},
+        qos_policy::{
+            DurabilityQosPolicy, DurabilityQosPolicyKind, ReliabilityQosPolicy,
+            ReliabilityQosPolicyKind,
+        },
+        status::{NO_STATUS, StatusKind},
+        time::{Duration, DurationKind},
+        type_support::TypeSupport,
+    },
+    wait_set::{Condition, WaitSet},
+};
+
+// TODO: remove when dust_dds_gen adds support for union
+pub mod interoperability {
+    pub mod test {
+        use dust_dds::infrastructure::type_support::DdsType;
+
+        #[derive(DdsType, Debug, Clone, PartialEq)]
+        #[dust_dds(name = "interoperability::test::UnionTypeWrapper")]
+        pub struct UnionTypeWrapper {
+            pub r#union: UnionType,
+            pub union_array: [UnionType; 20],
+            pub union_sequence: Vec<UnionType>,
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq)]
+        #[dust_dds(name = "interoperability::test::UnionType", discriminator = UnionDescriptor)]
+        pub enum UnionType {
+            #[dust_dds(discriminator = UnionDescriptor::None)]
+            None,
+            #[dust_dds(discriminator = UnionDescriptor::Boolean)]
+            Boolean(bool),
+            #[dust_dds(discriminator = UnionDescriptor::Byte)]
+            Byte(u8),
+            #[dust_dds(discriminator = UnionDescriptor::Int16)]
+            Int16(i16),
+            #[dust_dds(discriminator = UnionDescriptor::Int32)]
+            Int32(i32),
+            #[dust_dds(discriminator = UnionDescriptor::Int64)]
+            Int64(i64),
+            #[dust_dds(discriminator = UnionDescriptor::UInt16)]
+            UInt16(u16),
+            #[dust_dds(discriminator = UnionDescriptor::UInt32)]
+            UInt32(u32),
+            #[dust_dds(discriminator = UnionDescriptor::UInt64)]
+            UInt64(u64),
+            #[dust_dds(discriminator = UnionDescriptor::Float32)]
+            Float32(f32),
+            #[dust_dds(discriminator = UnionDescriptor::Float64)]
+            Float64(f64),
+            #[dust_dds(discriminator = UnionDescriptor::Int8)]
+            Int8(i8),
+            #[dust_dds(discriminator = UnionDescriptor::UInt8)]
+            UInt8(u8),
+            #[dust_dds(discriminator = UnionDescriptor::Char8)]
+            Char8(u8),
+            #[dust_dds(discriminator = UnionDescriptor::String8)]
+            String8(String),
+            #[dust_dds(discriminator = UnionDescriptor::Enum)]
+            Enum(VariantEnum),
+            #[dust_dds(discriminator = UnionDescriptor::Structure)]
+            Structure(VariantStructure),
+            #[dust_dds(discriminator = UnionDescriptor::Union)]
+            Union(VariantUnion),
+            #[dust_dds(discriminator = UnionDescriptor::Sequence)]
+            Sequence(Vec<String>),
+            #[dust_dds(discriminator = UnionDescriptor::Array)]
+            Array([f64; 3]),
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq, Eq)]
+        #[dust_dds(name = "interoperability::test::UnionDiscriminator")]
+        pub enum UnionDescriptor {
+            None = 0,
+            Boolean = 1,
+            Byte = 2,
+            Int16 = 4,
+            Int32 = 8,
+            Int64 = 16,
+            UInt16 = 32,
+            UInt32 = 64,
+            UInt64 = 128,
+            Float32 = 256,
+            Float64 = 512,
+            // Float128 = 1024,
+            Int8 = 2048,
+            UInt8 = 4096,
+            Char8 = 8192,
+            // Char16 = 16_384,
+            String8 = 32_768,
+            // String16 = 65_536,
+            // Alias = 131_072,
+            Enum = 262_144,
+            // Bitmask = 524_288,
+            // Annotation = 1_048_576,
+            Structure = 2_097_152,
+            Union = 4_194_304,
+            // Bitset = 8_388_608,
+            Sequence = 16_777_216,
+            Array = 33_554_432,
+            // Map = 67_108_864
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq, Eq)]
+        #[dust_dds(name = "interoperability::test::VariantEnum")]
+        pub enum VariantEnum {
+            X,
+            Y,
+            Z,
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq, Eq)]
+        #[dust_dds(name = "interoperability::test::VariantStructure")]
+        pub struct VariantStructure {
+            pub x: u8,
+            pub y: u16,
+            pub z: u32,
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq)]
+        #[dust_dds(name = "interoperability::test::VariantUnion", discriminator = u16)]
+        pub enum VariantUnion {
+            #[dust_dds(discriminator = [10, 20, 30])]
+            X(u8),
+            #[dust_dds(discriminator = [100, 200, 300])]
+            Y(u16),
+            #[dust_dds(discriminator = [1000, 2000, 3000])]
+            Z(u32),
+        }
+
+        impl VariantUnion {
+            pub fn new_random() -> Self {
+                match crate::random_value(3) {
+                    0 => Self::X(u8::MAX / 2),
+                    1 => Self::Y(u16::MAX / 2),
+                    2 => Self::Z(u32::MAX / 2),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    let domain_id = 0;
+    let participant_factory = DomainParticipantFactory::get_instance();
+
+    let participant = participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<UnionTypeWrapper>(
+            "Union",
+            UnionTypeWrapper::TYPE_NAME,
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        durability: DurabilityQosPolicy {
+            kind: DurabilityQosPolicyKind::TransientLocal,
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+    let writer_cond = writer.get_statuscondition();
+    writer_cond
+        .set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(writer_cond))
+        .unwrap();
+
+    wait_set.wait(Duration::new(60, 0)).unwrap();
+
+    let unions = [
+        UnionType::None,
+        UnionType::Boolean(true),
+        UnionType::Byte(u8::MAX / 2),
+        UnionType::Int16(i16::MAX / 2),
+        UnionType::Int32(i32::MAX / 2),
+        UnionType::Int64(i64::MAX / 2),
+        UnionType::UInt16(u16::MAX / 2),
+        UnionType::UInt32(u32::MAX / 2),
+        UnionType::UInt64(u64::MAX / 2),
+        UnionType::Float32(f32::MAX / 2.0),
+        UnionType::Float64(f64::MAX / 2.0),
+        UnionType::Int8(i8::MAX / 2),
+        UnionType::UInt8(u8::MAX / 2),
+        UnionType::Char8(b'M'),
+        UnionType::String8(String::from("Hello World!")),
+        UnionType::Enum(VariantEnum::Y),
+        UnionType::Structure(VariantStructure {
+            x: u8::MAX / 2,
+            y: u16::MAX / 2,
+            z: u32::MAX / 2,
+        }),
+        UnionType::Union(VariantUnion::new_random()),
+        UnionType::Sequence(vec![
+            String::from("Hello"),
+            String::from("World"),
+            String::from("!"),
+        ]),
+        UnionType::Array([f64::MIN, std::f64::consts::PI, f64::MAX]),
+    ];
+
+    let data = UnionTypeWrapper {
+        union: unions[random_value(unions.len())].clone(),
+        union_array: unions.clone(),
+        union_sequence: unions.to_vec(),
+    };
+
+    println!("write: {data:?}");
+    writer.write(data, None).unwrap();
+
+    writer
+        .wait_for_acknowledgments(Duration::new(30, 0))
+        .unwrap();
+}
+
+fn random_value(end: usize) -> usize {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+        time::SystemTime,
+    };
+
+    let mut hasher = DefaultHasher::new();
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos()
+        .hash(&mut hasher);
+
+    (hasher.finish() as usize) % end
+}

--- a/interoperability_tests/dust_dds_subscriber_union.rs
+++ b/interoperability_tests/dust_dds_subscriber_union.rs
@@ -1,0 +1,285 @@
+use crate::interoperability::test::{
+    UnionType, UnionTypeWrapper, VariantEnum, VariantStructure, VariantUnion,
+};
+use dust_dds::{
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{
+        listener::NO_LISTENER,
+        qos::{DataReaderQos, QosKind},
+        qos_policy::{
+            DurabilityQosPolicy, DurabilityQosPolicyKind, ReliabilityQosPolicy,
+            ReliabilityQosPolicyKind,
+        },
+        sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE},
+        status::{NO_STATUS, StatusKind},
+        time::{Duration, DurationKind},
+    },
+    wait_set::{Condition, WaitSet},
+};
+
+// TODO: remove when dust_dds_gen adds support for union
+pub mod interoperability {
+    pub mod test {
+        use dust_dds::infrastructure::type_support::DdsType;
+
+        #[derive(DdsType, Debug, Clone, PartialEq)]
+        #[dust_dds(name = "interoperability::test::UnionTypeWrapper")]
+        pub struct UnionTypeWrapper {
+            pub r#union: UnionType,
+            pub union_array: [UnionType; 20],
+            pub union_sequence: Vec<UnionType>,
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq)]
+        #[dust_dds(name = "interoperability::test::UnionType", discriminator = UnionDescriptor)]
+        pub enum UnionType {
+            #[dust_dds(discriminator = UnionDescriptor::None)]
+            None,
+            #[dust_dds(discriminator = UnionDescriptor::Boolean)]
+            Boolean(bool),
+            #[dust_dds(discriminator = UnionDescriptor::Byte)]
+            Byte(u8),
+            #[dust_dds(discriminator = UnionDescriptor::Int16)]
+            Int16(i16),
+            #[dust_dds(discriminator = UnionDescriptor::Int32)]
+            Int32(i32),
+            #[dust_dds(discriminator = UnionDescriptor::Int64)]
+            Int64(i64),
+            #[dust_dds(discriminator = UnionDescriptor::UInt16)]
+            UInt16(u16),
+            #[dust_dds(discriminator = UnionDescriptor::UInt32)]
+            UInt32(u32),
+            #[dust_dds(discriminator = UnionDescriptor::UInt64)]
+            UInt64(u64),
+            #[dust_dds(discriminator = UnionDescriptor::Float32)]
+            Float32(f32),
+            #[dust_dds(discriminator = UnionDescriptor::Float64)]
+            Float64(f64),
+            #[dust_dds(discriminator = UnionDescriptor::Int8)]
+            Int8(i8),
+            #[dust_dds(discriminator = UnionDescriptor::UInt8)]
+            UInt8(u8),
+            #[dust_dds(discriminator = UnionDescriptor::Char8)]
+            Char8(u8),
+            #[dust_dds(discriminator = UnionDescriptor::String8)]
+            String8(String),
+            #[dust_dds(discriminator = UnionDescriptor::Enum)]
+            Enum(VariantEnum),
+            #[dust_dds(discriminator = UnionDescriptor::Structure)]
+            Structure(VariantStructure),
+            #[dust_dds(discriminator = UnionDescriptor::Union)]
+            Union(VariantUnion),
+            #[dust_dds(discriminator = UnionDescriptor::Sequence)]
+            Sequence(Vec<String>),
+            #[dust_dds(discriminator = UnionDescriptor::Array)]
+            Array([f64; 3]),
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq, Eq)]
+        #[dust_dds(name = "interoperability::test::UnionDiscriminator")]
+        pub enum UnionDescriptor {
+            None = 0,
+            Boolean = 1,
+            Byte = 2,
+            Int16 = 4,
+            Int32 = 8,
+            Int64 = 16,
+            UInt16 = 32,
+            UInt32 = 64,
+            UInt64 = 128,
+            Float32 = 256,
+            Float64 = 512,
+            // Float128 = 1024,
+            Int8 = 2048,
+            UInt8 = 4096,
+            Char8 = 8192,
+            // Char16 = 16_384,
+            String8 = 32_768,
+            // String16 = 65_536,
+            // Alias = 131_072,
+            Enum = 262_144,
+            // Bitmask = 524_288,
+            // Annotation = 1_048_576,
+            Structure = 2_097_152,
+            Union = 4_194_304,
+            // Bitset = 8_388_608,
+            Sequence = 16_777_216,
+            Array = 33_554_432,
+            // Map = 67_108_864
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq, Eq)]
+        #[dust_dds(name = "interoperability::test::VariantEnum")]
+        pub enum VariantEnum {
+            X,
+            Y,
+            Z,
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq, Eq)]
+        #[dust_dds(name = "interoperability::test::VariantStructure")]
+        pub struct VariantStructure {
+            pub x: u8,
+            pub y: u16,
+            pub z: u32,
+        }
+
+        #[derive(DdsType, Debug, Clone, PartialEq)]
+        #[dust_dds(name = "interoperability::test::VariantUnion", discriminator = u16)]
+        pub enum VariantUnion {
+            #[dust_dds(discriminator = [10, 20, 30])]
+            X(u8),
+            #[dust_dds(discriminator = [100, 200, 300])]
+            Y(u16),
+            #[dust_dds(discriminator = [1000, 2000, 3000])]
+            Z(u32),
+        }
+    }
+}
+
+fn main() {
+    let domain_id = 0;
+    let participant_factory = DomainParticipantFactory::get_instance();
+
+    let participant = participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .find_topic::<UnionTypeWrapper>("Union", Duration::new(120, 0))
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        durability: DurabilityQosPolicy {
+            kind: DurabilityQosPolicyKind::TransientLocal,
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader::<UnionTypeWrapper>(
+            &topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let reader_cond = reader.get_statuscondition();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond.clone()))
+        .unwrap();
+
+    wait_set.wait(Duration::new(60, 0)).unwrap();
+
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::DataAvailable])
+        .unwrap();
+    wait_set.wait(Duration::new(30, 0)).unwrap();
+
+    let samples = reader
+        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    let data = samples[0].data.as_ref().unwrap();
+    println!("read: {data:?}");
+    assert_eq!(data.union_sequence.len(), 20);
+    union_checker(&data.union);
+    for r#union in &data.union_array {
+        union_checker(r#union);
+    }
+    for r#union in &data.union_sequence {
+        union_checker(r#union);
+    }
+
+    // Sleep to allow sending acknowledgements
+    std::thread::sleep(std::time::Duration::from_secs(2));
+}
+
+fn union_checker(union_type: &UnionType) {
+    match union_type {
+        UnionType::None => (),
+        UnionType::Boolean(boolean) => {
+            assert!(boolean);
+        }
+        UnionType::Byte(byte) => {
+            assert_eq!(*byte, u8::MAX / 2);
+        }
+        UnionType::Int16(int16) => {
+            assert_eq!(*int16, i16::MAX / 2);
+        }
+        UnionType::Int32(int32) => {
+            assert_eq!(*int32, i32::MAX / 2);
+        }
+        UnionType::Int64(int64) => {
+            assert_eq!(*int64, i64::MAX / 2);
+        }
+        UnionType::UInt16(uint16) => {
+            assert_eq!(*uint16, u16::MAX / 2);
+        }
+        UnionType::UInt32(uint32) => {
+            assert_eq!(*uint32, u32::MAX / 2);
+        }
+        UnionType::UInt64(uint64) => {
+            assert_eq!(*uint64, u64::MAX / 2);
+        }
+        UnionType::Float32(float32) => {
+            assert_eq!(*float32, f32::MAX / 2.0);
+        }
+        UnionType::Float64(float64) => {
+            assert_eq!(*float64, f64::MAX / 2.0);
+        }
+        UnionType::Int8(int8) => {
+            assert_eq!(*int8, i8::MAX / 2);
+        }
+        UnionType::UInt8(uint8) => {
+            assert_eq!(*uint8, u8::MAX / 2);
+        }
+        UnionType::Char8(r#char) => {
+            assert_eq!(char::from(*r#char), 'M');
+        }
+        UnionType::String8(string) => {
+            assert_eq!(string, "Hello World!");
+        }
+        UnionType::Enum(r#enum) => {
+            assert_eq!(*r#enum, VariantEnum::Y);
+        }
+        UnionType::Structure(structure) => {
+            assert_eq!(
+                structure,
+                &VariantStructure {
+                    x: u8::MAX / 2,
+                    y: u16::MAX / 2,
+                    z: u32::MAX / 2
+                }
+            );
+        }
+        UnionType::Union(r#union) => match r#union {
+            VariantUnion::X(x) => assert_eq!(*x, u8::MAX / 2),
+            VariantUnion::Y(y) => assert_eq!(*y, u16::MAX / 2),
+            VariantUnion::Z(z) => assert_eq!(*z, u32::MAX / 2),
+        },
+        UnionType::Sequence(sequence) => {
+            assert_eq!(sequence.len(), 3);
+            assert_eq!(sequence[0], "Hello");
+            assert_eq!(sequence[1], "World");
+            assert_eq!(sequence[2], "!");
+        }
+        UnionType::Array(array) => {
+            assert_eq!(array[0], f64::MIN);
+            assert_eq!(array[1], std::f64::consts::PI);
+            assert_eq!(array[2], f64::MAX);
+        }
+    }
+}


### PR DESCRIPTION
Fix #504

We now support `XTypes union`.

Each `union` must specify its _discriminator_ type via `discriminator`, and each variant must define at least one `discriminator` value (or multiple values, `[D0, D1, D2, ...]`), also via `discriminator`.

The discriminator type may be any `[u]int{8,16,32,64}`, an `enum`, or a `bool`.
The only requirement is that the `value`(s) specified for each variant must resolve to a numeric value within the range `[0, u32::MAX]`, due to the current mapping limitation, specifically, the fact that we rely on the `id` which is represented as a `u32`.

We cannot introduce a default case because there isn't sufficient `discriminator` information to correctly serialize or deserialize the variant.
However, we do support unit variants (i.e., variants with only a discriminator and no associated value) to partially compensate this limitation.

Example using `MyDiscriminator` (an `enum`) as `discriminator`:

```rust
#[derive(DdsType)]
#[dust_dds(discriminator = MyDiscriminator)]
enum MyUnion {
    #[dust_dds(discriminator = MyDiscriminator::None)]
    None,
    #[dust_dds(discriminator = MyDiscriminator::UInt8)]
    UInt8(u8),
    #[dust_dds(discriminator = MyDiscriminator::String)]
    String(String),
    #[dust_dds(discriminator = MyDiscriminator::Array)]
    Array([f64; 3]),
}

#[derive(DdsType)]
enum MyDiscriminator {
    None = 0,
    UInt8 = 10,
    String = 100,
    Array = 1000,
}
```

Example using `u16` as `discriminator`:
```rust
#[derive(DdsType)]
#[dust_dds(discriminator = u16)]
enum MyUnion {
    #[dust_dds(discriminator = 0)]
    None,
    #[dust_dds(discriminator = [10, 20, 30])]
    UInt8(u8),
    #[dust_dds(discriminator = [40, 50, 60])]
    String(String),
    #[dust_dds(discriminator = [70, 80, 90])]
    Array([f64; 3]),
}
```

Note that, as indicated in https://github.com/s2e-systems/dust-dds/issues/504#issuecomment-4328556292, the current implementation is primarily validated through interoperability tests rather than unit or integration tests.