### PR TITLE
357 Detect and remove stale participants

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -44,7 +44,7 @@ use crate::{
             TransportPriorityQosPolicy, XCDR_DATA_REPRESENTATION,
         },
         status::StatusKind,
-        time::Duration,
+        time::{Duration, Time},
         type_support::TypeSupport,
     },
     rtps::types::{PROTOCOLVERSION, VENDOR_ID_S2E},
@@ -166,6 +166,23 @@ impl DcpsDomainParticipant {
                 )
                 .ok();
             }
+        }
+    }
+
+    pub fn remove_stale_participants(&mut self, now: Time) {
+        while let Some(handle) = self
+            .domain_participant
+            .discovered_participant_list
+            .iter()
+            .find_map(|x| {
+                if now - x.reception_timestamp > x.lease_duration {
+                    Some(InstanceHandle::new(x.dds_participant_data.key.value))
+                } else {
+                    None
+                }
+            })
+        {
+            self.remove_discovered_participant(&handle);
         }
     }
 
@@ -1789,6 +1806,7 @@ impl DcpsDomainParticipant {
                 default_multicast_locator_list: discovered_participant_data
                     .participant_proxy
                     .default_multicast_locator_list,
+                lease_duration: discovered_participant_data.lease_duration.into(),
                 reception_timestamp: runtime.clock().now(),
             };
             match self

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -24,7 +24,7 @@ use crate::{
         },
         dcps_domain_participant::{
             BuiltInKeyHolder, DataReaderEntity, DataWriterEntity, DcpsDomainParticipant,
-            ENTITYID_SEDP_BUILTIN_PUBLICATIONS_ANNOUNCER,
+            DiscoveredParticipantInfo, ENTITYID_SEDP_BUILTIN_PUBLICATIONS_ANNOUNCER,
             ENTITYID_SEDP_BUILTIN_PUBLICATIONS_DETECTOR,
             ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_ANNOUNCER,
             ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_DETECTOR, ENTITYID_SEDP_BUILTIN_TOPICS_ANNOUNCER,
@@ -488,13 +488,13 @@ impl DcpsDomainParticipant {
             .discovered_participant_list
             .iter()
             .find(|p| {
-                p.participant_proxy.guid_prefix
+                p.guid_prefix
                     == discovered_reader_data
                         .reader_proxy
                         .remote_reader_guid
                         .prefix()
             }) {
-            p.participant_proxy.default_unicast_locator_list.clone()
+            p.default_unicast_locator_list.clone()
         } else {
             vec![]
         };
@@ -503,13 +503,13 @@ impl DcpsDomainParticipant {
             .discovered_participant_list
             .iter()
             .find(|p| {
-                p.participant_proxy.guid_prefix
+                p.guid_prefix
                     == discovered_reader_data
                         .reader_proxy
                         .remote_reader_guid
                         .prefix()
             }) {
-            p.participant_proxy.default_multicast_locator_list.clone()
+            p.default_multicast_locator_list.clone()
         } else {
             vec![]
         };
@@ -924,13 +924,13 @@ impl DcpsDomainParticipant {
             .discovered_participant_list
             .iter()
             .find(|p| {
-                p.participant_proxy.guid_prefix
+                p.guid_prefix
                     == discovered_writer_data
                         .writer_proxy
                         .remote_writer_guid
                         .prefix()
             }) {
-            p.participant_proxy.default_unicast_locator_list.clone()
+            p.default_unicast_locator_list.clone()
         } else {
             vec![]
         };
@@ -939,13 +939,13 @@ impl DcpsDomainParticipant {
             .discovered_participant_list
             .iter()
             .find(|p| {
-                p.participant_proxy.guid_prefix
+                p.guid_prefix
                     == discovered_writer_data
                         .writer_proxy
                         .remote_writer_guid
                         .prefix()
             }) {
-            p.participant_proxy.default_multicast_locator_list.clone()
+            p.default_multicast_locator_list.clone()
         } else {
             vec![]
         };
@@ -1756,8 +1756,34 @@ impl DcpsDomainParticipant {
 
             self.announce_participant(runtime);
 
-            self.domain_participant
-                .add_discovered_participant(discovered_participant_data);
+            let discovered_participant_info = DiscoveredParticipantInfo {
+                dds_participant_data: discovered_participant_data.dds_participant_data,
+                guid_prefix: discovered_participant_data
+                    .participant_proxy
+                    .guid_prefix
+                    .into(),
+                default_unicast_locator_list: discovered_participant_data
+                    .participant_proxy
+                    .default_unicast_locator_list,
+                default_multicast_locator_list: discovered_participant_data
+                    .participant_proxy
+                    .default_multicast_locator_list,
+                reception_timestamp: runtime.clock().now(),
+            };
+            match self
+                .domain_participant
+                .discovered_participant_list
+                .iter_mut()
+                .find(|p| {
+                    p.dds_participant_data.key()
+                        == discovered_participant_info.dds_participant_data.key()
+                }) {
+                Some(x) => *x = discovered_participant_info,
+                None => self
+                    .domain_participant
+                    .discovered_participant_list
+                    .push(discovered_participant_info),
+            }
         }
     }
 

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -1796,17 +1796,14 @@ impl DcpsDomainParticipant {
 
             let discovered_participant_info = DiscoveredParticipantInfo {
                 dds_participant_data: discovered_participant_data.dds_participant_data,
-                guid_prefix: discovered_participant_data
-                    .participant_proxy
-                    .guid_prefix
-                    .into(),
+                guid_prefix: discovered_participant_data.participant_proxy.guid_prefix,
                 default_unicast_locator_list: discovered_participant_data
                     .participant_proxy
                     .default_unicast_locator_list,
                 default_multicast_locator_list: discovered_participant_data
                     .participant_proxy
                     .default_multicast_locator_list,
-                lease_duration: discovered_participant_data.lease_duration.into(),
+                lease_duration: discovered_participant_data.lease_duration,
                 reception_timestamp: runtime.clock().now(),
             };
             match self

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -279,6 +279,7 @@ struct DiscoveredParticipantInfo {
     guid_prefix: GuidPrefix,
     default_unicast_locator_list: Vec<Locator>,
     default_multicast_locator_list: Vec<Locator>,
+    lease_duration: Duration,
     reception_timestamp: Time,
 }
 
@@ -643,7 +644,7 @@ impl DcpsDomainParticipant {
         self.domain_participant
             .discovered_participant_list
             .iter()
-            .map(|dp| now - dp.reception_timestamp)
+            .map(|dp| dp.lease_duration - (now - dp.reception_timestamp))
             .min()
     }
 

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -74,7 +74,7 @@ use crate::{
             BUILT_IN_READER_GROUP, BUILT_IN_READER_NO_KEY, BUILT_IN_READER_WITH_KEY,
             BUILT_IN_TOPIC, BUILT_IN_WRITER_GROUP, BUILT_IN_WRITER_NO_KEY,
             BUILT_IN_WRITER_WITH_KEY, CacheChange, ChangeKind, ENTITYID_PARTICIPANT, EntityId,
-            Guid, GuidPrefix, ReliabilityKind, TopicKind,
+            Guid, GuidPrefix, Locator, ReliabilityKind, TopicKind,
         },
     },
     xtypes::{
@@ -282,6 +282,14 @@ const TYPE_LOOKUP_WRITER_QOS: DataWriterQos = DataWriterQos {
     writer_data_lifecycle: WriterDataLifecycleQosPolicy::const_default(),
     representation: DataRepresentationQosPolicy::const_default(),
 };
+
+struct DiscoveredParticipantInfo {
+    dds_participant_data: ParticipantBuiltinTopicData,
+    guid_prefix: GuidPrefix,
+    default_unicast_locator_list: Vec<Locator>,
+    default_multicast_locator_list: Vec<Locator>,
+    reception_timestamp: Time,
+}
 
 fn poll_timeout<T>(
     mut timer_handle: impl Timer,
@@ -638,6 +646,14 @@ impl DcpsDomainParticipant {
             domain_participant,
             dcps_sender,
         }
+    }
+
+    pub fn time_until_stale_participant(&self, now: Time) -> Option<Duration> {
+        self.domain_participant
+            .discovered_participant_list
+            .iter()
+            .map(|dp| now - dp.reception_timestamp)
+            .min()
     }
 
     fn get_participant_async(&self) -> DomainParticipantAsync {
@@ -1106,7 +1122,7 @@ struct DomainParticipantEntity {
     default_publisher_qos: PublisherQos,
     topic_description_list: Vec<TopicDescriptionKind>,
     default_topic_qos: TopicQos,
-    discovered_participant_list: Vec<SpdpDiscoveredParticipantData>,
+    discovered_participant_list: Vec<DiscoveredParticipantInfo>,
     discovered_topic_list: Vec<TopicBuiltinTopicData>,
     discovered_reader_list: Vec<DiscoveredReaderData>,
     discovered_writer_list: Vec<DiscoveredWriterData>,
@@ -1188,20 +1204,6 @@ impl DomainParticipantEntity {
         self.discovered_topic_list
             .iter()
             .find(|&discovered_topic_data| discovered_topic_data.name() == topic_name)
-    }
-
-    fn add_discovered_participant(
-        &mut self,
-        discovered_participant_data: SpdpDiscoveredParticipantData,
-    ) {
-        match self.discovered_participant_list.iter_mut().find(|p| {
-            p.dds_participant_data.key() == discovered_participant_data.dds_participant_data.key()
-        }) {
-            Some(x) => *x = discovered_participant_data,
-            None => self
-                .discovered_participant_list
-                .push(discovered_participant_data),
-        }
     }
 
     fn add_discovered_reader(&mut self, discovered_reader_data: DiscoveredReaderData) {

--- a/dds/src/dcps/dcps_mail.rs
+++ b/dds/src/dcps/dcps_mail.rs
@@ -605,9 +605,6 @@ pub enum MessageServiceMail {
         participant_handle: InstanceHandle,
         data_message: Vec<u8>,
     },
-    Poke {
-        participant_handle: InstanceHandle,
-    },
 }
 
 pub enum EventServiceMail {

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -1080,16 +1080,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     p.handle_data(data_message.as_slice(), &self.runtime);
                 }
             }
-            DcpsMail::Message(MessageServiceMail::Poke { participant_handle }) => {
-                if let Ok(p) = self
-                    .domain_participant_list
-                    .iter_mut()
-                    .find(|x| x.get_instance_handle() == &participant_handle)
-                    .ok_or(DdsError::AlreadyDeleted)
-                {
-                    p.poke(&self.runtime.clock())
-                }
-            }
             DcpsMail::Event(EventServiceMail::OfferedDeadlineMissed {
                 participant_handle,
                 publisher_handle,

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -168,4 +168,11 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             dp.poke(&self.runtime.clock());
         }
     }
+
+    pub(crate) fn remove_stale_participants(&mut self) {
+        let now = self.runtime.clock().now();
+        for dp in &mut self.domain_participant_list {
+            dp.remove_stale_participants(now);
+        }
+    }
 }

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -1,7 +1,7 @@
 use crate::{
     dcps::{
         dcps_domain_participant::DcpsDomainParticipant,
-        dcps_mail::{DcpsMail, DiscoveryServiceMail, MessageServiceMail},
+        dcps_mail::{DcpsMail, DiscoveryServiceMail},
         listeners::domain_participant_listener::DcpsDomainParticipantListener,
         status_mask::StatusMask,
     },
@@ -11,8 +11,9 @@ use crate::{
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
+        time::Duration,
     },
-    runtime::{DdsRuntime, Spawner, Timer},
+    runtime::{Clock, DdsRuntime, Spawner, Timer},
     transport::{interface::RtpsTransportParticipant, types::GuidPrefix},
 };
 use alloc::{string::String, vec::Vec};
@@ -87,23 +88,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             }
         });
 
-        // Start regular message writing
-        let dcps_sender_clone = self.dcps_sender;
-        let mut timer_handle = self.runtime.timer();
-        spawner_handle.spawn(async move {
-            loop {
-                dcps_sender_clone
-                    .send(DcpsMail::Message(MessageServiceMail::Poke {
-                        participant_handle,
-                    }))
-                    .await;
-
-                timer_handle
-                    .delay(core::time::Duration::from_millis(50))
-                    .await;
-            }
-        });
-
         if self.qos.entity_factory.autoenable_created_entities {
             dcps_participant.enable_domain_participant(&self.runtime)?;
         }
@@ -169,5 +153,19 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
 
     pub fn get_qos(&mut self) -> DomainParticipantFactoryQos {
         self.qos.clone()
+    }
+
+    pub(crate) fn time_until_stale_participant(&self) -> Option<Duration> {
+        let now = self.runtime.clock().now();
+        self.domain_participant_list
+            .iter()
+            .filter_map(|x| x.time_until_stale_participant(now))
+            .min()
+    }
+
+    pub(crate) fn poke(&mut self) {
+        for dp in &mut self.domain_participant_list {
+            dp.poke(&self.runtime.clock());
+        }
     }
 }

--- a/dds/src/dcps/infrastructure/time.rs
+++ b/dds/src/dcps/infrastructure/time.rs
@@ -53,7 +53,7 @@ impl PartialOrd<DurationKind> for DurationKind {
 }
 
 /// Structure representing a time interval with a nanosecond resolution.
-#[derive(PartialOrd, PartialEq, Eq, Debug, Clone, Copy, TypeSupport)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Debug, Clone, Copy, TypeSupport)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct Duration {
     sec: i32,
@@ -108,15 +108,6 @@ impl Sub<Duration> for Duration {
             self.nanosec - rhs.nanosec
         };
         Self { sec, nanosec }
-    }
-}
-
-impl Ord for Duration {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match self.sec.cmp(&other.sec) {
-            std::cmp::Ordering::Equal => self.nanosec.cmp(&other.nanosec),
-            ord => ord,
-        }
     }
 }
 

--- a/dds/src/dcps/infrastructure/time.rs
+++ b/dds/src/dcps/infrastructure/time.rs
@@ -111,6 +111,15 @@ impl Sub<Duration> for Duration {
     }
 }
 
+impl Ord for Duration {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.sec.cmp(&other.sec) {
+            std::cmp::Ordering::Equal => self.nanosec.cmp(&other.nanosec),
+            ord => ord,
+        }
+    }
+}
+
 fn fraction_to_nanosec(fraction: u32) -> u32 {
     ((fraction as u64 * 1_000_000_000) / (1u64 << 32)) as u32
 }
@@ -251,5 +260,20 @@ mod tests {
         let dds_time_from_rtps_time = Duration::from(rtps_time);
 
         assert_eq!(dds_time, dds_time_from_rtps_time)
+    }
+
+    #[test]
+    fn duration_ord() {
+        let d1 = Duration::new(1, 100);
+        let d2 = Duration::new(1, 200);
+        let d3 = Duration::new(2, 50);
+
+        assert!(d1 == d1);
+        assert!(d1 < d2);
+        assert!(d2 < d3);
+        assert!(d1 < d3);
+        assert_eq!(d1.cmp(&d1), std::cmp::Ordering::Equal);
+        assert_eq!(d1.cmp(&d2), std::cmp::Ordering::Less);
+        assert_eq!(d2.cmp(&d1), std::cmp::Ordering::Greater);
     }
 }

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -13,24 +13,20 @@ use crate::{
     },
     rtps_udp_transport::udp_transport::RtpsUdpTransportParticipantFactory,
     std_runtime::executor::block_on,
+    transport::interface::TransportParticipantFactory,
 };
 use tracing::warn;
 
 /// The sole purpose of this class is to allow the creation and destruction of [`DomainParticipant`] objects.
 /// [`DomainParticipantFactory`] itself has no factory. It is a pre-existing singleton object that can be accessed by means of the
 /// [`DomainParticipantFactory::get_instance`] operation.
-pub struct DomainParticipantFactory {
-    participant_factory_async:
-        &'static DomainParticipantFactoryAsync<RtpsUdpTransportParticipantFactory>,
+pub struct DomainParticipantFactory<T: TransportParticipantFactory> {
+    participant_factory_async: &'static DomainParticipantFactoryAsync<T>,
 }
 
-impl DomainParticipantFactory {
+impl<T: TransportParticipantFactory> DomainParticipantFactory<T> {
     /// Construct a new ['DomainParticipantFactory'] from an existing ['DomainParticipantFactoryAsync'] static reference
-    pub fn new(
-        participant_factory_async: &'static DomainParticipantFactoryAsync<
-            RtpsUdpTransportParticipantFactory,
-        >,
-    ) -> Self {
+    pub fn new(participant_factory_async: &'static DomainParticipantFactoryAsync<T>) -> Self {
         Self {
             participant_factory_async,
         }
@@ -120,11 +116,9 @@ impl DomainParticipantFactory {
     }
 }
 
-impl DomainParticipantFactory {
+impl<T: TransportParticipantFactory> DomainParticipantFactory<T> {
     /// Get a mutable reference to the transport object
-    pub fn get_mut_transport(
-        &self,
-    ) -> impl DerefMut<Target = RtpsUdpTransportParticipantFactory> + '_ {
+    pub fn get_mut_transport(&self) -> impl DerefMut<Target = T> + '_ {
         block_on(self.participant_factory_async.get_mut_transport())
     }
 
@@ -134,13 +128,14 @@ impl DomainParticipantFactory {
     }
 }
 
-impl DomainParticipantFactory {
+impl DomainParticipantFactory<RtpsUdpTransportParticipantFactory> {
     /// This operation returns the [`DomainParticipantFactory`] singleton. The operation is idempotent, that is, it can be called multiple
     /// times without side-effects and it will return the same [`DomainParticipantFactory`] instance.
     #[tracing::instrument]
     pub fn get_instance() -> &'static Self {
-        static PARTICIPANT_FACTORY: std::sync::OnceLock<DomainParticipantFactory> =
-            std::sync::OnceLock::new();
+        static PARTICIPANT_FACTORY: std::sync::OnceLock<
+            DomainParticipantFactory<RtpsUdpTransportParticipantFactory>,
+        > = std::sync::OnceLock::new();
         PARTICIPANT_FACTORY.get_or_init(|| DomainParticipantFactory {
             participant_factory_async: DomainParticipantFactoryAsync::get_instance(),
         })

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -20,7 +20,9 @@ use tracing::warn;
 /// The sole purpose of this class is to allow the creation and destruction of [`DomainParticipant`] objects.
 /// [`DomainParticipantFactory`] itself has no factory. It is a pre-existing singleton object that can be accessed by means of the
 /// [`DomainParticipantFactory::get_instance`] operation.
-pub struct DomainParticipantFactory<T: TransportParticipantFactory> {
+pub struct DomainParticipantFactory<
+    T: TransportParticipantFactory = RtpsUdpTransportParticipantFactory,
+> {
     participant_factory_async: &'static DomainParticipantFactoryAsync<T>,
 }
 

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -267,7 +267,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         let dcps_receiver = DCPS_CHANNEL.receiver();
         spawner_handle.spawn(async move {
             loop {
-                let poke_time = Duration::new(0, 500_000_000);
+                let poke_time = Duration::new(0, 50_000_000);
                 let next_task_time = domain_participant_factory
                     .time_until_stale_participant()
                     .unwrap_or(poke_time)
@@ -286,6 +286,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                 };
 
                 domain_participant_factory.poke();
+                domain_participant_factory.remove_stale_participants();
             }
         });
         Self {

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -19,8 +19,9 @@ use crate::{
         instance::InstanceHandle,
         qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
         status::StatusKind,
+        time::Duration,
     },
-    runtime::{DdsRuntime, Spawner},
+    runtime::{DdsRuntime, Either, Spawner, Timer, select_future},
     transport::{
         interface::{TransportDataReceiver, TransportParticipantFactory},
         types::{ENTITYID_PARTICIPANT, Guid, GuidPrefix},
@@ -256,6 +257,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
     ) -> Self {
         static DCPS_CHANNEL: DcpsChannel = DcpsChannel::new();
         let spawner_handle = runtime.spawner();
+        let mut timer_handle = runtime.timer();
 
         let mut domain_participant_factory =
             crate::dcps::dcps_participant_factory::DcpsParticipantFactory::new(
@@ -265,8 +267,25 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         let dcps_receiver = DCPS_CHANNEL.receiver();
         spawner_handle.spawn(async move {
             loop {
-                let m = dcps_receiver.receive().await;
-                domain_participant_factory.handle(m);
+                let poke_time = Duration::new(0, 500_000_000);
+                let next_task_time = domain_participant_factory
+                    .time_until_stale_participant()
+                    .unwrap_or(poke_time)
+                    .min(poke_time);
+
+                match select_future(
+                    dcps_receiver.receive(),
+                    timer_handle.delay(next_task_time.into()),
+                )
+                .await
+                {
+                    Either::A(m) => {
+                        domain_participant_factory.handle(m);
+                    }
+                    Either::B(_) => (),
+                };
+
+                domain_participant_factory.poke();
             }
         });
         Self {

--- a/dds/src/std_runtime/timer.rs
+++ b/dds/src/std_runtime/timer.rs
@@ -40,12 +40,23 @@ impl Ord for TimerWake {
     }
 }
 
+pub enum TimerMessage {
+    Wake(TimerWake),
+    Cancel(usize),
+}
+
 #[derive(Debug)]
 pub struct Sleep {
     id: usize,
     deadline: Option<Instant>,
     duration: Duration,
-    periodic_task_sender: std::sync::mpsc::Sender<TimerWake>,
+    periodic_task_sender: std::sync::mpsc::Sender<TimerMessage>,
+}
+
+impl Drop for Sleep {
+    fn drop(&mut self) {
+        let _ = self.periodic_task_sender.send(TimerMessage::Cancel(self.id));
+    }
 }
 
 impl Sleep {
@@ -85,7 +96,7 @@ impl Future for Sleep {
                 waker: cx.waker().clone(),
             };
             this.periodic_task_sender
-                .send(timer_wake)
+                .send(TimerMessage::Wake(timer_wake))
                 .expect("Shouldn't fail to send");
             Poll::Pending
         }
@@ -131,12 +142,18 @@ impl TimerHeap {
             t.waker.wake();
         }
     }
+
+    #[inline(always)]
+    fn remove(&mut self, id: usize) {
+        let heap = std::mem::take(&mut self.heap);
+        self.heap = heap.into_iter().filter(|t| t.id != id).collect();
+    }
 }
 
 #[derive(Debug)]
 struct HandleInner {
     sleep_task_id: usize,
-    periodic_task_sender: std::sync::mpsc::Sender<TimerWake>,
+    periodic_task_sender: std::sync::mpsc::Sender<TimerMessage>,
 }
 
 #[derive(Clone, Debug)]
@@ -181,7 +198,7 @@ impl Default for TimerDriver {
 impl TimerDriver {
     pub fn new() -> Self {
         let (periodic_task_sender, periodic_task_receiver) =
-            std::sync::mpsc::channel::<TimerWake>();
+            std::sync::mpsc::channel::<TimerMessage>();
         let timer_thread_join_handle = std::thread::Builder::new()
             .name("Dust DDS Timer".to_string())
             .spawn(move || {
@@ -211,7 +228,8 @@ impl TimerDriver {
                     };
 
                     match new_timer {
-                        Ok(t) => timer_heap.push(t),
+                        Ok(TimerMessage::Wake(t)) => timer_heap.push(t),
+                        Ok(TimerMessage::Cancel(id)) => timer_heap.remove(id),
                         Err(RecvTimeoutError::Timeout) => (),
                         Err(RecvTimeoutError::Disconnected) => break,
                     }

--- a/dds/src/std_runtime/timer.rs
+++ b/dds/src/std_runtime/timer.rs
@@ -55,7 +55,9 @@ pub struct Sleep {
 
 impl Drop for Sleep {
     fn drop(&mut self) {
-        let _ = self.periodic_task_sender.send(TimerMessage::Cancel(self.id));
+        let _ = self
+            .periodic_task_sender
+            .send(TimerMessage::Cancel(self.id));
     }
 }
 

--- a/dds/tests/wire_tests.rs
+++ b/dds/tests/wire_tests.rs
@@ -1,0 +1,131 @@
+mod utils;
+use std::sync::OnceLock;
+
+use dust_dds::{
+    dds_async::domain_participant_factory::DomainParticipantFactoryAsync,
+    domain::domain_participant_factory::DomainParticipantFactory,
+    infrastructure::{listener::NO_LISTENER, qos::QosKind, status::NO_STATUS},
+    rtps_messages::{
+        overall_structure::RtpsMessageWrite,
+        submessage_elements::{Data, ParameterList},
+        submessages::data::DataSubmessage,
+    },
+    transport::{
+        interface::{
+            RtpsTransportParticipant, TransportDataReceiver, TransportParticipantFactory,
+            WriteMessage,
+        },
+        types::{BUILT_IN_WRITER_WITH_KEY, ENTITYID_UNKNOWN, EntityId, Locator},
+    },
+};
+
+use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
+
+#[test]
+fn detect_stale_participant() {
+    struct MockWriter;
+    impl WriteMessage for MockWriter {
+        fn write_message(&self, _buf: &[u8], _locators: &[Locator]) {}
+    }
+
+    struct MockTransport(std::sync::mpsc::SyncSender<TransportDataReceiver>);
+    impl TransportParticipantFactory for MockTransport {
+        fn create_participant(
+            &self,
+            _domain_id: i32,
+            data_receiver: TransportDataReceiver,
+        ) -> RtpsTransportParticipant {
+            self.0.send(data_receiver).unwrap();
+            RtpsTransportParticipant {
+                message_writer: Box::new(MockWriter),
+                default_unicast_locator_list: Vec::new(),
+                metatraffic_unicast_locator_list: Vec::new(),
+                metatraffic_multicast_locator_list: Vec::new(),
+                default_multicast_locator_list: Vec::new(),
+                fragment_size: 1000,
+            }
+        }
+    }
+    static PARTICIPANT_FACTORY_ASYNC: OnceLock<DomainParticipantFactoryAsync<MockTransport>> =
+        OnceLock::new();
+
+    let (data_receiver_sender, data_receiver_receiver) = std::sync::mpsc::sync_channel(1);
+    let transport = MockTransport(data_receiver_sender);
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let domain_participant_factory =
+        DomainParticipantFactory::new(PARTICIPANT_FACTORY_ASYNC.get_or_init(|| {
+            let executor = dust_dds::std_runtime::executor::Executor::new();
+            let timer_driver = dust_dds::std_runtime::timer::TimerDriver::new();
+            let runtime = dust_dds::std_runtime::StdRuntime::new(executor, timer_driver);
+            let app_id = [1, 2, 3, 4];
+            let host_id = [5, 6, 7, 8];
+            let configuration = Default::default();
+
+            DomainParticipantFactoryAsync::new(runtime, app_id, host_id, transport, configuration)
+        }));
+
+    let participant = domain_participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let guid_prefix = <[u8; 16]>::from(participant.get_instance_handle())[0..12]
+        .try_into()
+        .unwrap();
+
+    let data_receiver = data_receiver_receiver.recv().unwrap();
+
+    let reader_id = ENTITYID_UNKNOWN;
+    const ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER: EntityId =
+        EntityId::new([0x00, 0x01, 0x00], BUILT_IN_WRITER_WITH_KEY);
+    let writer_id = ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER;
+    let inline_qos_flag = false;
+    let data_flag = true;
+    let key_flag = false;
+    let non_standard_payload_flag = false;
+    let writer_sn = 1;
+    let inline_qos = ParameterList::empty();
+    let serialized_payload = Data::new(
+        vec![
+            0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
+            0x50, 0x00, 16, 0x00, // PID_PARTICIPANT_GUID, Length
+            8, 8, 8, 8, // GuidPrefix
+            8, 8, 8, 8, // GuidPrefix
+            8, 8, 8, 8, // GuidPrefix
+            0, 0, 1, 0xc1, // EntityId
+            0x15, 0x00, 4, 0x00, // PID_PROTOCOL_VERSION, Length
+            0x02, 0x04, 0x00, 0x00, // ProtocolVersion
+            0x16, 0x00, 4, 0x00, // PID_VENDORID
+            73, 74, 0x00, 0x00, // VendorId
+            88, 0x00, 4, 0x00, // PID_BUILTIN_ENDPOINT_SET
+            0x02, 0x00, 0x00, 0x00, //
+            0x02, 0x00, 8, 0x00, // PID_PARTICIPANT_LEASE_DURATION
+            1, 0x00, 0x00, 0x00, // Duration: seconds
+            0, 0x00, 0x00, 0x00, // Duration: fraction
+            0x01, 0x00, 0x00, 0x00, // PID_SENTINEL
+        ]
+        .into(),
+    );
+    let spdp_data_submessage = DataSubmessage::new(
+        inline_qos_flag,
+        data_flag,
+        key_flag,
+        non_standard_payload_flag,
+        reader_id,
+        writer_id,
+        writer_sn,
+        inline_qos,
+        serialized_payload,
+    );
+    let spdp_rtps_message =
+        RtpsMessageWrite::from_submessages(&[&spdp_data_submessage], guid_prefix);
+
+    dust_dds::std_runtime::executor::block_on(
+        data_receiver.receive_message(spdp_rtps_message.buffer().to_vec()),
+    );
+
+    assert_eq!(participant.get_discovered_participants().unwrap().len(), 1);
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+
+    assert_eq!(participant.get_discovered_participants().unwrap().len(), 0);
+}

--- a/dds/tests/wire_tests.rs
+++ b/dds/tests/wire_tests.rs
@@ -49,8 +49,8 @@ fn detect_stale_participant() {
     static PARTICIPANT_FACTORY_ASYNC: OnceLock<DomainParticipantFactoryAsync<MockTransport>> =
         OnceLock::new();
 
-    let (data_receiver_sender, data_receiver_receiver) = std::sync::mpsc::sync_channel(1);
-    let transport = MockTransport(data_receiver_sender);
+    let (data_receiver_send, data_receiver_recv) = std::sync::mpsc::sync_channel(1);
+    let transport = MockTransport(data_receiver_send);
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
     let domain_participant_factory =
         DomainParticipantFactory::new(PARTICIPANT_FACTORY_ASYNC.get_or_init(|| {
@@ -72,7 +72,7 @@ fn detect_stale_participant() {
         .try_into()
         .unwrap();
 
-    let data_receiver = data_receiver_receiver.recv().unwrap();
+    let data_receiver = data_receiver_recv.recv().unwrap();
 
     let reader_id = ENTITYID_UNKNOWN;
     const ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER: EntityId =
@@ -125,6 +125,7 @@ fn detect_stale_participant() {
 
     assert_eq!(participant.get_discovered_participants().unwrap().len(), 1);
 
+    // Wait longer than lease duration communicated in the discovery message
     std::thread::sleep(std::time::Duration::from_secs(2));
 
     assert_eq!(participant.get_discovered_participants().unwrap().len(), 0);


### PR DESCRIPTION
Add functionality to detect and remove stale participants. This fixes issue #357.

This change involves an adjustment in the internal architecture in which the main loop is now triggered both by receiving mail or once a time is elapsed. This time has a minimum bound on the time that used to be used for sending the Poke mail which keeps the system running.