### PR TITLE
Enable external visibility of the XTypes module

### DIFF
--- a/dds/src/lib.rs
+++ b/dds/src/lib.rs
@@ -40,8 +40,7 @@ pub mod runtime;
 #[doc(hidden)]
 pub mod std_runtime;
 
-/// Contains the XTypes serializer and deserializer
-#[doc(hidden)]
+/// Contains the DDS XTypes standard types and methods definitions
 pub mod xtypes;
 
 // To enable using our own derive macros to allow the name dust_dds:: to be used

--- a/dds/src/xtypes/data_storage.rs
+++ b/dds/src/xtypes/data_storage.rs
@@ -5,44 +5,84 @@ use crate::xtypes::{
 };
 use alloc::{boxed::Box, string::String, vec::Vec};
 
+/// Representation of data storage for dynamic types.
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataStorage {
+    /// Unsigned 8-bit integer.
     UInt8(u8),
+    /// Signed 8-bit integer.
     Int8(i8),
+    /// Unsigned 16-bit integer.
     UInt16(u16),
+    /// Signed 16-bit integer.
     Int16(i16),
+    /// Signed 32-bit integer.
     Int32(i32),
+    /// Unsigned 32-bit integer.
     UInt32(u32),
+    /// Signed 64-bit integer.
     Int64(i64),
+    /// Unsigned 64-bit integer.
     UInt64(u64),
+    /// Single-precision floating-point number.
     Float32(f32),
+    /// Double-precision floating-point number.
     Float64(f64),
+    /// 128-bit floating-point number.
     Float128(i128),
+    /// 8-bit character.
     Char8(char),
+    /// Boolean value.
     Boolean(bool),
+    /// String value.
     String(String),
+    /// Complex data value represented by a [`DynamicData`].
     ComplexValue(DynamicData),
-    // Sequence
+    /// Sequence of unsigned 8-bit integers.
     SequenceUInt8(Vec<u8>),
+    /// Sequence of signed 8-bit integers.
     SequenceInt8(Vec<i8>),
+    /// Sequence of unsigned 16-bit integers.
     SequenceUInt16(Vec<u16>),
+    /// Sequence of signed 16-bit integers.
     SequenceInt16(Vec<i16>),
+    /// Sequence of signed 32-bit integers.
     SequenceInt32(Vec<i32>),
+    /// Sequence of unsigned 32-bit integers.
     SequenceUInt32(Vec<u32>),
+    /// Sequence of signed 64-bit integers.
     SequenceInt64(Vec<i64>),
+    /// Sequence of unsigned 64-bit integers.
     SequenceUInt64(Vec<u64>),
+    /// Sequence of single-precision floating-point numbers.
     SequenceFloat32(Vec<f32>),
+    /// Sequence of double-precision floating-point numbers.
     SequenceFloat64(Vec<f64>),
+    /// Sequence of 128-bit floating-point numbers.
     SequenceFloat128(Vec<i128>),
+    /// Sequence of 8-bit characters.
     SequenceChar8(Vec<char>),
+    /// Sequence of boolean values.
     SequenceBoolean(Vec<bool>),
+    /// Sequence of string values.
     SequenceString(Vec<String>),
+    /// Sequence of complex data values.
     SequenceComplexValue(Vec<DynamicData>),
 }
 
+/// Trait used to map Rust types to and from their corresponding [`DataStorage`] variants.
+///
+/// This trait is typically used by the derive macro to convert types into
+/// their dynamic data representation format.
 pub trait DataStorageMapping: Sized {
+    /// Converts this type into its corresponding [`DataStorage`] variant.
     fn into_storage(self) -> DataStorage;
 
+    /// Tries to convert a [`DataStorage`] variant back into this type.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`XTypesError::InvalidType`] if the storage variant does not match.
     fn try_from_storage(data_storage: DataStorage) -> XTypesResult<Self>;
 }
 

--- a/dds/src/xtypes/dynamic_type.rs
+++ b/dds/src/xtypes/dynamic_type.rs
@@ -7,55 +7,83 @@ use crate::xtypes::{
 };
 use alloc::{boxed::Box, collections::BTreeMap, string::String, vec::Vec};
 
+/// Represents a sequence bound.
 pub type BoundSeq = Option<u32>;
+/// Represents a sequence of include paths.
 pub type IncludePathSeq = Vec<String>;
+/// Represents the name of an object.
 pub type ObjectName<'a> = &'a str;
 
 // ---------- TypeKinds (begin) -------------------
+/// Represents the kind of a dynamic type (e.g., primitive, constructed, or collection type).
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(u8)]
 pub enum TypeKind {
-    // Primitive TKs
+    /// No type kind.
     NONE = 0x00,
+    /// Boolean type kind.
     BOOLEAN = 0x01,
+    /// Byte type kind.
     BYTE = 0x02,
+    /// 16-bit signed integer type kind.
     INT16 = 0x03,
+    /// 32-bit signed integer type kind.
     INT32 = 0x04,
+    /// 64-bit signed integer type kind.
     INT64 = 0x05,
+    /// 16-bit unsigned integer type kind.
     UINT16 = 0x06,
+    /// 32-bit unsigned integer type kind.
     UINT32 = 0x07,
+    /// 64-bit unsigned integer type kind.
     UINT64 = 0x08,
+    /// 32-bit floating point type kind.
     FLOAT32 = 0x09,
+    /// 64-bit floating point type kind.
     FLOAT64 = 0x0A,
+    /// 128-bit floating point type kind.
     FLOAT128 = 0x0B,
+    /// 8-bit signed integer type kind.
     INT8 = 0x0C,
+    /// 8-bit unsigned integer type kind.
     UINT8 = 0x0D,
+    /// 8-bit character type kind.
     CHAR8 = 0x10,
+    /// 16-bit character type kind.
     CHAR16 = 0x11,
-    // String TK;
+    /// 8-bit string type kind.
     STRING8 = 0x20,
+    /// 16-bit string type kind.
     STRING16 = 0x21,
-    // Constructed/Named type;
+    /// Alias type kind.
     ALIAS = 0x30,
-    // Enumerated TK;
+    /// Enumeration type kind.
     ENUM = 0x40,
+    /// Bitmask type kind.
     BITMASK = 0x41,
-    // Structured TK;
+    /// Annotation type kind.
     ANNOTATION = 0x50,
+    /// Structure type kind.
     STRUCTURE = 0x51,
+    /// Union type kind.
     UNION = 0x52,
+    /// Bitset type kind.
     BITSET = 0x53,
-    // Collection TK;
+    /// Sequence type kind.
     SEQUENCE = 0x60,
+    /// Array type kind.
     ARRAY = 0x61,
+    /// Map type kind.
     MAP = 0x62,
 }
 
 // ---------- TypeKinds (end) -------------------
 
+/// A factory class used to create [`DynamicType`] and [`DynamicTypeBuilder`] instances.
 pub struct DynamicTypeBuilderFactory;
 
 impl DynamicTypeBuilderFactory {
+    /// Returns a [`DynamicType`] representing the specified primitive type kind.
     pub fn get_primitive_type(kind: TypeKind) -> DynamicType {
         DynamicType {
             descriptor: Box::leak(Box::new(TypeDescriptor {
@@ -73,6 +101,7 @@ impl DynamicTypeBuilderFactory {
         }
     }
 
+    /// Creates a [`DynamicTypeBuilder`] with the given type descriptor.
     pub fn create_type(descriptor: TypeDescriptor) -> DynamicTypeBuilder {
         DynamicTypeBuilder {
             descriptor,
@@ -80,14 +109,17 @@ impl DynamicTypeBuilderFactory {
         }
     }
 
+    /// Creates a [`DynamicTypeBuilder`] as a copy of an existing type.
     pub fn create_type_copy(r#_type: DynamicType) -> DynamicTypeBuilder {
         todo!()
     }
 
+    /// Creates a [`DynamicTypeBuilder`] from a [`TypeObject`].
     pub fn create_type_w_type_object(_type_object: TypeObject) -> DynamicTypeBuilder {
         todo!()
     }
 
+    /// Creates a [`DynamicTypeBuilder`] for a string type with the specified bound.
     pub fn create_string_type(bound: u32) -> DynamicTypeBuilder {
         DynamicTypeBuilder {
             descriptor: TypeDescriptor {
@@ -105,10 +137,12 @@ impl DynamicTypeBuilderFactory {
         }
     }
 
+    /// Creates a [`DynamicTypeBuilder`] for a wide string type with the specified bound.
     pub fn create_wstring_type(_bound: u32) -> DynamicTypeBuilder {
         unimplemented!("wstring not supported in Rust")
     }
 
+    /// Creates a [`DynamicTypeBuilder`] for a sequence type with the specified element type and bound.
     pub fn create_sequence_type(element_type: DynamicType, bound: u32) -> DynamicTypeBuilder {
         DynamicTypeBuilder {
             descriptor: TypeDescriptor {
@@ -126,6 +160,7 @@ impl DynamicTypeBuilderFactory {
         }
     }
 
+    /// Creates a [`DynamicTypeBuilder`] for an array type with the specified element type and dimensions/bound.
     pub fn create_array_type(element_type: DynamicType, bound: BoundSeq) -> DynamicTypeBuilder {
         DynamicTypeBuilder {
             descriptor: TypeDescriptor {
@@ -143,6 +178,7 @@ impl DynamicTypeBuilderFactory {
         }
     }
 
+    /// Creates a [`DynamicTypeBuilder`] for a map type with the specified key, element type, and bound.
     pub fn create_map_type(
         _key_element_type: DynamicType,
         _element_type: DynamicType,
@@ -151,10 +187,12 @@ impl DynamicTypeBuilderFactory {
         todo!()
     }
 
+    /// Creates a [`DynamicTypeBuilder`] for a bitmask type with the specified bound.
     pub fn create_bitmask_type(_bound: u32) -> DynamicTypeBuilder {
         todo!()
     }
 
+    /// Creates a [`DynamicTypeBuilder`] for a type defined at the specified URI.
     pub fn create_type_w_uri(
         _document_url: String,
         _type_name: String,
@@ -164,6 +202,7 @@ impl DynamicTypeBuilderFactory {
     }
 
     #[cfg(feature = "xtypes-xml")]
+    /// Creates a [`DynamicTypeBuilder`] for a type defined by the input XML.
     pub fn create_type_w_document(
         document: &str,
         type_name: &str,
@@ -470,58 +509,96 @@ impl DynamicTypeBuilderFactory {
     }
 }
 
+/// Represents parameter name-value pairs.
 pub type Parameters = BTreeMap<ObjectName<'static>, ObjectName<'static>>;
 
+/// Defines how a type can be extended or modified in future versions.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ExtensibilityKind {
+    /// Cannot be extended or modified.
     Final,
+    /// Members can be appended to the end of the type in future versions.
     Appendable,
+    /// Members can be added, removed, or reordered in future versions.
     Mutable,
 }
 
+/// Defines the behavior when constructing an object of a type that fails some validation or constraints.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TryConstructKind {
+    /// Fall back to the default value.
     UseDefault,
+    /// Discard the entire object or element.
     Discard,
+    /// Trim the elements to fit the constraints.
     Trim,
 }
 
+/// Describes the properties and characteristics of a [`DynamicType`].
 pub struct TypeDescriptor {
+    /// The kind of the type.
     pub kind: TypeKind,
+    /// The name of the type.
     pub name: ObjectName<'static>,
+    /// The base type if this type inherits from another type.
     pub base_type: Option<DynamicType>,
+    /// The discriminator type if this type is a union.
     pub discriminator_type: Option<DynamicType>,
+    /// The bound(s) of the type if it is a collection or string.
     pub bound: BoundSeq,
+    /// The element type if this type is a collection.
     pub element_type: Option<DynamicType>,
+    /// The key element type if this type is a map.
     pub key_element_type: Option<DynamicType>,
+    /// The extensibility kind of the type.
     pub extensibility_kind: ExtensibilityKind,
+    /// Indicates whether this is a nested type.
     pub is_nested: bool,
 }
 
+/// Represents the unique identifier of a member.
 pub type MemberId = u32;
+/// Represents case labels for a union member.
 pub type UnionCaseLabelSeq = Option<i32>;
 
+/// Describes a member of a constructed type.
 pub struct MemberDescriptor {
+    /// The name of the member.
     pub name: ObjectName<'static>,
+    /// The unique identifier of the member.
     pub id: MemberId,
+    /// The dynamic type of the member.
     pub r#type: DynamicType,
+    /// The optional default value of the member.
     pub default_value: Option<&'static str>,
+    /// The index of the member within the parent type.
     pub index: u32,
+    /// The union case labels if this member belongs to a union.
     pub label: UnionCaseLabelSeq,
+    /// The construct fail action of the member.
     pub try_construct_kind: TryConstructKind,
+    /// Indicates if the member is part of the type's key.
     pub is_key: bool,
+    /// Indicates if the member is optional.
     pub is_optional: bool,
+    /// Indicates if a receiver must understand this member to process the data.
     pub is_must_understand: bool,
+    /// Indicates if the member is shared.
     pub is_shared: bool,
+    /// Indicates if this is the default case for a union.
     pub is_default_label: bool,
+    /// Indicates if the member is external (stored by reference).
     pub is_external: bool,
 }
 
+/// Represents a member of a [`DynamicType`].
 pub struct DynamicTypeMember {
+    /// The descriptor describing this member.
     pub descriptor: MemberDescriptor,
 }
 
 impl DynamicTypeMember {
+    /// Returns a reference to the member's descriptor.
     pub fn get_descriptor(&self) -> XTypesResult<&MemberDescriptor> {
         Ok(&self.descriptor)
     }
@@ -530,32 +607,39 @@ impl DynamicTypeMember {
     // unsigned long get_verbatim_text_count();
     // DDS::ReturnCode_t get_verbatim_text(inout VerbatimTextDescriptor descriptor, in unsigned long idx);
 
+    /// Returns the unique member ID.
     pub fn get_id(&self) -> MemberId {
         self.descriptor.id
     }
+    /// Returns the name of the member.
     pub fn get_name(&self) -> ObjectName<'static> {
         self.descriptor.name
     }
 }
 
+/// A builder class used to construct a [`DynamicType`].
 pub struct DynamicTypeBuilder {
     descriptor: TypeDescriptor,
     member_list: Vec<DynamicTypeMember>,
 }
 
 impl DynamicTypeBuilder {
+    /// Returns a reference to the type descriptor being built.
     pub fn get_descriptor(&self) -> XTypesResult<&TypeDescriptor> {
         Ok(&self.descriptor)
     }
 
+    /// Returns the name of the type.
     pub fn get_name(&self) -> ObjectName<'static> {
         self.descriptor.name
     }
 
+    /// Returns the kind of the type.
     pub fn get_kind(&self) -> TypeKind {
         self.descriptor.kind
     }
 
+    /// Returns a mutable reference to a member by its name.
     pub fn get_member_by_name(
         &mut self,
         name: &ObjectName,
@@ -566,28 +650,34 @@ impl DynamicTypeBuilder {
             .ok_or(XTypesError::InvalidData)
     }
 
+    /// Returns all members indexed by their names.
     pub fn get_all_members_by_name(
         &self,
     ) -> Result<Vec<(ObjectName<'static>, DynamicTypeMember)>, XTypesError> {
         todo!()
     }
 
+    /// Returns a member by its ID.
     pub fn get_member(&self, _id: MemberId) -> Result<DynamicTypeMember, XTypesError> {
         todo!()
     }
 
+    /// Returns all members indexed by their ID.
     pub fn get_all_members(&self) -> Result<Vec<(MemberId, DynamicTypeMember)>, XTypesError> {
         todo!()
     }
 
+    /// Returns the number of annotations on this type.
     pub fn get_annotation_count(&self) -> u32 {
         todo!()
     }
 
+    /// Returns the annotation at the specified index.
     pub fn get_annotation(&self, _idx: u32) -> XTypesResult<()> {
         todo!()
     }
 
+    /// Adds a member to the type.
     pub fn add_member(&mut self, descriptor: MemberDescriptor) -> XTypesResult<()> {
         if let TypeKind::ENUM
         | TypeKind::BITMASK
@@ -605,10 +695,12 @@ impl DynamicTypeBuilder {
         Ok(())
     }
 
+    /// Applies an annotation descriptor to this type.
     pub fn apply_annotation(&mut self) -> XTypesResult<()> {
         todo!()
     }
 
+    /// Builds and returns the constructed [`DynamicType`].
     pub fn build(self) -> DynamicType {
         DynamicType {
             descriptor: Box::leak(Box::new(self.descriptor)),
@@ -617,9 +709,12 @@ impl DynamicTypeBuilder {
     }
 }
 
+/// Represents a data type's schema at runtime.
 #[derive(Clone, Copy)]
 pub struct DynamicType {
+    /// The type descriptor.
     pub descriptor: &'static TypeDescriptor,
+    /// The list of members belonging to this type.
     pub member_list: &'static [DynamicTypeMember],
 }
 
@@ -631,16 +726,20 @@ impl PartialEq for DynamicType {
 }
 
 impl DynamicType {
+    /// Returns the type descriptor.
     pub fn get_descriptor(&self) -> &TypeDescriptor {
         self.descriptor
     }
+    /// Returns the name of the type.
     pub fn get_name(&self) -> ObjectName<'static> {
         self.descriptor.name
     }
+    /// Returns the kind of the type.
     pub fn get_kind(&self) -> TypeKind {
         self.descriptor.kind
     }
 
+    /// Retrieves a member by name.
     pub fn get_member_by_name(&self, name: ObjectName) -> Result<&DynamicTypeMember, XTypesError> {
         self.member_list
             .iter()
@@ -649,6 +748,7 @@ impl DynamicType {
     }
 
     // DDS::ReturnCode_t get_all_members_by_name(inout DynamicTypeMembersByName member);
+    /// Retrieves a member by ID.
     pub fn get_member(&self, id: MemberId) -> Result<&DynamicTypeMember, XTypesError> {
         self.member_list
             .iter()
@@ -658,9 +758,11 @@ impl DynamicType {
 
     // DDS::ReturnCode_t get_all_members(inout DynamicTypeMembersById member);
 
+    /// Returns the total number of members in the type.
     pub fn get_member_count(&self) -> u32 {
         self.member_list.len() as u32
     }
+    /// Retrieves a member by index.
     pub fn get_member_by_index(&self, index: u32) -> Result<&DynamicTypeMember, XTypesError> {
         self.member_list
             .get(index as usize)
@@ -673,9 +775,11 @@ impl DynamicType {
     // DDS::ReturnCode_t get_verbatim_text(inout VerbatimTextDescriptor descriptor, in unsigned long idx);
 }
 
+/// A factory class used to instantiate [`DynamicData`] samples.
 pub struct DynamicDataFactory;
 
 impl DynamicDataFactory {
+    /// Creates a [`DynamicData`] sample of the specified [`DynamicType`].
     pub fn create_data(r#type: DynamicType) -> DynamicData {
         DynamicData {
             r#type,
@@ -684,6 +788,7 @@ impl DynamicDataFactory {
     }
 }
 
+/// Represents a data sample conforming to a [`DynamicType`] schema.
 #[derive(Clone)]
 pub struct DynamicData {
     r#type: DynamicType,
@@ -705,10 +810,12 @@ impl PartialEq for DynamicData {
 }
 
 impl DynamicData {
+    /// Returns the [`DynamicType`] of this data sample.
     pub fn r#type(&self) -> DynamicType {
         self.r#type
     }
 
+    /// Returns a reference to the descriptor of the specified member.
     pub fn get_descriptor(&self, id: MemberId) -> XTypesResult<&MemberDescriptor> {
         if let Ok(x) = self.r#type.get_member(id) {
             Ok(&x.descriptor)
@@ -719,10 +826,12 @@ impl DynamicData {
         }
     }
 
+    /// Sets the descriptor of the specified member.
     pub fn set_descriptor(&mut self, _id: MemberId, _value: MemberDescriptor) -> XTypesResult<()> {
         todo!()
     }
 
+    /// Retrieves the member ID corresponding to the given member name.
     pub fn get_member_id_by_name(&self, name: &str) -> Option<MemberId> {
         self.r#type
             .get_member_by_name(name)
@@ -730,6 +839,7 @@ impl DynamicData {
             .map(|m| m.get_id())
     }
 
+    /// Retrieves the member ID at the specified index.
     pub fn get_member_id_at_index(&self, index: u32) -> XTypesResult<MemberId> {
         self.abstract_data
             .keys()
@@ -738,15 +848,18 @@ impl DynamicData {
             .ok_or(XTypesError::InvalidIndex(index))
     }
 
+    /// Returns the number of items/members in this data sample.
     pub fn get_item_count(&self) -> u32 {
         self.abstract_data.len() as u32
     }
 
+    /// Clears all member values from this data sample.
     pub fn clear_all_values(&mut self) -> XTypesResult<()> {
         self.abstract_data.clear();
         Ok(())
     }
 
+    /// Clears all non-key member values from this data sample.
     pub fn clear_nonkey_values(&mut self) -> XTypesResult<()> {
         for index in 0..self.r#type.get_member_count() {
             let member = self.r#type.get_member_by_index(index)?;
@@ -758,6 +871,7 @@ impl DynamicData {
         Ok(())
     }
 
+    /// Clears the value of the specified member.
     pub fn clear_value(&mut self, id: MemberId) -> XTypesResult<()> {
         self.abstract_data
             .remove(&id)
@@ -765,6 +879,7 @@ impl DynamicData {
         Ok(())
     }
 
+    /// Gets the `i32` value for the specified member.
     pub fn get_int32_value(&self, id: MemberId) -> XTypesResult<&i32> {
         if let DataStorage::Int32(d) = self
             .abstract_data
@@ -777,11 +892,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `i32` value for the specified member.
     pub fn set_int32_value(&mut self, id: MemberId, value: i32) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::Int32(value));
         Ok(())
     }
 
+    /// Gets the `u32` value for the specified member.
     pub fn get_uint32_value(&self, id: MemberId) -> XTypesResult<&u32> {
         if let DataStorage::UInt32(d) = self
             .abstract_data
@@ -794,11 +911,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `u32` value for the specified member.
     pub fn set_uint32_value(&mut self, id: MemberId, value: u32) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::UInt32(value));
         Ok(())
     }
 
+    /// Gets the `i8` value for the specified member.
     pub fn get_int8_value(&self, id: MemberId) -> XTypesResult<&i8> {
         if let DataStorage::Int8(d) = self
             .abstract_data
@@ -811,11 +930,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `i8` value for the specified member.
     pub fn set_int8_value(&mut self, id: MemberId, value: i8) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::Int8(value));
         Ok(())
     }
 
+    /// Gets the `u8` value for the specified member.
     pub fn get_uint8_value(&self, id: MemberId) -> XTypesResult<&u8> {
         if let DataStorage::UInt8(d) = self
             .abstract_data
@@ -828,11 +949,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `u8` value for the specified member.
     pub fn set_uint8_value(&mut self, id: MemberId, value: u8) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::UInt8(value));
         Ok(())
     }
 
+    /// Gets the `i16` value for the specified member.
     pub fn get_int16_value(&self, id: MemberId) -> XTypesResult<&i16> {
         if let DataStorage::Int16(d) = self
             .abstract_data
@@ -845,11 +968,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `i16` value for the specified member.
     pub fn set_int16_value(&mut self, id: MemberId, value: i16) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::Int16(value));
         Ok(())
     }
 
+    /// Gets the `u16` value for the specified member.
     pub fn get_uint16_value(&self, id: MemberId) -> XTypesResult<&u16> {
         if let DataStorage::UInt16(d) = self
             .abstract_data
@@ -862,11 +987,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `u16` value for the specified member.
     pub fn set_uint16_value(&mut self, id: MemberId, value: u16) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::UInt16(value));
         Ok(())
     }
 
+    /// Gets the `i64` value for the specified member.
     pub fn get_int64_value(&self, id: MemberId) -> XTypesResult<&i64> {
         if let DataStorage::Int64(d) = self
             .abstract_data
@@ -879,11 +1006,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `i64` value for the specified member.
     pub fn set_int64_value(&mut self, id: MemberId, value: i64) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::Int64(value));
         Ok(())
     }
 
+    /// Gets the `u64` value for the specified member.
     pub fn get_uint64_value(&self, id: MemberId) -> XTypesResult<&u64> {
         if let DataStorage::UInt64(d) = self
             .abstract_data
@@ -896,11 +1025,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `u64` value for the specified member.
     pub fn set_uint64_value(&mut self, id: MemberId, value: u64) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::UInt64(value));
         Ok(())
     }
 
+    /// Gets the `f32` value for the specified member.
     pub fn get_float32_value(&self, id: MemberId) -> XTypesResult<&f32> {
         if let DataStorage::Float32(d) = self
             .abstract_data
@@ -913,11 +1044,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `f32` value for the specified member.
     pub fn set_float32_value(&mut self, id: MemberId, value: f32) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::Float32(value));
         Ok(())
     }
 
+    /// Gets the `f64` value for the specified member.
     pub fn get_float64_value(&self, id: MemberId) -> XTypesResult<&f64> {
         if let DataStorage::Float64(d) = self
             .abstract_data
@@ -930,11 +1063,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `f64` value for the specified member.
     pub fn set_float64_value(&mut self, id: MemberId, value: f64) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::Float64(value));
         Ok(())
     }
 
+    /// Gets the `i128` (representing `float128`) value for the specified member.
     pub fn get_float128_value(&self, id: MemberId) -> XTypesResult<&i128> {
         if let DataStorage::Float128(d) = self
             .abstract_data
@@ -947,11 +1082,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `i128` (representing `float128`) value for the specified member.
     pub fn set_float128_value(&mut self, id: MemberId, value: i128) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::Float128(value));
         Ok(())
     }
 
+    /// Gets the `char` (representing `char8`) value for the specified member.
     pub fn get_char8_value(&self, id: MemberId) -> XTypesResult<&char> {
         if let DataStorage::Char8(d) = self
             .abstract_data
@@ -964,11 +1101,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `char` (representing `char8`) value for the specified member.
     pub fn set_char8_value(&mut self, id: MemberId, value: char) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::Char8(value));
         Ok(())
     }
 
+    /// Gets the byte (8-bit unsigned integer) value for the specified member.
     pub fn get_byte_value(&self, id: MemberId) -> XTypesResult<&u8> {
         if let DataStorage::UInt8(d) = self
             .abstract_data
@@ -981,11 +1120,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the byte (8-bit unsigned integer) value for the specified member.
     pub fn set_byte_value(&mut self, id: MemberId, value: u8) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::UInt8(value));
         Ok(())
     }
 
+    /// Gets the `bool` value for the specified member.
     pub fn get_boolean_value(&self, id: MemberId) -> XTypesResult<&bool> {
         if let DataStorage::Boolean(d) = self
             .abstract_data
@@ -998,11 +1139,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `bool` value for the specified member.
     pub fn set_boolean_value(&mut self, id: MemberId, value: bool) -> XTypesResult<()> {
         self.abstract_data.insert(id, value.into_storage());
         Ok(())
     }
 
+    /// Gets the `String` value for the specified member.
     pub fn get_string_value(&self, id: MemberId) -> XTypesResult<&String> {
         if let DataStorage::String(d) = self
             .abstract_data
@@ -1015,11 +1158,13 @@ impl DynamicData {
         }
     }
 
+    /// Sets the `String` value for the specified member.
     pub fn set_string_value(&mut self, id: MemberId, value: String) -> XTypesResult<()> {
         self.abstract_data.insert(id, DataStorage::String(value));
         Ok(())
     }
 
+    /// Gets the complex (nested `DynamicData`) value for the specified member.
     pub fn get_complex_value(&self, id: MemberId) -> XTypesResult<&DynamicData> {
         if let DataStorage::ComplexValue(d) = self
             .abstract_data
@@ -1032,18 +1177,21 @@ impl DynamicData {
         }
     }
 
+    /// Gets the raw data kind/storage for the specified member.
     pub fn get_data_kind(&self, id: MemberId) -> XTypesResult<&DataStorage> {
         self.abstract_data
             .get(&id)
             .ok_or(XTypesError::InvalidId(id))
     }
 
+    /// Sets the complex (nested `DynamicData`) value for the specified member.
     pub fn set_complex_value(&mut self, id: MemberId, value: DynamicData) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::ComplexValue(value));
         Ok(())
     }
 
+    /// Gets a slice of `i32` values for the specified sequence/array member.
     pub fn get_int32_values(&self, id: MemberId) -> XTypesResult<&[i32]> {
         if let DataStorage::SequenceInt32(d) = self
             .abstract_data
@@ -1056,12 +1204,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `i32` values for the specified member.
     pub fn set_int32_values(&mut self, id: MemberId, value: Vec<i32>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceInt32(value));
         Ok(())
     }
 
+    /// Gets a slice of `u32` values for the specified sequence/array member.
     pub fn get_uint32_values(&self, id: MemberId) -> XTypesResult<&[u32]> {
         if let DataStorage::SequenceUInt32(d) = self
             .abstract_data
@@ -1074,12 +1224,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `u32` values for the specified member.
     pub fn set_uint32_values(&mut self, id: MemberId, value: Vec<u32>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceUInt32(value));
         Ok(())
     }
 
+    /// Gets a slice of `i16` values for the specified sequence/array member.
     pub fn get_int16_values(&self, id: MemberId) -> XTypesResult<&[i16]> {
         if let DataStorage::SequenceInt16(d) = self
             .abstract_data
@@ -1092,12 +1244,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `i16` values for the specified member.
     pub fn set_int16_values(&mut self, id: MemberId, value: Vec<i16>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceInt16(value));
         Ok(())
     }
 
+    /// Gets a slice of `u16` values for the specified sequence/array member.
     pub fn get_uint16_values(&self, id: MemberId) -> XTypesResult<&[u16]> {
         if let DataStorage::SequenceUInt16(d) = self
             .abstract_data
@@ -1110,12 +1264,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `u16` values for the specified member.
     pub fn set_uint16_values(&mut self, id: MemberId, value: Vec<u16>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceUInt16(value));
         Ok(())
     }
 
+    /// Gets a slice of `i64` values for the specified sequence/array member.
     pub fn get_int64_values(&self, id: MemberId) -> XTypesResult<&[i64]> {
         if let DataStorage::SequenceInt64(d) = self
             .abstract_data
@@ -1128,12 +1284,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `i64` values for the specified member.
     pub fn set_int64_values(&mut self, id: MemberId, value: Vec<i64>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceInt64(value));
         Ok(())
     }
 
+    /// Gets a slice of `u64` values for the specified sequence/array member.
     pub fn get_uint64_values(&self, id: MemberId) -> XTypesResult<&[u64]> {
         if let DataStorage::SequenceUInt64(d) = self
             .abstract_data
@@ -1146,12 +1304,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `u64` values for the specified member.
     pub fn set_uint64_values(&mut self, id: MemberId, value: Vec<u64>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceUInt64(value));
         Ok(())
     }
 
+    /// Gets a slice of `f32` values for the specified sequence/array member.
     pub fn get_float32_values(&self, id: MemberId) -> XTypesResult<&[f32]> {
         if let DataStorage::SequenceFloat32(d) = self
             .abstract_data
@@ -1164,12 +1324,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `f32` values for the specified member.
     pub fn set_float32_values(&mut self, id: MemberId, value: Vec<f32>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceFloat32(value));
         Ok(())
     }
 
+    /// Gets a slice of `f64` values for the specified sequence/array member.
     pub fn get_float64_values(&self, id: MemberId) -> XTypesResult<&[f64]> {
         if let DataStorage::SequenceFloat64(d) = self
             .abstract_data
@@ -1182,12 +1344,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `f64` values for the specified member.
     pub fn set_float64_values(&mut self, id: MemberId, value: Vec<f64>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceFloat64(value));
         Ok(())
     }
 
+    /// Gets a slice of `i128` (representing `float128`) values for the specified sequence/array member.
     pub fn get_float128_values(&self, id: MemberId) -> XTypesResult<&[i128]> {
         if let DataStorage::SequenceFloat128(d) = self
             .abstract_data
@@ -1200,12 +1364,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `i128` (representing `float128`) values for the specified member.
     pub fn set_float128_values(&mut self, id: MemberId, value: Vec<i128>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceFloat128(value));
         Ok(())
     }
 
+    /// Gets a slice of `char` (representing `char8`) values for the specified sequence/array member.
     pub fn get_char8_values(&self, id: MemberId) -> XTypesResult<&[char]> {
         if let DataStorage::SequenceChar8(d) = self
             .abstract_data
@@ -1218,12 +1384,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `char` (representing `char8`) values for the specified member.
     pub fn set_char8_values(&mut self, id: MemberId, value: Vec<char>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceChar8(value));
         Ok(())
     }
 
+    /// Gets a slice of byte (8-bit unsigned integer) values for the specified sequence/array member.
     pub fn get_byte_values(&self, id: MemberId) -> XTypesResult<&[u8]> {
         if let DataStorage::SequenceUInt8(d) = self
             .abstract_data
@@ -1236,12 +1404,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of byte (8-bit unsigned integer) values for the specified member.
     pub fn set_byte_values(&mut self, id: MemberId, value: Vec<u8>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceUInt8(value));
         Ok(())
     }
 
+    /// Gets a slice of `bool` values for the specified sequence/array member.
     pub fn get_boolean_values(&self, id: MemberId) -> XTypesResult<&[bool]> {
         if let DataStorage::SequenceBoolean(d) = self
             .abstract_data
@@ -1254,12 +1424,14 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `bool` values for the specified member.
     pub fn set_boolean_values(&mut self, id: MemberId, value: Vec<bool>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceBoolean(value));
         Ok(())
     }
 
+    /// Gets a slice of `String` values for the specified sequence/array member.
     pub fn get_string_values(&self, id: MemberId) -> XTypesResult<&[String]> {
         if let DataStorage::SequenceString(d) = self
             .abstract_data
@@ -1272,6 +1444,7 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `String` values for the specified member.
     pub fn set_string_values(&mut self, id: MemberId, value: Vec<String>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceString(value));
@@ -1279,6 +1452,7 @@ impl DynamicData {
     }
 
     // Custom functions
+    /// Gets a slice of `u8` values for the specified sequence/array member.
     pub fn get_uint8_values(&self, id: MemberId) -> XTypesResult<&[u8]> {
         if let DataStorage::SequenceUInt8(d) = self
             .abstract_data
@@ -1291,6 +1465,7 @@ impl DynamicData {
         }
     }
 
+    /// Gets a slice of `i8` values for the specified sequence/array member.
     pub fn get_int8_values(&self, id: MemberId) -> XTypesResult<&[i8]> {
         if let DataStorage::SequenceInt8(d) = self
             .abstract_data
@@ -1303,18 +1478,21 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of `u8` values for the specified member.
     pub fn set_uint8_values(&mut self, id: MemberId, value: Vec<u8>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceUInt8(value));
         Ok(())
     }
 
+    /// Sets a sequence of `i8` values for the specified member.
     pub fn set_int8_values(&mut self, id: MemberId, value: Vec<i8>) -> XTypesResult<()> {
         self.abstract_data
             .insert(id, DataStorage::SequenceInt8(value));
         Ok(())
     }
 
+    /// Gets a slice of complex (nested `DynamicData`) values for the specified sequence/array member.
     pub fn get_complex_values(&self, id: MemberId) -> XTypesResult<&[DynamicData]> {
         if let DataStorage::SequenceComplexValue(d) = self
             .abstract_data
@@ -1327,6 +1505,7 @@ impl DynamicData {
         }
     }
 
+    /// Sets a sequence of complex (nested `DynamicData`) values for the specified member.
     pub fn set_complex_values(
         &mut self,
         id: MemberId,
@@ -1337,16 +1516,19 @@ impl DynamicData {
         Ok(())
     }
 
+    /// Sets the value of the specified member to the given raw data storage.
     pub fn set_value(&mut self, id: MemberId, value: DataStorage) {
         self.abstract_data.insert(id, value);
     }
 
+    /// Gets the raw data storage for the specified member.
     pub fn get_value(&self, id: MemberId) -> XTypesResult<&DataStorage> {
         self.abstract_data
             .get(&id)
             .ok_or(XTypesError::InvalidId(id))
     }
 
+    /// Removes and returns the raw data storage for the specified member.
     pub fn remove_value(&mut self, id: MemberId) -> XTypesResult<DataStorage> {
         self.abstract_data
             .remove(&id)
@@ -1382,6 +1564,7 @@ impl TypeSupport for DynamicData {
 
 #[cfg(feature = "xtypes-xml")]
 impl DynamicData {
+    /// Deserializes data from an XML string into this `DynamicData` instance.
     pub fn from_xml(&mut self, xml: &str) -> XTypesResult<()> {
         let doc = roxmltree::Document::parse(xml).map_err(|_| XTypesError::InvalidData)?;
         let root = doc.root_element();

--- a/dds/src/xtypes/error.rs
+++ b/dds/src/xtypes/error.rs
@@ -1,15 +1,26 @@
+/// Specialized [`Result`] type for XTypes operations.
 pub type XTypesResult<T> = Result<T, XTypesError>;
 
+/// XTypes error conditions
 #[derive(Debug, PartialEq)]
 pub enum XTypesError {
+    /// The operation ran out of memory.
     OutOfMemory,
+    /// The data provided is invalid.
     InvalidData,
+    /// The type provided or encountered is invalid or mismatched.
     InvalidType,
+    /// The parameter ID (PID) was not found.
     PidNotFound(u16),
+    /// The member ID or identifier is invalid or not found.
     InvalidId(u32),
+    /// The index is out of bounds or invalid.
     InvalidIndex(u32),
+    /// The member name or identifier name is invalid or not found.
     InvalidName,
+    /// Not enough data was available to complete the operation.
     NotEnoughData,
+    /// The representation identifier is not supported.
     NotSupported([u8; 2]),
     /// An operation was invoked on an inappropriate object or
     /// at an inappropriate time (as determined by policies set by the

--- a/dds/src/xtypes/mod.rs
+++ b/dds/src/xtypes/mod.rs
@@ -14,10 +14,7 @@ pub mod dynamic_type;
 /// Classes related to the XTypes error and return codes.
 pub mod error;
 
-/// Type Object representation as defined in the DDS-XTypes 1.3 standard.
-///
-/// A TypeObject describes a type structure completely or minimally, allowing DDS participants
-/// to exchange type information dynamically during discovery.
+/// Classes related to the Type Object representation as defined in the DDS-XTypes 1.3 standard.
 pub mod type_object;
 
 /// Traits related to the representation of XTypes required to be transmitted using DDS

--- a/dds/src/xtypes/mod.rs
+++ b/dds/src/xtypes/mod.rs
@@ -14,7 +14,10 @@ pub mod dynamic_type;
 /// Classes related to the XTypes error and return codes.
 pub mod error;
 
-#[doc(hidden)]
+/// Type Object representation as defined in the DDS-XTypes 1.3 standard.
+///
+/// A TypeObject describes a type structure completely or minimally, allowing DDS participants
+/// to exchange type information dynamically during discovery.
 pub mod type_object;
 
 /// Traits related to the representation of XTypes required to be transmitted using DDS

--- a/dds/src/xtypes/mod.rs
+++ b/dds/src/xtypes/mod.rs
@@ -1,17 +1,19 @@
+pub(crate) mod deserializer;
+pub(crate) mod read_write;
+pub(crate) mod serializer;
+
 #[doc(hidden)]
 pub mod bytes;
 #[doc(hidden)]
 pub mod data_storage;
-#[doc(hidden)]
-pub mod deserializer;
+
 #[doc(hidden)]
 pub mod dynamic_type;
-#[doc(hidden)]
+
+/// Classes related to the XTypes error and return codes.
 pub mod error;
+
 #[doc(hidden)]
-pub mod read_write;
-#[doc(hidden)]
-pub mod serializer;
 #[doc(hidden)]
 pub mod type_object;
 

--- a/dds/src/xtypes/mod.rs
+++ b/dds/src/xtypes/mod.rs
@@ -4,16 +4,16 @@ pub(crate) mod serializer;
 
 #[doc(hidden)]
 pub mod bytes;
+
 #[doc(hidden)]
 pub mod data_storage;
 
-#[doc(hidden)]
+/// Classes related to the dynamic representation of types and data.
 pub mod dynamic_type;
 
 /// Classes related to the XTypes error and return codes.
 pub mod error;
 
-#[doc(hidden)]
 #[doc(hidden)]
 pub mod type_object;
 

--- a/dds/src/xtypes/mod.rs
+++ b/dds/src/xtypes/mod.rs
@@ -1,9 +1,19 @@
+#[doc(hidden)]
 pub mod bytes;
+#[doc(hidden)]
 pub mod data_storage;
+#[doc(hidden)]
 pub mod deserializer;
+#[doc(hidden)]
 pub mod dynamic_type;
+#[doc(hidden)]
 pub mod error;
+#[doc(hidden)]
 pub mod read_write;
+#[doc(hidden)]
 pub mod serializer;
+#[doc(hidden)]
 pub mod type_object;
+
+/// Traits related to the representation of XTypes required to be transmitted using DDS
 pub mod type_support;

--- a/dds/src/xtypes/mod.rs
+++ b/dds/src/xtypes/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod serializer;
 #[doc(hidden)]
 pub mod bytes;
 
-#[doc(hidden)]
+/// Representation of data storage for dynamic types.
 pub mod data_storage;
 
 /// Classes related to the dynamic representation of types and data.

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -455,12 +455,12 @@ pub struct ExtendedTypeDefn {
 /// For Plain Types and Hash-defined TypeIdentifiers there are three
 /// possibilities: MINIMAL, COMPLETE, and COMMON:
 /// - MINIMAL indicates the TypeIdentifier identifies equivalent types
-/// according to the MINIMAL equivalence relation
+///   according to the MINIMAL equivalence relation
 /// - COMPLETE indicates the TypeIdentifier identifies equivalent types
-/// according to the COMPLETE equivalence relation
+///   according to the COMPLETE equivalence relation
 /// - COMMON indicates the TypeIdentifier identifies equivalent types
-/// according to both the MINIMAL and the COMMON equivalence relation.
-/// This means the TypeIdentifier is the same for both relationships
+///   according to both the MINIMAL and the COMMON equivalence relation.
+///   This means the TypeIdentifier is the same for both relationships
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested, switch(u8))]
 pub enum TypeIdentifier {

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -13,107 +13,171 @@ use super::dynamic_type::{ExtensibilityKind, TryConstructKind, TypeKind};
 /* Manually created from dds-xtypes_typeobject.idl */
 
 // ---------- Equivalence Kinds -------------------
+/// The kind of equivalence relation used for a type representation.
 pub type EquivalenceKind = u8;
+/// Represents the minimal equivalence kind.
 pub const EK_MINIMAL: EquivalenceKind = 0xF1; // 0x1111 0001
+/// Represents the complete equivalence kind.
 pub const EK_COMPLETE: EquivalenceKind = 0xF2; // 0x1111 0010
+/// Represents both minimal and complete equivalence kinds.
 pub const EK_BOTH: EquivalenceKind = 0xF3; // 0x1111 0011
 
 // ---------- TypeKinds (begin) -------------------
 // Primitive TKs
+/// Represents no type kind.
 pub const TK_NONE: u8 = 0x00;
+/// Represents the boolean type kind.
 pub const TK_BOOLEAN: u8 = 0x01;
+/// Represents the byte type kind.
 pub const TK_BYTE: u8 = 0x02;
+/// Represents the signed 16-bit integer type kind.
 pub const TK_INT16: u8 = 0x03;
+/// Represents the signed 32-bit integer type kind.
 pub const TK_INT32: u8 = 0x04;
+/// Represents the signed 64-bit integer type kind.
 pub const TK_INT64: u8 = 0x05;
+/// Represents the unsigned 16-bit integer type kind.
 pub const TK_UINT16: u8 = 0x06;
+/// Represents the unsigned 32-bit integer type kind.
 pub const TK_UINT32: u8 = 0x07;
+/// Represents the unsigned 64-bit integer type kind.
 pub const TK_UINT64: u8 = 0x08;
+/// Represents the single-precision floating-point type kind.
 pub const TK_FLOAT32: u8 = 0x09;
+/// Represents the double-precision floating-point type kind.
 pub const TK_FLOAT64: u8 = 0x0A;
+/// Represents the 128-bit floating-point type kind.
 pub const TK_FLOAT128: u8 = 0x0B;
+/// Represents the signed 8-bit integer type kind.
 pub const TK_INT8: u8 = 0x0C;
+/// Represents the unsigned 8-bit integer type kind.
 pub const TK_UINT8: u8 = 0x0D;
+/// Represents the 8-bit character type kind.
 pub const TK_CHAR8: u8 = 0x10;
+/// Represents the 16-bit character type kind.
 pub const TK_CHAR16: u8 = 0x11;
 
 // String TKs
+/// Represents the 8-bit string type kind.
 pub const TK_STRING8: u8 = 0x20;
+/// Represents the 16-bit string type kind.
 pub const TK_STRING16: u8 = 0x21;
 
 // Constructed/Named types
+/// Represents the alias type kind.
 pub const TK_ALIAS: u8 = 0x30;
 
 // Enumerated TKs
+/// Represents the enumeration type kind.
 pub const TK_ENUM: u8 = 0x40;
+/// Represents the bitmask type kind.
 pub const TK_BITMASK: u8 = 0x41;
 
 // Structured TKs
+/// Represents the annotation type kind.
 pub const TK_ANNOTATION: u8 = 0x50;
+/// Represents the structure type kind.
 pub const TK_STRUCTURE: u8 = 0x51;
+/// Represents the union type kind.
 pub const TK_UNION: u8 = 0x52;
+/// Represents the bitset type kind.
 pub const TK_BITSET: u8 = 0x53;
 
 // Collection TKs
+/// Represents the sequence type kind.
 pub const TK_SEQUENCE: u8 = 0x60;
+/// Represents the array type kind.
 pub const TK_ARRAY: u8 = 0x61;
+/// Represents the map type kind.
 pub const TK_MAP: u8 = 0x62;
 // ---------- TypeKinds (end) -------------------
 
 // ---------- Extra TypeIdentifiers (begin) ------------
+/// The kind of extra type identifiers.
 pub type TypeIdentiferKind = u8;
+/// Represents a small 8-bit string type identifier.
 pub const TI_STRING8_SMALL: u8 = 0x70;
+/// Represents a large 8-bit string type identifier.
 pub const TI_STRING8_LARGE: u8 = 0x71;
+/// Represents a small 16-bit string type identifier.
 pub const TI_STRING16_SMALL: u8 = 0x72;
+/// Represents a large 16-bit string type identifier.
 pub const TI_STRING16_LARGE: u8 = 0x73;
+/// Represents a small plain sequence type identifier.
 pub const TI_PLAIN_SEQUENCE_SMALL: u8 = 0x80;
+/// Represents a large plain sequence type identifier.
 pub const TI_PLAIN_SEQUENCE_LARGE: u8 = 0x81;
+/// Represents a small plain array type identifier.
 pub const TI_PLAIN_ARRAY_SMALL: u8 = 0x90;
+/// Represents a large plain array type identifier.
 pub const TI_PLAIN_ARRAY_LARGE: u8 = 0x91;
+/// Represents a small plain map type identifier.
 pub const TI_PLAIN_MAP_SMALL: u8 = 0xA0;
+/// Represents a large plain map type identifier.
 pub const TI_PLAIN_MAP_LARGE: u8 = 0xA1;
+/// Represents a strongly connected component type identifier.
 pub const TI_STRONGLY_CONNECTED_COMPONENT: u8 = 0xB0;
 // ---------- Extra TypeIdentifiers (end) --------------
 
 // The name of some element (e.g. type, type member, module)
 // Valid characters are alphanumeric plus the "_" cannot start with digit
+/// The maximum length of a member name.
 pub const MEMBER_NAME_MAX_LENGTH: i32 = 256;
+/// Type alias for a member name.
 pub type MemberName = String; //string<MEMBER_NAME_MAX_LENGTH>
 
 // Qualified type name includes the name of containing modules
 // using "::" as separator. No leading "::". E.g. "MyModule::MyType"
+/// The maximum length of a type name.
 pub const TYPE_NAME_MAX_LENGTH: i32 = 256;
+/// Type alias for a qualified type name.
 pub type QualifiedTypeName = String; //string<TYPE_NAME_MAX_LENGTH>
 
+/// Type alias for a primitive type ID.
 // Every type has an ID. Those of the primitive types are pre-defined.
 pub type PrimitiveTypeId = u8;
 
+/// Hash representing the equivalence of a TypeObject.
 // First 14 bytes of MD5 of the serialized TypeObject using XCDR
 // version 2 with Little Endian encoding
 pub type EquivalenceHash = [u8; 14];
 
+/// Hash representing a member name.
 // First 4 bytes of MD5 of of a member name converted to bytes
 // using UTF-8 encoding and without a 'nul' terminator.
 // Example: the member name "color" has NameHash {0x70, 0xDD, 0xA5, 0xDF}
 pub type NameHash = [u8; 4];
 
-// Long Bound of a collection type
+/// Long bound representation.
 pub type LBound = u32;
+/// Sequence of long bounds.
 pub type LBoundSeq = Vec<LBound>;
+/// Value representing an invalid long bound.
 pub const INVALID_LBOUND: LBound = 0;
 
-// Short Bound of a collection type
+/// Short bound representation.
 pub type SBound = u8;
+/// Sequence of short bounds.
 pub type SBoundSeq = Vec<SBound>;
+/// Value representing an invalid short bound.
 pub const INVALID_SBOUND: SBound = 0;
 
+/// Unique identifier for a TypeObject based on its equivalence hash.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested, switch(u8))]
 pub enum TypeObjectHashId {
+    /// The hash for a complete TypeObject representation.
     #[dust_dds(case=EK_COMPLETE)]
-    EkComplete { hash: EquivalenceHash },
+    EkComplete {
+        /// The 14-byte MD5 equivalence hash of the complete TypeObject.
+        hash: EquivalenceHash,
+    },
+    /// The hash for a minimal TypeObject representation.
     #[dust_dds(case=EK_MINIMAL)]
-    EkMinimal { hash: EquivalenceHash },
+    EkMinimal {
+        /// The 14-byte MD5 equivalence hash of the minimal TypeObject.
+        hash: EquivalenceHash,
+    },
 }
 
 // Flags that apply to struct/union/collection/enum/bitmask/bitset
@@ -121,6 +185,7 @@ pub enum TypeObjectHashId {
 // Depending on the flag it may not apply to members of all types
 // When not all, the applicable member types are listed
 
+/// Flags that apply to struct/union/collection/enum/bitmask/bitset members/elements and affect type assignability.
 #[derive(Debug, Clone, Copy, DdsType)]
 pub struct MemberFlag(u16);
 
@@ -144,33 +209,51 @@ impl core::ops::BitOrAssign for MemberFlag {
     }
 }
 
+/// Flag indicating try construct behavior bit 1.
 pub const MEMBER_FLAG_TRY_CONSTRUCT1: MemberFlag = MemberFlag(1 << 0); // T1 | 00 = INVALID, 01 = DISCARD
+/// Flag indicating try construct behavior bit 2.
 pub const MEMBER_FLAG_TRY_CONSTRUCT2: MemberFlag = MemberFlag(1 << 1); // T2 | 10 = USE_DEFAULT, 11 = TRIM
+/// Flag indicating the member is external (allocated out-of-line).
 pub const MEMBER_FLAG_IS_EXTERNAL: MemberFlag = MemberFlag(1 << 2); // X StructMember, UnionMember,
 // CollectionElement
+/// Flag indicating the member is optional.
 pub const MEMBER_FLAG_IS_OPTIONAL: MemberFlag = MemberFlag(1 << 3); // O StructMember
+/// Flag indicating the member must be understood by the reader.
 pub const MEMBER_FLAG_IS_MUST_UNDERSTAND: MemberFlag = MemberFlag(1 << 4); // M StructMember
+/// Flag indicating the member is part of the type's key.
 pub const MEMBER_FLAG_IS_KEY: MemberFlag = MemberFlag(1 << 5); // K StructMember, UnionDiscriminator
+/// Flag indicating the member is the default member (e.g. for unions).
 pub const MEMBER_FLAG_IS_DEFAULT: MemberFlag = MemberFlag(1 << 6); // D UnionMember, EnumerationLiteral
 
+/// Flags that apply to collection elements.
 pub type CollectionElementFlag = MemberFlag; // T1, T2, X
 
+/// Flags that apply to structure members.
 pub type StructMemberFlag = MemberFlag; // T1, T2, O, M, K, X
+/// Flags that apply to union members.
 pub type UnionMemberFlag = MemberFlag; // T1, T2, D, X
+/// Flags that apply to union discriminator.
 pub type UnionDiscriminatorFlag = MemberFlag; // T1, T2, K
+/// Flags that apply to enumerated literals.
 pub type EnumeratedLiteralFlag = MemberFlag; // D
+/// Flags that apply to annotation parameters.
 pub type AnnotationParameterFlag = MemberFlag; // Unused. No flags apply
+/// Flags that apply to alias members.
 pub type AliasMemberFlag = MemberFlag; // Unused. No flags apply
+/// Flags that apply to bitflags.
 pub type BitflagFlag = MemberFlag; // Unused. No flags apply
+/// Flags that apply to bitset members.
 pub type BitsetMemberFlag = MemberFlag; // Unused. No flags apply
 
 // Mask used to remove the flags that do no affect assignability
 // Selects T1, T2, O, M, K, D
+/// Mask selecting member flags that affect minimal equivalence checking.
 pub const MEMBER_FLAG_MINIMAL_MASK: MemberFlag = MemberFlag(0x003f);
 // Flags that apply to type declarationa and DO affect assignability
 // Depending on the flag it may not apply to all types
 // When not all, the applicable types are listed
 
+/// Flags that apply to type declarations and affect type assignability.
 #[derive(DdsType, Debug, Clone)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct TypeFlag(u16);
@@ -194,209 +277,330 @@ impl core::ops::BitOrAssign for TypeFlag {
     }
 }
 
+/// Flag indicating the type is final (cannot be extended).
 pub const TYPE_FLAG_IS_FINAL: TypeFlag = TypeFlag(1 << 0); // F
+/// Flag indicating the type is appendable (new members can be added at the end).
 pub const TYPE_FLAG_IS_APPENDABLE: TypeFlag = TypeFlag(1 << 1); // A |- Struct, Union
+/// Flag indicating the type is mutable (members can be added, removed, or reordered).
 pub const TYPE_FLAG_IS_MUTABLE: TypeFlag = TypeFlag(1 << 2); // M | (exactly one flag)
+/// Flag indicating the type is nested inside another type.
 pub const TYPE_FLAG_IS_NESTED: TypeFlag = TypeFlag(1 << 3); // N Struct, Union
+/// Flag indicating member IDs are automatically assigned based on hash.
 pub const TYPE_FLAG_IS_AUTOID_HASH: TypeFlag = TypeFlag(1 << 4); // H Struct
 
+/// Type flags that apply to structures.
 pub type StructTypeFlag = TypeFlag; // All flags apply
+/// Type flags that apply to unions.
 pub type UnionTypeFlag = TypeFlag; // All flags apply
+/// Type flags that apply to collections.
 pub type CollectionTypeFlag = TypeFlag; // Unused. No flags apply
+/// Type flags that apply to annotations.
 pub type AnnotationTypeFlag = TypeFlag; // Unused. No flags apply
+/// Type flags that apply to aliases.
 pub type AliasTypeFlag = TypeFlag; // Unused. No flags apply
+/// Type flags that apply to enumerations.
 pub type EnumTypeFlag = TypeFlag; // Unused. No flags apply
+/// Type flags that apply to bitmasks.
 pub type BitmaskTypeFlag = TypeFlag; // Unused. No flags apply
+/// Type flags that apply to bitsets.
 pub type BitsetTypeFlag = TypeFlag; // Unused. No flags apply
 
 // Mask used to remove the flags that do no affect assignability
+/// Mask selecting type flags that affect minimal equivalence checking.
 pub const TYPE_FLAG_MINIMAL_MASK: TypeFlag = TypeFlag(0x0007); // Selects M, A, F
 
 // 1 Byte
+/// Definition of a small string type (bound <= 255).
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct StringSTypeDefn {
+    /// The short bound (maximum length) of the string.
     pub bound: SBound,
 }
 // 4 Bytes
+/// Definition of a large string type (bound > 255).
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct StringLTypeDefn {
+    /// The long bound (maximum length) of the string.
     pub bound: LBound,
 }
 
+/// Common header for plain collection types (sequence, array, map).
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainCollectionHeader {
+    /// The equivalence kind of the collection.
     pub equiv_kind: EquivalenceKind,
+    /// Flags that apply to the elements of the collection.
     pub element_flags: CollectionElementFlag,
 }
 
+/// Definition of a plain sequence with a small bound.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainSequenceSElemDefn {
+    /// The header containing collection properties.
     pub header: PlainCollectionHeader,
+    /// The small bound (maximum number of elements).
     pub bound: SBound,
+    /// The identifier of the element type.
     #[dust_dds(external)]
     pub element_identifier: Box<TypeIdentifier>,
 }
 
+/// Definition of a plain sequence with a large bound.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainSequenceLElemDefn {
+    /// The header containing collection properties.
     pub header: PlainCollectionHeader,
+    /// The large bound (maximum number of elements).
     pub bound: LBound,
+    /// The identifier of the element type.
     #[dust_dds(external)]
     pub element_identifier: Box<TypeIdentifier>,
 }
 
+/// Definition of a plain array with small bounds.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainArraySElemDefn {
+    /// The header containing collection properties.
     pub header: PlainCollectionHeader,
+    /// The sequence of small bounds for each dimension.
     pub array_bound_seq: SBoundSeq,
+    /// The identifier of the element type.
     #[dust_dds(external)]
     pub element_identifier: Box<TypeIdentifier>,
 }
 
+/// Definition of a plain array with large bounds.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainArrayLElemDefn {
+    /// The header containing collection properties.
     pub header: PlainCollectionHeader,
+    /// The sequence of large bounds for each dimension.
     pub array_bound_seq: LBoundSeq,
+    /// The identifier of the element type.
     #[dust_dds(external)]
     pub element_identifier: Box<TypeIdentifier>,
 }
 
+/// Definition of a plain map with a small bound.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainMapSTypeDefn {
+    /// The header containing collection properties.
     pub header: PlainCollectionHeader,
+    /// The small bound (maximum number of key-value pairs).
     pub bound: SBound,
+    /// The identifier of the element type.
     #[dust_dds(external)]
     pub element_identifier: Box<TypeIdentifier>,
+    /// Flags that apply to the keys of the map.
     pub key_flags: CollectionElementFlag,
+    /// The identifier of the key type.
     #[dust_dds(external)]
     pub key_identifier: Box<TypeIdentifier>,
 }
 
+/// Definition of a plain map with a large bound.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainMapLTypeDefn {
+    /// The header containing collection properties.
     pub header: PlainCollectionHeader,
+    /// The large bound (maximum number of key-value pairs).
     pub bound: LBound,
+    /// The identifier of the element type.
     #[dust_dds(external)]
     pub element_identifier: Box<TypeIdentifier>,
+    /// Flags that apply to the keys of the map.
     pub key_flags: CollectionElementFlag,
+    /// The identifier of the key type.
     #[dust_dds(external)]
     pub key_identifier: Box<TypeIdentifier>,
 }
 
-// Used for Types that have cyclic depencencies with other types
+/// Identifier for a type that belongs to a strongly connected component (has cyclic dependencies).
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct StronglyConnectedComponentId {
+    /// The hash of the strongly connected component.
     pub sc_component_id: TypeObjectHashId, // Hash StronglyConnectedComponent
-    pub scc_length: i32,                   // StronglyConnectedComponent.length
-    pub scc_index: i32,                    // identify type in Strongly Connected Comp.
+    /// The number of types in the strongly connected component.
+    pub scc_length: i32, // StronglyConnectedComponent.length
+    /// The 0-based index identifying this specific type within the strongly connected component.
+    pub scc_index: i32, // identify type in Strongly Connected Comp.
 }
-// Future extensibility
+/// Structure representing future extensions to type definitions.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "mutable", nested)]
 pub struct ExtendedTypeDefn {
     // Empty. Available for future extension
 }
 
-// The TypeIdentifier uniquely identifies a type (a set of equivalent
-// types according to an equivalence relationship: COMPLETE, MNIMAL).
-//
-// In some cases (primitive types, strings, plain types) the identifier
-// is a explicit description of the type.
-// In other cases the Identifier is a Hash of the type description
-//
-// In the of primitive types and strings the implied equivalence
-// relation is the identity.
-//
-// For Plain Types and Hash-defined TypeIdentifiers there are three
-// possibilities: MINIMAL, COMPLETE, and COMMON:
-// - MINIMAL indicates the TypeIdentifier identifies equivalent types
-// according to the MINIMAL equivalence relation
-// - COMPLETE indicates the TypeIdentifier identifies equivalent types
-// according to the COMPLETE equivalence relation
-// - COMMON indicates the TypeIdentifier identifies equivalent types
-// according to both the MINIMAL and the COMMON equivalence relation.
-// This means the TypeIdentifier is the same for both relationships
-//
+/// The TypeIdentifier uniquely identifies a type (a set of equivalent
+/// types according to an equivalence relationship: COMPLETE, MNIMAL).
+///
+/// In some cases (primitive types, strings, plain types) the identifier
+/// is a explicit description of the type.
+/// In other cases the Identifier is a Hash of the type description
+///
+/// In the of primitive types and strings the implied equivalence
+/// relation is the identity.
+///
+/// For Plain Types and Hash-defined TypeIdentifiers there are three
+/// possibilities: MINIMAL, COMPLETE, and COMMON:
+/// - MINIMAL indicates the TypeIdentifier identifies equivalent types
+/// according to the MINIMAL equivalence relation
+/// - COMPLETE indicates the TypeIdentifier identifies equivalent types
+/// according to the COMPLETE equivalence relation
+/// - COMMON indicates the TypeIdentifier identifies equivalent types
+/// according to both the MINIMAL and the COMMON equivalence relation.
+/// This means the TypeIdentifier is the same for both relationships
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested, switch(u8))]
 pub enum TypeIdentifier {
+    /// No type.
     #[dust_dds(case=TK_NONE)]
     TkNone,
+    /// Boolean type.
     #[dust_dds(case=TK_BOOLEAN)]
     TkBoolean,
+    /// Byte type.
     #[dust_dds(case=TK_BYTE)]
     TkByteType,
+    /// Signed 8-bit integer type.
     #[dust_dds(case=TK_INT8)]
     TkInt8Type,
+    /// Signed 16-bit integer type.
     #[dust_dds(case=TK_INT16)]
     TkInt16Type,
+    /// Signed 32-bit integer type.
     #[dust_dds(case=TK_INT32)]
     TkInt32Type,
+    /// Signed 64-bit integer type.
     #[dust_dds(case=TK_INT64)]
     TkInt64Type,
+    /// Unsigned 8-bit integer type.
     #[dust_dds(case=TK_UINT8)]
     TkUint8Type,
+    /// Unsigned 16-bit integer type.
     #[dust_dds(case=TK_UINT16)]
     TkUint16Type,
+    /// Unsigned 32-bit integer type.
     #[dust_dds(case=TK_UINT32)]
     TkUint32Type,
+    /// Unsigned 64-bit integer type.
     #[dust_dds(case=TK_UINT64)]
     TkUint64Type,
+    /// Single-precision floating-point type.
     #[dust_dds(case=TK_FLOAT32)]
     TkFloat32Type,
+    /// Double-precision floating-point type.
     #[dust_dds(case=TK_FLOAT64)]
     TkFloat64Type,
+    /// 128-bit floating-point type.
     #[dust_dds(case=TK_FLOAT128)]
     TkFloat128Type,
+    /// 8-bit character type.
     #[dust_dds(case=TK_CHAR8)]
     TkChar8Type,
+    /// 16-bit character type.
     #[dust_dds(case=TK_CHAR16)]
     TkChar16Type,
     // ============ Strings - use TypeIdentifierKind ===================
+    /// Small 8-bit string type definition.
     #[dust_dds(case=TI_STRING8_SMALL)]
-    TiString8Small { string_sdefn: StringSTypeDefn },
+    TiString8Small {
+        /// The string definition.
+        string_sdefn: StringSTypeDefn,
+    },
+    /// Small 16-bit string type definition.
     #[dust_dds(case=TI_STRING16_SMALL)]
-    TiString16Small { string_sdefn: StringSTypeDefn },
+    TiString16Small {
+        /// The string definition.
+        string_sdefn: StringSTypeDefn,
+    },
+    /// Large 8-bit string type definition.
     #[dust_dds(case=TI_STRING8_LARGE)]
-    TiString8Large { string_ldefn: StringLTypeDefn },
+    TiString8Large {
+        /// The string definition.
+        string_ldefn: StringLTypeDefn,
+    },
+    /// Large 16-bit string type definition.
     #[dust_dds(case=TI_STRING16_LARGE)]
-    TiString16Large { string_ldefn: StringLTypeDefn },
+    TiString16Large {
+        /// The string definition.
+        string_ldefn: StringLTypeDefn,
+    },
     // ============ Plain collectios - use TypeIdentifierKind =========
+    /// Small plain sequence type identifier.
     #[dust_dds(case=TI_PLAIN_SEQUENCE_SMALL)]
-    TiPlainSequenceSmall { seq_sdefn: PlainSequenceSElemDefn },
+    TiPlainSequenceSmall {
+        /// The sequence definition.
+        seq_sdefn: PlainSequenceSElemDefn,
+    },
+    /// Large plain sequence type identifier.
     #[dust_dds(case=TI_PLAIN_SEQUENCE_LARGE)]
-    TiPlainSequenceLarge { seq_ldefn: PlainSequenceLElemDefn },
+    TiPlainSequenceLarge {
+        /// The sequence definition.
+        seq_ldefn: PlainSequenceLElemDefn,
+    },
+    /// Small plain array type identifier.
     #[dust_dds(case=TI_PLAIN_ARRAY_SMALL)]
-    TiPlainArraySmall { array_sdefn: PlainArraySElemDefn },
+    TiPlainArraySmall {
+        /// The array definition.
+        array_sdefn: PlainArraySElemDefn,
+    },
+    /// Large plain array type identifier.
     #[dust_dds(case=TI_PLAIN_ARRAY_LARGE)]
-    TiPlainArrayLarge { array_ldefn: PlainArrayLElemDefn },
+    TiPlainArrayLarge {
+        /// The array definition.
+        array_ldefn: PlainArrayLElemDefn,
+    },
+    /// Small plain map type identifier.
     #[dust_dds(case=TI_PLAIN_MAP_SMALL)]
-    TiPlainMapSmall { map_sdefn: PlainMapSTypeDefn },
+    TiPlainMapSmall {
+        /// The map definition.
+        map_sdefn: PlainMapSTypeDefn,
+    },
+    /// Large plain map type identifier.
     #[dust_dds(case=TI_PLAIN_MAP_LARGE)]
-    TiPlainMapLarge { map_ldefn: PlainMapLTypeDefn },
+    TiPlainMapLarge {
+        /// The map definition.
+        map_ldefn: PlainMapLTypeDefn,
+    },
     // ============ Types that are mutually dependent on each other ===
+    /// Type identifier for a strongly connected component.
     #[dust_dds(case=TI_STRONGLY_CONNECTED_COMPONENT)]
     TiStronglyConnectedComponent {
+        /// The strongly connected component ID.
         sc_component_id: StronglyConnectedComponentId,
     },
     // ============ The remaining cases - use EquivalenceKind =========
+    /// Type identifier based on the complete equivalence hash.
     #[dust_dds(case=EK_COMPLETE)]
-    EkComplete { equivalence_hash: EquivalenceHash },
+    EkComplete {
+        /// The complete equivalence hash.
+        equivalence_hash: EquivalenceHash,
+    },
+    /// Type identifier based on the minimal equivalence hash.
     #[dust_dds(case=EK_MINIMAL)]
-    EkMinimal { equivalence_hash: EquivalenceHash },
+    EkMinimal {
+        /// The minimal equivalence hash.
+        equivalence_hash: EquivalenceHash,
+    },
     // =================== Future extensibility ============
+    /// Default case for future extensibility.
     #[dust_dds(default)]
-    Default { extended_type: MinimalExtendedType },
+    Default {
+        /// The extended type information.
+        extended_type: MinimalExtendedType,
+    },
 }
 
 impl Default for TypeIdentifier {
@@ -407,842 +611,1254 @@ impl Default for TypeIdentifier {
     }
 }
 
+/// Sequence of type identifiers.
 pub type TypeIdentifierSeq = Vec<TypeIdentifier>;
 
 // --- Annotation usage: -----------------------------------------------
-// ID of a type member
+/// Unique ID of a type member.
 pub type MemberId = u32;
+/// Maximum length of an annotation string value.
 pub const ANNOTATION_STR_VALUE_MAX_LEN: u32 = 128;
+/// Maximum length of an annotation octet sequence value.
 pub const ANNOTATION_OCTETSEC_VALUE_MAX_LEN: u32 = 128;
 
+/// Structure representing future extensions to annotation parameter values.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "mutable", nested)]
 pub struct ExtendedAnnotationParameterValue {
     // Empty. Available for future extension
 }
 
-/* Literal value of an annotation member: either the default value in its
-* definition or the value applied in its usage.
-*/
+/// Literal value of an annotation member.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested, switch(u8))]
 pub enum AnnotationParameterValue {
+    /// Boolean value.
     #[dust_dds(case=TK_BOOLEAN)]
-    TkBoolean { boolean_value: bool },
+    TkBoolean {
+        /// The boolean value.
+        boolean_value: bool,
+    },
+    /// Byte value.
     #[dust_dds(case=TK_BYTE)]
-    TkByte { byte_value: u8 },
+    TkByte {
+        /// The byte value.
+        byte_value: u8,
+    },
+    /// Signed 8-bit integer value.
     #[dust_dds(case=TK_INT8)]
-    TkInt8 { int8_value: i8 },
+    TkInt8 {
+        /// The signed 8-bit integer value.
+        int8_value: i8,
+    },
+    /// Unsigned 8-bit integer value.
     #[dust_dds(case=TK_UINT8)]
-    TkUint8 { uint8_value: u8 },
+    TkUint8 {
+        /// The unsigned 8-bit integer value.
+        uint8_value: u8,
+    },
+    /// Signed 16-bit integer value.
     #[dust_dds(case=TK_INT16)]
-    TkInt16 { int16_value: i16 },
+    TkInt16 {
+        /// The signed 16-bit integer value.
+        int16_value: i16,
+    },
+    /// Unsigned 16-bit integer value.
     #[dust_dds(case=TK_UINT16)]
-    TkUint16 { uint_16_value: u16 },
+    TkUint16 {
+        /// The unsigned 16-bit integer value.
+        uint_16_value: u16,
+    },
+    /// Signed 32-bit integer value.
     #[dust_dds(case=TK_INT32)]
-    TkInt32 { int32_value: i32 },
+    TkInt32 {
+        /// The signed 32-bit integer value.
+        int32_value: i32,
+    },
+    /// Unsigned 32-bit integer value.
     #[dust_dds(case=TK_UINT32)]
-    TkUint32 { uint32_value: u32 },
+    TkUint32 {
+        /// The unsigned 32-bit integer value.
+        uint32_value: u32,
+    },
+    /// Signed 64-bit integer value.
     #[dust_dds(case=TK_INT64)]
-    TkInt64 { int64_value: i64 },
+    TkInt64 {
+        /// The signed 64-bit integer value.
+        int64_value: i64,
+    },
+    /// Unsigned 64-bit integer value.
     #[dust_dds(case=TK_UINT64)]
-    TkUint64 { uint64_value: u64 },
+    TkUint64 {
+        /// The unsigned 64-bit integer value.
+        uint64_value: u64,
+    },
+    /// Single-precision floating-point value.
     #[dust_dds(case=TK_FLOAT32)]
-    TkFloat32 { float32_value: f32 },
+    TkFloat32 {
+        /// The single-precision floating-point value.
+        float32_value: f32,
+    },
+    /// Double-precision floating-point value.
     #[dust_dds(case=TK_FLOAT64)]
-    TkFloat64 { float64_value: f64 },
+    TkFloat64 {
+        /// The double-precision floating-point value.
+        float64_value: f64,
+    },
     // TkFloat128 {
     //     float128_value: i128,
     // },
+    /// 8-bit character value.
     #[dust_dds(case=TK_CHAR8)]
-    TkChar8 { char_value: char },
+    TkChar8 {
+        /// The 8-bit character value.
+        char_value: char,
+    },
     // TypeKind::CHAR16 {
     // wchar_value: char16},
+    /// Enumerated value represented as an integer.
     #[dust_dds(case=TK_ENUM)]
-    TkEnum { enumerated_value: i32 },
+    TkEnum {
+        /// The enumerated value.
+        enumerated_value: i32,
+    },
+    /// 8-bit string value.
     #[dust_dds(case=TK_STRING8)]
     TkString8 {
+        /// The string value.
         string8_value: String, /*string<ANNOTATION_STR_VALUE_MAX_LEN>  */
     },
     // TypeKind::STRING16:
     // wstring<ANNOTATION_STR_VALUE_MAX_LEN> string16_value;
+    /// Default case for future extensibility.
     #[dust_dds(default)]
     Default {
+        /// The extended value.
         extended_value: ExtendedAnnotationParameterValue,
     },
 }
 
-// The application of an annotation to some type or type member
+/// The application of an annotation parameter to a member.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct AppliedAnnotationParameter {
+    /// Hash of the parameter name.
     pub paramname_hash: NameHash,
+    /// Value of the annotation parameter.
     pub value: AnnotationParameterValue,
 }
 
-// Sorted by AppliedAnnotationParameter.paramname_hash
+/// Sequence of applied annotation parameters.
 pub type AppliedAnnotationParameterSeq = Vec<AppliedAnnotationParameter>;
 
+/// The application of an annotation to a type or type member.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct AppliedAnnotation {
+    /// The type identifier of the annotation.
     pub annotation_typeid: TypeIdentifier,
+    /// Sequence of parameters applied to the annotation.
     #[dust_dds(optional)]
     pub param_seq: Option<AppliedAnnotationParameterSeq>,
 }
-// Sorted by AppliedAnnotation.annotation_typeid
+/// Sequence of applied annotations.
 pub type AppliedAnnotationSeq = Vec<AppliedAnnotation>;
-// @verbatim(placement="<placement>", language="<lang>", text="<text>")
+/// Verbatim annotation representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct AppliedVerbatimAnnotation {
+    /// Where the verbatim text should be placed.
     pub placement: String, //string<32>
-    pub language: String,  //string<32>
+    /// The language/format of the verbatim text.
+    pub language: String, //string<32>
+    /// The verbatim text content.
     pub text: String,
 }
 
 // --- Aggregate types: ------------------------------------------------
+/// Applied builtin annotations for a member (e.g., unit, min, max, hash_id).
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct AppliedBuiltinMemberAnnotations {
+    /// The unit associated with the member.
     #[dust_dds(optional)]
     pub unit: Option<String>, // @unit("<unit>")
+    /// The minimum value allowed for the member.
     #[dust_dds(optional)]
     pub min: Option<AnnotationParameterValue>, // @min , @range
+    /// The maximum value allowed for the member.
     #[dust_dds(optional)]
     pub max: Option<AnnotationParameterValue>, // @max , @range
+    /// The hash ID of the member name.
     #[dust_dds(optional)]
     pub hash_id: Option<String>, // @hashid("<membername>")
 }
 
+/// Common properties for a struct member.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonStructMember {
+    /// The unique ID of the member.
     pub member_id: MemberId,
+    /// Flags associated with the structure member.
     pub member_flags: StructMemberFlag,
+    /// The TypeIdentifier of the member type.
     pub member_type_id: TypeIdentifier,
 }
 
-// COMPLETE Details for a member of an aggregate type
+/// Complete details of a member in a complete TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteMemberDetail {
+    /// The name of the member.
     pub name: MemberName,
+    /// Builtin annotations applied to the member.
     #[dust_dds(optional)]
     pub ann_builtin: Option<AppliedBuiltinMemberAnnotations>,
+    /// Custom annotations applied to the member.
     #[dust_dds(optional)]
     pub ann_custom: Option<AppliedAnnotationSeq>,
 }
-// MINIMAL Details for a member of an aggregate type
+/// Minimal details of a member in a minimal TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalMemberDetail {
+    /// The hash of the member name.
     pub name_hash: NameHash,
 }
 
-// Member of an aggregate type
+/// Complete structure representing a struct member.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteStructMember {
+    /// Common member properties.
     pub common: CommonStructMember,
+    /// Detailed complete properties (name, annotations).
     pub detail: CompleteMemberDetail,
 }
-// Ordered by the member_index
+/// Sequence of complete struct members.
 pub type CompleteStructMemberSeq = Vec<CompleteStructMember>;
-// Member of an aggregate type
+/// Minimal structure representing a struct member.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalStructMember {
+    /// Common member properties.
     pub common: CommonStructMember,
+    /// Detailed minimal properties (name hash).
     pub detail: MinimalMemberDetail,
 }
-// Ordered by common.member_id
+/// Sequence of minimal struct members.
 pub type MinimalStructMemberSeq = Vec<MinimalStructMember>;
+/// Builtin annotations applied to a type definition.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct AppliedBuiltinTypeAnnotations {
+    /// Verbatim annotation applied to the type.
     #[dust_dds(optional)]
     pub verbatim: Option<AppliedVerbatimAnnotation>, // @verbatim(...)
 }
 
+/// Minimal details of a type definition.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalTypeDetail {
     // Empty. Available for future extension
 }
 
+/// Complete details of a type definition.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteTypeDetail {
+    /// Builtin annotations applied to the type.
     #[dust_dds(optional)]
     pub ann_builtin: Option<AppliedBuiltinTypeAnnotations>,
+    /// Custom annotations applied to the type.
     #[dust_dds(optional)]
     pub ann_custom: Option<AppliedAnnotationSeq>,
+    /// The qualified name of the type.
     pub type_name: QualifiedTypeName,
 }
 
+/// Header for a complete struct type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteStructHeader {
+    /// The TypeIdentifier of the base type, if any.
     pub base_type: TypeIdentifier,
+    /// Detailed complete properties of the struct type.
     pub detail: CompleteTypeDetail,
 }
 
+/// Header for a minimal struct type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalStructHeader {
+    /// The TypeIdentifier of the base type, if any.
     pub base_type: TypeIdentifier,
+    /// Detailed minimal properties of the struct type.
     pub detail: MinimalTypeDetail,
 }
 
+/// Complete struct type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteStructType {
+    /// Flags associated with the structure type.
     pub struct_flags: StructTypeFlag,
+    /// The header containing base type and details.
     pub header: CompleteStructHeader,
+    /// The sequence of members in the structure.
     pub member_seq: CompleteStructMemberSeq,
 }
 
+/// Minimal struct type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalStructType {
+    /// Flags associated with the structure type.
     pub struct_flags: StructTypeFlag,
+    /// The header containing base type and details.
     pub header: MinimalStructHeader,
+    /// The sequence of members in the structure.
     pub member_seq: MinimalStructMemberSeq,
 }
 
 // --- Union: ----------------------------------------------------------
-// labels that apply to a member of a union type
-// Ordered by their values
+/// Sequence of union case labels.
 pub type UnionCaseLabelSeq = Vec<i32>;
 
+/// Common properties of a union member.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonUnionMember {
+    /// The unique ID of the member.
     pub member_id: MemberId,
+    /// Flags associated with the union member.
     pub member_flags: UnionMemberFlag,
+    /// The TypeIdentifier of the member type.
     pub type_id: TypeIdentifier,
+    /// The case labels associated with this union member.
     pub label_seq: UnionCaseLabelSeq,
 }
 
-// Member of a union type
+/// Complete details of a union member in a complete TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteUnionMember {
+    /// Common union member properties.
     pub common: CommonUnionMember,
+    /// Detailed complete properties (name, annotations) of the union member.
     pub detail: CompleteMemberDetail,
 }
-// Ordered by member_index
+/// Sequence of complete union members.
 pub type CompleteUnionMemberSeq = Vec<CompleteUnionMember>;
 
-// Member of a union type
+/// Minimal details of a union member in a minimal TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalUnionMember {
+    /// Common union member properties.
     pub common: CommonUnionMember,
+    /// Detailed minimal properties (name hash) of the union member.
     pub detail: MinimalMemberDetail,
 }
-// Ordered by MinimalUnionMember.common.member_id
+/// Sequence of minimal union members.
 pub type MinimalUnionMemberSeq = Vec<MinimalUnionMember>;
 
+/// Common properties of a union discriminator member.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonDiscriminatorMember {
+    /// Flags associated with the union discriminator.
     pub member_flags: UnionDiscriminatorFlag,
+    /// The TypeIdentifier of the discriminator type.
     pub type_id: TypeIdentifier,
 }
-// Member of a union type
+/// Complete details of a union discriminator member in a complete TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteDiscriminatorMember {
+    /// Common discriminator properties.
     pub common: CommonDiscriminatorMember,
+    /// Builtin annotations applied to the discriminator.
     #[dust_dds(optional)]
     pub ann_builtin: Option<AppliedBuiltinTypeAnnotations>,
+    /// Custom annotations applied to the discriminator.
     #[dust_dds(optional)]
     pub ann_custom: Option<AppliedAnnotationSeq>,
 }
-// Member of a union type
+/// Minimal details of a union discriminator member in a minimal TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalDiscriminatorMember {
+    /// Common discriminator properties.
     pub common: CommonDiscriminatorMember,
 }
 
+/// Header for a complete union type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteUnionHeader {
+    /// Detailed complete properties of the union type.
     pub detail: CompleteTypeDetail,
 }
 
+/// Header for a minimal union type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalUnionHeader {
+    /// Detailed minimal properties of the union type.
     pub detail: MinimalTypeDetail,
 }
 
+/// Complete union type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteUnionType {
+    /// Flags associated with the union type.
     pub union_flags: UnionTypeFlag,
+    /// The header containing details.
     pub header: CompleteUnionHeader,
+    /// The discriminator member details.
     pub discriminator: CompleteDiscriminatorMember,
+    /// The sequence of union members.
     pub member_seq: CompleteUnionMemberSeq,
 }
 
+/// Minimal union type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalUnionType {
+    /// Flags associated with the union type.
     pub union_flags: UnionTypeFlag,
+    /// The header containing details.
     pub header: MinimalUnionHeader,
+    /// The discriminator member details.
     pub discriminator: MinimalDiscriminatorMember,
+    /// The sequence of union members.
     pub member_seq: MinimalUnionMemberSeq,
 }
 
 // --- Annotation: ----------------------------------------------------
+/// Common properties of an annotation parameter.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonAnnotationParameter {
+    /// Flags associated with the annotation parameter.
     pub member_flags: AnnotationParameterFlag,
+    /// The TypeIdentifier of the parameter type.
     pub member_type_id: TypeIdentifier,
 }
 
-// Member of an annotation type
+/// Complete details of an annotation parameter in a complete TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteAnnotationParameter {
+    /// Common annotation parameter properties.
     pub common: CommonAnnotationParameter,
+    /// The name of the parameter.
     pub name: MemberName,
+    /// The default value of the parameter.
     pub default_value: AnnotationParameterValue,
 }
-// Ordered by CompleteAnnotationParameter.name
+/// Sequence of complete annotation parameters.
 pub type CompleteAnnotationParameterSeq = Vec<CompleteAnnotationParameter>;
 
+/// Minimal details of an annotation parameter in a minimal TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalAnnotationParameter {
+    /// Common annotation parameter properties.
     pub common: CommonAnnotationParameter,
+    /// The hash of the parameter name.
     pub name_hash: NameHash,
+    /// The default value of the parameter.
     pub default_value: AnnotationParameterValue,
 }
-// Ordered by MinimalAnnotationParameter.name_hash
+/// Sequence of minimal annotation parameters.
 pub type MinimalAnnotationParameterSeq = Vec<MinimalAnnotationParameter>;
+/// Header for a complete annotation type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteAnnotationHeader {
+    /// The qualified name of the annotation type.
     pub annotation_name: QualifiedTypeName,
 }
 
+/// Header for a minimal annotation type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalAnnotationHeader {
     // Empty. Available for future extension
 }
 
+/// Complete annotation type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteAnnotationType {
+    /// Flags associated with the annotation type.
     pub annotation_flag: AnnotationTypeFlag,
+    /// The header containing annotation name.
     pub header: CompleteAnnotationHeader,
+    /// The sequence of annotation parameters.
     pub member_seq: CompleteAnnotationParameterSeq,
 }
 
+/// Minimal annotation type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalAnnotationType {
+    /// Flags associated with the annotation type.
     pub annotation_flag: AnnotationTypeFlag,
+    /// The header containing details.
     pub header: MinimalAnnotationHeader,
+    /// The sequence of annotation parameters.
     pub member_seq: MinimalAnnotationParameterSeq,
 }
 
 // --- Alias: ----------------------------------------------------------
+/// Common properties of an alias type.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonAliasBody {
+    /// Flags associated with the related type.
     pub related_flags: AliasMemberFlag,
+    /// The TypeIdentifier of the related type.
     pub related_type: TypeIdentifier,
 }
 
+/// Complete body of an alias in a complete TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteAliasBody {
+    /// Common alias properties.
     pub common: CommonAliasBody,
+    /// Builtin annotations applied to the alias.
     #[dust_dds(optional)]
     pub ann_builtin: Option<AppliedBuiltinMemberAnnotations>,
+    /// Custom annotations applied to the alias.
     #[dust_dds(optional)]
     pub ann_custom: Option<AppliedAnnotationSeq>,
 }
 
+/// Minimal body of an alias in a minimal TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalAliasBody {
+    /// Common alias properties.
     pub common: CommonAliasBody,
 }
 
+/// Header for a complete alias type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteAliasHeader {
+    /// Detailed complete properties of the alias type.
     pub detail: CompleteTypeDetail,
 }
 
+/// Header for a minimal alias type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalAliasHeader {
     // Empty. Available for future extension
 }
 
+/// Complete alias type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteAliasType {
+    /// Flags associated with the alias type.
     pub alias_flags: AliasTypeFlag,
+    /// The header containing details.
     pub header: CompleteAliasHeader,
+    /// The alias body containing the related type.
     pub body: CompleteAliasBody,
 }
 
+/// Minimal alias type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalAliasType {
+    /// Flags associated with the alias type.
     pub alias_flags: AliasTypeFlag,
+    /// The header containing details.
     pub header: MinimalAliasHeader,
+    /// The alias body containing the related type.
     pub body: MinimalAliasBody,
 }
 
 // --- Collections: ----------------------------------------------------
+/// Complete details of a collection element in a complete TypeObject representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteElementDetail {
+    /// Builtin annotations applied to the collection element.
     #[dust_dds(optional)]
     pub ann_builtin: Option<AppliedBuiltinMemberAnnotations>,
+    /// Custom annotations applied to the collection element.
     #[dust_dds(optional)]
     pub ann_custom: Option<AppliedAnnotationSeq>,
 }
 
+/// Common properties of a collection element.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonCollectionElement {
+    /// Flags associated with the collection element.
     pub element_flags: CollectionElementFlag,
+    /// The TypeIdentifier of the element type.
     pub _type: TypeIdentifier,
 }
 
+/// Complete details of a collection element.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteCollectionElement {
+    /// Common collection element properties.
     pub common: CommonCollectionElement,
+    /// Detailed complete properties (annotations) of the element.
     pub detail: CompleteElementDetail,
 }
 
+/// Minimal details of a collection element.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalCollectionElement {
+    /// Common collection element properties.
     pub common: CommonCollectionElement,
 }
 
+/// Common header for collection types.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonCollectionHeader {
+    /// The bound (maximum number of elements) of the collection.
     pub bound: LBound,
 }
 
+/// Header for a complete collection representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteCollectionHeader {
+    /// Common collection header properties.
     pub common: CommonCollectionHeader,
+    /// Detailed complete properties of the collection.
     #[dust_dds(optional)]
     pub detail: Option<CompleteTypeDetail>, // not present for anonymous
 }
 
+/// Header for a minimal collection representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalCollectionHeader {
+    /// Common collection header properties.
     pub common: CommonCollectionHeader,
 }
 
 // --- Sequence: ------------------------------------------------------
+/// Complete sequence type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteSequenceType {
+    /// Flags associated with the sequence collection type.
     pub collection_flag: CollectionTypeFlag,
+    /// The header containing sequence properties.
     pub header: CompleteCollectionHeader,
+    /// The details of the sequence elements.
     pub element: CompleteCollectionElement,
 }
 
+/// Minimal sequence type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalSequenceType {
+    /// Flags associated with the sequence collection type.
     pub collection_flag: CollectionTypeFlag,
+    /// The header containing sequence properties.
     pub header: MinimalCollectionHeader,
+    /// The details of the sequence elements.
     pub element: MinimalCollectionElement,
 }
 
 // --- Array: ------------------------------------------------------
+/// Common header for array types.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonArrayHeader {
+    /// The sequence of bounds for each dimension.
     pub bound_seq: LBoundSeq,
 }
 
+/// Header for a complete array representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteArrayHeader {
+    /// Common array header properties.
     pub common: CommonArrayHeader,
+    /// Detailed complete properties of the array.
     pub detail: CompleteTypeDetail,
 }
 
+/// Header for a minimal array representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalArrayHeader {
+    /// Common array header properties.
     pub common: CommonArrayHeader,
 }
 
+/// Complete array type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteArrayType {
+    /// Flags associated with the array collection type.
     pub collection_flag: CollectionTypeFlag,
+    /// The header containing array properties.
     pub header: CompleteArrayHeader,
+    /// The details of the array elements.
     pub element: CompleteCollectionElement,
 }
 
+/// Minimal array type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalArrayType {
+    /// Flags associated with the array collection type.
     pub collection_flag: CollectionTypeFlag,
+    /// The header containing array properties.
     pub header: MinimalArrayHeader,
+    /// The details of the array elements.
     pub element: MinimalCollectionElement,
 }
 
 // --- Map: ------------------------------------------------------
+/// Complete map type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteMapType {
+    /// Flags associated with the map collection type.
     pub collection_flag: CollectionTypeFlag,
+    /// The header containing map properties.
     pub header: CompleteCollectionHeader,
+    /// The details of the map keys.
     pub key: CompleteCollectionElement,
+    /// The details of the map elements.
     pub element: CompleteCollectionElement,
 }
 
+/// Minimal map type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalMapType {
+    /// Flags associated with the map collection type.
     pub collection_flag: CollectionTypeFlag,
+    /// The header containing map properties.
     pub header: MinimalCollectionHeader,
+    /// The details of the map keys.
     pub key: MinimalCollectionElement,
+    /// The details of the map elements.
     pub element: MinimalCollectionElement,
 }
 
 // --- Enumeration: ----------------------------------------------------
+/// The bit bound (e.g. 8, 16, 32) of an enumerated type or bitmask.
 pub type BitBound = u16;
 // Constant in an enumerated type
+/// Common properties of an enumerated literal.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CommonEnumeratedLiteral {
+    /// The integer value of the enumerated literal.
     pub value: i32,
+    /// Flags associated with the enumerated literal.
     pub flags: EnumeratedLiteralFlag,
 }
 
 // Constant in an enumerated type
+/// Complete details of an enumerated literal.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteEnumeratedLiteral {
+    /// Common enumerated literal properties.
     pub common: CommonEnumeratedLiteral,
+    /// Detailed complete properties of the literal.
     pub detail: CompleteMemberDetail,
 }
 
-// Ordered by EnumeratedLiteral.common.value
+/// Sequence of complete enumerated literals.
 pub type CompleteEnumeratedLiteralSeq = Vec<CompleteEnumeratedLiteral>;
 
 // Constant in an enumerated type
+/// Minimal details of an enumerated literal.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalEnumeratedLiteral {
+    /// Common enumerated literal properties.
     pub common: CommonEnumeratedLiteral,
+    /// Detailed minimal properties of the literal.
     pub detail: MinimalMemberDetail,
 }
 
-// Ordered by EnumeratedLiteral.common.value
+/// Sequence of minimal enumerated literals.
 pub type MinimalEnumeratedLiteralSeq = Vec<MinimalEnumeratedLiteral>;
 
+/// Common header for enumerated types.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonEnumeratedHeader {
+    /// The bit bound of the enumerated type.
     pub bit_bound: BitBound,
 }
 
+/// Header for a complete enumerated type.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteEnumeratedHeader {
+    /// Common enumerated header properties.
     pub common: CommonEnumeratedHeader,
+    /// Detailed complete properties of the enumerated type.
     pub detail: CompleteTypeDetail,
 }
 
+/// Header for a minimal enumerated type.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalEnumeratedHeader {
+    /// Common enumerated header properties.
     pub common: CommonEnumeratedHeader,
 }
 
 // Enumerated type
+/// Complete enumerated type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CompleteEnumeratedType {
+    /// Flags associated with the enumerated type.
     pub enum_flags: EnumTypeFlag, // unused
+    /// The header containing details.
     pub header: CompleteEnumeratedHeader,
+    /// The sequence of literals in the enumeration.
     pub literal_seq: CompleteEnumeratedLiteralSeq,
 }
 
 // Enumerated type
+/// Minimal enumerated type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct MinimalEnumeratedType {
+    /// Flags associated with the enumerated type.
     pub enum_flags: EnumTypeFlag, // unused
+    /// The header containing details.
     pub header: MinimalEnumeratedHeader,
+    /// The sequence of literals in the enumeration.
     pub literal_seq: MinimalEnumeratedLiteralSeq,
 }
 
 // --- Bitmask: --------------------------------------------------------
 // Bit in a bit mask
+/// Common properties of a bitflag inside a bitmask.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonBitflag {
+    /// The position (0-based) of the bit flag.
     pub position: u16,
+    /// Flags associated with the bit flag.
     pub flags: BitflagFlag,
 }
 
+/// Complete details of a bitflag inside a bitmask.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteBitflag {
+    /// Common bitflag properties.
     pub common: CommonBitflag,
+    /// Detailed complete properties of the bitflag.
     pub detail: CompleteMemberDetail,
 }
-// Ordered by Bitflag.position
+/// Sequence of complete bitflags.
 pub type CompleteBitflagSeq = Vec<CompleteBitflag>;
 
+/// Minimal details of a bitflag inside a bitmask.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalBitflag {
+    /// Common bitflag properties.
     pub common: CommonBitflag,
+    /// Detailed minimal properties of the bitflag.
     pub detail: MinimalMemberDetail,
 }
-// Ordered by Bitflag.position
+/// Sequence of minimal bitflags.
 pub type MinimalBitflagSeq = Vec<MinimalBitflag>;
 
+/// Common header for bitmask types.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonBitmaskHeader {
+    /// The bit bound of the bitmask type.
     pub bit_bound: BitBound,
 }
+/// Header for a complete bitmask type representation.
 pub type CompleteBitmaskHeader = CompleteEnumeratedHeader;
+/// Header for a minimal bitmask type representation.
 pub type MinimalBitmaskHeader = MinimalEnumeratedHeader;
 
+/// Complete bitmask type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteBitmaskType {
+    /// Flags associated with the bitmask type.
     pub bitmask_flags: BitmaskTypeFlag, // unused
+    /// The header containing details.
     pub header: CompleteBitmaskHeader,
+    /// The sequence of bitflags.
     pub flag_seq: CompleteBitflagSeq,
 }
 
+/// Minimal bitmask type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalBitmaskType {
+    /// Flags associated with the bitmask type.
     pub bitmask_flags: BitmaskTypeFlag, // unused
+    /// The header containing details.
     pub header: MinimalBitmaskHeader,
+    /// The sequence of bitflags.
     pub flag_seq: MinimalBitflagSeq,
 }
 
 // --- Bitset: ----------------------------------------------------------
+/// Common properties of a bitfield inside a bitset.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct CommonBitfield {
+    /// The position (0-based) of the bitfield.
     pub position: u16,
+    /// Flags associated with the bitfield.
     pub flags: BitsetMemberFlag,
+    /// The number of bits used by the bitfield.
     pub bitcount: u8,
+    /// The TypeKind of the primitive integer type holding this bitfield.
     pub holder_type: u8, // Original in IDL: TypeKind which for us is a Rust enum but in IDL is an octet // Must be primitive integer type
 }
 
+/// Complete details of a bitfield inside a bitset.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteBitfield {
+    /// Common bitfield properties.
     pub common: CommonBitfield,
+    /// Detailed complete properties of the bitfield.
     pub detail: CompleteMemberDetail,
 }
 
-// Ordered by Bitfield.position
+/// Sequence of complete bitfields.
 pub type CompleteBitfieldSeq = Vec<CompleteBitfield>;
 
+/// Minimal details of a bitfield inside a bitset.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalBitfield {
+    /// Common bitfield properties.
     pub common: CommonBitfield,
+    /// The hash of the bitfield name.
     pub name_hash: NameHash,
 }
 
-// Ordered by Bitfield.position
+/// Sequence of minimal bitfields.
 pub type MinimalBitfieldSeq = Vec<MinimalBitfield>;
 
+/// Header for a complete bitset type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteBitsetHeader {
+    /// Detailed complete properties of the bitset.
     pub detail: CompleteTypeDetail,
 }
 
+/// Header for a minimal bitset type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalBitsetHeader {
     // Empty. Available for future extension
 }
 
+/// Complete bitset type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct CompleteBitsetType {
+    /// Flags associated with the bitset type.
     pub bitset_flags: BitsetTypeFlag, // unused
+    /// The header containing details.
     pub header: CompleteBitsetHeader,
+    /// The sequence of bitfields in the bitset.
     pub field_seq: CompleteBitfieldSeq,
 }
 
+/// Minimal bitset type representation.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct MinimalBitsetType {
+    /// Flags associated with the bitset type.
     pub bitset_flags: BitsetTypeFlag, // unused
+    /// The header containing details.
     pub header: MinimalBitsetHeader,
+    /// The sequence of bitfields in the bitset.
     pub field_seq: MinimalBitfieldSeq,
 }
 
 // --- Type Object: ---------------------------------------------------
 // The types associated with each selection must have extensibility
 // kind APPENDABLE or MUTABLE so that they can be extended in the future
+/// Complete extended type representation for future extensions.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "mutable", nested)]
 pub struct CompleteExtendedType {
     // Empty. Available for future extension
 }
 
+/// Complete TypeObject representation switchable by TypeKind.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested, switch(u8))]
 pub enum CompleteTypeObject {
+    /// The alias type object representation.
     #[dust_dds(case = TK_ALIAS)]
-    TkAlias { alias_type: CompleteAliasType },
+    TkAlias {
+        /// Detailed complete alias type properties.
+        alias_type: CompleteAliasType,
+    },
+    /// The annotation type object representation.
     #[dust_dds(case = TK_ANNOTATION)]
     TkAnnotation {
+        /// Detailed complete annotation type properties.
         annotation_type: CompleteAnnotationType,
     },
+    /// The structure type object representation.
     #[dust_dds(case = TK_STRUCTURE)]
-    TkStructure { struct_type: CompleteStructType },
+    TkStructure {
+        /// Detailed complete struct type properties.
+        struct_type: CompleteStructType,
+    },
+    /// The union type object representation.
     #[dust_dds(case = TK_UNION)]
-    TkUnion { union_type: CompleteUnionType },
+    TkUnion {
+        /// Detailed complete union type properties.
+        union_type: CompleteUnionType,
+    },
+    /// The bitset type object representation.
     #[dust_dds(case = TK_BITSET)]
-    TkBitset { bitset_type: CompleteBitsetType },
+    TkBitset {
+        /// Detailed complete bitset type properties.
+        bitset_type: CompleteBitsetType,
+    },
+    /// The sequence type object representation.
     #[dust_dds(case = TK_SEQUENCE)]
-    TkSequence { sequence_type: CompleteSequenceType },
+    TkSequence {
+        /// Detailed complete sequence type properties.
+        sequence_type: CompleteSequenceType,
+    },
+    /// The array type object representation.
     #[dust_dds(case = TK_ARRAY)]
-    TkArray { array_type: CompleteArrayType },
+    TkArray {
+        /// Detailed complete array type properties.
+        array_type: CompleteArrayType,
+    },
+    /// The map type object representation.
     #[dust_dds(case = TK_MAP)]
-    TkMap { map_type: CompleteMapType },
+    TkMap {
+        /// Detailed complete map type properties.
+        map_type: CompleteMapType,
+    },
+    /// The enumeration type object representation.
     #[dust_dds(case = TK_ENUM)]
     TkEnum {
+        /// Detailed complete enumerated type properties.
         enumerated_type: CompleteEnumeratedType,
     },
+    /// The bitmask type object representation.
     #[dust_dds(case = TK_BITMASK)]
-    TkBitmask { bitmask_type: CompleteBitmaskType },
+    TkBitmask {
+        /// Detailed complete bitmask type properties.
+        bitmask_type: CompleteBitmaskType,
+    },
     // =================== Future extensibility ============
+    /// Default case for future extensibility.
     #[dust_dds(default)]
-    Default { extended_type: CompleteExtendedType },
+    Default {
+        /// The complete extended type properties.
+        extended_type: CompleteExtendedType,
+    },
 }
 
+/// Minimal extended type representation for future extensions.
 #[derive(DdsType, Debug, Clone, PartialEq, Default)]
 #[dust_dds(extensibility = "mutable", nested)]
 pub struct MinimalExtendedType {
     // Empty. Available for future extension
 }
 
+/// Minimal TypeObject representation switchable by TypeKind.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested, switch(u8))]
 pub enum MinimalTypeObject {
+    /// The alias type object representation.
     #[dust_dds(case = TK_ALIAS)]
-    TkAlias { alias_type: MinimalAliasType },
+    TkAlias {
+        /// Detailed minimal alias type properties.
+        alias_type: MinimalAliasType,
+    },
+    /// The annotation type object representation.
     #[dust_dds(case = TK_ANNOTATION)]
     TkAnnotation {
+        /// Detailed minimal annotation type properties.
         annotation_type: MinimalAnnotationType,
     },
+    /// The structure type object representation.
     #[dust_dds(case = TK_STRUCTURE)]
-    TkStructure { struct_type: MinimalStructType },
+    TkStructure {
+        /// Detailed minimal struct type properties.
+        struct_type: MinimalStructType,
+    },
+    /// The union type object representation.
     #[dust_dds(case = TK_UNION)]
-    TkUnion { union_type: MinimalUnionType },
+    TkUnion {
+        /// Detailed minimal union type properties.
+        union_type: MinimalUnionType,
+    },
+    /// The bitset type object representation.
     #[dust_dds(case = TK_BITSET)]
-    TkBitset { bitset_type: MinimalBitsetType },
+    TkBitset {
+        /// Detailed minimal bitset type properties.
+        bitset_type: MinimalBitsetType,
+    },
+    /// The sequence type object representation.
     #[dust_dds(case = TK_SEQUENCE)]
-    TkSequence { sequence_type: MinimalSequenceType },
+    TkSequence {
+        /// Detailed minimal sequence type properties.
+        sequence_type: MinimalSequenceType,
+    },
+    /// The array type object representation.
     #[dust_dds(case = TK_ARRAY)]
-    TkArray { array_type: MinimalArrayType },
+    TkArray {
+        /// Detailed minimal array type properties.
+        array_type: MinimalArrayType,
+    },
+    /// The map type object representation.
     #[dust_dds(case = TK_MAP)]
-    TkMap { map_type: MinimalMapType },
+    TkMap {
+        /// Detailed minimal map type properties.
+        map_type: MinimalMapType,
+    },
+    /// The enumeration type object representation.
     #[dust_dds(case = TK_ENUM)]
     TkEnum {
+        /// Detailed minimal enumerated type properties.
         enumerated_type: MinimalEnumeratedType,
     },
+    /// The bitmask type object representation.
     #[dust_dds(case = TK_BITMASK)]
-    TkBitmask { bitmask_type: MinimalBitmaskType },
+    TkBitmask {
+        /// Detailed minimal bitmask type properties.
+        bitmask_type: MinimalBitmaskType,
+    },
     // =================== Future extensibility ============
+    /// Default case for future extensibility.
     #[dust_dds(default)]
-    Default { extended_type: MinimalExtendedType },
+    Default {
+        /// The minimal extended type properties.
+        extended_type: MinimalExtendedType,
+    },
 }
 
+/// The TypeObject is the ultimate representation of a type in XTypes, containing complete or minimal type descriptions.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "appendable", nested, switch(u8))]
 #[allow(clippy::large_enum_variant)]
 pub enum TypeObject {
+    /// Complete type representation.
     #[dust_dds(case=EK_COMPLETE)]
-    EkComplete { complete: CompleteTypeObject },
+    EkComplete {
+        /// The complete type object.
+        complete: CompleteTypeObject,
+    },
+    /// Minimal type representation.
     #[dust_dds(case=EK_MINIMAL)]
-    EkMinimal { minimal: MinimalTypeObject },
+    EkMinimal {
+        /// The minimal type object.
+        minimal: MinimalTypeObject,
+    },
 }
+/// Sequence of TypeObjects.
 pub type TypeObjectSeq = Vec<TypeObject>;
 // Set of TypeObjects representing a strong component: Equivalence class
 // for the Strong Connectivity relationship (mutual reachability between
 // types).
 // Ordered by fully qualified typename lexicographic order
+/// Set of TypeObjects representing a strongly connected component (equivalence class for mutual reachability).
 pub type StronglyConnectedComponent = TypeObjectSeq;
 
+/// A pair of TypeIdentifier and TypeObject, used in discovery.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct TypeIdentifierTypeObjectPair {
+    /// The TypeIdentifier of the type.
     pub type_identifier: TypeIdentifier,
+    /// The TypeObject description of the type.
     pub type_object: TypeObject,
 }
+/// Sequence of TypeIdentifier and TypeObject pairs.
 pub type TypeIdentifierTypeObjectPairSeq = Vec<TypeIdentifierTypeObjectPair>;
 
+/// A pair of TypeIdentifiers, used to represent relationships or mappings.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct TypeIdentifierPair {
+    /// The first type identifier.
     pub type_identifier1: TypeIdentifier,
+    /// The second type identifier.
     pub type_identifier2: TypeIdentifier,
 }
+/// Sequence of TypeIdentifier pairs.
 pub type TypeIdentifierPairSeq = Vec<TypeIdentifierPair>;
 
+/// A TypeIdentifier packaged with the serialized size of its corresponding TypeObject.
 #[derive(DdsType, Debug, Clone, PartialEq, Default)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct TypeIdentifierWithSize {
+    /// The TypeIdentifier.
     pub type_id: TypeIdentifier,
+    /// The serialized size in bytes of the TypeObject.
     pub typeobject_serialized_size: u32,
 }
+/// Sequence of TypeIdentifiers packaged with sizes.
 pub type TypeIdentfierWithSizeSeq = Vec<TypeIdentifierWithSize>;
 
+/// A TypeIdentifier packaged with its size and all the dependent type identifiers it relies on.
 #[derive(DdsType, Debug, Clone, PartialEq, Default)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct TypeIdentifierWithDependencies {
+    /// The TypeIdentifier with its serialized size.
     pub typeid_with_size: TypeIdentifierWithSize,
-    // The total additional types related to minimal_type
+    /// The count of dependent type IDs.
     pub dependent_typeid_count: i32,
+    /// The sequence of dependent type IDs with sizes.
     pub dependent_typeids: Vec<TypeIdentifierWithSize>,
 }
+/// Sequence of TypeIdentifiers with dependencies.
 pub type TypeIdentifierWithDependenciesSeq = Vec<TypeIdentifierWithDependencies>;
 
+/// Complete type information containing both complete and minimal representations with their dependencies.
 #[derive(DdsType, Debug, Clone, PartialEq)]
 #[dust_dds(extensibility = "mutable", nested)]
 pub struct TypeInformation {
+    /// Minimal type representation with dependencies.
     #[dust_dds(id = 0x1001)]
     pub minimal: TypeIdentifierWithDependencies,
+    /// Complete type representation with dependencies.
     #[dust_dds(id = 0x1002)]
     pub complete: TypeIdentifierWithDependencies,
 }
+/// Sequence of TypeInformation.
 pub type TypeInformationSeq = Vec<TypeInformation>;
 
 impl From<&DynamicType> for MinimalTypeObject {

--- a/dds/src/xtypes/type_support.rs
+++ b/dds/src/xtypes/type_support.rs
@@ -8,6 +8,7 @@ use crate::xtypes::dynamic_type::{
 
 /// The Type trait represents static type information of Rust types
 pub trait Type {
+    /// This constant represent the ['DynamicType'] object corresponding to the TypeSupport’s data type
     const TYPE: DynamicType;
 }
 


### PR DESCRIPTION
Enable external visibility of the XTypes module and add documentation throughout. 

The bytes module remained hidden as this is only a convenience for the benchmarks and it should be replaced by the actual predefined built-in types defined in the XTypes standard. This step will be done in a separate PR to avoid mixing large documentation and code changes in one go.