### PR TITLE
Cleanup deserializer

### DIFF
--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -141,7 +141,7 @@ trait EncodingVersion {
     fn deserialize_mmember<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         member: &DynamicTypeMember,
-        dynamic_data: &mut DynamicData
+        dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()>;
 
     /// Serialization Rule (27) & (28)
@@ -223,7 +223,7 @@ impl EncodingVersion for EncodingVersion1 {
     fn deserialize_mmember<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         member: &DynamicTypeMember,
-        dynamic_data: &mut DynamicData
+        dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
         // (24) using short PL encoding when both M.id <= 2^14 and M.value.ssize <= 2^16
         deserializer.align(4);
@@ -315,7 +315,7 @@ impl EncodingVersion for EncodingVersion2 {
     fn deserialize_mmember<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         member: &DynamicTypeMember,
-        dynamic_data: &mut DynamicData
+        dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
         deserializer.align(4)?;
         // TODO: If LC(C)>=4
@@ -415,10 +415,11 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     }
 
     fn align(&mut self, alignment: usize) -> XTypesResult<()> {
-        self.reader.seek_padding(alignment)
+        self.reader
+            .seek_padding(core::cmp::min(alignment, V::MAX_ALIGN))
     }
 
-    fn deserialize_primitive_sequence_elements<O: AsBytes + Align<V>>(
+    fn deserialize_primitive_sequence_elements<O: AsBytes + Align>(
         &mut self,
         length: usize,
     ) -> XTypesResult<Vec<O>> {
@@ -656,7 +657,7 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     }
 
     /// Serialization Rule (2)
-    fn deserialize_primitive_type<O: AsBytes + Align<V>>(&mut self) -> XTypesResult<O> {
+    fn deserialize_primitive_type<O: AsBytes + Align>(&mut self) -> XTypesResult<O> {
         self.align(O::ALIGNMENT)?;
         O::as_bytes::<E>(&mut self.reader)
     }
@@ -760,49 +761,46 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     }
 }
 
-trait Align<V> {
+trait Align {
     const ALIGNMENT: usize;
 }
-const fn const_min(a: usize, b: usize) -> usize {
-    if a <= b { a } else { b }
-}
-impl<V> Align<V> for bool {
-    const ALIGNMENT: usize = 1;
-}
-impl<V> Align<V> for u8 {
-    const ALIGNMENT: usize = 1;
-}
-impl<V> Align<V> for u16 {
+impl Align for u8 {
     const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl<V> Align<V> for u32 {
+impl Align for u16 {
     const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl<V: EncodingVersion> Align<V> for u64 {
-    const ALIGNMENT: usize = const_min(Self::BITS as usize / 8, V::MAX_ALIGN);
-}
-impl<V> Align<V> for i8 {
-    const ALIGNMENT: usize = 1;
-}
-impl<V> Align<V> for i16 {
+impl Align for u32 {
     const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl<V> Align<V> for i32 {
+impl Align for u64 {
     const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl<V> Align<V> for i64 {
+impl Align for i8 {
     const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl<V> Align<V> for i128 {
+impl Align for i16 {
     const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl<V> Align<V> for f32 {
+impl Align for i32 {
+    const ALIGNMENT: usize = Self::BITS as usize / 8;
+}
+impl Align for i64 {
+    const ALIGNMENT: usize = Self::BITS as usize / 8;
+}
+impl Align for i128 {
+    const ALIGNMENT: usize = Self::BITS as usize / 8;
+}
+impl Align for f32 {
     const ALIGNMENT: usize = 4;
 }
-impl<V: EncodingVersion> Align<V> for f64 {
-    const ALIGNMENT: usize = const_min(8, V::MAX_ALIGN);
+impl Align for f64 {
+    const ALIGNMENT: usize = 8;
 }
-impl<V> Align<V> for char {
+impl Align for bool {
+    const ALIGNMENT: usize = 1;
+}
+impl Align for char {
     const ALIGNMENT: usize = 1;
 }
 

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -101,48 +101,48 @@ impl EndiannessRead for LittleEndian {
     }
 }
 
-trait EncodingVersion {
-    fn align<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+trait EncodingVersion: Sized {
+    fn align<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         alignment: usize,
     ) -> XTypesResult<()>;
 
-    fn seek_to_pid<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn seek_to_pid<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         pid: u16,
     ) -> XTypesResult<()>;
 
     /// Serialization Rule (9) & (10)
-    fn deserialize_array_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_array_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()>;
 
     /// Serialization Rule (12)
-    fn deserialize_sequence_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_sequence_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()>;
 
     /// Serialization Rule (15) & (16)
-    fn _deserialize_map_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        _deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn _deserialize_map_type<'a, E: EndiannessRead>(
+        _deserializer: &mut XTypesDeserializer<'a, E, Self>,
     ) -> XTypesResult<()> {
         todo!()
     }
 
     /// Serialization Rule (21) & (23)
-    fn deserialize_mstruct_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_mstruct_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         dynamic_type: DynamicType,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()>;
 
     /// Serialization Rule (22) & (24) & (25)
-    fn deserialize_mmember<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_mmember<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()>;
@@ -153,8 +153,8 @@ trait EncodingVersion {
     }
 
     /// Serialization Rule (29) & (30)
-    fn deserialize_appendable_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_appendable_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         dynamic_type: DynamicType,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()>;
@@ -162,8 +162,8 @@ trait EncodingVersion {
 
 struct EncodingVersion1;
 impl EncodingVersion for EncodingVersion1 {
-    fn seek_to_pid<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn seek_to_pid<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         pid: u16,
     ) -> XTypesResult<()> {
         const PID_SENTINEL: u16 = 1;
@@ -176,13 +176,20 @@ impl EncodingVersion for EncodingVersion1 {
                 return Err(PidNotFound(pid));
             } else {
                 deserializer.reader.seek(length as usize)?;
-                V::align(deserializer, 4)?;
+                Self::align(deserializer, 4)?;
             }
         }
     }
 
-    fn deserialize_array_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn align<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
+        alignment: usize,
+    ) -> XTypesResult<()> {
+        deserializer.reader.seek_padding(alignment)
+    }
+
+    fn deserialize_array_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
@@ -196,8 +203,8 @@ impl EncodingVersion for EncodingVersion1 {
     }
 
     /// Serialization Rule (12)
-    fn deserialize_sequence_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_sequence_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
@@ -206,31 +213,31 @@ impl EncodingVersion for EncodingVersion1 {
     }
 
     /// Serialization Rule (23)
-    fn deserialize_mstruct_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_mstruct_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         dynamic_type: DynamicType,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
         for member_index in 0..dynamic_type.get_member_count() {
             let member = dynamic_type.get_member_by_index(member_index)?;
-            V::deserialize_mmember(deserializer, member, dynamic_data)?;
+            Self::deserialize_mmember(deserializer, member, dynamic_data)?;
         }
         const PID_SENTINEL: u16 = 1;
-        V::seek_to_pid(deserializer, PID_SENTINEL)?;
+        Self::seek_to_pid(deserializer, PID_SENTINEL)?;
         Ok(())
     }
 
     /// Serialization Rule (24) & (25)
-    fn deserialize_mmember<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_mmember<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
         // (24) using short PL encoding when both M.id <= 2^14 and M.value.ssize <= 2^16
-        V::align(deserializer, 4)?;
+        Self::align(deserializer, 4)?;
         let pid: u16 = member.get_id() as u16;
         let orig_pos = deserializer.reader.pos;
-        let result = if V::seek_to_pid(deserializer, pid).is_ok() {
+        let result = if Self::seek_to_pid(deserializer, pid).is_ok() {
             deserializer.deserialize_nopt_fmember(member, dynamic_data)
         } else {
             Ok(())
@@ -242,26 +249,19 @@ impl EncodingVersion for EncodingVersion1 {
     }
 
     /// Serialization Rule (29)
-    fn deserialize_appendable_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_appendable_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         dynamic_type: DynamicType,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
         deserializer.deserialize_fstruct_type(dynamic_type, dynamic_data)
     }
-
-    fn align<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
-        alignment: usize,
-    ) -> XTypesResult<()> {
-        deserializer.reader.seek_padding(alignment)
-    }
 }
 
 struct EncodingVersion2;
 impl EncodingVersion for EncodingVersion2 {
-    fn seek_to_pid<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn seek_to_pid<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         pid: u16,
     ) -> XTypesResult<()> {
         loop {
@@ -272,13 +272,13 @@ impl EncodingVersion for EncodingVersion2 {
                 return Ok(());
             } else {
                 deserializer.reader.seek(length)?;
-                V::align(deserializer, 4)?;
+                Self::align(deserializer, 4)?;
             }
         }
     }
 
-    fn deserialize_array_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_array_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
@@ -293,8 +293,8 @@ impl EncodingVersion for EncodingVersion2 {
     }
 
     /// Serialization Rule (12)
-    fn deserialize_sequence_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_sequence_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
@@ -304,31 +304,31 @@ impl EncodingVersion for EncodingVersion2 {
     }
 
     /// Serialization Rule (21)
-    fn deserialize_mstruct_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_mstruct_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         dynamic_type: DynamicType,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
         let _dheader = deserializer.deserialize_primitive_type::<u32>()?;
         for member_index in 0..dynamic_type.get_member_count() {
             let member = dynamic_type.get_member_by_index(member_index)?;
-            V::deserialize_mmember(deserializer, member, dynamic_data)?;
+            Self::deserialize_mmember(deserializer, member, dynamic_data)?;
         }
         Ok(())
     }
 
     /// Serialization Rule (22)
-    fn deserialize_mmember<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_mmember<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
-        V::align(deserializer, 4)?;
+        Self::align(deserializer, 4)?;
         // TODO: If LC(C)>=4
         //let _next_int = deserializer.deserialize_primitive_type::<u32>();
         let pid: u16 = member.get_id() as u16;
         let orig_pos = deserializer.reader.pos;
-        let result = if V::seek_to_pid(deserializer, pid).is_ok() {
+        let result = if Self::seek_to_pid(deserializer, pid).is_ok() {
             deserializer.deserialize_nopt_fmember(member, dynamic_data)
         } else if !member.descriptor.is_optional {
             Err(XTypesError::PidNotFound(pid))
@@ -340,8 +340,8 @@ impl EncodingVersion for EncodingVersion2 {
     }
 
     /// Serialization Rule (30)
-    fn deserialize_appendable_type<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn deserialize_appendable_type<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         dynamic_type: DynamicType,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
@@ -349,8 +349,8 @@ impl EncodingVersion for EncodingVersion2 {
         deserializer.deserialize_fstruct_type(dynamic_type, dynamic_data)
     }
 
-    fn align<'a, E: EndiannessRead, V: EncodingVersion>(
-        deserializer: &mut XTypesDeserializer<'a, E, V>,
+    fn align<'a, E: EndiannessRead>(
+        deserializer: &mut XTypesDeserializer<'a, E, Self>,
         alignment: usize,
     ) -> XTypesResult<()> {
         deserializer

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -36,7 +36,9 @@ trait EndiannessRead {
 }
 
 fn read_array<const N: usize>(reader: &mut Reader) -> XTypesResult<[u8; N]> {
-    Ok(*reader.read_bytes(N)?.as_array().expect("must have length"))
+    let mut array = [0u8; N];
+    array.copy_from_slice(reader.read_bytes(N)?);
+    Ok(array)
 }
 
 struct BigEndian;

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -102,7 +102,10 @@ impl EndiannessRead for LittleEndian {
 }
 
 trait EncodingVersion {
-    const MAX_ALIGN: usize;
+    fn align<'a, E: EndiannessRead, V: EncodingVersion>(
+        deserializer: &mut XTypesDeserializer<'a, E, V>,
+        alignment: usize,
+    ) -> XTypesResult<()>;
 
     fn seek_to_pid<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
@@ -159,8 +162,6 @@ trait EncodingVersion {
 
 struct EncodingVersion1;
 impl EncodingVersion for EncodingVersion1 {
-    const MAX_ALIGN: usize = 8;
-
     fn seek_to_pid<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         pid: u16,
@@ -175,7 +176,7 @@ impl EncodingVersion for EncodingVersion1 {
                 return Err(PidNotFound(pid));
             } else {
                 deserializer.reader.seek(length as usize)?;
-                deserializer.align(4)?;
+                V::align(deserializer, 4)?;
             }
         }
     }
@@ -226,7 +227,7 @@ impl EncodingVersion for EncodingVersion1 {
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
         // (24) using short PL encoding when both M.id <= 2^14 and M.value.ssize <= 2^16
-        deserializer.align(4);
+        V::align(deserializer, 4)?;
         let pid: u16 = member.get_id() as u16;
         let orig_pos = deserializer.reader.pos;
         let result = if V::seek_to_pid(deserializer, pid).is_ok() {
@@ -248,12 +249,17 @@ impl EncodingVersion for EncodingVersion1 {
     ) -> XTypesResult<()> {
         deserializer.deserialize_fstruct_type(dynamic_type, dynamic_data)
     }
+
+    fn align<'a, E: EndiannessRead, V: EncodingVersion>(
+        deserializer: &mut XTypesDeserializer<'a, E, V>,
+        alignment: usize,
+    ) -> XTypesResult<()> {
+        deserializer.reader.seek_padding(alignment)
+    }
 }
 
 struct EncodingVersion2;
 impl EncodingVersion for EncodingVersion2 {
-    const MAX_ALIGN: usize = 4;
-
     fn seek_to_pid<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         pid: u16,
@@ -266,7 +272,7 @@ impl EncodingVersion for EncodingVersion2 {
                 return Ok(());
             } else {
                 deserializer.reader.seek(length)?;
-                deserializer.align(4)?;
+                V::align(deserializer, 4)?;
             }
         }
     }
@@ -317,10 +323,9 @@ impl EncodingVersion for EncodingVersion2 {
         member: &DynamicTypeMember,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
-        deserializer.align(4)?;
+        V::align(deserializer, 4)?;
         // TODO: If LC(C)>=4
         //let _next_int = deserializer.deserialize_primitive_type::<u32>();
-        deserializer.align(4)?;
         let pid: u16 = member.get_id() as u16;
         let orig_pos = deserializer.reader.pos;
         let result = if V::seek_to_pid(deserializer, pid).is_ok() {
@@ -342,6 +347,15 @@ impl EncodingVersion for EncodingVersion2 {
     ) -> XTypesResult<()> {
         let _dheader = deserializer.deserialize_primitive_type::<u32>();
         deserializer.deserialize_fstruct_type(dynamic_type, dynamic_data)
+    }
+
+    fn align<'a, E: EndiannessRead, V: EncodingVersion>(
+        deserializer: &mut XTypesDeserializer<'a, E, V>,
+        alignment: usize,
+    ) -> XTypesResult<()> {
+        deserializer
+            .reader
+            .seek_padding(core::cmp::min(alignment, 4))
     }
 }
 
@@ -412,11 +426,6 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
             _endianness: endianness,
             _encoding_version: encoding_version,
         }
-    }
-
-    fn align(&mut self, alignment: usize) -> XTypesResult<()> {
-        self.reader
-            .seek_padding(core::cmp::min(alignment, V::MAX_ALIGN))
     }
 
     fn deserialize_primitive_sequence_elements<O: AsBytes + Align>(
@@ -658,7 +667,7 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
 
     /// Serialization Rule (2)
     fn deserialize_primitive_type<O: AsBytes + Align>(&mut self) -> XTypesResult<O> {
-        self.align(O::ALIGNMENT)?;
+        V::align(self, O::ALIGNMENT)?;
         O::as_bytes::<E>(&mut self.reader)
     }
 

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -3,7 +3,7 @@ use crate::xtypes::{
         DynamicData, DynamicDataFactory, DynamicType, DynamicTypeMember, ExtensibilityKind,
         TypeKind,
     },
-    error::{XTypesError, XTypesResult},
+    error::{XTypesError::{self, PidNotFound}, XTypesResult},
 };
 use alloc::{string::String, vec::Vec};
 use tracing::debug;
@@ -32,65 +32,69 @@ trait EndiannessRead {
     fn read_f64(reader: &mut NextCdrReader) -> XTypesResult<f64>;
 }
 
+fn read_array<const N: usize>(reader: &mut NextCdrReader) -> XTypesResult<[u8; N]> {
+    Ok(*reader.read_bytes(N)?.as_array().expect("must have length"))
+}
+
 struct BigEndian;
 impl EndiannessRead for BigEndian {
     fn read_i16(reader: &mut NextCdrReader) -> XTypesResult<i16> {
-        Ok(i16::from_be_bytes(reader.read_array::<2>()?))
+        Ok(i16::from_be_bytes(read_array(reader)?))
     }
     fn read_u16(reader: &mut NextCdrReader) -> XTypesResult<u16> {
-        Ok(u16::from_be_bytes(reader.read_array::<2>()?))
+        Ok(u16::from_be_bytes(read_array(reader)?))
     }
     fn read_i32(reader: &mut NextCdrReader) -> XTypesResult<i32> {
-        Ok(i32::from_be_bytes(reader.read_array::<4>()?))
+        Ok(i32::from_be_bytes(read_array(reader)?))
     }
     fn read_u32(reader: &mut NextCdrReader) -> XTypesResult<u32> {
-        Ok(u32::from_be_bytes(reader.read_array::<4>()?))
+        Ok(u32::from_be_bytes(read_array(reader)?))
     }
     fn read_i64(reader: &mut NextCdrReader) -> XTypesResult<i64> {
-        Ok(i64::from_be_bytes(reader.read_array::<8>()?))
+        Ok(i64::from_be_bytes(read_array(reader)?))
     }
     fn read_u64(reader: &mut NextCdrReader) -> XTypesResult<u64> {
-        Ok(u64::from_be_bytes(reader.read_array::<8>()?))
+        Ok(u64::from_be_bytes(read_array(reader)?))
     }
     fn read_i128(reader: &mut NextCdrReader) -> XTypesResult<i128> {
-        Ok(i128::from_be_bytes(reader.read_array::<16>()?))
+        Ok(i128::from_be_bytes(read_array(reader)?))
     }
     fn read_f32(reader: &mut NextCdrReader) -> XTypesResult<f32> {
-        Ok(f32::from_be_bytes(reader.read_array::<4>()?))
+        Ok(f32::from_be_bytes(read_array(reader)?))
     }
     fn read_f64(reader: &mut NextCdrReader) -> XTypesResult<f64> {
-        Ok(f64::from_be_bytes(reader.read_array::<8>()?))
+        Ok(f64::from_be_bytes(read_array(reader)?))
     }
 }
 
 struct LittleEndian;
 impl EndiannessRead for LittleEndian {
     fn read_i16(reader: &mut NextCdrReader) -> XTypesResult<i16> {
-        Ok(i16::from_le_bytes(reader.read_array::<2>()?))
+        Ok(i16::from_le_bytes(read_array(reader)?))
     }
     fn read_u16(reader: &mut NextCdrReader) -> XTypesResult<u16> {
-        Ok(u16::from_le_bytes(reader.read_array::<2>()?))
+        Ok(u16::from_le_bytes(read_array(reader)?))
     }
     fn read_i32(reader: &mut NextCdrReader) -> XTypesResult<i32> {
-        Ok(i32::from_le_bytes(reader.read_array::<4>()?))
+        Ok(i32::from_le_bytes(read_array(reader)?))
     }
     fn read_u32(reader: &mut NextCdrReader) -> XTypesResult<u32> {
-        Ok(u32::from_le_bytes(reader.read_array::<4>()?))
+        Ok(u32::from_le_bytes(read_array(reader)?))
     }
     fn read_i64(reader: &mut NextCdrReader) -> XTypesResult<i64> {
-        Ok(i64::from_le_bytes(reader.read_array::<8>()?))
+        Ok(i64::from_le_bytes(read_array(reader)?))
     }
     fn read_u64(reader: &mut NextCdrReader) -> XTypesResult<u64> {
-        Ok(u64::from_le_bytes(reader.read_array::<8>()?))
+        Ok(u64::from_le_bytes(read_array(reader)?))
     }
     fn read_i128(reader: &mut NextCdrReader) -> XTypesResult<i128> {
-        Ok(i128::from_le_bytes(reader.read_array::<16>()?))
+        Ok(i128::from_le_bytes(read_array(reader)?))
     }
     fn read_f32(reader: &mut NextCdrReader) -> XTypesResult<f32> {
-        Ok(f32::from_le_bytes(reader.read_array::<4>()?))
+        Ok(f32::from_le_bytes(read_array(reader)?))
     }
     fn read_f64(reader: &mut NextCdrReader) -> XTypesResult<f64> {
-        Ok(f64::from_le_bytes(reader.read_array::<8>()?))
+        Ok(f64::from_le_bytes(read_array(reader)?))
     }
 }
 
@@ -98,10 +102,9 @@ trait EncodingVersion {
     const MAX_ALIGN: usize;
 
     fn seek_to_pid<'a, E: EndiannessRead, V: EncodingVersion>(
-        reader: &mut XTypesDeserializer<'a, E, V>,
+        deserializer: &mut XTypesDeserializer<'a, E, V>,
         pid: u16,
-        max_length: usize,
-    ) -> XTypesResult<bool>;
+    ) -> XTypesResult<()>;
 
     /// Serialization Rule (9) & (10)
     fn deserialize_array_type<'a, E: EndiannessRead, V: EncodingVersion>(
@@ -159,20 +162,18 @@ impl EncodingVersion for EncodingVersion1 {
     fn seek_to_pid<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         pid: u16,
-        _max_length: usize,
-    ) -> XTypesResult<bool> {
+    ) -> XTypesResult<()> {
         const PID_SENTINEL: u16 = 1;
         loop {
             let current_pid: u16 = deserializer.deserialize_primitive_type()?;
             let length: u16 = deserializer.deserialize_primitive_type()?;
             if current_pid == pid {
-                return Ok(true);
+                return Ok(());
             } else if current_pid == PID_SENTINEL {
-                return Ok(false);
+                return Err(PidNotFound(pid));
             } else {
-                deserializer.reader.seek(length as usize);
-
-                deserializer.reader.seek_padding(4);
+                deserializer.reader.seek(length as usize)?;
+                deserializer.align(4)?;
             }
         }
     }
@@ -212,9 +213,7 @@ impl EncodingVersion for EncodingVersion1 {
             V::deserialize_mmember(deserializer, member, dynamic_data, 0)?;
         }
         const PID_SENTINEL: u16 = 1;
-        V::seek_to_pid(deserializer, PID_SENTINEL, 0)?;
-        // let _pid_sentinel = deserializer.deserialize_primitive_type::<u16>()?;
-        // let _length_0 = deserializer.deserialize_primitive_type::<u16>()?;
+        V::seek_to_pid(deserializer, PID_SENTINEL)?;
         Ok(())
     }
 
@@ -229,7 +228,7 @@ impl EncodingVersion for EncodingVersion1 {
         deserializer.align(4);
         let pid: u16 = member.get_id() as u16;
         let orig_pos = deserializer.reader.pos;
-        let result = if V::seek_to_pid(deserializer, pid, 0)? {
+        let result = if V::seek_to_pid(deserializer, pid).is_ok() {
             deserializer.deserialize_nopt_fmember(member, dynamic_data)
         } else {
             Ok(())
@@ -257,19 +256,16 @@ impl EncodingVersion for EncodingVersion2 {
     fn seek_to_pid<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         pid: u16,
-        max_length: usize,
-    ) -> XTypesResult<bool> {
+    ) -> XTypesResult<()> {
         loop {
             let emheader: u32 = deserializer.deserialize_primitive_type()?;
             let current_pid = (emheader & 0x0fffffff) as u16;
             let length = ((emheader & 0b01110000_00000000_00000000_00000000) >> 28) as usize;
             if current_pid == pid {
-                return Ok(true);
-            } else if deserializer.reader.pos + length > max_length {
-                return Ok(false);
+                return Ok(());
             } else {
-                deserializer.reader.seek(length);
-                deserializer.reader.seek_padding(4);
+                deserializer.reader.seek(length)?;
+                deserializer.align(4)?;
             }
         }
     }
@@ -327,7 +323,7 @@ impl EncodingVersion for EncodingVersion2 {
         deserializer.align(4);
         let pid: u16 = member.get_id() as u16;
         let orig_pos = deserializer.reader.pos;
-        let result = if V::seek_to_pid(deserializer, pid, length)? {
+        let result = if V::seek_to_pid(deserializer, pid).is_ok() {
             deserializer.deserialize_nopt_fmember(member, dynamic_data)
         } else if !member.descriptor.is_optional {
             Err(XTypesError::PidNotFound(pid))
@@ -418,8 +414,8 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
         }
     }
 
-    fn align(&mut self, alignment: usize) {
-        self.reader.seek_padding(alignment);
+    fn align(&mut self, alignment: usize) -> XTypesResult<()>{
+        self.reader.seek_padding(alignment)
     }
 
     fn deserialize_primitive_sequence_elements<O: AsBytes + Align>(
@@ -668,7 +664,7 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     /// Serialization Rule (3) & (4)
     fn deserialize_string_type(&mut self) -> XTypesResult<String> {
         let length = self.deserialize_primitive_type::<u32>()?;
-        let values = self.reader.read_all(length as usize - 1)?.to_vec();
+        let values = self.reader.read_bytes(length as usize - 1)?.to_vec();
         self.reader.read_byte()?; // 0-termination
         String::from_utf8(values).map_err(|_| XTypesError::InvalidData)
     }
@@ -918,7 +914,7 @@ impl<'a> NextCdrReader<'a> {
         Ok(ret)
     }
 
-    fn read_all(&mut self, length: usize) -> XTypesResult<&'a [u8]> {
+    fn read_bytes(&mut self, length: usize) -> XTypesResult<&'a [u8]> {
         if self.pos + length > self.buffer.len() {
             return Err(XTypesError::NotEnoughData);
         }
@@ -927,17 +923,16 @@ impl<'a> NextCdrReader<'a> {
         Ok(ret)
     }
 
-    fn read_array<const N: usize>(&mut self) -> XTypesResult<[u8; N]> {
-        let ret = *self.read_all(N)?.as_array().expect("must have length");
-        self.pos += N;
-        Ok(ret)
+    fn seek(&mut self, v: usize) -> XTypesResult<()>{
+        if self.pos + v > self.buffer.len() {
+            Err(XTypesError::NotEnoughData)
+        } else {
+            self.pos += v;
+            Ok(())
+        }
     }
 
-    fn seek(&mut self, v: usize) {
-        self.pos += v
-    }
-
-    fn seek_padding(&mut self, alignment: usize) {
+    fn seek_padding(&mut self, alignment: usize) -> XTypesResult<()> {
         let mask = alignment - 1;
         self.seek(((self.pos + mask) & !mask) - self.pos)
     }
@@ -998,11 +993,13 @@ mod tests {
         struct FinalType {
             field_u16: u16,
             field_u64: u64,
+            field_u32: u32,
         }
         let mut expected = DynamicDataFactory::create_data(FinalType::TYPE);
         FinalType {
             field_u16: 7,
             field_u64: 9,
+            field_u32: 10,
         }
         .create_dynamic_sample(&mut expected);
         assert_eq!(
@@ -1012,6 +1009,7 @@ mod tests {
                     0x00, 0x00, 0x00, 0x00, // CDR_BE
                     0, 7, 0, 0, 0, 0, 0, 0, // field_u16 | padding (6 bytes)
                     0, 0, 0, 0, 0, 0, 0, 9, // field_u64
+                    0, 0, 0, 10, // field_u32
                 ],
             )
             .unwrap(),
@@ -1024,6 +1022,7 @@ mod tests {
                     0x00, 0x01, 0x00, 0x00, // CDR_LE
                     7, 0, 0, 0, 0, 0, 0, 0, // field_u16 | padding (6 bytes)
                     9, 0, 0, 0, 0, 0, 0, 0, // field_u64
+                    10, 0, 0, 0, // field_u32
                 ],
             )
             .unwrap(),
@@ -1036,6 +1035,7 @@ mod tests {
                     0x00, 0x06, 0x00, 0x00, // CDR2_BE
                     0, 7, 0, 0, // field_u16 | padding (2 bytes)
                     0, 0, 0, 0, 0, 0, 0, 9, // field_u64
+                    0, 0, 0, 10, // field_u32
                 ],
             )
             .unwrap(),
@@ -1048,6 +1048,7 @@ mod tests {
                     0x00, 0x07, 0x00, 0x00, // CDR2_LE
                     7, 0, 0, 0, // field_u16 | padding (2 bytes)
                     9, 0, 0, 0, 0, 0, 0, 0, // field_u64
+                    10, 0, 0, 0, // field_u32
                 ],
             )
             .unwrap(),

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -24,79 +24,79 @@ const PL_CDR2_BE: RepresentationIdentifier = [0x00, 0x0a];
 const PL_CDR2_LE: RepresentationIdentifier = [0x00, 0x0b];
 
 trait EndiannessRead {
-    fn read_i16(reader: &mut NextCdrReader) -> XTypesResult<i16>;
-    fn read_u32(reader: &mut NextCdrReader) -> XTypesResult<u32>;
-    fn read_u16(reader: &mut NextCdrReader) -> XTypesResult<u16>;
-    fn read_i64(reader: &mut NextCdrReader) -> XTypesResult<i64>;
-    fn read_i32(reader: &mut NextCdrReader) -> XTypesResult<i32>;
-    fn read_u64(reader: &mut NextCdrReader) -> XTypesResult<u64>;
-    fn read_i128(reader: &mut NextCdrReader) -> XTypesResult<i128>;
-    fn read_f32(reader: &mut NextCdrReader) -> XTypesResult<f32>;
-    fn read_f64(reader: &mut NextCdrReader) -> XTypesResult<f64>;
+    fn read_i16(reader: &mut Reader) -> XTypesResult<i16>;
+    fn read_u32(reader: &mut Reader) -> XTypesResult<u32>;
+    fn read_u16(reader: &mut Reader) -> XTypesResult<u16>;
+    fn read_i64(reader: &mut Reader) -> XTypesResult<i64>;
+    fn read_i32(reader: &mut Reader) -> XTypesResult<i32>;
+    fn read_u64(reader: &mut Reader) -> XTypesResult<u64>;
+    fn read_i128(reader: &mut Reader) -> XTypesResult<i128>;
+    fn read_f32(reader: &mut Reader) -> XTypesResult<f32>;
+    fn read_f64(reader: &mut Reader) -> XTypesResult<f64>;
 }
 
-fn read_array<const N: usize>(reader: &mut NextCdrReader) -> XTypesResult<[u8; N]> {
+fn read_array<const N: usize>(reader: &mut Reader) -> XTypesResult<[u8; N]> {
     Ok(*reader.read_bytes(N)?.as_array().expect("must have length"))
 }
 
 struct BigEndian;
 impl EndiannessRead for BigEndian {
-    fn read_i16(reader: &mut NextCdrReader) -> XTypesResult<i16> {
+    fn read_i16(reader: &mut Reader) -> XTypesResult<i16> {
         Ok(i16::from_be_bytes(read_array(reader)?))
     }
-    fn read_u16(reader: &mut NextCdrReader) -> XTypesResult<u16> {
+    fn read_u16(reader: &mut Reader) -> XTypesResult<u16> {
         Ok(u16::from_be_bytes(read_array(reader)?))
     }
-    fn read_i32(reader: &mut NextCdrReader) -> XTypesResult<i32> {
+    fn read_i32(reader: &mut Reader) -> XTypesResult<i32> {
         Ok(i32::from_be_bytes(read_array(reader)?))
     }
-    fn read_u32(reader: &mut NextCdrReader) -> XTypesResult<u32> {
+    fn read_u32(reader: &mut Reader) -> XTypesResult<u32> {
         Ok(u32::from_be_bytes(read_array(reader)?))
     }
-    fn read_i64(reader: &mut NextCdrReader) -> XTypesResult<i64> {
+    fn read_i64(reader: &mut Reader) -> XTypesResult<i64> {
         Ok(i64::from_be_bytes(read_array(reader)?))
     }
-    fn read_u64(reader: &mut NextCdrReader) -> XTypesResult<u64> {
+    fn read_u64(reader: &mut Reader) -> XTypesResult<u64> {
         Ok(u64::from_be_bytes(read_array(reader)?))
     }
-    fn read_i128(reader: &mut NextCdrReader) -> XTypesResult<i128> {
+    fn read_i128(reader: &mut Reader) -> XTypesResult<i128> {
         Ok(i128::from_be_bytes(read_array(reader)?))
     }
-    fn read_f32(reader: &mut NextCdrReader) -> XTypesResult<f32> {
+    fn read_f32(reader: &mut Reader) -> XTypesResult<f32> {
         Ok(f32::from_be_bytes(read_array(reader)?))
     }
-    fn read_f64(reader: &mut NextCdrReader) -> XTypesResult<f64> {
+    fn read_f64(reader: &mut Reader) -> XTypesResult<f64> {
         Ok(f64::from_be_bytes(read_array(reader)?))
     }
 }
 
 struct LittleEndian;
 impl EndiannessRead for LittleEndian {
-    fn read_i16(reader: &mut NextCdrReader) -> XTypesResult<i16> {
+    fn read_i16(reader: &mut Reader) -> XTypesResult<i16> {
         Ok(i16::from_le_bytes(read_array(reader)?))
     }
-    fn read_u16(reader: &mut NextCdrReader) -> XTypesResult<u16> {
+    fn read_u16(reader: &mut Reader) -> XTypesResult<u16> {
         Ok(u16::from_le_bytes(read_array(reader)?))
     }
-    fn read_i32(reader: &mut NextCdrReader) -> XTypesResult<i32> {
+    fn read_i32(reader: &mut Reader) -> XTypesResult<i32> {
         Ok(i32::from_le_bytes(read_array(reader)?))
     }
-    fn read_u32(reader: &mut NextCdrReader) -> XTypesResult<u32> {
+    fn read_u32(reader: &mut Reader) -> XTypesResult<u32> {
         Ok(u32::from_le_bytes(read_array(reader)?))
     }
-    fn read_i64(reader: &mut NextCdrReader) -> XTypesResult<i64> {
+    fn read_i64(reader: &mut Reader) -> XTypesResult<i64> {
         Ok(i64::from_le_bytes(read_array(reader)?))
     }
-    fn read_u64(reader: &mut NextCdrReader) -> XTypesResult<u64> {
+    fn read_u64(reader: &mut Reader) -> XTypesResult<u64> {
         Ok(u64::from_le_bytes(read_array(reader)?))
     }
-    fn read_i128(reader: &mut NextCdrReader) -> XTypesResult<i128> {
+    fn read_i128(reader: &mut Reader) -> XTypesResult<i128> {
         Ok(i128::from_le_bytes(read_array(reader)?))
     }
-    fn read_f32(reader: &mut NextCdrReader) -> XTypesResult<f32> {
+    fn read_f32(reader: &mut Reader) -> XTypesResult<f32> {
         Ok(f32::from_le_bytes(read_array(reader)?))
     }
-    fn read_f64(reader: &mut NextCdrReader) -> XTypesResult<f64> {
+    fn read_f64(reader: &mut Reader) -> XTypesResult<f64> {
         Ok(f64::from_le_bytes(read_array(reader)?))
     }
 }
@@ -242,7 +242,7 @@ impl EncodingVersion for EncodingVersion1 {
         } else {
             Ok(())
         };
-        deserializer.reader.set_position(orig_pos);
+        deserializer.reader.pos = orig_pos;
         result
 
         // TODO (25) using long PL encoding
@@ -335,7 +335,7 @@ impl EncodingVersion for EncodingVersion2 {
         } else {
             Ok(())
         };
-        deserializer.reader.set_position(orig_pos);
+        deserializer.reader.pos = orig_pos;
         result
     }
 
@@ -387,7 +387,7 @@ pub fn deserialize_top_level_type<'a>(
 }
 
 struct XTypesDeserializer<'a, E, V> {
-    reader: NextCdrReader<'a>,
+    reader: Reader<'a>,
     _endianness: E,
     _encoding_version: V,
 }
@@ -422,7 +422,7 @@ fn is_element_type_kind_primitive(member: &DynamicTypeMember) -> XTypesResult<bo
 impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     fn new(buffer: &'a [u8], encoding_version: V, endianness: E) -> Self {
         Self {
-            reader: NextCdrReader::new(buffer),
+            reader: Reader { buffer, pos: 0 },
             _endianness: endianness,
             _encoding_version: encoding_version,
         }
@@ -667,7 +667,7 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
 
     /// Serialization Rule (2)
     fn deserialize_primitive_type<O: AsBytes + Align>(&mut self) -> XTypesResult<O> {
-        V::align(self, O::ALIGNMENT)?;
+        V::align(self, O::SSIZE)?;
         O::as_bytes::<E>(&mut self.reader)
     }
 
@@ -771,55 +771,55 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
 }
 
 trait Align {
-    const ALIGNMENT: usize;
+    const SSIZE: usize;
 }
 impl Align for u8 {
-    const ALIGNMENT: usize = Self::BITS as usize / 8;
+    const SSIZE: usize = Self::BITS as usize / 8;
 }
 impl Align for u16 {
-    const ALIGNMENT: usize = Self::BITS as usize / 8;
+    const SSIZE: usize = Self::BITS as usize / 8;
 }
 impl Align for u32 {
-    const ALIGNMENT: usize = Self::BITS as usize / 8;
+    const SSIZE: usize = Self::BITS as usize / 8;
 }
 impl Align for u64 {
-    const ALIGNMENT: usize = Self::BITS as usize / 8;
+    const SSIZE: usize = Self::BITS as usize / 8;
 }
 impl Align for i8 {
-    const ALIGNMENT: usize = Self::BITS as usize / 8;
+    const SSIZE: usize = Self::BITS as usize / 8;
 }
 impl Align for i16 {
-    const ALIGNMENT: usize = Self::BITS as usize / 8;
+    const SSIZE: usize = Self::BITS as usize / 8;
 }
 impl Align for i32 {
-    const ALIGNMENT: usize = Self::BITS as usize / 8;
+    const SSIZE: usize = Self::BITS as usize / 8;
 }
 impl Align for i64 {
-    const ALIGNMENT: usize = Self::BITS as usize / 8;
+    const SSIZE: usize = Self::BITS as usize / 8;
 }
 impl Align for i128 {
-    const ALIGNMENT: usize = Self::BITS as usize / 8;
+    const SSIZE: usize = Self::BITS as usize / 8;
 }
 impl Align for f32 {
-    const ALIGNMENT: usize = 4;
+    const SSIZE: usize = 4;
 }
 impl Align for f64 {
-    const ALIGNMENT: usize = 8;
+    const SSIZE: usize = 8;
 }
 impl Align for bool {
-    const ALIGNMENT: usize = 1;
+    const SSIZE: usize = 1;
 }
 impl Align for char {
-    const ALIGNMENT: usize = 1;
+    const SSIZE: usize = 1;
 }
 
 trait AsBytes {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self>
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self>
     where
         Self: Sized;
 }
 impl AsBytes for bool {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         match reader.read_byte()? {
             0 => Ok(false),
             1 => Ok(true),
@@ -828,75 +828,72 @@ impl AsBytes for bool {
     }
 }
 impl AsBytes for u8 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         reader.read_byte()
     }
 }
 impl AsBytes for u16 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         E::read_u16(reader)
     }
 }
 impl AsBytes for u32 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         E::read_u32(reader)
     }
 }
 impl AsBytes for u64 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         E::read_u64(reader)
     }
 }
 impl AsBytes for i8 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         Ok(reader.read_byte()? as Self)
     }
 }
 impl AsBytes for i16 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         E::read_i16(reader)
     }
 }
 impl AsBytes for i32 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         E::read_i32(reader)
     }
 }
 impl AsBytes for i64 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         E::read_i64(reader)
     }
 }
 impl AsBytes for i128 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         E::read_i128(reader)
     }
 }
 impl AsBytes for f32 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         E::read_f32(reader)
     }
 }
 impl AsBytes for f64 {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         E::read_f64(reader)
     }
 }
 impl AsBytes for char {
-    fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
+    fn as_bytes<'a, E: EndiannessRead>(reader: &mut Reader<'a>) -> XTypesResult<Self> {
         Ok(char::from(reader.read_byte()?))
     }
 }
 
-struct NextCdrReader<'a> {
+struct Reader<'a> {
     buffer: &'a [u8],
     pos: usize,
 }
 
-impl<'a> NextCdrReader<'a> {
-    fn new(buffer: &'a [u8]) -> Self {
-        Self { buffer, pos: 0 }
-    }
+impl<'a> Reader<'a> {
     fn read_byte(&mut self) -> XTypesResult<u8> {
         if self.pos + 1 > self.buffer.len() {
             return Err(XTypesError::NotEnoughData);
@@ -928,10 +925,6 @@ impl<'a> NextCdrReader<'a> {
         let mask = alignment - 1;
         self.seek(((self.pos + mask) & !mask) - self.pos)
     }
-
-    fn set_position(&mut self, pos: usize) {
-        self.pos = pos;
-    }
 }
 
 #[cfg(test)]
@@ -945,10 +938,10 @@ mod tests {
     #[test]
     fn cyclone_dispose_message() {
         #[derive(Debug, PartialEq, TypeSupport)]
-        pub struct DisposeDataType {
+        struct DisposeDataType {
             #[dust_dds(key)]
-            pub name: String,
-            pub value: u8,
+            name: String,
+            value: u8,
         }
 
         let mut dispose_data_type_key_holder = DisposeDataType::TYPE;

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -3,7 +3,10 @@ use crate::xtypes::{
         DynamicData, DynamicDataFactory, DynamicType, DynamicTypeMember, ExtensibilityKind,
         TypeKind,
     },
-    error::{XTypesError::{self, PidNotFound}, XTypesResult},
+    error::{
+        XTypesError::{self, PidNotFound},
+        XTypesResult,
+    },
 };
 use alloc::{string::String, vec::Vec};
 use tracing::debug;
@@ -138,8 +141,7 @@ trait EncodingVersion {
     fn deserialize_mmember<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         member: &DynamicTypeMember,
-        dynamic_data: &mut DynamicData,
-        length: usize,
+        dynamic_data: &mut DynamicData
     ) -> XTypesResult<()>;
 
     /// Serialization Rule (27) & (28)
@@ -210,7 +212,7 @@ impl EncodingVersion for EncodingVersion1 {
     ) -> XTypesResult<()> {
         for member_index in 0..dynamic_type.get_member_count() {
             let member = dynamic_type.get_member_by_index(member_index)?;
-            V::deserialize_mmember(deserializer, member, dynamic_data, 0)?;
+            V::deserialize_mmember(deserializer, member, dynamic_data)?;
         }
         const PID_SENTINEL: u16 = 1;
         V::seek_to_pid(deserializer, PID_SENTINEL)?;
@@ -221,8 +223,7 @@ impl EncodingVersion for EncodingVersion1 {
     fn deserialize_mmember<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         member: &DynamicTypeMember,
-        dynamic_data: &mut DynamicData,
-        _length: usize,
+        dynamic_data: &mut DynamicData
     ) -> XTypesResult<()> {
         // (24) using short PL encoding when both M.id <= 2^14 and M.value.ssize <= 2^16
         deserializer.align(4);
@@ -302,10 +303,10 @@ impl EncodingVersion for EncodingVersion2 {
         dynamic_type: DynamicType,
         dynamic_data: &mut DynamicData,
     ) -> XTypesResult<()> {
-        let dheader = deserializer.deserialize_primitive_type::<u32>()?;
+        let _dheader = deserializer.deserialize_primitive_type::<u32>()?;
         for member_index in 0..dynamic_type.get_member_count() {
             let member = dynamic_type.get_member_by_index(member_index)?;
-            V::deserialize_mmember(deserializer, member, dynamic_data, dheader as usize)?;
+            V::deserialize_mmember(deserializer, member, dynamic_data)?;
         }
         Ok(())
     }
@@ -314,13 +315,12 @@ impl EncodingVersion for EncodingVersion2 {
     fn deserialize_mmember<'a, E: EndiannessRead, V: EncodingVersion>(
         deserializer: &mut XTypesDeserializer<'a, E, V>,
         member: &DynamicTypeMember,
-        dynamic_data: &mut DynamicData,
-        length: usize,
+        dynamic_data: &mut DynamicData
     ) -> XTypesResult<()> {
-        deserializer.align(4);
+        deserializer.align(4)?;
         // TODO: If LC(C)>=4
         //let _next_int = deserializer.deserialize_primitive_type::<u32>();
-        deserializer.align(4);
+        deserializer.align(4)?;
         let pid: u16 = member.get_id() as u16;
         let orig_pos = deserializer.reader.pos;
         let result = if V::seek_to_pid(deserializer, pid).is_ok() {
@@ -414,11 +414,11 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
         }
     }
 
-    fn align(&mut self, alignment: usize) -> XTypesResult<()>{
+    fn align(&mut self, alignment: usize) -> XTypesResult<()> {
         self.reader.seek_padding(alignment)
     }
 
-    fn deserialize_primitive_sequence_elements<O: AsBytes + Align>(
+    fn deserialize_primitive_sequence_elements<O: AsBytes + Align<V>>(
         &mut self,
         length: usize,
     ) -> XTypesResult<Vec<O>> {
@@ -656,8 +656,8 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     }
 
     /// Serialization Rule (2)
-    fn deserialize_primitive_type<O: AsBytes + Align>(&mut self) -> XTypesResult<O> {
-        O::align::<V>(&mut self.reader);
+    fn deserialize_primitive_type<O: AsBytes + Align<V>>(&mut self) -> XTypesResult<O> {
+        self.align(O::ALIGNMENT)?;
         O::as_bytes::<E>(&mut self.reader)
     }
 
@@ -760,65 +760,50 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     }
 }
 
-trait Align {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>);
+trait Align<V> {
+    const ALIGNMENT: usize;
 }
-impl Align for bool {
-    fn align<'a, V: EncodingVersion>(_reader: &mut NextCdrReader<'a>) {}
+const fn const_min(a: usize, b: usize) -> usize {
+    if a <= b { a } else { b }
 }
-impl Align for u8 {
-    fn align<'a, V: EncodingVersion>(_reader: &mut NextCdrReader<'a>) {}
+impl<V> Align<V> for bool {
+    const ALIGNMENT: usize = 1;
 }
-impl Align for u16 {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>) {
-        reader.seek_padding(Self::BITS as usize / 8);
-    }
+impl<V> Align<V> for u8 {
+    const ALIGNMENT: usize = 1;
 }
-impl Align for u32 {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>) {
-        reader.seek_padding(Self::BITS as usize / 8);
-    }
+impl<V> Align<V> for u16 {
+    const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl Align for u64 {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>) {
-        reader.seek_padding(core::cmp::min(Self::BITS as usize / 8, V::MAX_ALIGN));
-    }
+impl<V> Align<V> for u32 {
+    const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl Align for i8 {
-    fn align<'a, V: EncodingVersion>(_reader: &mut NextCdrReader<'a>) {}
+impl<V: EncodingVersion> Align<V> for u64 {
+    const ALIGNMENT: usize = const_min(Self::BITS as usize / 8, V::MAX_ALIGN);
 }
-impl Align for i16 {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>) {
-        reader.seek_padding(Self::BITS as usize / 8);
-    }
+impl<V> Align<V> for i8 {
+    const ALIGNMENT: usize = 1;
 }
-impl Align for i32 {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>) {
-        reader.seek_padding(Self::BITS as usize / 8);
-    }
+impl<V> Align<V> for i16 {
+    const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl Align for i64 {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>) {
-        reader.seek_padding(core::cmp::min(Self::BITS as usize / 8, V::MAX_ALIGN));
-    }
+impl<V> Align<V> for i32 {
+    const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl Align for i128 {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>) {
-        reader.seek_padding(core::cmp::min(Self::BITS as usize / 8, V::MAX_ALIGN));
-    }
+impl<V> Align<V> for i64 {
+    const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl Align for f32 {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>) {
-        reader.seek_padding(32 / 8);
-    }
+impl<V> Align<V> for i128 {
+    const ALIGNMENT: usize = Self::BITS as usize / 8;
 }
-impl Align for f64 {
-    fn align<'a, V: EncodingVersion>(reader: &mut NextCdrReader<'a>) {
-        reader.seek_padding(core::cmp::min(64 / 8, V::MAX_ALIGN));
-    }
+impl<V> Align<V> for f32 {
+    const ALIGNMENT: usize = 4;
 }
-impl Align for char {
-    fn align<'a, V: EncodingVersion>(_reader: &mut NextCdrReader<'a>) {}
+impl<V: EncodingVersion> Align<V> for f64 {
+    const ALIGNMENT: usize = const_min(8, V::MAX_ALIGN);
+}
+impl<V> Align<V> for char {
+    const ALIGNMENT: usize = 1;
 }
 
 trait AsBytes {
@@ -923,7 +908,7 @@ impl<'a> NextCdrReader<'a> {
         Ok(ret)
     }
 
-    fn seek(&mut self, v: usize) -> XTypesResult<()>{
+    fn seek(&mut self, v: usize) -> XTypesResult<()> {
         if self.pos + v > self.buffer.len() {
             Err(XTypesError::NotEnoughData)
         } else {

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -20,105 +20,77 @@ const D_CDR2_LE: RepresentationIdentifier = [0x00, 0x09];
 const PL_CDR2_BE: RepresentationIdentifier = [0x00, 0x0a];
 const PL_CDR2_LE: RepresentationIdentifier = [0x00, 0x0b];
 
-trait Read {
-    fn read_exact(&mut self, size: usize) -> XTypesResult<&[u8]>;
-
-    fn read_array<const N: usize>(&mut self) -> XTypesResult<&[u8; N]> {
-        self.read_exact(N)?
-            .try_into()
-            .map_err(|_e| XTypesError::InvalidData)
-    }
-}
-
 trait EndiannessRead {
-    fn read_i16<R: Read>(reader: &mut R) -> XTypesResult<i16>;
-    fn read_u16<R: Read>(reader: &mut R) -> XTypesResult<u16>;
-    fn read_i32<R: Read>(reader: &mut R) -> XTypesResult<i32>;
-    fn read_u32<R: Read>(reader: &mut R) -> XTypesResult<u32>;
-    fn read_i64<R: Read>(reader: &mut R) -> XTypesResult<i64>;
-    fn read_u64<R: Read>(reader: &mut R) -> XTypesResult<u64>;
-    fn read_i128<R: Read>(reader: &mut R) -> XTypesResult<i128>;
-    fn read_f32<R: Read>(reader: &mut R) -> XTypesResult<f32>;
-    fn read_f64<R: Read>(reader: &mut R) -> XTypesResult<f64>;
+    fn read_i16(reader: &mut NextCdrReader) -> XTypesResult<i16>;
+    fn read_u32(reader: &mut NextCdrReader) -> XTypesResult<u32>;
+    fn read_u16(reader: &mut NextCdrReader) -> XTypesResult<u16>;
+    fn read_i64(reader: &mut NextCdrReader) -> XTypesResult<i64>;
+    fn read_i32(reader: &mut NextCdrReader) -> XTypesResult<i32>;
+    fn read_u64(reader: &mut NextCdrReader) -> XTypesResult<u64>;
+    fn read_i128(reader: &mut NextCdrReader) -> XTypesResult<i128>;
+    fn read_f32(reader: &mut NextCdrReader) -> XTypesResult<f32>;
+    fn read_f64(reader: &mut NextCdrReader) -> XTypesResult<f64>;
 }
 
 struct BigEndian;
-
 impl EndiannessRead for BigEndian {
-    fn read_i16<R: Read>(reader: &mut R) -> XTypesResult<i16> {
-        Ok(i16::from_be_bytes(*reader.read_array::<2>()?))
+    fn read_i16(reader: &mut NextCdrReader) -> XTypesResult<i16> {
+        Ok(i16::from_be_bytes(reader.read_array::<2>()?))
     }
-
-    fn read_u16<R: Read>(reader: &mut R) -> XTypesResult<u16> {
-        Ok(u16::from_be_bytes(*reader.read_array::<2>()?))
+    fn read_u16(reader: &mut NextCdrReader) -> XTypesResult<u16> {
+        Ok(u16::from_be_bytes(reader.read_array::<2>()?))
     }
-
-    fn read_i32<R: Read>(reader: &mut R) -> XTypesResult<i32> {
-        Ok(i32::from_be_bytes(*reader.read_array::<4>()?))
+    fn read_i32(reader: &mut NextCdrReader) -> XTypesResult<i32> {
+        Ok(i32::from_be_bytes(reader.read_array::<4>()?))
     }
-
-    fn read_u32<R: Read>(reader: &mut R) -> XTypesResult<u32> {
-        Ok(u32::from_be_bytes(*reader.read_array::<4>()?))
+    fn read_u32(reader: &mut NextCdrReader) -> XTypesResult<u32> {
+        Ok(u32::from_be_bytes(reader.read_array::<4>()?))
     }
-
-    fn read_i64<R: Read>(reader: &mut R) -> XTypesResult<i64> {
-        Ok(i64::from_be_bytes(*reader.read_array::<8>()?))
+    fn read_i64(reader: &mut NextCdrReader) -> XTypesResult<i64> {
+        Ok(i64::from_be_bytes(reader.read_array::<8>()?))
     }
-
-    fn read_u64<R: Read>(reader: &mut R) -> XTypesResult<u64> {
-        Ok(u64::from_be_bytes(*reader.read_array::<8>()?))
+    fn read_u64(reader: &mut NextCdrReader) -> XTypesResult<u64> {
+        Ok(u64::from_be_bytes(reader.read_array::<8>()?))
     }
-
-    fn read_i128<R: Read>(reader: &mut R) -> XTypesResult<i128> {
-        Ok(i128::from_be_bytes(*reader.read_array::<16>()?))
+    fn read_i128(reader: &mut NextCdrReader) -> XTypesResult<i128> {
+        Ok(i128::from_be_bytes(reader.read_array::<16>()?))
     }
-
-    fn read_f32<R: Read>(reader: &mut R) -> XTypesResult<f32> {
-        Ok(f32::from_be_bytes(*reader.read_array::<4>()?))
+    fn read_f32(reader: &mut NextCdrReader) -> XTypesResult<f32> {
+        Ok(f32::from_be_bytes(reader.read_array::<4>()?))
     }
-
-    fn read_f64<R: Read>(reader: &mut R) -> XTypesResult<f64> {
-        Ok(f64::from_be_bytes(*reader.read_array::<8>()?))
+    fn read_f64(reader: &mut NextCdrReader) -> XTypesResult<f64> {
+        Ok(f64::from_be_bytes(reader.read_array::<8>()?))
     }
 }
 
 struct LittleEndian;
-
 impl EndiannessRead for LittleEndian {
-    fn read_i16<R: Read>(reader: &mut R) -> XTypesResult<i16> {
-        Ok(i16::from_le_bytes(*reader.read_array::<2>()?))
+    fn read_i16(reader: &mut NextCdrReader) -> XTypesResult<i16> {
+        Ok(i16::from_le_bytes(reader.read_array::<2>()?))
     }
-
-    fn read_u16<R: Read>(reader: &mut R) -> XTypesResult<u16> {
-        Ok(u16::from_le_bytes(*reader.read_array::<2>()?))
+    fn read_u16(reader: &mut NextCdrReader) -> XTypesResult<u16> {
+        Ok(u16::from_le_bytes(reader.read_array::<2>()?))
     }
-
-    fn read_i32<R: Read>(reader: &mut R) -> XTypesResult<i32> {
-        Ok(i32::from_le_bytes(*reader.read_array::<4>()?))
+    fn read_i32(reader: &mut NextCdrReader) -> XTypesResult<i32> {
+        Ok(i32::from_le_bytes(reader.read_array::<4>()?))
     }
-
-    fn read_u32<R: Read>(reader: &mut R) -> XTypesResult<u32> {
-        Ok(u32::from_le_bytes(*reader.read_array::<4>()?))
+    fn read_u32(reader: &mut NextCdrReader) -> XTypesResult<u32> {
+        Ok(u32::from_le_bytes(reader.read_array::<4>()?))
     }
-
-    fn read_i64<R: Read>(reader: &mut R) -> XTypesResult<i64> {
-        Ok(i64::from_le_bytes(*reader.read_array::<8>()?))
+    fn read_i64(reader: &mut NextCdrReader) -> XTypesResult<i64> {
+        Ok(i64::from_le_bytes(reader.read_array::<8>()?))
     }
-
-    fn read_u64<R: Read>(reader: &mut R) -> XTypesResult<u64> {
-        Ok(u64::from_le_bytes(*reader.read_array::<8>()?))
+    fn read_u64(reader: &mut NextCdrReader) -> XTypesResult<u64> {
+        Ok(u64::from_le_bytes(reader.read_array::<8>()?))
     }
-
-    fn read_i128<R: Read>(reader: &mut R) -> XTypesResult<i128> {
-        Ok(i128::from_le_bytes(*reader.read_array::<16>()?))
+    fn read_i128(reader: &mut NextCdrReader) -> XTypesResult<i128> {
+        Ok(i128::from_le_bytes(reader.read_array::<16>()?))
     }
-
-    fn read_f32<R: Read>(reader: &mut R) -> XTypesResult<f32> {
-        Ok(f32::from_le_bytes(*reader.read_array::<4>()?))
+    fn read_f32(reader: &mut NextCdrReader) -> XTypesResult<f32> {
+        Ok(f32::from_le_bytes(reader.read_array::<4>()?))
     }
-
-    fn read_f64<R: Read>(reader: &mut R) -> XTypesResult<f64> {
-        Ok(f64::from_le_bytes(*reader.read_array::<8>()?))
+    fn read_f64(reader: &mut NextCdrReader) -> XTypesResult<f64> {
+        Ok(f64::from_le_bytes(reader.read_array::<8>()?))
     }
 }
 
@@ -199,6 +171,7 @@ impl EncodingVersion for EncodingVersion1 {
                 return Ok(false);
             } else {
                 deserializer.reader.seek(length as usize);
+
                 deserializer.reader.seek_padding(4);
             }
         }
@@ -859,7 +832,7 @@ trait AsBytes {
 }
 impl AsBytes for bool {
     fn as_bytes<'a, E: EndiannessRead>(reader: &mut NextCdrReader<'a>) -> XTypesResult<Self> {
-        match reader.read_exact(1)?[0] {
+        match reader.read_byte()? {
             0 => Ok(false),
             1 => Ok(true),
             _ => Err(XTypesError::InvalidData),
@@ -954,6 +927,12 @@ impl<'a> NextCdrReader<'a> {
         Ok(ret)
     }
 
+    fn read_array<const N: usize>(&mut self) -> XTypesResult<[u8; N]> {
+        let ret = *self.read_all(N)?.as_array().expect("must have length");
+        self.pos += N;
+        Ok(ret)
+    }
+
     fn seek(&mut self, v: usize) {
         self.pos += v
     }
@@ -965,11 +944,6 @@ impl<'a> NextCdrReader<'a> {
 
     fn set_position(&mut self, pos: usize) {
         self.pos = pos;
-    }
-}
-impl<'a> Read for NextCdrReader<'a> {
-    fn read_exact(&mut self, size: usize) -> XTypesResult<&[u8]> {
-        self.read_all(size)
     }
 }
 
@@ -1003,7 +977,7 @@ mod tests {
                 0x56, 0x65, 0x72, 0x79, // String
                 0x20, 0x4c, 0x6f, 0x6e, // String
                 0x67, 0x20, 0x4e, 0x61, // String
-                0x6d, 0x65, 0x0, 0x0, // String = terminiating 0 + 1 byte padding
+                0x6d, 0x65, 0x0, 0x0, // String | terminating 0 | 1 byte padding
             ],
         )
         .unwrap();


### PR DESCRIPTION
remove some obsolete traits from the XTypesDeserializer and move dependencies closer to where they are strictly necessary. An error is now returned in case of seeking outside the data as well.