### PR TITLE
Improve IDL gen error messages

### DIFF
--- a/dds_gen/src/generator/rust.rs
+++ b/dds_gen/src/generator/rust.rs
@@ -28,6 +28,7 @@ impl<'a> RustGenerator<'a> {
             Rule::line_comment => (),
             Rule::COMMENT => (),
             Rule::reserved_keyword => (),
+            Rule::semicolon => (),
             Rule::identifier => self.identifier(pair),
             Rule::character_literal => todo!(),
             Rule::string_literal => todo!(),
@@ -1136,5 +1137,18 @@ mod tests {
             &writer,
             "pub mod root{pub mod a{#[derive(Debug, dust_dds::infrastructure::type_support::DdsType)]\n#[dust_dds(name = \"root::a::A\")]\npub struct A {pub x:u8,pub y:u16,pub z:u32,}\n}pub mod b{#[derive(Debug, dust_dds::infrastructure::type_support::DdsType)]\n#[dust_dds(name = \"root::b::B\")]\npub enum B {X,Y,Z,}\n}}",
         );
+    }
+
+    #[test]
+    fn parse_missing_semicolon_error() {
+        let err = IdlParser::parse(
+            Rule::specification,
+            "struct SomeStruct {}
+            enum SomeEnum {}",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("expected semicolon"));
     }
 }

--- a/dds_gen/src/parser/idl_v4_grammar.pest
+++ b/dds_gen/src/parser/idl_v4_grammar.pest
@@ -105,11 +105,10 @@ reserved_keyword = {
     | ^"uint64"
 }
 
-// Identifier can not be a keyword. The optional is used instead of the negative lookahead (!)
-// because the identifier might start with a keyword as long as it has something after it.
+// Identifier cannot be a keyword. We use negative lookahead to ensure exact keywords are not matched
+// as identifiers, while still allowing identifiers that start with keywords.
 identifier = @{
-    reserved_keyword? ~ (ASCII | "_") ~ ("_" | ASCII_ALPHANUMERIC )*
-    | "_" ~ (ASCII | "_") ~ ("_" | ASCII_ALPHANUMERIC )*
+    !(reserved_keyword ~ !("_" | ASCII_ALPHANUMERIC)) ~ (ASCII_ALPHA | "_") ~ ("_" | ASCII_ALPHANUMERIC)*
 }
 
 character_literal = @{ "'" ~ (!"'" ~ (escape | ANY)) ~ "'" }
@@ -143,33 +142,34 @@ float_suffix = ${ ("f" | "F" | "d" | "D") }
 // (1)
 specification = { SOI ~ definition+ ~ EOI}
 // (2)
+semicolon = { ";" }
 definition = {
-    module_dcl ~ ";"
-    | const_dcl ~ ";"
-    | type_dcl ~ ";"
+    module_dcl ~ semicolon
+    | const_dcl ~ semicolon
+    | type_dcl ~ semicolon
     // (71)
-    | except_dcl ~ ";"
-    | interface_dcl ~ ";"
+    | except_dcl ~ semicolon
+    | interface_dcl ~ semicolon
     // (98)
-    | value_dcl ~ ";"
+    | value_dcl ~ semicolon
     // (111)
-    | type_id_dcl ~ ";"
-    | type_prefix_dcl ~ ";"
-    | import_dcl ~ ";"
+    | type_id_dcl ~ semicolon
+    | type_prefix_dcl ~ semicolon
+    | import_dcl ~ semicolon
     // (133)
-    | component_dcl ~ ";"
+    | component_dcl ~ semicolon
     // (144)
-    | home_dcl ~ ";"
+    | home_dcl ~ semicolon
     // (153)
-    | event_dcl ~ ";"
+    | event_dcl ~ semicolon
     // (171)
-    | porttype_dcl ~ ";"
-    | connector_dcl ~ ";"
+    | porttype_dcl ~ semicolon
+    | connector_dcl ~ semicolon
     // (184)
-    | template_module_dcl ~ ";"
-    | template_module_inst ~ ";"
+    | template_module_dcl ~ semicolon
+    | template_module_inst ~ semicolon
     // (218)
-    | annotation_dcl ~ ";"
+    | annotation_dcl ~ semicolon
 
 }
 // (3)


### PR DESCRIPTION
Add semicolon rule to make the error message more explicit when ; is missing. This fixes issue #493 