### PR TITLE
492 dust dds gen cannot have trailing whitespace or comments after endif

### DIFF
--- a/dds_gen/src/preprocessor/mod.rs
+++ b/dds_gen/src/preprocessor/mod.rs
@@ -126,6 +126,9 @@ impl<'a> Preprocessor<'a> {
             | Rule::angle_bracketed_string
             | Rule::identifier
             | Rule::value
+            | Rule::line_comment
+            | Rule::block_comment
+            | Rule::trailing_comment
             | Rule::WHITESPACE
             | Rule::NEWLINE
             | Rule::EOI => (),

--- a/dds_gen/src/preprocessor/mod.rs
+++ b/dds_gen/src/preprocessor/mod.rs
@@ -201,4 +201,13 @@ mod tests {
 
         assert_eq!(output, expected);
     }
+
+    #[test]
+    fn preprocessor_file_with_comments() {
+        let idl_file = Path::new("src/preprocessor/test_resources/file_with_comments.idl");
+        let expected = "\nstruct SimpleStruct {\nboolean a;\nchar b;\nlong i;\n};\n\nstruct OtherStruct {\nlong i;\n};\n\nstruct SimpleStruct {\nlong i;\n};\n\n";
+        let output = Preprocessor::parse(idl_file).unwrap();
+
+        assert_eq!(output, expected);
+    }
 }

--- a/dds_gen/src/preprocessor/preprocessor_grammar.pest
+++ b/dds_gen/src/preprocessor/preprocessor_grammar.pest
@@ -1,11 +1,11 @@
 file              =  { SOI ~ line* ~ EOI }
-line              =  { (directive | other_line) ~ NEWLINE }
+line              =  { (directive ~ value? | other_line) ~ NEWLINE }
 directive         = _{ include_directive | define_directive | ifdef_directive | ifndef_directive }
 include_directive = _{ "#include" ~ include_file }
 include_file      =  { (quoted_string | angle_bracketed_string) }
 define_directive  =  { "#define" ~ identifier ~ value? }
-ifdef_directive   =  { "#ifdef" ~ identifier ~ NEWLINE ~ line* ~ "#endif" }
-ifndef_directive  =  { "#ifndef" ~ identifier ~ NEWLINE ~ line* ~ "#endif" }
+ifdef_directive   =  { "#ifdef" ~ identifier ~ value? ~ NEWLINE ~ line* ~ "#endif" }
+ifndef_directive  =  { "#ifndef" ~ identifier ~ value? ~ NEWLINE ~ line* ~ "#endif" }
 other_line        =  { !"#" ~ (!NEWLINE ~ ANY)* }
 
 quoted_string          = @{ ("\"") ~ (!"\"" ~ ANY)* ~ "\"" }

--- a/dds_gen/src/preprocessor/preprocessor_grammar.pest
+++ b/dds_gen/src/preprocessor/preprocessor_grammar.pest
@@ -1,12 +1,16 @@
 file              =  { SOI ~ line* ~ EOI }
-line              =  { (directive ~ value? | other_line) ~ NEWLINE }
+line              =  { (directive ~ trailing_comment | other_line) ~ NEWLINE }
 directive         = _{ include_directive | define_directive | ifdef_directive | ifndef_directive }
 include_directive = _{ "#include" ~ include_file }
 include_file      =  { (quoted_string | angle_bracketed_string) }
 define_directive  =  { "#define" ~ identifier ~ value? }
-ifdef_directive   =  { "#ifdef" ~ identifier ~ value? ~ NEWLINE ~ line* ~ "#endif" }
-ifndef_directive  =  { "#ifndef" ~ identifier ~ value? ~ NEWLINE ~ line* ~ "#endif" }
+ifdef_directive   =  { "#ifdef" ~ identifier ~ trailing_comment ~ NEWLINE ~ line* ~ "#endif" }
+ifndef_directive  =  { "#ifndef" ~ identifier ~ trailing_comment ~ NEWLINE ~ line* ~ "#endif" }
 other_line        =  { !"#" ~ (!NEWLINE ~ ANY)* }
+
+line_comment      = _{ "//" ~ (!NEWLINE ~ ANY)* }
+block_comment     = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
+trailing_comment  = _{ (line_comment | block_comment)? }
 
 quoted_string          = @{ ("\"") ~ (!"\"" ~ ANY)* ~ "\"" }
 angle_bracketed_string = @{ ("<") ~ (!">" ~ ANY)* ~ ">" }

--- a/dds_gen/src/preprocessor/test_resources/file_with_comments.idl
+++ b/dds_gen/src/preprocessor/test_resources/file_with_comments.idl
@@ -1,0 +1,17 @@
+#define SIMPLE_STRUCT // comment for define
+
+#ifdef SIMPLE_STRUCT // comment for ifdef
+struct SimpleStruct {
+    boolean a;
+    char b;
+    long i;
+};
+#endif // comment for endif
+
+#ifndef OTHER // comment for ifndef
+struct OtherStruct {
+    long i;
+};
+#endif // comment for endif
+
+#include "file_included.idl" // comment for include


### PR DESCRIPTION
Add support for comments after preprocessor directives. This solves issue #492 