### PR TITLE
Add derive for union types

### DIFF
--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -305,58 +305,6 @@ fn foo_xtypes_union_should_read_and_write() {
     #[derive(Clone, Debug, PartialEq, DdsType)]
     struct MyInnerType(u32);
 
-    // impl dust_dds::infrastructure::type_support::TypeSupport for MyEnum {
-    //     const r#TYPE: dust_dds::xtypes::dynamic_type::DynamicType = dust_dds::xtypes::dynamic_type::DynamicType {
-    //     descriptor: &dust_dds::xtypes::dynamic_type::TypeDescriptor {
-    //         kind: dust_dds::xtypes::dynamic_type::TypeKind::UNION,name: "MyEnum",base_type: None,discriminator_type: ::core::option::Option::Some(<u8 as ::dust_dds::xtypes::binding::XTypesBinding> ::TYPE_INFORMATION),bound: None,element_type: None,key_element_type: None,extensibility_kind: dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final,is_nested: false,
-    //     },member_list: &[dust_dds::xtypes::dynamic_type::DynamicTypeMember {
-    //         descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
-    //             name: "disc",id: 0u32,r#type: <u8 as dust_dds::xtypes::binding::XTypesBinding> ::TYPE_INFORMATION,default_value: None,index: 0u32,try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,label: None,is_key: false,is_optional: false,is_must_understand: true,is_shared: false,is_default_label: false,
-    //         }
-    //     },dust_dds::xtypes::dynamic_type::DynamicTypeMember {
-    //         descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
-    //             name: "_VariantA",id: 1usize as u32,r#type: <MyInnerType as dust_dds::xtypes::binding::XTypesBinding> ::TYPE_INFORMATION,default_value: None,index: 1usize as u32,try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,label: None,is_key: false,is_optional: true,is_must_understand: true,is_shared: false,is_default_label: false,
-    //         }
-    //     },dust_dds::xtypes::dynamic_type::DynamicTypeMember {
-    //         descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
-    //             name: "a",id: 2usize as u32,r#type: <u32 as dust_dds::xtypes::binding::XTypesBinding> ::TYPE_INFORMATION,default_value: None,index: 2usize as u32,try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,label: None,is_key: false,is_optional: true,is_must_understand: true,is_shared: false,is_default_label: false,
-    //         }
-    //     },dust_dds::xtypes::dynamic_type::DynamicTypeMember {
-    //         descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
-    //             name: "_VariantC",id: 3usize as u32,r#type: dust_dds::xtypes::dynamic_type::DynamicType {
-    //                 descriptor: &dust_dds::xtypes::dynamic_type::TypeDescriptor {
-    //                     kind: dust_dds::xtypes::dynamic_type::TypeKind::NONE,name: "",base_type: None,discriminator_type: None,bound: None,element_type: None,key_element_type: None,extensibility_kind: dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final,is_nested: false,
-    //                 },member_list: &[],
-    //             },default_value: None,index: 3usize as u32,try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,label: None,is_key: false,is_optional: true,is_must_understand: true,is_shared: false,is_default_label: false,
-    //         }
-    //     },]
-    // };
-    //     fn create_sample(src: &mut dust_dds::xtypes::dynamic_type::DynamicData) -> Self {
-    //         let disc =
-    //             <u8 as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
-    //                 src.remove_value(0).expect("Must exist"),
-    //             )
-    //             .expect("Must match");
-    //         match disc {
-    //             5 => MyEnum::_VariantA(
-    //                 <MyInnerType as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
-    //                     src.remove_value(1).expect("Must exist"),
-    //                 )
-    //                 .expect("Must match"),
-    //             ),
-    //             6 => MyEnum::VariantB { a: <u32 as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
-    //                     src.remove_value(2).expect("Must exist"),
-    //                 )
-    //                 .expect("Must match") },
-    //             7 => MyEnum::_VariantC,
-    //             _ => panic!(),
-    //         }
-    //     }
-    //     fn create_dynamic_sample(self, data: &mut dust_dds::xtypes::dynamic_type::DynamicData) {
-    //         todo!()
-    //     }
-    // }
-
     #[derive(Clone, Debug, PartialEq, DdsType)]
     #[dust_dds(switch(u8))]
     enum MyEnum {

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -306,12 +306,12 @@ fn foo_xtypes_union_should_read_and_write() {
     struct MyInnerType(u32);
 
     #[derive(Clone, Debug, PartialEq, DdsType)]
-    #[dust_dds(switch=u8)]
+    #[dust_dds(switch(u8))]
     enum MyEnum {
         #[dust_dds(case = 5)]
         _VariantA(MyInnerType),
         #[dust_dds(case = 6)]
-        VariantB { a: u32, b: i16 },
+        VariantB { a: u32 },
         #[dust_dds(case = 7)]
         _VariantC,
     }
@@ -380,7 +380,7 @@ fn foo_xtypes_union_should_read_and_write() {
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
-    let data = MyEnum::VariantB { a: 10, b: -20 };
+    let data = MyEnum::VariantB { a: 10 };
 
     writer.write(data.clone(), None).unwrap();
 

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -306,11 +306,14 @@ fn foo_xtypes_union_should_read_and_write() {
     struct MyInnerType(u32);
 
     #[derive(Clone, Debug, PartialEq, DdsType)]
-    #[repr(u8)]
+    #[dust_dds(switch=u8)]
     enum MyEnum {
-        _VariantA(MyInnerType) = 5,
-        VariantB { a: u32, b: i16 } = 6,
-        _VariantC = 7,
+        #[dust_dds(case = 5)]
+        _VariantA(MyInnerType),
+        #[dust_dds(case = 6)]
+        VariantB { a: u32, b: i16 },
+        #[dust_dds(case = 7)]
+        _VariantC,
     }
 
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -305,6 +305,58 @@ fn foo_xtypes_union_should_read_and_write() {
     #[derive(Clone, Debug, PartialEq, DdsType)]
     struct MyInnerType(u32);
 
+    // impl dust_dds::infrastructure::type_support::TypeSupport for MyEnum {
+    //     const r#TYPE: dust_dds::xtypes::dynamic_type::DynamicType = dust_dds::xtypes::dynamic_type::DynamicType {
+    //     descriptor: &dust_dds::xtypes::dynamic_type::TypeDescriptor {
+    //         kind: dust_dds::xtypes::dynamic_type::TypeKind::UNION,name: "MyEnum",base_type: None,discriminator_type: ::core::option::Option::Some(<u8 as ::dust_dds::xtypes::binding::XTypesBinding> ::TYPE_INFORMATION),bound: None,element_type: None,key_element_type: None,extensibility_kind: dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final,is_nested: false,
+    //     },member_list: &[dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+    //         descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+    //             name: "disc",id: 0u32,r#type: <u8 as dust_dds::xtypes::binding::XTypesBinding> ::TYPE_INFORMATION,default_value: None,index: 0u32,try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,label: None,is_key: false,is_optional: false,is_must_understand: true,is_shared: false,is_default_label: false,
+    //         }
+    //     },dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+    //         descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+    //             name: "_VariantA",id: 1usize as u32,r#type: <MyInnerType as dust_dds::xtypes::binding::XTypesBinding> ::TYPE_INFORMATION,default_value: None,index: 1usize as u32,try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,label: None,is_key: false,is_optional: true,is_must_understand: true,is_shared: false,is_default_label: false,
+    //         }
+    //     },dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+    //         descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+    //             name: "a",id: 2usize as u32,r#type: <u32 as dust_dds::xtypes::binding::XTypesBinding> ::TYPE_INFORMATION,default_value: None,index: 2usize as u32,try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,label: None,is_key: false,is_optional: true,is_must_understand: true,is_shared: false,is_default_label: false,
+    //         }
+    //     },dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+    //         descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+    //             name: "_VariantC",id: 3usize as u32,r#type: dust_dds::xtypes::dynamic_type::DynamicType {
+    //                 descriptor: &dust_dds::xtypes::dynamic_type::TypeDescriptor {
+    //                     kind: dust_dds::xtypes::dynamic_type::TypeKind::NONE,name: "",base_type: None,discriminator_type: None,bound: None,element_type: None,key_element_type: None,extensibility_kind: dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final,is_nested: false,
+    //                 },member_list: &[],
+    //             },default_value: None,index: 3usize as u32,try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,label: None,is_key: false,is_optional: true,is_must_understand: true,is_shared: false,is_default_label: false,
+    //         }
+    //     },]
+    // };
+    //     fn create_sample(src: &mut dust_dds::xtypes::dynamic_type::DynamicData) -> Self {
+    //         let disc =
+    //             <u8 as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
+    //                 src.remove_value(0).expect("Must exist"),
+    //             )
+    //             .expect("Must match");
+    //         match disc {
+    //             5 => MyEnum::_VariantA(
+    //                 <MyInnerType as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
+    //                     src.remove_value(1).expect("Must exist"),
+    //                 )
+    //                 .expect("Must match"),
+    //             ),
+    //             6 => MyEnum::VariantB { a: <u32 as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
+    //                     src.remove_value(2).expect("Must exist"),
+    //                 )
+    //                 .expect("Must match") },
+    //             7 => MyEnum::_VariantC,
+    //             _ => panic!(),
+    //         }
+    //     }
+    //     fn create_dynamic_sample(self, data: &mut dust_dds::xtypes::dynamic_type::DynamicData) {
+    //         todo!()
+    //     }
+    // }
+
     #[derive(Clone, Debug, PartialEq, DdsType)]
     #[dust_dds(switch(u8))]
     enum MyEnum {

--- a/dds_derive/src/derive/attributes.rs
+++ b/dds_derive/src/derive/attributes.rs
@@ -1,27 +1,7 @@
 use syn::{DeriveInput, Expr, Field, Result, Variant, spanned::Spanned};
 
-pub struct MemberAttributes {
-    pub id: Option<Expr>,
-}
-
-pub fn get_member_attributes(field: &Field) -> Result<MemberAttributes> {
-    let mut id = None;
-    if let Some(xtypes_attribute) = field
-        .attrs
-        .iter()
-        .find(|attr| attr.path().is_ident("dust_dds"))
-    {
-        xtypes_attribute.parse_nested_meta(|meta| {
-            if meta.path.is_ident("id") {
-                id = Some(meta.value()?.parse()?);
-            }
-            Ok(())
-        })?;
-    }
-    Ok(MemberAttributes { id })
-}
-
 pub struct StructureMemberAttributes {
+    pub id: Option<Expr>,
     pub key: bool,
     pub optional: bool,
     pub non_serialized: bool,
@@ -29,6 +9,7 @@ pub struct StructureMemberAttributes {
 }
 
 pub fn get_structure_member_attributes(field: &Field) -> Result<StructureMemberAttributes> {
+    let mut id = None;
     let mut key = false;
     let mut optional = false;
     let mut default_value = None;
@@ -39,7 +20,9 @@ pub fn get_structure_member_attributes(field: &Field) -> Result<StructureMemberA
         .find(|attr| attr.path().is_ident("dust_dds"))
     {
         xtypes_attribute.parse_nested_meta(|meta| {
-            if meta.path.is_ident("key") {
+            if meta.path.is_ident("id") {
+                id = Some(meta.value()?.parse()?);
+            } else if meta.path.is_ident("key") {
                 key = true;
             } else if meta.path.is_ident("default_value") {
                 default_value = Some(meta.value()?.parse()?);
@@ -52,6 +35,7 @@ pub fn get_structure_member_attributes(field: &Field) -> Result<StructureMemberA
         })?;
     }
     Ok(StructureMemberAttributes {
+        id,
         key,
         optional,
         default_value,
@@ -66,13 +50,13 @@ pub enum Extensibility {
     Mutable,
 }
 
-pub struct TypeDeclarationAttributes {
+pub struct StructAttributes {
     pub name: String,
     pub extensibility: Extensibility,
     pub is_nested: bool,
 }
 
-pub fn get_type_declaration_attributes(input: &DeriveInput) -> Result<TypeDeclarationAttributes> {
+pub fn get_struct_attributes(input: &DeriveInput) -> Result<StructAttributes> {
     let mut name = input.ident.to_string();
     let mut extensibility = Extensibility::Final;
     let mut is_nested = false;
@@ -114,7 +98,7 @@ pub fn get_type_declaration_attributes(input: &DeriveInput) -> Result<TypeDeclar
             }
         })?;
     }
-    Ok(TypeDeclarationAttributes {
+    Ok(StructAttributes {
         name,
         extensibility,
         is_nested,
@@ -128,10 +112,14 @@ pub enum BitBound {
 }
 
 pub struct EnumeratedTypeAttributes {
+    pub name: String,
+    pub is_nested: bool,
     pub bit_bound: BitBound,
 }
 
 pub fn get_enumerated_type_attributes(input: &DeriveInput) -> Result<EnumeratedTypeAttributes> {
+    let mut name = input.ident.to_string();
+    let mut is_nested = false;
     let mut bit_bound = BitBound::I32;
     if let Some(xtypes_attribute) = input
         .attrs
@@ -139,7 +127,13 @@ pub fn get_enumerated_type_attributes(input: &DeriveInput) -> Result<EnumeratedT
         .find(|attr| attr.path().is_ident("dust_dds"))
     {
         xtypes_attribute.parse_nested_meta(|meta| {
-            if meta.path.is_ident("bit_bound") {
+            if meta.path.is_ident("name") {
+                name = meta.value()?.parse::<syn::LitStr>()?.value();
+                Ok(())
+            } else if meta.path.is_ident("nested") {
+                is_nested = true;
+                Ok(())
+            } else if meta.path.is_ident("bit_bound") {
                 let format_str: syn::LitStr = meta.value()?.parse()?;
                 match format_str.value().as_ref() {
                     "8" => {
@@ -164,15 +158,25 @@ pub fn get_enumerated_type_attributes(input: &DeriveInput) -> Result<EnumeratedT
             }
         })?;
     }
-    Ok(EnumeratedTypeAttributes { bit_bound })
+    Ok(EnumeratedTypeAttributes {
+        name,
+        is_nested,
+        bit_bound,
+    })
 }
 
 pub struct UnionAttributes {
+    pub name: String,
+    pub extensibility: Extensibility,
+    pub is_nested: bool,
     pub discriminator_type: syn::Type,
     pub is_discriminator_key: bool,
 }
 
 pub fn get_union_type_attributes(input: &DeriveInput) -> Result<UnionAttributes> {
+    let mut name = input.ident.to_string();
+    let mut extensibility = Extensibility::Final;
+    let mut is_nested = false;
     let mut is_discriminator_key = false;
     let mut discriminator_type = None;
     if let Some(xtypes_attribute) = input
@@ -181,7 +185,29 @@ pub fn get_union_type_attributes(input: &DeriveInput) -> Result<UnionAttributes>
         .find(|attr| attr.path().is_ident("dust_dds"))
     {
         xtypes_attribute.parse_nested_meta(|meta| {
-            if meta.path.is_ident("switch") {
+            if meta.path.is_ident("name") {
+                name = meta.value()?.parse::<syn::LitStr>()?.value();
+            } else if meta.path.is_ident("extensibility") {
+                let format_str: syn::LitStr = meta.value()?.parse()?;
+                match format_str.value().as_ref() {
+                    "final" => {
+                        extensibility = Extensibility::Final;
+                    }
+                    "appendable" => {
+                        extensibility = Extensibility::Appendable;
+                    }
+                    "mutable" => {
+                        extensibility = Extensibility::Mutable;
+                    }
+                    _ => return Err(syn::Error::new(
+                        meta.path.span(),
+                        r#"Invalid format specified. Valid options are "final", "appendable", "mutable". "#,
+                    )),
+                }
+            } else if meta.path.is_ident("nested") {
+                is_nested = true;
+            }
+             else if meta.path.is_ident("switch") {
                 let content;
                 syn::parenthesized!(content in meta.input);
                 let fork = content.fork();
@@ -202,6 +228,9 @@ pub fn get_union_type_attributes(input: &DeriveInput) -> Result<UnionAttributes>
         r#"Union must defined its discriminator type by adding #[dust_dds(switch(#type))] "#,
     ))?;
     Ok(UnionAttributes {
+        name,
+        extensibility,
+        is_nested,
         discriminator_type,
         is_discriminator_key,
     })

--- a/dds_derive/src/derive/attributes.rs
+++ b/dds_derive/src/derive/attributes.rs
@@ -236,17 +236,14 @@ pub fn get_union_type_attributes(input: &DeriveInput) -> Result<UnionAttributes>
     })
 }
 
-pub enum UnionDiscriminatorKind {
-    Case(Expr),
-    Default,
-}
-
 pub struct UnionVariantAttributes {
-    pub case: UnionDiscriminatorKind,
+    pub case: Expr,
+    pub is_default: bool,
 }
 
 pub fn get_union_variant_attributes(variant: &Variant) -> Result<UnionVariantAttributes> {
     let mut case = None;
+    let mut is_default = false;
     if let Some(xtypes_attribute) = variant
         .attrs
         .iter()
@@ -254,16 +251,16 @@ pub fn get_union_variant_attributes(variant: &Variant) -> Result<UnionVariantAtt
     {
         xtypes_attribute.parse_nested_meta(|meta| {
             if meta.path.is_ident("case") {
-                case = Some(UnionDiscriminatorKind::Case(meta.value()?.parse()?));
+                case = Some(meta.value()?.parse()?);
             } else if meta.path.is_ident("default") {
-                case = Some(UnionDiscriminatorKind::Default);
+                is_default = true;
             }
             Ok(())
         })?;
     }
     let case = case.ok_or(syn::Error::new(
         variant.span(),
-        r#"Union variant must define its discriminator value by using #[dust_dds(case = #value)] or #[dust_dds(default)] "#,
+        r#"Union variant must define its discriminator value by using #[dust_dds(case = #value)] "#,
     ))?;
-    Ok(UnionVariantAttributes { case })
+    Ok(UnionVariantAttributes { case, is_default })
 }

--- a/dds_derive/src/derive/attributes.rs
+++ b/dds_derive/src/derive/attributes.rs
@@ -121,7 +121,7 @@ pub fn get_type_declaration_attributes(input: &DeriveInput) -> Result<TypeDeclar
     })
 }
 
-pub enum BitBound{
+pub enum BitBound {
     I8,
     I16,
     I32,
@@ -140,7 +140,6 @@ pub fn get_enumerated_type_attributes(input: &DeriveInput) -> Result<EnumeratedT
     {
         xtypes_attribute.parse_nested_meta(|meta| {
             if meta.path.is_ident("bit_bound") {
-                
                 let format_str: syn::LitStr = meta.value()?.parse()?;
                 match format_str.value().as_ref() {
                     "8" => {
@@ -160,11 +159,62 @@ pub fn get_enumerated_type_attributes(input: &DeriveInput) -> Result<EnumeratedT
                         r#"Invalid bit_bound specified. Valid options are "8", "16", "32". "#,
                     )),
                 }
-            } 
-            else {
+            } else {
                 Ok(())
             }
         })?;
     }
     Ok(EnumeratedTypeAttributes { bit_bound })
+}
+
+pub struct UnionAttributes {
+    pub discriminator_type: syn::Type,
+    pub is_discriminator_key: bool,
+}
+
+pub fn get_union_type_attributes(input: &DeriveInput) -> Result<UnionAttributes> {
+    let mut is_discriminator_key = false;
+    let mut discriminator_type = None;
+    if let Some(xtypes_attribute) = input
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("dust_dds"))
+    {
+        // xtypes_attribute.parse_nested_meta(|meta| {
+        //     if meta.path.is_ident("switch") {
+        //         switch_attributes.parse_nested_meta
+
+        //         let format_str: syn::LitStr = meta.value()?.parse()?;
+        //         match format_str.value().as_ref() {
+        //             "8" => {
+        //                 bit_bound = BitBound::I8;
+        //                 Ok(())
+        //             }
+        //             "16" => {
+        //                 bit_bound = BitBound::I16;
+        //                 Ok(())
+        //             }
+        //             "32" => {
+        //                 bit_bound = BitBound::I32;
+        //                 Ok(())
+        //             }
+        //             _ => Err(syn::Error::new(
+        //                 meta.path.span(),
+        //                 r#"Invalid bit_bound specified. Valid options are "8", "16", "32". "#,
+        //             )),
+        //         }
+        //     }
+        //     else {
+        //         Ok(())
+        //     }
+        // })?;
+    };
+    let discriminator_type = discriminator_type.ok_or(syn::Error::new(
+        input.span(),
+        r#"Union must defined its discriminator type by adding #[dust_dds(switch(#type))] "#,
+    ))?;
+    Ok(UnionAttributes {
+        discriminator_type,
+        is_discriminator_key,
+    })
 }

--- a/dds_derive/src/derive/attributes.rs
+++ b/dds_derive/src/derive/attributes.rs
@@ -216,7 +216,7 @@ pub struct UnionVariantAttributes {
     pub case: UnionDiscriminatorKind,
 }
 
-pub fn get_union_member_attributes(variant: &Variant) -> Result<UnionVariantAttributes> {
+pub fn get_union_variant_attributes(variant: &Variant) -> Result<UnionVariantAttributes> {
     let mut case = None;
     if let Some(xtypes_attribute) = variant
         .attrs

--- a/dds_derive/src/derive/attributes.rs
+++ b/dds_derive/src/derive/attributes.rs
@@ -1,17 +1,36 @@
-use syn::{Expr, Field};
+use syn::{DeriveInput, Expr, Field, Result, spanned::Spanned};
 
-pub struct FieldAttributes {
-    pub key: bool,
-    pub optional: bool,
+pub struct MemberAttributes {
     pub id: Option<Expr>,
-    pub default_value: Option<Expr>,
-    pub non_serialized: bool,
 }
 
-pub fn get_field_attributes(field: &Field) -> syn::Result<FieldAttributes> {
+pub fn get_member_attributes(field: &Field) -> syn::Result<MemberAttributes> {
+    let mut id = None;
+    if let Some(xtypes_attribute) = field
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("dust_dds"))
+    {
+        xtypes_attribute.parse_nested_meta(|meta| {
+            if meta.path.is_ident("id") {
+                id = Some(meta.value()?.parse()?);
+            }
+            Ok(())
+        })?;
+    }
+    Ok(MemberAttributes { id })
+}
+
+pub struct StructureMemberAttributes {
+    pub key: bool,
+    pub optional: bool,
+    pub non_serialized: bool,
+    pub default_value: Option<Expr>,
+}
+
+pub fn get_structure_member_attributes(field: &Field) -> syn::Result<StructureMemberAttributes> {
     let mut key = false;
     let mut optional = false;
-    let mut id = None;
     let mut default_value = None;
     let mut non_serialized = false;
     if let Some(xtypes_attribute) = field
@@ -22,8 +41,6 @@ pub fn get_field_attributes(field: &Field) -> syn::Result<FieldAttributes> {
         xtypes_attribute.parse_nested_meta(|meta| {
             if meta.path.is_ident("key") {
                 key = true;
-            } else if meta.path.is_ident("id") {
-                id = Some(meta.value()?.parse()?);
             } else if meta.path.is_ident("default_value") {
                 default_value = Some(meta.value()?.parse()?);
             } else if meta.path.is_ident("optional") {
@@ -34,11 +51,120 @@ pub fn get_field_attributes(field: &Field) -> syn::Result<FieldAttributes> {
             Ok(())
         })?;
     }
-    Ok(FieldAttributes {
+    Ok(StructureMemberAttributes {
         key,
         optional,
-        id,
         default_value,
         non_serialized,
     })
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum Extensibility {
+    Final,
+    Appendable,
+    Mutable,
+}
+
+pub struct TypeDeclarationAttributes {
+    pub name: String,
+    pub extensibility: Extensibility,
+    pub is_nested: bool,
+}
+
+pub fn get_type_declaration_attributes(input: &DeriveInput) -> Result<TypeDeclarationAttributes> {
+    let mut name = input.ident.to_string();
+    let mut extensibility = Extensibility::Final;
+    let mut is_nested = false;
+    if let Some(xtypes_attribute) = input
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("dust_dds"))
+    {
+        xtypes_attribute.parse_nested_meta(|meta| {
+            if meta.path.is_ident("name") {
+                name = meta.value()?.parse::<syn::LitStr>()?.value();
+                Ok(())
+            } else if meta.path.is_ident("extensibility") {
+                let format_str: syn::LitStr = meta.value()?.parse()?;
+                match format_str.value().as_ref() {
+                    "final" => {
+                        extensibility = Extensibility::Final;
+                        Ok(())
+                    }
+                    "appendable" => {
+                        extensibility = Extensibility::Appendable;
+                        Ok(())
+                    }
+                    "mutable" => {
+                        extensibility = Extensibility::Mutable;
+                        Ok(())
+                    }
+                    _ => Err(syn::Error::new(
+                        meta.path.span(),
+                        r#"Invalid format specified. Valid options are "final", "appendable", "mutable". "#,
+                    )),
+                }
+            } else if meta.path.is_ident("nested") {
+                is_nested = true;
+                Ok(())
+            }
+            else {
+                Ok(())
+            }
+        })?;
+    }
+    Ok(TypeDeclarationAttributes {
+        name,
+        extensibility,
+        is_nested,
+    })
+}
+
+pub enum BitBound{
+    I8,
+    I16,
+    I32,
+}
+
+pub struct EnumeratedTypeAttributes {
+    pub bit_bound: BitBound,
+}
+
+pub fn get_enumerated_type_attributes(input: &DeriveInput) -> Result<EnumeratedTypeAttributes> {
+    let mut bit_bound = BitBound::I32;
+    if let Some(xtypes_attribute) = input
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("dust_dds"))
+    {
+        xtypes_attribute.parse_nested_meta(|meta| {
+            if meta.path.is_ident("bit_bound") {
+                
+                let format_str: syn::LitStr = meta.value()?.parse()?;
+                match format_str.value().as_ref() {
+                    "8" => {
+                        bit_bound = BitBound::I8;
+                        Ok(())
+                    }
+                    "16" => {
+                        bit_bound = BitBound::I16;
+                        Ok(())
+                    }
+                    "32" => {
+                        bit_bound = BitBound::I32;
+                        Ok(())
+                    }
+                    _ => Err(syn::Error::new(
+                        meta.path.span(),
+                        r#"Invalid bit_bound specified. Valid options are "8", "16", "32". "#,
+                    )),
+                }
+            } 
+            else {
+                Ok(())
+            }
+        })?;
+    }
+    Ok(EnumeratedTypeAttributes { bit_bound })
 }

--- a/dds_derive/src/derive/attributes.rs
+++ b/dds_derive/src/derive/attributes.rs
@@ -1,10 +1,10 @@
-use syn::{DeriveInput, Expr, Field, Result, spanned::Spanned};
+use syn::{DeriveInput, Expr, Field, Result, Variant, spanned::Spanned};
 
 pub struct MemberAttributes {
     pub id: Option<Expr>,
 }
 
-pub fn get_member_attributes(field: &Field) -> syn::Result<MemberAttributes> {
+pub fn get_member_attributes(field: &Field) -> Result<MemberAttributes> {
     let mut id = None;
     if let Some(xtypes_attribute) = field
         .attrs
@@ -28,7 +28,7 @@ pub struct StructureMemberAttributes {
     pub default_value: Option<Expr>,
 }
 
-pub fn get_structure_member_attributes(field: &Field) -> syn::Result<StructureMemberAttributes> {
+pub fn get_structure_member_attributes(field: &Field) -> Result<StructureMemberAttributes> {
     let mut key = false;
     let mut optional = false;
     let mut default_value = None;
@@ -205,4 +205,36 @@ pub fn get_union_type_attributes(input: &DeriveInput) -> Result<UnionAttributes>
         discriminator_type,
         is_discriminator_key,
     })
+}
+
+pub enum UnionDiscriminatorKind {
+    Case(Expr),
+    Default,
+}
+
+pub struct UnionVariantAttributes {
+    pub case: UnionDiscriminatorKind,
+}
+
+pub fn get_union_member_attributes(variant: &Variant) -> Result<UnionVariantAttributes> {
+    let mut case = None;
+    if let Some(xtypes_attribute) = variant
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("dust_dds"))
+    {
+        xtypes_attribute.parse_nested_meta(|meta| {
+            if meta.path.is_ident("case") {
+                case = Some(UnionDiscriminatorKind::Case(meta.value()?.parse()?));
+            } else if meta.path.is_ident("default") {
+                case = Some(UnionDiscriminatorKind::Default);
+            }
+            Ok(())
+        })?;
+    }
+    let case = case.ok_or(syn::Error::new(
+        variant.span(),
+        r#"Union variant must define its discriminator value by using #[dust_dds(case = #value)] or #[dust_dds(default)] "#,
+    ))?;
+    Ok(UnionVariantAttributes { case })
 }

--- a/dds_derive/src/derive/attributes.rs
+++ b/dds_derive/src/derive/attributes.rs
@@ -180,34 +180,22 @@ pub fn get_union_type_attributes(input: &DeriveInput) -> Result<UnionAttributes>
         .iter()
         .find(|attr| attr.path().is_ident("dust_dds"))
     {
-        // xtypes_attribute.parse_nested_meta(|meta| {
-        //     if meta.path.is_ident("switch") {
-        //         switch_attributes.parse_nested_meta
-
-        //         let format_str: syn::LitStr = meta.value()?.parse()?;
-        //         match format_str.value().as_ref() {
-        //             "8" => {
-        //                 bit_bound = BitBound::I8;
-        //                 Ok(())
-        //             }
-        //             "16" => {
-        //                 bit_bound = BitBound::I16;
-        //                 Ok(())
-        //             }
-        //             "32" => {
-        //                 bit_bound = BitBound::I32;
-        //                 Ok(())
-        //             }
-        //             _ => Err(syn::Error::new(
-        //                 meta.path.span(),
-        //                 r#"Invalid bit_bound specified. Valid options are "8", "16", "32". "#,
-        //             )),
-        //         }
-        //     }
-        //     else {
-        //         Ok(())
-        //     }
-        // })?;
+        xtypes_attribute.parse_nested_meta(|meta| {
+            if meta.path.is_ident("switch") {
+                let content;
+                syn::parenthesized!(content in meta.input);
+                let fork = content.fork();
+                if let Ok(ident) = fork.parse::<syn::Ident>() {
+                    if ident == "key" && fork.parse::<syn::Token![,]>().is_ok() {
+                        is_discriminator_key = true;
+                        let _: syn::Ident = content.parse()?;
+                        let _: syn::Token![,] = content.parse()?;
+                    }
+                }
+                discriminator_type = Some(content.parse::<syn::Type>()?);
+            }
+            Ok(())
+        })?;
     };
     let discriminator_type = discriminator_type.ok_or(syn::Error::new(
         input.span(),

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -1,14 +1,18 @@
 use crate::derive::{
-    attributes::get_field_attributes, enum_support::read_enum_variant_discriminant_mapping,
+    attributes::{
+        BitBound, Extensibility, get_enumerated_type_attributes, get_member_attributes,
+        get_structure_member_attributes, get_type_declaration_attributes,
+    },
+    enum_support::read_enum_variant_discriminant_mapping,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DataEnum, DeriveInput, Fields, Index, Result, spanned::Spanned};
 
 pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
-    let input_attributes = get_input_attributes(input)?;
+    // Get the type declaration attributes as defined in Table 21 – IDL Built-in Annotations Usage of the XTypes standard
+    let input_attributes = get_type_declaration_attributes(input)?;
     let ident = &input.ident;
-
     let type_name = input_attributes.name.as_str();
     let extensibility_kind = match input_attributes.extensibility {
         Extensibility::Final => {
@@ -25,7 +29,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
 
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
     let (get_type_quote, create_dynamic_sample_quote, create_sample_quote) = match &input.data {
-        syn::Data::Struct(data_struct) => {
+        syn::Data::Struct(xtypes_struct) => {
             let struct_descriptor = quote! {
                 &dust_dds::xtypes::dynamic_type::TypeDescriptor {
                     kind: dust_dds::xtypes::dynamic_type::TypeKind::STRUCTURE,
@@ -45,16 +49,17 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
             let mut member_dynamic_sample_seq = Vec::new();
 
             let mut next_auto_id = 0;
-            for (field_index, field) in data_struct.fields.iter().enumerate() {
-                let index = field_index as u32;
-                let field_attributes = get_field_attributes(field)?;
+            for (member_index, member) in xtypes_struct.fields.iter().enumerate() {
+                let index = member_index as u32;
+                let member_attributes = get_member_attributes(member)?;
+                let struct_member_attributes = get_structure_member_attributes(member)?;
 
                 let member_id = match input_attributes.extensibility {
                     Extensibility::Final | Extensibility::Appendable => {
-                        syn::parse_str(&field_index.to_string())
+                        syn::parse_str(&member_index.to_string())
                     }
                     Extensibility::Mutable => {
-                        if let Some(provided_id) = field_attributes.id {
+                        if let Some(provided_id) = member_attributes.id {
                             Ok(provided_id)
                         } else {
                             syn::parse_str(&next_auto_id.to_string())
@@ -68,22 +73,22 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 {
                     next_auto_id = lit_int.base10_parse::<u32>()? + 1;
                 }
-                let field_name = field
+                let member_name = member
                     .ident
                     .as_ref()
                     .map(|i| i.to_string())
-                    .unwrap_or(field_index.to_string());
+                    .unwrap_or(member_index.to_string());
 
-                let member_type = &field.ty;
-                let is_key = field_attributes.key;
-                let is_optional = field_attributes.optional;
-                let default_value = field_attributes.default_value.map(|x| quote! {#x});
+                let member_type = &member.ty;
+                let is_key = struct_member_attributes.key;
+                let is_optional = struct_member_attributes.optional;
+                let default_value = struct_member_attributes.default_value.map(|x| quote! {#x});
 
                 member_list.push(
                     quote! {
                          dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
-                                name: #field_name,
+                                name: #member_name,
                                 id: #member_id,
                                 r#type: <#member_type as dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION,
                                 default_value: None,
@@ -100,49 +105,49 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                     }
                 );
 
-                if !field_attributes.non_serialized {
-                    let field_type = &field.ty;
-                    let field_default_value = default_value
-                        .unwrap_or(quote! { <#field_type as ::core::default::Default>::default()});
-                    match &field.ident {
-                        Some(field_ident) => {
-                            // In Mutable structs every field is optional even when not explicitly marked as such
+                if !struct_member_attributes.non_serialized {
+                    let member_type = &member.ty;
+                    let member_default_value = default_value
+                        .unwrap_or(quote! { <#member_type as ::core::default::Default>::default()});
+                    match &member.ident {
+                        Some(member_ident) => {
+                            // In Mutable structs every member is optional even when not explicitly marked as such
                             if input_attributes.extensibility == Extensibility::Mutable
                                 || is_optional
                             {
                                 member_sample_seq.push(quote! {
-                                    #field_ident: src.remove_value(#member_id).map_or(#field_default_value, |x| {
+                                    #member_ident: src.remove_value(#member_id).map_or(#member_default_value, |x| {
                                         dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(x).expect("Must match")
                                     }),
                                 });
 
                                 member_dynamic_sample_seq
                                     .push(quote! {
-                                        if self.#field_ident != #field_default_value {
-                                            data.set_value(#member_id, dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(self.#field_ident));
+                                        if self.#member_ident != #member_default_value {
+                                            data.set_value(#member_id, dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(self.#member_ident));
                                         }
                                     });
                             } else {
                                 member_sample_seq.push(quote! {
-                                    #field_ident: dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(src.remove_value(#member_id).expect("Must exist")).expect("Must match"),
+                                    #member_ident: dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(src.remove_value(#member_id).expect("Must exist")).expect("Must match"),
                                 });
                                 member_dynamic_sample_seq
-                                    .push(quote! {data.set_value(#member_id, dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(self.#field_ident));});
+                                    .push(quote! {data.set_value(#member_id, dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(self.#member_ident));});
                             }
                         }
                         None => {
-                            let index = Index::from(field_index);
-                            // In Mutable structs every field is optional even when not explicitly marked as such
+                            let index = Index::from(member_index);
+                            // In Mutable structs every member is optional even when not explicitly marked as such
                             if input_attributes.extensibility == Extensibility::Mutable
                                 || is_optional
                             {
                                 member_sample_seq.push(quote! {
-                                    src.remove_value(#member_id).map_or(#field_default_value, |x| {
+                                    src.remove_value(#member_id).map_or(#member_default_value, |x| {
                                         DataStorageMapping::try_from_storage(x).expect("Must match")
                                     }),
                                 });
                                 member_dynamic_sample_seq.push(quote! {
-                                    if self.#index != #field_default_value {
+                                    if self.#index != #member_default_value {
                                         data.set_value(#member_id, dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(self.#index));
                                     }
                                 })
@@ -156,7 +161,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                     }
                 }
             }
-            let is_tuple = match data_struct.fields.iter().next() {
+            let is_tuple = match xtypes_struct.fields.iter().next() {
                 Some(s) => s.ident.is_none(),
                 None => false,
             };
@@ -183,96 +188,122 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 create_sample_quote,
             ))
         }
-        syn::Data::Enum(data_enum) => {
-            // Separate between Unions and Enumeration which are both
-            // mapped as Rust enum types
-            if is_enum_xtypes_union(data_enum) {
-                let union_descriptor = quote! {
-                    &dust_dds::xtypes::dynamic_type::TypeDescriptor {
-                        kind: dust_dds::xtypes::dynamic_type::TypeKind::UNION,
-                        name: #type_name,
-                        base_type: None,
-                        discriminator_type: None,
-                        bound: None,
-                        element_type: None,
-                        key_element_type: None,
-                        extensibility_kind: #extensibility_kind,
-                        is_nested: #is_nested,
-                    }
-                };
-                let get_type_quote = quote! {
-                    const r#TYPE: dust_dds::xtypes::dynamic_type::DynamicType =
-                        dust_dds::xtypes::dynamic_type::DynamicType {
-                            descriptor: #union_descriptor,
-                            member_list: &[]
-                        };
-                };
-
-                let create_dynamic_sample_quote = quote! {todo!()};
-                let create_sample_quote = quote! {
-                    todo!()
-                };
-                Ok((
-                    get_type_quote,
-                    create_dynamic_sample_quote,
-                    create_sample_quote,
-                ))
-            } else {
-                // Note: Mapping has to be done with a match self strategy because the enum might not be copy so casting it using e.g. "self as i64" would
-                // be consuming it.
-                let discriminator_type =
-                    quote! {<i32 as dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION};
-                let discriminator_dynamic_value =
-                    quote! {data.set_int32_value(0, self as i32).unwrap();};
-
-                let enum_descriptor = quote! {
-                    &dust_dds::xtypes::dynamic_type::TypeDescriptor {
-                        kind: dust_dds::xtypes::dynamic_type::TypeKind::ENUM,
-                        name: #type_name,
-                        base_type: None,
-                        discriminator_type: Some(#discriminator_type),
-                        bound: None,
-                        element_type: None,
-                        key_element_type: None,
-                        extensibility_kind: #extensibility_kind,
-                        is_nested: #is_nested,
-                    }
-                };
-                let get_type_quote = quote! {
-                    const r#TYPE: dust_dds::xtypes::dynamic_type::DynamicType =
-                        dust_dds::xtypes::dynamic_type::DynamicType {
-                            descriptor: #enum_descriptor,
-                            member_list: &[]
-                        };
-                };
-
-                let create_dynamic_sample_quote = quote! {
-                    #discriminator_dynamic_value
-                };
-                let enum_variant_mapping = read_enum_variant_discriminant_mapping(data_enum);
-                let mut create_sample_quote_variants = Vec::new();
-                for (variant_ident, variant_discriminant) in enum_variant_mapping {
-                    let d = Index::from(variant_discriminant);
-                    create_sample_quote_variants.push(quote! {#d => Self::#variant_ident,});
-                }
-                let create_sample_quote = quote! {
-                        let discriminator = src.get_int32_value(0).expect("Must exist");
-                        match discriminator {
-                            #(#create_sample_quote_variants)*
-                            d => panic!("Invalid discriminator {d:?}"),
-                        }
-                };
-
-                Ok((
-                    get_type_quote,
-                    create_dynamic_sample_quote,
-                    create_sample_quote,
-                ))
+        // Separate between Unions and Enumeration which are both
+        // mapped as Rust enum types
+        syn::Data::Enum(xtypes_union) if is_enum_xtypes_union(xtypes_union) => {
+            if xtypes_union.variants.len() > (u32::MAX as usize + 1) {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "Union can hold at most `u32::MAX + 1` variants",
+                ));
             }
+
+            let union_descriptor = quote! {
+                &dust_dds::xtypes::dynamic_type::TypeDescriptor {
+                    kind: dust_dds::xtypes::dynamic_type::TypeKind::UNION,
+                    name: #type_name,
+                    base_type: None,
+                    discriminator_type: None,
+                    bound: None,
+                    element_type: None,
+                    key_element_type: None,
+                    extensibility_kind: #extensibility_kind,
+                    is_nested: #is_nested,
+                }
+            };
+            let get_type_quote = quote! {
+                const r#TYPE: dust_dds::xtypes::dynamic_type::DynamicType =
+                    dust_dds::xtypes::dynamic_type::DynamicType {
+                        descriptor: #union_descriptor,
+                        member_list: &[]
+                    };
+            };
+
+            let create_dynamic_sample_quote = quote! {todo!()};
+            let create_sample_quote = quote! {
+                todo!()
+            };
+            Ok((
+                get_type_quote,
+                create_dynamic_sample_quote,
+                create_sample_quote,
+            ))
+        }
+        syn::Data::Enum(xtypes_enum) => {
+            let enum_type_attributes = get_enumerated_type_attributes(input)?;
+            // Note: Mapping has to be done with a match self strategy because the enum might not be copy so casting it using e.g. "self as i64" would
+            // be consuming it.
+            let discriminator_type = match enum_type_attributes.bit_bound {
+                BitBound::I8 => {
+                    quote! {<i8 as dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION}
+                }
+                BitBound::I16 => {
+                    quote! {<i16 as dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION}
+                }
+                BitBound::I32 => {
+                    quote! {<i32 as dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION}
+                }
+            };
+
+            let discriminator_dynamic_value = match enum_type_attributes.bit_bound {
+                BitBound::I8 => quote! {data.set_int8_value(0, self as i8).unwrap();},
+                BitBound::I16 => quote! {data.set_int16_value(0, self as i16).unwrap();},
+                BitBound::I32 => quote! {data.set_int32_value(0, self as i32).unwrap();},
+            };
+
+            let discriminator_sample = match enum_type_attributes.bit_bound  {
+                BitBound::I8 =>  quote!{src.get_int8_value(0).expect("Must exist");},
+                BitBound::I16 => quote!{src.get_int16_value(0).expect("Must exist");},
+                BitBound::I32 => quote!{src.get_int32_value(0).expect("Must exist");},
+            };
+
+            let enum_descriptor = quote! {
+                &dust_dds::xtypes::dynamic_type::TypeDescriptor {
+                    kind: dust_dds::xtypes::dynamic_type::TypeKind::ENUM,
+                    name: #type_name,
+                    base_type: None,
+                    discriminator_type: Some(#discriminator_type),
+                    bound: None,
+                    element_type: None,
+                    key_element_type: None,
+                    extensibility_kind: #extensibility_kind,
+                    is_nested: #is_nested,
+                }
+            };
+            let get_type_quote = quote! {
+                const r#TYPE: dust_dds::xtypes::dynamic_type::DynamicType =
+                    dust_dds::xtypes::dynamic_type::DynamicType {
+                        descriptor: #enum_descriptor,
+                        member_list: &[]
+                    };
+            };
+
+            let create_dynamic_sample_quote = quote! {
+                #discriminator_dynamic_value
+            };
+            let enum_variant_mapping = read_enum_variant_discriminant_mapping(xtypes_enum);
+            let mut create_sample_quote_variants = Vec::new();
+            for (variant_ident, variant_discriminant) in enum_variant_mapping {
+                let d = Index::from(variant_discriminant);
+                create_sample_quote_variants.push(quote! {#d => Self::#variant_ident,});
+            }
+            let create_sample_quote = quote! {
+                    let discriminator = #discriminator_sample;
+                    match discriminator {
+                        #(#create_sample_quote_variants)*
+                        d => panic!("Invalid discriminator {d:?}"),
+                    }
+            };
+
+            Ok((
+                get_type_quote,
+                create_dynamic_sample_quote,
+                create_sample_quote,
+            ))
         }
         syn::Data::Union(data_union) => Err(syn::Error::new(
             data_union.union_token.span,
-            "Union not supported",
+            "Rust union not supported in Dust DDS. For IDL union mapping use enum with types in variants.",
         )),
     }?;
 
@@ -289,68 +320,6 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 #create_dynamic_sample_quote
             }
         }
-    })
-}
-
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum Extensibility {
-    Final,
-    Appendable,
-    Mutable,
-}
-
-struct InputAttributes {
-    name: String,
-    extensibility: Extensibility,
-    is_nested: bool,
-}
-
-fn get_input_attributes(input: &DeriveInput) -> Result<InputAttributes> {
-    let mut name = input.ident.to_string();
-    let mut extensibility = Extensibility::Final;
-    let mut is_nested = false;
-    if let Some(xtypes_attribute) = input
-        .attrs
-        .iter()
-        .find(|attr| attr.path().is_ident("dust_dds"))
-    {
-        xtypes_attribute.parse_nested_meta(|meta| {
-            if meta.path.is_ident("name") {
-                name = meta.value()?.parse::<syn::LitStr>()?.value();
-                Ok(())
-            } else if meta.path.is_ident("extensibility") {
-                let format_str: syn::LitStr = meta.value()?.parse()?;
-                match format_str.value().as_ref() {
-                    "final" => {
-                        extensibility = Extensibility::Final;
-                        Ok(())
-                    }
-                    "appendable" => {
-                        extensibility = Extensibility::Appendable;
-                        Ok(())
-                    }
-                    "mutable" => {
-                        extensibility = Extensibility::Mutable;
-                        Ok(())
-                    }
-                    _ => Err(syn::Error::new(
-                        meta.path.span(),
-                        r#"Invalid format specified. Valid options are "final", "appendable", "mutable". "#,
-                    )),
-                }
-            } else if meta.path.is_ident("nested") {
-                is_nested = true;
-                Ok(())
-            }
-            else {
-                Ok(())
-            }
-        })?;
-    }
-    Ok(InputAttributes {
-        name,
-        extensibility,
-        is_nested,
     })
 }
 

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -1,8 +1,7 @@
 use crate::derive::{
     attributes::{
-        BitBound, Extensibility, get_enumerated_type_attributes, get_member_attributes,
-        get_structure_member_attributes, get_type_declaration_attributes,
-        get_union_type_attributes, get_union_variant_attributes,
+        BitBound, Extensibility, get_enumerated_type_attributes, get_struct_attributes,
+        get_structure_member_attributes, get_union_type_attributes, get_union_variant_attributes,
     },
     enum_support::read_enum_variant_discriminant_mapping,
 };
@@ -11,26 +10,26 @@ use quote::quote;
 use syn::{DataEnum, DeriveInput, Fields, Index, Result, spanned::Spanned};
 
 pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
-    // Get the type declaration attributes as defined in Table 21 – IDL Built-in Annotations Usage of the XTypes standard
-    let input_attributes = get_type_declaration_attributes(input)?;
     let ident = &input.ident;
-    let type_name = input_attributes.name.as_str();
-    let extensibility_kind = match input_attributes.extensibility {
-        Extensibility::Final => {
-            quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final}
-        }
-        Extensibility::Appendable => {
-            quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Appendable}
-        }
-        Extensibility::Mutable => {
-            quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Mutable}
-        }
-    };
-    let is_nested = input_attributes.is_nested;
-
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
     let (get_type_quote, create_dynamic_sample_quote, create_sample_quote) = match &input.data {
         syn::Data::Struct(xtypes_struct) => {
+            // Get the type declaration attributes as defined in Table 21 – IDL Built-in Annotations Usage of the XTypes standard
+            let r#struct = get_struct_attributes(input)?;
+            let type_name = r#struct.name.as_str();
+            let extensibility_kind = match r#struct.extensibility {
+                Extensibility::Final => {
+                    quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final}
+                }
+                Extensibility::Appendable => {
+                    quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Appendable}
+                }
+                Extensibility::Mutable => {
+                    quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Mutable}
+                }
+            };
+            let is_nested = r#struct.is_nested;
+
             let struct_descriptor = quote! {
                 &dust_dds::xtypes::dynamic_type::TypeDescriptor {
                     kind: dust_dds::xtypes::dynamic_type::TypeKind::STRUCTURE,
@@ -52,15 +51,14 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
             let mut next_auto_id = 0;
             for (member_index, member) in xtypes_struct.fields.iter().enumerate() {
                 let index = member_index as u32;
-                let member_attributes = get_member_attributes(member)?;
                 let struct_member_attributes = get_structure_member_attributes(member)?;
 
-                let member_id = match input_attributes.extensibility {
+                let member_id = match r#struct.extensibility {
                     Extensibility::Final | Extensibility::Appendable => {
                         syn::parse_str(&member_index.to_string())
                     }
                     Extensibility::Mutable => {
-                        if let Some(provided_id) = member_attributes.id {
+                        if let Some(provided_id) = struct_member_attributes.id {
                             Ok(provided_id)
                         } else {
                             syn::parse_str(&next_auto_id.to_string())
@@ -113,9 +111,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                     match &member.ident {
                         Some(member_ident) => {
                             // In Mutable structs every member is optional even when not explicitly marked as such
-                            if input_attributes.extensibility == Extensibility::Mutable
-                                || is_optional
-                            {
+                            if r#struct.extensibility == Extensibility::Mutable || is_optional {
                                 member_sample_seq.push(quote! {
                                     #member_ident: src.remove_value(#member_id).map_or(#member_default_value, |x| {
                                         dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(x).expect("Must match")
@@ -139,9 +135,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                         None => {
                             let index = Index::from(member_index);
                             // In Mutable structs every member is optional even when not explicitly marked as such
-                            if input_attributes.extensibility == Extensibility::Mutable
-                                || is_optional
-                            {
+                            if r#struct.extensibility == Extensibility::Mutable || is_optional {
                                 member_sample_seq.push(quote! {
                                     src.remove_value(#member_id).map_or(#member_default_value, |x| {
                                         DataStorageMapping::try_from_storage(x).expect("Must match")
@@ -194,6 +188,19 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
         syn::Data::Enum(xtypes_union) if is_enum_xtypes_union(xtypes_union) => {
             let union_attributes = get_union_type_attributes(input)?;
             let discriminator_type = union_attributes.discriminator_type;
+            let type_name = union_attributes.name.as_str();
+            let extensibility_kind = match union_attributes.extensibility {
+                Extensibility::Final => {
+                    quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final}
+                }
+                Extensibility::Appendable => {
+                    quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Appendable}
+                }
+                Extensibility::Mutable => {
+                    quote! {dust_dds::xtypes::dynamic_type::ExtensibilityKind::Mutable}
+                }
+            };
+            let is_nested = union_attributes.is_nested;
             if xtypes_union.variants.len() > (u32::MAX as usize + 1) {
                 return Err(syn::Error::new(
                     input.span(),
@@ -244,10 +251,63 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 let index = variant_index + 1;
 
                 match &variant.fields {
-                    Fields::Named(fields_named) => todo!(),
-                    Fields::Unnamed(fields_unnamed) => todo!(),
+                    // If there is a single field we handle this as the single type wrapper which is the most common case
+                    Fields::Named(fields_named) if fields_named.named.len() == 1 => {
+                        let variant_name = fields_named.named[0]
+                            .ident
+                            .as_ref()
+                            .ok_or(syn::Error::new(
+                                fields_named.span(),
+                                "Field of named variant must have defined name",
+                            ))?
+                            .to_string();
+                        let variant_ty = &fields_named.named[0].ty;
+                        variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+                            descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+                                name: #variant_name,
+                                id: #index as u32,
+                                r#type: <#variant_ty as dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION,
+                                default_value: None,
+                                index: #index as u32,
+                                try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,
+                                label: None,
+                                is_key: false,
+                                is_optional: true,
+                                is_must_understand: true,
+                                is_shared: false,
+                                is_default_label: false,
+                            }
+                        }
+                        });
+                    }
+                    Fields::Unnamed(fields_unnamed) if fields_unnamed.unnamed.len() == 1 => {
+                        let variant_ty = &fields_unnamed.unnamed[0].ty;
+                        variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+                            descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+                                name: #variant_name,
+                                id: #index as u32,
+                                r#type: <#variant_ty as dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION,
+                                default_value: None,
+                                index: #index as u32,
+                                try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,
+                                label: None,
+                                is_key: false,
+                                is_optional: true,
+                                is_must_understand: true,
+                                is_shared: false,
+                                is_default_label: false,
+                            }
+                        }
+                        });
+                    }
+                    Fields::Named(_) | Fields::Unnamed(_) => {
+                        return Err(syn::Error::new(
+                            variant.span(),
+                            "Only variants with a single field are supported",
+                        ));
+                    }
                     Fields::Unit => {
-                        variant_list.push(quote!{
+                        variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
                                 name: #variant_name,
                                 id: #index as u32,
@@ -275,6 +335,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                                 is_shared: false,
                                 is_default_label: false,
                             }
+                        }
                         });
                     }
                 }
@@ -300,6 +361,8 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
         }
         syn::Data::Enum(xtypes_enum) => {
             let enum_type_attributes = get_enumerated_type_attributes(input)?;
+            let type_name = enum_type_attributes.name;
+            let is_nested = enum_type_attributes.is_nested;
             // Note: Mapping has to be done with a match self strategy because the enum might not be copy so casting it using e.g. "self as i64" would
             // be consuming it.
             let discriminator_type = match enum_type_attributes.bit_bound {
@@ -335,7 +398,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                     bound: None,
                     element_type: None,
                     key_element_type: None,
-                    extensibility_kind: #extensibility_kind,
+                    extensibility_kind: dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final,
                     is_nested: #is_nested,
                 }
             };

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -2,6 +2,7 @@ use crate::derive::{
     attributes::{
         BitBound, Extensibility, get_enumerated_type_attributes, get_member_attributes,
         get_structure_member_attributes, get_type_declaration_attributes,
+        get_union_type_attributes,
     },
     enum_support::read_enum_variant_discriminant_mapping,
 };
@@ -191,6 +192,8 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
         // Separate between Unions and Enumeration which are both
         // mapped as Rust enum types
         syn::Data::Enum(xtypes_union) if is_enum_xtypes_union(xtypes_union) => {
+            let union_attributes = get_union_type_attributes(input)?;
+            let discriminator_type = union_attributes.discriminator_type;
             if xtypes_union.variants.len() > (u32::MAX as usize + 1) {
                 return Err(syn::Error::new(
                     input.span(),
@@ -203,7 +206,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                     kind: dust_dds::xtypes::dynamic_type::TypeKind::UNION,
                     name: #type_name,
                     base_type: None,
-                    discriminator_type: None,
+                    discriminator_type: ::core::option::Option::Some(<#discriminator_type as ::dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION),
                     bound: None,
                     element_type: None,
                     key_element_type: None,
@@ -211,11 +214,18 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                     is_nested: #is_nested,
                 }
             };
+
+            let mut variant_list: Vec<TokenStream> = Vec::new();
+            let mut variant_sample_seq: Vec<TokenStream> = Vec::new();
+            let mut variant_dynamic_sample_seq: Vec<TokenStream> = Vec::new();
+
+            for (variant_index, variant) in xtypes_union.variants.iter().enumerate() {}
+
             let get_type_quote = quote! {
                 const r#TYPE: dust_dds::xtypes::dynamic_type::DynamicType =
                     dust_dds::xtypes::dynamic_type::DynamicType {
                         descriptor: #union_descriptor,
-                        member_list: &[]
+                        member_list: &[#(#variant_list,)*]
                     };
             };
 
@@ -251,10 +261,10 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 BitBound::I32 => quote! {data.set_int32_value(0, self as i32).unwrap();},
             };
 
-            let discriminator_sample = match enum_type_attributes.bit_bound  {
-                BitBound::I8 =>  quote!{src.get_int8_value(0).expect("Must exist");},
-                BitBound::I16 => quote!{src.get_int16_value(0).expect("Must exist");},
-                BitBound::I32 => quote!{src.get_int32_value(0).expect("Must exist");},
+            let discriminator_sample = match enum_type_attributes.bit_bound {
+                BitBound::I8 => quote! {src.get_int8_value(0).expect("Must exist");},
+                BitBound::I16 => quote! {src.get_int16_value(0).expect("Must exist");},
+                BitBound::I32 => quote! {src.get_int32_value(0).expect("Must exist");},
             };
 
             let enum_descriptor = quote! {

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -9,6 +9,8 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DataEnum, DeriveInput, Fields, Index, Result, spanned::Spanned};
 
+use super::attributes::UnionDiscriminatorKind;
+
 pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
     let ident = &input.ident;
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
@@ -247,20 +249,18 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
             for (variant_index, variant) in xtypes_union.variants.iter().enumerate() {
                 let variant_attributes = get_union_variant_attributes(variant)?;
 
-                let variant_name = variant.ident.to_string();
+                let variant_ident = &variant.ident;
+                let variant_name = variant_ident.to_string();
                 let index = variant_index + 1;
 
                 match &variant.fields {
                     // If there is a single field we handle this as the single type wrapper which is the most common case
                     Fields::Named(fields_named) if fields_named.named.len() == 1 => {
-                        let variant_name = fields_named.named[0]
-                            .ident
-                            .as_ref()
-                            .ok_or(syn::Error::new(
+                        let variant_field_name =
+                            fields_named.named[0].ident.as_ref().ok_or(syn::Error::new(
                                 fields_named.span(),
                                 "Field of named variant must have defined name",
-                            ))?
-                            .to_string();
+                            ))?;
                         let variant_ty = &fields_named.named[0].ty;
                         variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
@@ -279,6 +279,15 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                             }
                         }
                         });
+                        let variant_sample = quote! {
+                            Self::#variant_ident {#variant_field_name: <#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
+                              src.remove_value(#index as u32).expect("Must exist"),
+                            ).expect("Must match")},
+                        };
+                        variant_sample_seq.push(match variant_attributes.case {
+                            UnionDiscriminatorKind::Case(expr) => quote! {#expr => #variant_sample},
+                            UnionDiscriminatorKind::Default => quote! {_ => #variant_sample},
+                        })
                     }
                     Fields::Unnamed(fields_unnamed) if fields_unnamed.unnamed.len() == 1 => {
                         let variant_ty = &fields_unnamed.unnamed[0].ty;
@@ -299,6 +308,15 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                             }
                         }
                         });
+                        let variant_sample = quote! {
+                            Self::#variant_ident(<#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
+                              src.remove_value(#index as u32).expect("Must exist"),
+                            ).expect("Must match")),
+                        };
+                        variant_sample_seq.push(match variant_attributes.case {
+                            UnionDiscriminatorKind::Case(expr) => quote! {#expr => #variant_sample},
+                            UnionDiscriminatorKind::Default => quote! {_ => #variant_sample},
+                        })
                     }
                     Fields::Named(_) | Fields::Unnamed(_) => {
                         return Err(syn::Error::new(
@@ -337,6 +355,13 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                             }
                         }
                         });
+                        let variant_sample = quote! {
+                            Self::#variant_ident,
+                        };
+                        variant_sample_seq.push(match variant_attributes.case {
+                            UnionDiscriminatorKind::Case(expr) => quote! {#expr => #variant_sample},
+                            UnionDiscriminatorKind::Default => quote! {_ => #variant_sample},
+                        })
                     }
                 }
             }
@@ -349,9 +374,20 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                     };
             };
 
-            let create_dynamic_sample_quote = quote! {todo!()};
-            let create_sample_quote = quote! {
+            let create_dynamic_sample_quote = quote! {
                 todo!()
+            };
+
+            let create_sample_quote = quote! {
+                let disc =
+                    <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
+                        src.remove_value(0).expect("Must exist"),
+                    )
+                    .expect("Must match");
+                match disc {
+                    #(#variant_sample_seq)*
+                    _ => panic!(),
+                }
             };
             Ok((
                 get_type_quote,

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -2,7 +2,7 @@ use crate::derive::{
     attributes::{
         BitBound, Extensibility, get_enumerated_type_attributes, get_member_attributes,
         get_structure_member_attributes, get_type_declaration_attributes,
-        get_union_type_attributes,
+        get_union_type_attributes, get_union_variant_attributes,
     },
     enum_support::read_enum_variant_discriminant_mapping,
 };
@@ -215,11 +215,70 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 }
             };
 
-            let mut variant_list: Vec<TokenStream> = Vec::new();
+            let is_key = union_attributes.is_discriminator_key;
+            let mut variant_list: Vec<TokenStream> = vec![quote! {
+                 dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+                    descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+                        name: "disc",
+                        id: 0u32,
+                        r#type: <#discriminator_type as dust_dds::xtypes::binding::XTypesBinding>::TYPE_INFORMATION,
+                        default_value: None,
+                        index: 0u32,
+                        try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,
+                        label: None,
+                        is_key: #is_key,
+                        is_optional: false,
+                        is_must_understand: true,
+                        is_shared: false,
+                        is_default_label: false,
+                    }
+                }
+            }];
             let mut variant_sample_seq: Vec<TokenStream> = Vec::new();
             let mut variant_dynamic_sample_seq: Vec<TokenStream> = Vec::new();
 
-            for (variant_index, variant) in xtypes_union.variants.iter().enumerate() {}
+            for (variant_index, variant) in xtypes_union.variants.iter().enumerate() {
+                let variant_attributes = get_union_variant_attributes(variant)?;
+
+                let variant_name = variant.ident.to_string();
+                let index = variant_index + 1;
+
+                match &variant.fields {
+                    Fields::Named(fields_named) => todo!(),
+                    Fields::Unnamed(fields_unnamed) => todo!(),
+                    Fields::Unit => {
+                        variant_list.push(quote!{
+                            descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+                                name: #variant_name,
+                                id: #index as u32,
+                                r#type: dust_dds::xtypes::dynamic_type::DynamicType {
+                                    descriptor: &dust_dds::xtypes::dynamic_type::TypeDescriptor {
+                                        kind: dust_dds::xtypes::dynamic_type::TypeKind::NONE,
+                                        name: "",
+                                        base_type: None,
+                                        discriminator_type: None,
+                                        bound: None,
+                                        element_type: None,
+                                        key_element_type: None,
+                                        extensibility_kind: dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final,
+                                        is_nested: false,
+                                    },
+                                    member_list: &[],
+                                },
+                                default_value: None,
+                                index: #index as u32,
+                                try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::UseDefault,
+                                label: None,
+                                is_key: false,
+                                is_optional: true,
+                                is_must_understand: true,
+                                is_shared: false,
+                                is_default_label: false,
+                            }
+                        });
+                    }
+                }
+            }
 
             let get_type_quote = quote! {
                 const r#TYPE: dust_dds::xtypes::dynamic_type::DynamicType =

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -9,8 +9,6 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DataEnum, DeriveInput, Fields, Index, Result, spanned::Spanned};
 
-use super::attributes::UnionDiscriminatorKind;
-
 pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
     let ident = &input.ident;
     let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
@@ -243,11 +241,16 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                     }
                 }
             }];
-            let mut variant_sample_seq: Vec<TokenStream> = Vec::new();
-            let mut variant_dynamic_sample_seq: Vec<TokenStream> = Vec::new();
+            let mut has_default = false;
+            let mut variant_sample_seq = Vec::new();
+            let mut variant_dynamic_sample_seq = Vec::new();
 
             for (variant_index, variant) in xtypes_union.variants.iter().enumerate() {
                 let variant_attributes = get_union_variant_attributes(variant)?;
+
+                if !has_default && variant_attributes.is_default {
+                    has_default = true;
+                }
 
                 let variant_ident = &variant.ident;
                 let variant_name = variant_ident.to_string();
@@ -284,10 +287,17 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                               src.remove_value(#index as u32).expect("Must exist"),
                             ).expect("Must match")},
                         };
-                        variant_sample_seq.push(match variant_attributes.case {
-                            UnionDiscriminatorKind::Case(expr) => quote! {#expr => #variant_sample},
-                            UnionDiscriminatorKind::Default => quote! {_ => #variant_sample},
-                        })
+                        let expr = &variant_attributes.case;
+                        variant_sample_seq.push(if variant_attributes.is_default {
+                            quote! {_ => #variant_sample}
+                        } else {
+                            quote! {#expr => #variant_sample}
+                        });
+                        variant_dynamic_sample_seq
+                            .push(quote! {Self::#variant_ident {#variant_field_name} => {
+                                data.set_value(0, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(#expr));
+                                data.set_value(#index as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(a));
+                            }});
                     }
                     Fields::Unnamed(fields_unnamed) if fields_unnamed.unnamed.len() == 1 => {
                         let variant_ty = &fields_unnamed.unnamed[0].ty;
@@ -313,16 +323,17 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                               src.remove_value(#index as u32).expect("Must exist"),
                             ).expect("Must match")),
                         };
-                        variant_sample_seq.push(match variant_attributes.case {
-                            UnionDiscriminatorKind::Case(expr) => quote! {#expr => #variant_sample},
-                            UnionDiscriminatorKind::Default => quote! {_ => #variant_sample},
-                        })
-                    }
-                    Fields::Named(_) | Fields::Unnamed(_) => {
-                        return Err(syn::Error::new(
-                            variant.span(),
-                            "Only variants with a single field are supported",
-                        ));
+                        let expr = &variant_attributes.case;
+                        variant_sample_seq.push(if variant_attributes.is_default {
+                            quote! {_ => #variant_sample}
+                        } else {
+                            quote! {#expr => #variant_sample}
+                        });
+                        variant_dynamic_sample_seq
+                            .push(quote! {Self::#variant_ident (a) => {
+                                data.set_value(0, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(#expr));
+                                data.set_value(#index as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(a));
+                            }});
                     }
                     Fields::Unit => {
                         variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
@@ -358,12 +369,27 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                         let variant_sample = quote! {
                             Self::#variant_ident,
                         };
-                        variant_sample_seq.push(match variant_attributes.case {
-                            UnionDiscriminatorKind::Case(expr) => quote! {#expr => #variant_sample},
-                            UnionDiscriminatorKind::Default => quote! {_ => #variant_sample},
-                        })
+                        let expr = &variant_attributes.case;
+                        variant_sample_seq.push(if variant_attributes.is_default {
+                            quote! {_ => #variant_sample}
+                        } else {
+                            quote! {#expr => #variant_sample}
+                        });
+                        variant_dynamic_sample_seq.push(quote! {Self::#variant_ident => {
+                            data.set_value(0, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(#expr));
+                        },});
+                    }
+                    Fields::Named(_) | Fields::Unnamed(_) => {
+                        return Err(syn::Error::new(
+                            variant.span(),
+                            "Only variants with a single field are supported",
+                        ));
                     }
                 }
+            }
+
+            if !has_default {
+                variant_sample_seq.push(quote! {_ => panic!("Invalid discriminator"),});
             }
 
             let get_type_quote = quote! {
@@ -375,7 +401,9 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
             };
 
             let create_dynamic_sample_quote = quote! {
-                todo!()
+                match self {
+                    #(#variant_dynamic_sample_seq)*
+                }
             };
 
             let create_sample_quote = quote! {
@@ -386,7 +414,6 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                     .expect("Must match");
                 match disc {
                     #(#variant_sample_seq)*
-                    _ => panic!(),
                 }
             };
             Ok((


### PR DESCRIPTION
Add the derive code for the DDS Union represented in Rust by Enum with types in its variants.