### PR TITLE
562 parsing error when key annotation is set on a field whose type is a scoped typedef

### DIFF
--- a/dds_gen/src/parser/idl_v4_grammar.pest
+++ b/dds_gen/src/parser/idl_v4_grammar.pest
@@ -175,7 +175,7 @@ definition = {
 // (3)
 module_dcl = { "module" ~ identifier ~ "{" ~ definition+ ~ "}" }
 // (4)
-scoped_name = { "::"? ~ identifier ~ ("::" ~ identifier)* }
+scoped_name = ${ "::"? ~ identifier ~ ("::" ~ identifier)* }
 // (5)
 const_dcl = { "const" ~ const_type ~ identifier ~ "=" ~ const_expr }
 // (6)

--- a/dds_gen/tests/module_generation.idl
+++ b/dds_gen/tests/module_generation.idl
@@ -34,10 +34,12 @@ struct Point
 
 module foo {
     typedef long Bar;
+    typedef long Car;
 
     module frob {
         struct Baz {
-            ::foo::Bar qux;
+            @key ::foo::Bar qux;
+            ::foo::Car qix;
         };
     };
 };

--- a/dds_gen/tests/module_generation.rs
+++ b/dds_gen/tests/module_generation.rs
@@ -45,11 +45,14 @@ fn module_generation() {
 
         pub mod foo{
             pub type Bar=i32;
+            pub type Car=i32;
             pub mod frob{
                 #[derive(Debug, dust_dds::infrastructure::type_support::DdsType)]
                 #[dust_dds(name = "foo::frob::Baz")]
                 pub struct Baz {
+                    #[dust_dds(key)]
                     pub qux: super::super::foo::Bar,
+                    pub qix: super::super::foo::Car,
                 }
             }
         }


### PR DESCRIPTION
Fix the parsing error by making the scoped_name a compound atomic. This prevents the @key ...text to be considered a scoped_name by not allowing white spaces to be part of it.