### PR TITLE
Refactor: Modify write method to remove built-in data representation

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -12,7 +12,6 @@ use crate::{
         TopicBuiltinTopicData,
     },
     dcps::{
-        channels::oneshot::oneshot,
         data_representation_builtin_endpoints::{
             discovered_reader_data::{DiscoveredReaderData, ReaderProxy},
             discovered_topic_data::DiscoveredTopicData,
@@ -377,26 +376,32 @@ impl DcpsDomainParticipant {
             dds_subscription_data,
             reader_proxy,
         };
-        let data_writer_handle = InstanceHandle::new(
-            Guid::new(
-                Guid::from(*self.domain_participant.instance_handle.as_ref()).prefix(),
-                ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_ANNOUNCER,
-            )
-            .into(),
-        );
-        let timestamp = runtime.clock().now();
-        let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
-        let (reply_sender, _) = oneshot();
+
         let mut data = DynamicDataFactory::create_data(DiscoveredReaderData::TYPE);
         discovered_reader_data.create_dynamic_sample(&mut data);
-        self.write_w_timestamp(
-            &publisher_handle,
-            &data_writer_handle,
-            &data,
-            timestamp,
-            runtime,
-            reply_sender,
-        );
+
+        if let Some(dw) = self
+            .domain_participant
+            .builtin_publisher
+            .data_writer_list
+            .iter_mut()
+            .find(|x| x.topic_name == DCPS_SUBSCRIPTION)
+        {
+            let now = runtime.clock().now();
+            let sample_instance_handle = data_reader.transport_reader.guid().into();
+            let serialized_data = serialize_rtps(&data).expect("Must succeed");
+            let sample_timestamp = now;
+            let message_writer = self.transport.message_writer.as_ref();
+            dw.write_w_timestamp(
+                sample_instance_handle,
+                serialized_data,
+                sample_timestamp,
+                now,
+                message_writer,
+                runtime,
+            )
+            .ok();
+        }
     }
 
     #[tracing::instrument(skip(self, data_reader, runtime))]
@@ -465,26 +470,31 @@ impl DcpsDomainParticipant {
             },
         };
 
-        let data_writer_handle = InstanceHandle::new(
-            Guid::new(
-                Guid::from(*self.domain_participant.instance_handle.as_ref()).prefix(),
-                ENTITYID_SEDP_BUILTIN_TOPICS_ANNOUNCER,
-            )
-            .into(),
-        );
-        let timestamp = runtime.clock().now();
-        let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
-        let (reply_sender, _) = oneshot();
         let mut data = DynamicDataFactory::create_data(DiscoveredTopicData::TYPE);
         discovered_topic_data.create_dynamic_sample(&mut data);
-        self.write_w_timestamp(
-            &publisher_handle,
-            &data_writer_handle,
-            &data,
-            timestamp,
-            runtime,
-            reply_sender,
-        );
+
+        if let Some(dw) = self
+            .domain_participant
+            .builtin_publisher
+            .data_writer_list
+            .iter_mut()
+            .find(|x| x.topic_name == DCPS_TOPIC)
+        {
+            let sample_instance_handle = topic.instance_handle;
+            let serialized_data = serialize_rtps(&data).expect("Must succeed");
+            let now = runtime.clock().now();
+            let sample_timestamp = now;
+            let message_writer = self.transport.message_writer.as_ref();
+            dw.write_w_timestamp(
+                sample_instance_handle,
+                serialized_data,
+                sample_timestamp,
+                now,
+                message_writer,
+                runtime,
+            )
+            .ok();
+        }
     }
 
     #[tracing::instrument(skip(self))]

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -28,8 +28,8 @@ use crate::{
             ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR,
             ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_ANNOUNCER,
             ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR, ENTITYID_SEDP_BUILTIN_TOPICS_ANNOUNCER,
-            ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR, ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER,
-            RtpsReaderKind, RtpsWriterKind, TopicDescriptionKind,
+            ENTITYID_SEDP_BUILTIN_TOPICS_DETECTOR, RtpsReaderKind, RtpsWriterKind,
+            TopicDescriptionKind,
         },
         listeners::domain_participant_listener::ListenerMail,
     },
@@ -60,6 +60,7 @@ use crate::{
     xtypes::{
         deserializer::{deserialize_builtin, deserialize_top_level_type},
         dynamic_type::DynamicDataFactory,
+        serializer::serialize_rtps,
     },
 };
 
@@ -110,26 +111,31 @@ impl DcpsDomainParticipant {
                     .map(|p| InstanceHandle::new(p.dds_participant_data.key().value))
                     .collect(),
             };
-            let data_writer_handle = InstanceHandle::new(
-                Guid::new(
-                    Guid::from(*self.domain_participant.instance_handle.as_ref()).prefix(),
-                    ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER,
-                )
-                .into(),
-            );
-            let timestamp = runtime.clock().now();
-            let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
-            let (reply_sender, _) = oneshot();
             let mut data = DynamicDataFactory::create_data(SpdpDiscoveredParticipantData::TYPE);
             spdp_discovered_participant_data.create_dynamic_sample(&mut data);
-            self.write_w_timestamp(
-                &publisher_handle,
-                &data_writer_handle,
-                &data,
-                timestamp,
-                runtime,
-                reply_sender,
-            );
+
+            if let Some(w) = self
+                .domain_participant
+                .builtin_publisher
+                .data_writer_list
+                .iter_mut()
+                .find(|x| x.topic_name == DCPS_PARTICIPANT)
+            {
+                let timestamp = runtime.clock().now();
+                let sample_instance_handle = self.domain_participant.instance_handle;
+                let serialized_data = serialize_rtps(&data).expect("Must succeed");
+                let sample_timestamp = timestamp;
+                let now = timestamp;
+                w.write_w_timestamp(
+                    sample_instance_handle,
+                    serialized_data,
+                    sample_timestamp,
+                    now,
+                    self.transport.message_writer.as_ref(),
+                    runtime,
+                )
+                .ok();
+            }
         }
     }
 
@@ -232,26 +238,31 @@ impl DcpsDomainParticipant {
             dds_publication_data,
             writer_proxy,
         };
-        let data_writer_handle = InstanceHandle::new(
-            Guid::new(
-                Guid::from(*self.domain_participant.instance_handle.as_ref()).prefix(),
-                ENTITYID_SEDP_BUILTIN_PUBLICATIONS_ANNOUNCER,
-            )
-            .into(),
-        );
-        let timestamp = runtime.clock().now();
-        let publisher_handle = self.domain_participant.builtin_publisher.instance_handle;
-        let (reply_sender, _) = oneshot();
+
         let mut data = DynamicDataFactory::create_data(DiscoveredWriterData::TYPE);
         discovered_writer_data.create_dynamic_sample(&mut data);
-        self.write_w_timestamp(
-            &publisher_handle,
-            &data_writer_handle,
-            &data,
-            timestamp,
-            runtime,
-            reply_sender,
-        );
+        if let Some(dw) = self
+            .domain_participant
+            .builtin_publisher
+            .data_writer_list
+            .iter_mut()
+            .find(|x| x.topic_name == DCPS_PUBLICATION)
+        {
+            let now = runtime.clock().now();
+            let sample_instance_handle = data_writer.transport_writer.guid().into();
+            let serialized_data = serialize_rtps(&data).expect("Must succeed");
+            let sample_timestamp = now;
+            let message_writer = self.transport.message_writer.as_ref();
+            dw.write_w_timestamp(
+                sample_instance_handle,
+                serialized_data,
+                sample_timestamp,
+                now,
+                message_writer,
+                runtime,
+            )
+            .ok();
+        }
     }
 
     #[tracing::instrument(skip(self, data_writer, runtime))]

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -43,15 +43,14 @@ use crate::{
             TopicQos,
         },
         qos_policy::{
-            BUILT_IN_DATA_REPRESENTATION, DataRepresentationQosPolicy, DeadlineQosPolicy,
-            DestinationOrderQosPolicy, DestinationOrderQosPolicyKind, DurabilityQosPolicy,
-            DurabilityQosPolicyKind, HistoryQosPolicy, HistoryQosPolicyKind,
-            LatencyBudgetQosPolicy, Length, LifespanQosPolicy, LivelinessQosPolicy,
-            OwnershipQosPolicy, OwnershipQosPolicyKind, OwnershipStrengthQosPolicy, QosPolicyId,
-            ReaderDataLifecycleQosPolicy, ReliabilityQosPolicy, ReliabilityQosPolicyKind,
-            ResourceLimitsQosPolicy, TimeBasedFilterQosPolicy, TransportPriorityQosPolicy,
-            UserDataQosPolicy, WriterDataLifecycleQosPolicy, XCDR_DATA_REPRESENTATION,
-            XCDR2_DATA_REPRESENTATION,
+            DataRepresentationQosPolicy, DeadlineQosPolicy, DestinationOrderQosPolicy,
+            DestinationOrderQosPolicyKind, DurabilityQosPolicy, DurabilityQosPolicyKind,
+            HistoryQosPolicy, HistoryQosPolicyKind, LatencyBudgetQosPolicy, Length,
+            LifespanQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy, OwnershipQosPolicyKind,
+            OwnershipStrengthQosPolicy, QosPolicyId, ReaderDataLifecycleQosPolicy,
+            ReliabilityQosPolicy, ReliabilityQosPolicyKind, ResourceLimitsQosPolicy,
+            TimeBasedFilterQosPolicy, TransportPriorityQosPolicy, UserDataQosPolicy,
+            WriterDataLifecycleQosPolicy, XCDR_DATA_REPRESENTATION, XCDR2_DATA_REPRESENTATION,
         },
         sample_info::{InstanceStateKind, SampleInfo, SampleStateKind, ViewStateKind},
         status::{
@@ -80,17 +79,13 @@ use crate::{
     xtypes::{
         deserializer::{deserialize_key_only, deserialize_top_level_type},
         dynamic_type::{DynamicData, DynamicDataFactory, DynamicType},
-        serializer::{
-            serialize_cdr1_be, serialize_cdr1_le, serialize_cdr2_be, serialize_cdr2_le,
-            serialize_rtps,
-        },
+        serializer::{serialize_cdr1_be, serialize_cdr1_le, serialize_cdr2_be, serialize_cdr2_le},
     },
 };
 use alloc::{
     boxed::Box,
     collections::{BTreeSet, VecDeque},
     string::{String, ToString},
-    vec,
     vec::Vec,
 };
 use core::{
@@ -208,9 +203,7 @@ fn spdp_writer_qos() -> DataWriterQos {
             kind: ReliabilityQosPolicyKind::BestEffort,
             max_blocking_time: DurationKind::Finite(Duration::new(0, 0)),
         },
-        representation: DataRepresentationQosPolicy {
-            value: vec![BUILT_IN_DATA_REPRESENTATION],
-        },
+        representation: DataRepresentationQosPolicy::const_default(),
         ..Default::default()
     }
 }
@@ -227,9 +220,7 @@ fn sedp_data_writer_qos() -> DataWriterQos {
             kind: ReliabilityQosPolicyKind::Reliable,
             max_blocking_time: DurationKind::Finite(Duration::new(0, 0)),
         },
-        representation: DataRepresentationQosPolicy {
-            value: vec![BUILT_IN_DATA_REPRESENTATION],
-        },
+        representation: DataRepresentationQosPolicy::const_default(),
         ..Default::default()
     }
 }
@@ -2765,8 +2756,6 @@ fn serialize(
             } else {
                 serialize_cdr2_le(dynamic_data)
             }
-        } else if representation.value[0] == BUILT_IN_DATA_REPRESENTATION {
-            serialize_rtps(dynamic_data)
         } else {
             panic!("Invalid data representation")
         }?,

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -46,8 +46,8 @@ use crate::{
             BUILT_IN_DATA_REPRESENTATION, DataRepresentationQosPolicy, DeadlineQosPolicy,
             DestinationOrderQosPolicy, DestinationOrderQosPolicyKind, DurabilityQosPolicy,
             DurabilityQosPolicyKind, HistoryQosPolicy, HistoryQosPolicyKind,
-            LatencyBudgetQosPolicy, LifespanQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy,
-            OwnershipQosPolicyKind, OwnershipStrengthQosPolicy, QosPolicyId,
+            LatencyBudgetQosPolicy, Length, LifespanQosPolicy, LivelinessQosPolicy,
+            OwnershipQosPolicy, OwnershipQosPolicyKind, OwnershipStrengthQosPolicy, QosPolicyId,
             ReaderDataLifecycleQosPolicy, ReliabilityQosPolicy, ReliabilityQosPolicyKind,
             ResourceLimitsQosPolicy, TimeBasedFilterQosPolicy, TransportPriorityQosPolicy,
             UserDataQosPolicy, WriterDataLifecycleQosPolicy, XCDR_DATA_REPRESENTATION,
@@ -1509,6 +1509,132 @@ impl DataWriterEntity {
             acknowledgement_notification: None,
             wait_for_acknowledgments_notification: Vec::new(),
         }
+    }
+
+    fn write_w_timestamp(
+        &mut self,
+        sample_instance_handle: InstanceHandle,
+        serialized_data: Vec<u8>,
+        sample_timestamp: Time,
+        now: Time,
+        message_writer: &(impl WriteMessage + ?Sized),
+        runtime: &impl DdsRuntime,
+    ) -> DdsResult<()> {
+        if !self
+            .registered_instance_list
+            .contains(&sample_instance_handle)
+        {
+            if self.registered_instance_list.len() < self.qos.resource_limits.max_instances {
+                self.registered_instance_list.push(sample_instance_handle);
+            } else {
+                return Err(DdsError::OutOfResources);
+            }
+        }
+
+        if let Length::Limited(max_instances) = self.qos.resource_limits.max_instances {
+            if !self
+                .instance_samples
+                .iter()
+                .any(|x| x.instance == sample_instance_handle)
+                && self.instance_samples.len() == max_instances as usize
+            {
+                return Err(DdsError::OutOfResources);
+            }
+        }
+
+        if let Length::Limited(max_samples_per_instance) =
+            self.qos.resource_limits.max_samples_per_instance
+        {
+            // If the history Qos guarantess that the number of samples
+            // is below the limit there is no need to check
+            match self.qos.history.kind {
+                HistoryQosPolicyKind::KeepLast(depth)
+                    if depth as i32 <= max_samples_per_instance => {}
+                _ => {
+                    if let Some(s) = self
+                        .instance_samples
+                        .iter()
+                        .find(|x| x.instance == sample_instance_handle)
+                    {
+                        // Only Alive changes count towards the resource limits
+                        if s.samples.len() >= max_samples_per_instance as usize {
+                            return Err(DdsError::OutOfResources);
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Length::Limited(max_samples) = self.qos.resource_limits.max_samples {
+            let total_samples = self
+                .instance_samples
+                .iter()
+                .fold(0, |acc, x| acc + x.samples.len());
+
+            if total_samples >= max_samples as usize {
+                return Err(DdsError::OutOfResources);
+            }
+        }
+
+        self.last_change_sequence_number += 1;
+        let change = CacheChange {
+            kind: ChangeKind::Alive,
+            writer_guid: self.transport_writer.guid(),
+            sequence_number: self.last_change_sequence_number,
+            source_timestamp: Some(sample_timestamp.into()),
+            instance_handle: Some(sample_instance_handle.into()),
+            data_value: serialized_data.into(),
+        };
+        let seq_num = change.sequence_number;
+
+        if seq_num > self.max_seq_num.unwrap_or(0) {
+            self.max_seq_num = Some(seq_num)
+        }
+
+        match self
+            .instance_publication_time
+            .iter_mut()
+            .find(|x| x.instance == sample_instance_handle)
+        {
+            Some(x) => {
+                if x.last_write_time < sample_timestamp {
+                    x.last_write_time = sample_timestamp;
+                }
+            }
+            None => self
+                .instance_publication_time
+                .push(InstancePublicationTime {
+                    instance: sample_instance_handle,
+                    last_write_time: sample_timestamp,
+                }),
+        }
+
+        match self
+            .instance_samples
+            .iter_mut()
+            .find(|x| x.instance == sample_instance_handle)
+        {
+            Some(s) => s.samples.push_back(change.sequence_number),
+            None => {
+                let s = InstanceSamples {
+                    instance: sample_instance_handle,
+                    samples: VecDeque::from([change.sequence_number]),
+                };
+                self.instance_samples.push(s);
+            }
+        }
+
+        if let DurationKind::Finite(lifespan_duration) = self.qos.lifespan.duration {
+            let duration_until_expired = sample_timestamp - now + lifespan_duration;
+            if duration_until_expired <= Duration::new(0, 0) {
+                return Ok(());
+            }
+        }
+
+        self.transport_writer
+            .add_change(change, message_writer, runtime);
+
+        Ok(())
     }
 
     fn dispose_w_timestamp(

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -1,13 +1,10 @@
-use alloc::{collections::VecDeque, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 use crate::{
     builtin_topics::SubscriptionBuiltinTopicData,
     dcps::{
         channels::oneshot::{OneshotSender, oneshot},
-        dcps_domain_participant::{
-            DcpsDomainParticipant, InstancePublicationTime, InstanceSamples, RtpsWriterKind,
-            serialize,
-        },
+        dcps_domain_participant::{DcpsDomainParticipant, RtpsWriterKind, serialize},
         dcps_mail::{DcpsMail, EventServiceMail, MessageServiceMail, WriterServiceMail},
         listeners::data_writer_listener::DcpsDataWriterListener,
         status_mask::StatusMask,
@@ -17,12 +14,11 @@ use crate::{
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{DataWriterQos, QosKind},
-        qos_policy::{HistoryQosPolicyKind, Length, ReliabilityQosPolicyKind},
+        qos_policy::{HistoryQosPolicyKind, ReliabilityQosPolicyKind},
         status::{OfferedDeadlineMissedStatus, PublicationMatchedStatus, StatusKind},
         time::{Duration, DurationKind, Time},
     },
     runtime::{Clock, DdsRuntime, Either, Spawner, Timer, select_future},
-    transport::types::{CacheChange, ChangeKind},
     xtypes::dynamic_type::DynamicData,
 };
 
@@ -278,80 +274,18 @@ impl DcpsDomainParticipant {
             return;
         }
 
-        let instance_handle = match get_instance_handle_from_dynamic_data(dynamic_data.clone()) {
-            Ok(h) => h,
-            Err(e) => {
-                reply_sender.send(Err(e.into()));
-                return;
-            }
-        };
-
-        if !data_writer
-            .registered_instance_list
-            .contains(&instance_handle)
-        {
-            if data_writer.registered_instance_list.len()
-                < data_writer.qos.resource_limits.max_instances
-            {
-                data_writer.registered_instance_list.push(instance_handle);
-            } else {
-                reply_sender.send(Err(DdsError::OutOfResources));
-                return;
-            }
-        }
-
-        if let Length::Limited(max_instances) = data_writer.qos.resource_limits.max_instances {
-            if !data_writer
-                .instance_samples
-                .iter()
-                .any(|x| x.instance == instance_handle)
-                && data_writer.instance_samples.len() == max_instances as usize
-            {
-                reply_sender.send(Err(DdsError::OutOfResources));
-                return;
-            }
-        }
-
-        if let Length::Limited(max_samples_per_instance) =
-            data_writer.qos.resource_limits.max_samples_per_instance
-        {
-            // If the history Qos guarantess that the number of samples
-            // is below the limit there is no need to check
-            match data_writer.qos.history.kind {
-                HistoryQosPolicyKind::KeepLast(depth)
-                    if depth as i32 <= max_samples_per_instance => {}
-                _ => {
-                    if let Some(s) = data_writer
-                        .instance_samples
-                        .iter()
-                        .find(|x| x.instance == instance_handle)
-                    {
-                        // Only Alive changes count towards the resource limits
-                        if s.samples.len() >= max_samples_per_instance as usize {
-                            reply_sender.send(Err(DdsError::OutOfResources));
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-
-        if let Length::Limited(max_samples) = data_writer.qos.resource_limits.max_samples {
-            let total_samples = data_writer
-                .instance_samples
-                .iter()
-                .fold(0, |acc, x| acc + x.samples.len());
-
-            if total_samples >= max_samples as usize {
-                reply_sender.send(Err(DdsError::OutOfResources));
-                return;
-            }
-        }
-
         let serialized_data = match serialize(dynamic_data, &data_writer.qos.representation) {
             Ok(s) => s,
             Err(e) => {
                 reply_sender.send(Err(e));
+                return;
+            }
+        };
+
+        let instance_handle = match get_instance_handle_from_dynamic_data(dynamic_data.clone()) {
+            Ok(h) => h,
+            Err(e) => {
+                reply_sender.send(Err(e.into()));
                 return;
             }
         };
@@ -446,52 +380,17 @@ impl DcpsDomainParticipant {
             }
         }
 
-        data_writer.last_change_sequence_number += 1;
-        let change = CacheChange {
-            kind: ChangeKind::Alive,
-            writer_guid: data_writer.transport_writer.guid(),
-            sequence_number: data_writer.last_change_sequence_number,
-            source_timestamp: Some(timestamp.into()),
-            instance_handle: Some(instance_handle.into()),
-            data_value: serialized_data.into(),
-        };
-        let seq_num = change.sequence_number;
-
-        if seq_num > data_writer.max_seq_num.unwrap_or(0) {
-            data_writer.max_seq_num = Some(seq_num)
-        }
-
-        match data_writer
-            .instance_publication_time
-            .iter_mut()
-            .find(|x| x.instance == instance_handle)
-        {
-            Some(x) => {
-                if x.last_write_time < timestamp {
-                    x.last_write_time = timestamp;
-                }
-            }
-            None => data_writer
-                .instance_publication_time
-                .push(InstancePublicationTime {
-                    instance: instance_handle,
-                    last_write_time: timestamp,
-                }),
-        }
-
-        match data_writer
-            .instance_samples
-            .iter_mut()
-            .find(|x| x.instance == instance_handle)
-        {
-            Some(s) => s.samples.push_back(change.sequence_number),
-            None => {
-                let s = InstanceSamples {
-                    instance: instance_handle,
-                    samples: VecDeque::from([change.sequence_number]),
-                };
-                data_writer.instance_samples.push(s);
-            }
+        let write_result = data_writer.write_w_timestamp(
+            instance_handle,
+            serialized_data,
+            timestamp,
+            now,
+            self.transport.message_writer.as_ref(),
+            runtime,
+        );
+        if write_result.is_err() {
+            reply_sender.send(write_result);
+            return;
         }
 
         let dcps_sender_clone = self.dcps_sender;
@@ -540,12 +439,6 @@ impl DcpsDomainParticipant {
                     .await;
             });
         }
-
-        data_writer.transport_writer.add_change(
-            change,
-            self.transport.message_writer.as_ref(),
-            runtime,
-        );
 
         reply_sender.send(Ok(()));
     }

--- a/dds/src/dcps/infrastructure/qos_policy.rs
+++ b/dds/src/dcps/infrastructure/qos_policy.rs
@@ -1410,8 +1410,7 @@ pub const XCDR_DATA_REPRESENTATION: DataRepresentationId = 0;
 pub const XML_DATA_REPRESENTATION: DataRepresentationId = 1;
 /// XCDR2 data representation
 pub const XCDR2_DATA_REPRESENTATION: DataRepresentationId = 2;
-/// Built-in topic data representation
-pub(crate) const BUILT_IN_DATA_REPRESENTATION: DataRepresentationId = 9999;
+
 type DataRepresentationIdSeq = Vec<DataRepresentationId>;
 
 /// This policy is a DDS-XTypes extension and represents the standard data Representations available.


### PR DESCRIPTION
This PR modifies the write method to allow specializing the built-in participant to use their own serialization method. This allows us to remove the self-made builtin data representation. The follow-up step would be to remove the specialized RTPS serializer which is not related to XTypes.