### PR TITLE
544 Remove clone from oneshot sender

### DIFF
--- a/dds/src/dcps/channels/mod.rs
+++ b/dds/src/dcps/channels/mod.rs
@@ -1,2 +1,3 @@
 pub mod mpsc;
 pub mod oneshot;
+pub mod notification;

--- a/dds/src/dcps/channels/mod.rs
+++ b/dds/src/dcps/channels/mod.rs
@@ -1,3 +1,3 @@
 pub mod mpsc;
-pub mod oneshot;
 pub mod notification;
+pub mod oneshot;

--- a/dds/src/dcps/channels/notification.rs
+++ b/dds/src/dcps/channels/notification.rs
@@ -1,0 +1,97 @@
+use core::{
+    cell::RefCell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+};
+
+use alloc::sync::Arc;
+use critical_section::Mutex;
+
+use crate::infrastructure::error::DdsError;
+
+pub fn notification() -> (NotificationSender, NotificationReceiver) {
+    let inner = Arc::new(Mutex::new(RefCell::new(NotificationInner {
+        notified: false,
+        waker: None,
+        sender_count: 1,
+    })));
+    (
+        NotificationSender {
+            inner: inner.clone(),
+        },
+        NotificationReceiver { inner },
+    )
+}
+
+struct NotificationInner {
+    notified: bool,
+    waker: Option<Waker>,
+    sender_count: usize,
+}
+
+pub struct NotificationSender {
+    inner: Arc<Mutex<RefCell<NotificationInner>>>,
+}
+
+impl Clone for NotificationSender {
+    fn clone(&self) -> Self {
+        critical_section::with(|cs| {
+            self.inner.borrow(cs).borrow_mut().sender_count += 1;
+        });
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl NotificationSender {
+    pub fn notify(&self) {
+        critical_section::with(|cs| {
+            let mut inner_lock = self.inner.borrow(cs).borrow_mut();
+            inner_lock.notified = true;
+            if let Some(w) = inner_lock.waker.take() {
+                w.wake()
+            }
+        })
+    }
+}
+
+impl Drop for NotificationSender {
+    fn drop(&mut self) {
+        critical_section::with(|cs| {
+            let mut inner_lock = self.inner.borrow(cs).borrow_mut();
+            inner_lock.sender_count -= 1;
+            if inner_lock.sender_count == 0 {
+                // When the last sender is dropped wake the waiting task
+                // so that it can finish knowing it won't get any message
+                if let Some(w) = inner_lock.waker.take() {
+                    w.wake()
+                }
+            }
+        })
+    }
+}
+
+pub struct NotificationReceiver {
+    inner: Arc<Mutex<RefCell<NotificationInner>>>,
+}
+
+impl Future for NotificationReceiver {
+    type Output = Result<(), DdsError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        critical_section::with(|cs| {
+            let mut inner_lock = self.inner.borrow(cs).borrow_mut();
+            if inner_lock.notified {
+                inner_lock.notified = false;
+                Poll::Ready(Ok(()))
+            } else if inner_lock.sender_count == 0 {
+                Poll::Ready(Err(DdsError::AlreadyDeleted))
+            } else {
+                inner_lock.waker.replace(cx.waker().clone());
+                Poll::Pending
+            }
+        })
+    }
+}

--- a/dds/src/dcps/channels/oneshot.rs
+++ b/dds/src/dcps/channels/oneshot.rs
@@ -41,7 +41,6 @@ struct OneshotInner<T> {
     has_sender: bool,
 }
 
-#[derive(Clone)]
 pub struct OneshotSender<T> {
     inner: Arc<Mutex<RefCell<OneshotInner<T>>>>,
 }

--- a/dds/src/dcps/dcps_domain_participant/status_condition_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/status_condition_methods.rs
@@ -1,7 +1,7 @@
 use crate::{
     dcps::{
-        channels::oneshot::OneshotSender, dcps_participant_factory::DcpsParticipantFactory,
-        status_condition::StatusConditionEntity,
+        channels::notification::NotificationSender,
+        dcps_participant_factory::DcpsParticipantFactory, status_condition::StatusConditionEntity,
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -290,7 +290,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
     pub fn register_notification(
         &mut self,
         entity: StatusConditionEntity,
-        notification_sender: OneshotSender<()>,
+        notification_sender: NotificationSender,
     ) -> DdsResult<()> {
         match entity {
             StatusConditionEntity::Subscriber {

--- a/dds/src/dcps/dcps_mail.rs
+++ b/dds/src/dcps/dcps_mail.rs
@@ -7,7 +7,7 @@ use crate::{
         TopicBuiltinTopicData,
     },
     dcps::{
-        channels::oneshot::OneshotSender,
+        channels::{notification::NotificationSender, oneshot::OneshotSender},
         listeners::{
             data_reader_listener::DcpsDataReaderListener,
             data_writer_listener::DcpsDataWriterListener,
@@ -576,7 +576,7 @@ pub enum StatusConditionMail {
     },
     RegisterNotification {
         entity: StatusConditionEntity,
-        notification_sender: OneshotSender<()>,
+        notification_sender: NotificationSender,
         reply_sender: OneshotSender<DdsResult<()>>,
     },
 }

--- a/dds/src/dcps/status_condition.rs
+++ b/dds/src/dcps/status_condition.rs
@@ -1,5 +1,5 @@
 use crate::{
-    dcps::channels::oneshot::OneshotSender,
+    dcps::channels::notification::NotificationSender,
     infrastructure::{instance::InstanceHandle, status::StatusKind},
 };
 use alloc::{vec, vec::Vec};
@@ -29,7 +29,7 @@ pub enum StatusConditionEntity {
 pub struct DcpsStatusCondition {
     enabled_statuses: Vec<StatusKind>,
     status_changes: Vec<StatusKind>,
-    registered_notifications: Vec<OneshotSender<()>>,
+    registered_notifications: Vec<NotificationSender>,
 }
 
 impl Default for DcpsStatusCondition {
@@ -62,7 +62,7 @@ impl DcpsStatusCondition {
         if self.get_trigger_value() {
             for w in self.registered_notifications.drain(..) {
                 // Do not care if there is no channel waiting for response
-                w.send(());
+                w.notify();
             }
         }
     }
@@ -88,9 +88,9 @@ impl DcpsStatusCondition {
         false
     }
 
-    pub fn register_notification(&mut self, notification_sender: OneshotSender<()>) {
+    pub fn register_notification(&mut self, notification_sender: NotificationSender) {
         if self.get_trigger_value() {
-            notification_sender.send(());
+            notification_sender.notify();
         } else {
             self.registered_notifications.push(notification_sender);
         }

--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -1,9 +1,6 @@
 use crate::{
     dcps::{
-        channels::{
-            notification::NotificationSender,
-            oneshot::{OneshotSender, oneshot},
-        },
+        channels::{notification::NotificationSender, oneshot::oneshot},
         dcps_mail::{DcpsMail, StatusConditionMail},
         status_condition::StatusConditionEntity,
     },

--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -1,6 +1,9 @@
 use crate::{
     dcps::{
-        channels::oneshot::{OneshotSender, oneshot},
+        channels::{
+            notification::NotificationSender,
+            oneshot::{OneshotSender, oneshot},
+        },
         dcps_mail::{DcpsMail, StatusConditionMail},
         status_condition::StatusConditionEntity,
     },
@@ -34,7 +37,7 @@ impl StatusConditionAsync {
 
     pub(crate) async fn register_notification(
         &self,
-        notification_sender: OneshotSender<()>,
+        notification_sender: NotificationSender,
     ) -> DdsResult<()> {
         let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender

--- a/dds/src/dds_async/wait_set.rs
+++ b/dds/src/dds_async/wait_set.rs
@@ -1,6 +1,6 @@
 use super::condition::StatusConditionAsync;
 use crate::{
-    dcps::channels::oneshot::oneshot,
+    dcps::channels::notification::notification,
     infrastructure::error::{DdsError, DdsResult},
 };
 use alloc::{string::String, vec::Vec};
@@ -64,7 +64,7 @@ impl WaitSetAsync {
         }
 
         // No status condition is yet triggered so now we have to wait for at least one status condition to trigger
-        let (notification_sender, notification_receiver) = oneshot();
+        let (notification_sender, notification_receiver) = notification();
 
         for condition in &self.conditions {
             match condition {


### PR DESCRIPTION
Remove the Clone trait from the oneshot send and instead create a Notification sender and receiver which is used to for the purpose of notifying waiting objects. This fixes #544 and makes the semantics of the two objects cleaner.