### PR TITLE
IDL-gen: Add support for enum @bit_bound

### DIFF
--- a/dds_gen/src/generator/rust.rs
+++ b/dds_gen/src/generator/rust.rs
@@ -364,7 +364,7 @@ impl<'a> RustGenerator<'a> {
     }
 
     fn enum_dcl(&mut self, pair: IdlPair) {
-        let inner_pairs = pair.into_inner();
+        let inner_pairs = pair.clone().into_inner();
         let identifier = inner_pairs
             .clone()
             .find(|p| p.as_rule() == Rule::identifier)
@@ -377,6 +377,38 @@ impl<'a> RustGenerator<'a> {
                 self.hierarchical_type_name(identifier.as_str())
             );
             self.writer.push_str(&name);
+        }
+        for annotation_appl in pair
+            .into_inner()
+            .filter(|x| x.as_rule() == Rule::annotation_appl)
+        {
+            let inner_pairs = annotation_appl.into_inner();
+
+            let scoped_name = inner_pairs
+                .clone()
+                .find(|p| p.as_rule() == Rule::scoped_name)
+                .expect("Must have a scoped name according to the grammar");
+
+            let identifier = scoped_name
+                .into_inner()
+                .next()
+                .expect("Must have an identifier according to the grammar");
+
+            if identifier.as_str() == "bit_bound" {
+                if let Some(annotation_appl_params) = inner_pairs
+                    .clone()
+                    .find(|p| p.as_rule() == Rule::annotation_appl_params)
+                {
+                    if let Some(expr) = annotation_appl_params
+                        .into_inner()
+                        .find(|p| p.as_rule() == Rule::const_expr)
+                    {
+                        self.writer.push_str("#[dust_dds(bit_bound( ");
+                        self.writer.push_str(expr.as_str());
+                        self.writer.push_str("))]");
+                    }
+                }
+            }
         }
         self.writer.push_str("pub enum ");
         self.generate(identifier);

--- a/dds_gen/src/parser/idl_v4_grammar.pest
+++ b/dds_gen/src/parser/idl_v4_grammar.pest
@@ -441,7 +441,7 @@ element_spec = { type_spec ~ declarator }
 // (56)
 union_forward_dcl = { "union" ~ identifier }
 // (57)
-enum_dcl = { "enum" ~ identifier ~ "{" ~ enumerator ~ ("," ~ enumerator)* ~ "}" }
+enum_dcl = { annotation_appl* ~ "enum" ~ identifier ~ "{" ~ enumerator ~ ("," ~ enumerator)* ~ "}" }
 // (58)
 enumerator = { annotation_appl* ~ identifier }
 // (59)

--- a/dds_gen/tests/enums.idl
+++ b/dds_gen/tests/enums.idl
@@ -1,5 +1,6 @@
 enum Suits { Spades, Hearts, Diamonds, Clubs };
 
+@bit_bound(16)
 enum HttpStatusCode {
     @value(100)
     CONTINUE,

--- a/dds_gen/tests/enums.rs
+++ b/dds_gen/tests/enums.rs
@@ -17,6 +17,7 @@ fn enums() {
             }
 
             #[derive(Debug, dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(bit_bound(16))]
             pub enum HttpStatusCode {
                 CONTINUE = 100,
                 OK = 200,


### PR DESCRIPTION
Add support for @bit_bound on enum declarations in IDL. This fixes #418.