### PR TITLE
Send type information on topic announcement

### DIFF
--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_topic_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_topic_data.rs
@@ -7,7 +7,7 @@ use crate::{
             PID_OWNERSHIP, PID_RELIABILITY, PID_RESOURCE_LIMITS, PID_TOPIC_DATA, PID_TOPIC_NAME,
             PID_TRANSPORT_PRIORITY, PID_TYPE_INFORMATION, PID_TYPE_NAME,
         },
-        rtps_data_representation::CdrResult,
+        rtps_data_representation::{CdrResult, ParameterList},
         rtps_data_representation_serialization::ParameterListSerializer,
     },
     infrastructure::qos_policy::{
@@ -15,10 +15,6 @@ use crate::{
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, HistoryQosPolicy,
         LatencyBudgetQosPolicy, LifespanQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy,
         ResourceLimitsQosPolicy, TopicDataQosPolicy, TransportPriorityQosPolicy,
-    },
-    xtypes::{
-        deserializer::deserialize_top_level_type,
-        type_support::{Type, TypeSupport},
     },
 };
 use alloc::vec::Vec;
@@ -101,9 +97,35 @@ impl DiscoveredTopicData {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> CdrResult<Self> {
-        let topic_builtin_topic_data = TopicBuiltinTopicData::create_sample(
-            &mut deserialize_top_level_type(TopicBuiltinTopicData::TYPE, bytes)?,
-        );
+        let pl = ParameterList::new(bytes)?;
+
+        let topic_builtin_topic_data = TopicBuiltinTopicData {
+            key: pl.get_optional_parameter_xdcr(PID_ENDPOINT_GUID, Default::default())?,
+            name: pl.get_optional_parameter_xdcr(PID_TOPIC_NAME, Default::default())?,
+            type_name: pl.get_optional_parameter_xdcr(PID_TYPE_NAME, Default::default())?,
+            type_information: None, //pl.get_optional_parameter_xdcr(PID_TYPE_INFORMATION, Default::default())?,
+            durability: pl.get_optional_parameter_xdcr(PID_DURABILITY, Default::default())?,
+            deadline: pl.get_optional_parameter_xdcr(PID_DEADLINE, Default::default())?,
+            latency_budget: pl
+                .get_optional_parameter_xdcr(PID_LATENCY_BUDGET, Default::default())?,
+            liveliness: pl.get_optional_parameter_xdcr(PID_LIVELINESS, Default::default())?,
+            reliability: pl.get_optional_parameter_xdcr(
+                PID_RELIABILITY,
+                DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS,
+            )?,
+            transport_priority: pl
+                .get_optional_parameter_xdcr(PID_TRANSPORT_PRIORITY, Default::default())?,
+            lifespan: pl.get_optional_parameter_xdcr(PID_LIFESPAN, Default::default())?,
+            destination_order: pl
+                .get_optional_parameter_xdcr(PID_DESTINATION_ORDER, Default::default())?,
+            history: pl.get_optional_parameter_xdcr(PID_HISTORY, Default::default())?,
+            resource_limits: pl
+                .get_optional_parameter_xdcr(PID_RESOURCE_LIMITS, Default::default())?,
+            ownership: pl.get_optional_parameter_xdcr(PID_OWNERSHIP, Default::default())?,
+            topic_data: pl.get_optional_parameter_xdcr(PID_TOPIC_DATA, Default::default())?,
+            representation: pl
+                .get_optional_parameter_xdcr(PID_DATA_REPRESENTATION, Default::default())?,
+        };
         Ok(Self {
             topic_builtin_topic_data,
         })

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -11,6 +11,7 @@ use crate::{
         },
         dcps_mail::{DcpsMail, EventServiceMail},
         listeners::domain_participant_listener::ListenerMail,
+        xtypes_glue::key_and_instance_handle::get_instance_handle_from_dynamic_data,
     },
     infrastructure::{instance::InstanceHandle, status::StatusKind, time::DurationKind},
     rtps::message_receiver::MessageReceiver,
@@ -210,7 +211,63 @@ impl DcpsDomainParticipant {
             }
 
             let participant_handle = self.domain_participant.instance_handle;
-            match data_reader.add_reader_change(cache_change, reception_timestamp) {
+            let (dynamic_data, change_instance_handle) = match cache_change.kind {
+                ChangeKind::Alive | ChangeKind::AliveFiltered => {
+                    let Ok(data_value) = deserialize_top_level_type(
+                        data_reader.type_support,
+                        cache_change.data_value.as_ref(),
+                    ) else {
+                        tracing::warn!("Failed to deserialize user defined data");
+                        return;
+                    };
+                    let Ok(instance_handle) =
+                        get_instance_handle_from_dynamic_data(data_value.clone())
+                    else {
+                        tracing::warn!("Failed to get instance handle from dynamic_data");
+                        return;
+                    };
+                    (Some(data_value), instance_handle)
+                }
+                ChangeKind::NotAliveDisposed
+                | ChangeKind::NotAliveUnregistered
+                | ChangeKind::NotAliveDisposedUnregistered => match cache_change.instance_handle {
+                    Some(i) => {
+                        let instance_handle = InstanceHandle::new(i);
+                        (None, instance_handle)
+                    }
+                    None => {
+                        let mut dispose_data_type_key_holder = data_reader.type_support;
+                        let mut member_list = data_reader.type_support.member_list.to_vec();
+                        member_list.retain(|f| f.descriptor.is_key);
+                        dispose_data_type_key_holder.member_list = &member_list;
+
+                        let Ok(data_value) = deserialize_top_level_type(
+                            dispose_data_type_key_holder,
+                            cache_change.data_value.as_ref(),
+                        ) else {
+                            tracing::warn!("Failed to deserialize disposed user defined data");
+                            return;
+                        };
+
+                        let Ok(instance_handle) =
+                            get_instance_handle_from_dynamic_data(data_value.clone())
+                        else {
+                            tracing::warn!("Failed to deserialize disposed key user defined data");
+                            return;
+                        };
+                        (None, instance_handle)
+                    }
+                },
+            };
+
+            match data_reader.add_reader_change(
+                cache_change.writer_guid,
+                dynamic_data,
+                cache_change.kind,
+                change_instance_handle.into(),
+                cache_change.source_timestamp.map(Into::into),
+                reception_timestamp,
+            ) {
                 Ok(AddChangeResult::Added(change_instance_handle)) => {
                     info!("New change added");
                     if let DurationKind::Finite(deadline_missed_period) =

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -460,7 +460,7 @@ impl DcpsDomainParticipant {
                     value: topic.instance_handle.into(),
                 },
                 name: topic.topic_name.clone().into(),
-                type_information: None,
+                type_information: Some(topic.type_support.into()),
                 type_name: topic.type_name.clone().into(),
                 durability: topic.qos.durability.clone(),
                 deadline: topic.qos.deadline.clone(),

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -24,6 +24,7 @@ use crate::{
             TopicDescriptionKind,
         },
         listeners::domain_participant_listener::ListenerMail,
+        xtypes_glue::key_and_instance_handle::get_instance_handle_from_dynamic_data,
     },
     infrastructure::{
         instance::InstanceHandle,
@@ -1394,7 +1395,39 @@ impl DcpsDomainParticipant {
                 if let Ok(discovered_participant_data) =
                     SpdpDiscoveredParticipantData::from_bytes(cache_change.data_value.as_ref())
                 {
-                    self.add_discovered_participant(discovered_participant_data, runtime);
+                    self.add_discovered_participant(&discovered_participant_data, runtime);
+
+                    let reception_timestamp = runtime.clock().now();
+                    if let Some(reader) = self
+                        .domain_participant
+                        .builtin_subscriber
+                        .data_reader_list
+                        .iter_mut()
+                        .find(|dr| dr.topic_name == DCPS_PARTICIPANT)
+                    {
+                        let mut dynamic_data =
+                            DynamicDataFactory::create_data(ParticipantBuiltinTopicData::TYPE);
+                        discovered_participant_data
+                            .dds_participant_data
+                            .create_dynamic_sample(&mut dynamic_data);
+                        let change_instance_handle = match cache_change.instance_handle {
+                            Some(i) => i,
+                            None => get_instance_handle_from_dynamic_data(dynamic_data.clone())
+                                .expect("Should not fail")
+                                .into(),
+                        };
+
+                        reader
+                            .add_reader_change(
+                                cache_change.writer_guid,
+                                Some(dynamic_data),
+                                cache_change.kind,
+                                change_instance_handle,
+                                cache_change.source_timestamp.map(Into::into),
+                                reception_timestamp,
+                            )
+                            .ok();
+                    }
                 }
             }
             ChangeKind::NotAliveDisposed | ChangeKind::NotAliveDisposedUnregistered => {
@@ -1412,21 +1445,28 @@ impl DcpsDomainParticipant {
                 };
 
                 self.remove_discovered_participant(&discovered_participant_handle);
+
+                let reception_timestamp = runtime.clock().now();
+                if let Some(reader) = self
+                    .domain_participant
+                    .builtin_subscriber
+                    .data_reader_list
+                    .iter_mut()
+                    .find(|dr| dr.topic_name == DCPS_PARTICIPANT)
+                {
+                    reader
+                        .add_reader_change(
+                            cache_change.writer_guid,
+                            None,
+                            cache_change.kind,
+                            discovered_participant_handle.into(),
+                            cache_change.source_timestamp.map(Into::into),
+                            reception_timestamp,
+                        )
+                        .ok();
+                }
             }
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (), // Do nothing,
-        }
-
-        let reception_timestamp = runtime.clock().now();
-        if let Some(reader) = self
-            .domain_participant
-            .builtin_subscriber
-            .data_reader_list
-            .iter_mut()
-            .find(|dr| dr.topic_name == DCPS_PARTICIPANT)
-        {
-            reader
-                .add_reader_change(cache_change, reception_timestamp)
-                .ok();
         }
     }
 
@@ -1487,6 +1527,38 @@ impl DcpsDomainParticipant {
                             &data_reader_handle,
                         );
                     }
+
+                    let reception_timestamp = runtime.clock().now();
+                    if let Some(reader) = self
+                        .domain_participant
+                        .builtin_subscriber
+                        .data_reader_list
+                        .iter_mut()
+                        .find(|dr| dr.topic_name == DCPS_PUBLICATION)
+                    {
+                        let mut dynamic_data =
+                            DynamicDataFactory::create_data(PublicationBuiltinTopicData::TYPE);
+                        discovered_writer_data
+                            .dds_publication_data
+                            .create_dynamic_sample(&mut dynamic_data);
+                        let change_instance_handle = match cache_change.instance_handle {
+                            Some(i) => i,
+                            None => get_instance_handle_from_dynamic_data(dynamic_data.clone())
+                                .expect("Should not fail")
+                                .into(),
+                        };
+
+                        reader
+                            .add_reader_change(
+                                cache_change.writer_guid,
+                                Some(dynamic_data),
+                                cache_change.kind,
+                                change_instance_handle,
+                                cache_change.source_timestamp.map(Into::into),
+                                reception_timestamp,
+                            )
+                            .ok();
+                    }
                 }
             }
             ChangeKind::NotAliveDisposed | ChangeKind::NotAliveDisposedUnregistered => {
@@ -1519,21 +1591,27 @@ impl DcpsDomainParticipant {
                         data_reader_handle,
                     );
                 }
+                let reception_timestamp = runtime.clock().now();
+                if let Some(reader) = self
+                    .domain_participant
+                    .builtin_subscriber
+                    .data_reader_list
+                    .iter_mut()
+                    .find(|dr| dr.topic_name == DCPS_PUBLICATION)
+                {
+                    reader
+                        .add_reader_change(
+                            cache_change.writer_guid,
+                            None,
+                            cache_change.kind,
+                            discovered_writer_handle.into(),
+                            cache_change.source_timestamp.map(Into::into),
+                            reception_timestamp,
+                        )
+                        .ok();
+                }
             }
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (),
-        }
-
-        let reception_timestamp = runtime.clock().now();
-        if let Some(reader) = self
-            .domain_participant
-            .builtin_subscriber
-            .data_reader_list
-            .iter_mut()
-            .find(|dr| dr.topic_name == DCPS_PUBLICATION)
-        {
-            reader
-                .add_reader_change(cache_change, reception_timestamp)
-                .ok();
         }
     }
 
@@ -1623,6 +1701,38 @@ impl DcpsDomainParticipant {
                             &data_writer_handle,
                         );
                     }
+
+                    let reception_timestamp = runtime.clock().now();
+                    if let Some(reader) = self
+                        .domain_participant
+                        .builtin_subscriber
+                        .data_reader_list
+                        .iter_mut()
+                        .find(|dr| dr.topic_name == DCPS_SUBSCRIPTION)
+                    {
+                        let mut dynamic_data =
+                            DynamicDataFactory::create_data(SubscriptionBuiltinTopicData::TYPE);
+                        discovered_reader_data
+                            .dds_subscription_data
+                            .create_dynamic_sample(&mut dynamic_data);
+                        let change_instance_handle = match cache_change.instance_handle {
+                            Some(i) => i,
+                            None => get_instance_handle_from_dynamic_data(dynamic_data.clone())
+                                .expect("Should not fail")
+                                .into(),
+                        };
+
+                        reader
+                            .add_reader_change(
+                                cache_change.writer_guid,
+                                Some(dynamic_data),
+                                cache_change.kind,
+                                change_instance_handle,
+                                cache_change.source_timestamp.map(Into::into),
+                                reception_timestamp,
+                            )
+                            .ok();
+                    }
                 }
             }
             ChangeKind::NotAliveDisposed | ChangeKind::NotAliveDisposedUnregistered => {
@@ -1654,21 +1764,28 @@ impl DcpsDomainParticipant {
                         data_writer_handle,
                     );
                 }
+
+                let reception_timestamp = runtime.clock().now();
+                if let Some(reader) = self
+                    .domain_participant
+                    .builtin_subscriber
+                    .data_reader_list
+                    .iter_mut()
+                    .find(|dr| dr.topic_name == DCPS_SUBSCRIPTION)
+                {
+                    reader
+                        .add_reader_change(
+                            cache_change.writer_guid,
+                            None,
+                            cache_change.kind,
+                            discovered_reader_handle.into(),
+                            cache_change.source_timestamp.map(Into::into),
+                            reception_timestamp,
+                        )
+                        .ok();
+                }
             }
             ChangeKind::AliveFiltered | ChangeKind::NotAliveUnregistered => (),
-        }
-
-        let reception_timestamp = runtime.clock().now();
-        if let Some(reader) = self
-            .domain_participant
-            .builtin_subscriber
-            .data_reader_list
-            .iter_mut()
-            .find(|dr| dr.topic_name == DCPS_SUBSCRIPTION)
-        {
-            reader
-                .add_reader_change(cache_change, reception_timestamp)
-                .ok();
         }
     }
 
@@ -1702,6 +1819,29 @@ impl DcpsDomainParticipant {
                             }
                         }
                     }
+                    let reception_timestamp = runtime.clock().now();
+                    if let Some(reader) = self
+                        .domain_participant
+                        .builtin_subscriber
+                        .data_reader_list
+                        .iter_mut()
+                        .find(|dr| dr.topic_name == DCPS_TOPIC)
+                    {
+                        let change_instance_handle = topic_builtin_topic_data.key.value;
+                        let mut dynamic_data =
+                            DynamicDataFactory::create_data(TopicBuiltinTopicData::TYPE);
+                        topic_builtin_topic_data.create_dynamic_sample(&mut dynamic_data);
+                        reader
+                            .add_reader_change(
+                                cache_change.writer_guid,
+                                Some(dynamic_data),
+                                cache_change.kind,
+                                change_instance_handle,
+                                cache_change.source_timestamp.map(Into::into),
+                                reception_timestamp,
+                            )
+                            .ok();
+                    }
                 }
             }
             ChangeKind::NotAliveDisposed
@@ -1709,25 +1849,12 @@ impl DcpsDomainParticipant {
             | ChangeKind::NotAliveUnregistered
             | ChangeKind::NotAliveDisposedUnregistered => (),
         }
-
-        let reception_timestamp = runtime.clock().now();
-        if let Some(reader) = self
-            .domain_participant
-            .builtin_subscriber
-            .data_reader_list
-            .iter_mut()
-            .find(|dr| dr.topic_name == DCPS_TOPIC)
-        {
-            reader
-                .add_reader_change(cache_change, reception_timestamp)
-                .ok();
-        }
     }
 
     #[tracing::instrument(skip(self, runtime))]
     fn add_discovered_participant(
         &mut self,
-        discovered_participant_data: SpdpDiscoveredParticipantData,
+        discovered_participant_data: &SpdpDiscoveredParticipantData,
         runtime: &impl DdsRuntime,
     ) {
         // Check that the domainId of the discovered participant equals the local one.
@@ -1764,24 +1891,26 @@ impl DcpsDomainParticipant {
             && !is_participant_discovered
             && !is_participant_ignored
         {
-            self.add_matched_publications_detector(&discovered_participant_data);
-            self.add_matched_publications_announcer(&discovered_participant_data);
-            self.add_matched_subscriptions_detector(&discovered_participant_data);
-            self.add_matched_subscriptions_announcer(&discovered_participant_data);
-            self.add_matched_topics_detector(&discovered_participant_data);
-            self.add_matched_topics_announcer(&discovered_participant_data);
+            self.add_matched_publications_detector(discovered_participant_data);
+            self.add_matched_publications_announcer(discovered_participant_data);
+            self.add_matched_subscriptions_detector(discovered_participant_data);
+            self.add_matched_subscriptions_announcer(discovered_participant_data);
+            self.add_matched_topics_detector(discovered_participant_data);
+            self.add_matched_topics_announcer(discovered_participant_data);
 
             self.announce_participant(runtime);
 
             let discovered_participant_info = DiscoveredParticipantInfo {
-                dds_participant_data: discovered_participant_data.dds_participant_data,
+                dds_participant_data: discovered_participant_data.dds_participant_data.clone(),
                 guid_prefix: discovered_participant_data.participant_proxy.guid_prefix,
                 default_unicast_locator_list: discovered_participant_data
                     .participant_proxy
-                    .default_unicast_locator_list,
+                    .default_unicast_locator_list
+                    .clone(),
                 default_multicast_locator_list: discovered_participant_data
                     .participant_proxy
-                    .default_multicast_locator_list,
+                    .default_multicast_locator_list
+                    .clone(),
                 lease_duration: discovered_participant_data.lease_duration,
                 reception_timestamp: runtime.clock().now(),
             };

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -74,8 +74,7 @@ use crate::{
         },
     },
     xtypes::{
-        deserializer::deserialize_top_level_type,
-        dynamic_type::{DynamicData, DynamicDataFactory, DynamicType},
+        dynamic_type::{DynamicData, DynamicType},
         serializer::{serialize_cdr1_be, serialize_cdr1_le, serialize_cdr2_be, serialize_cdr2_le},
         type_support::{Type, TypeSupport},
     },
@@ -1904,7 +1903,7 @@ struct ReaderSample {
     writer_guid: [u8; 16],
     instance_handle: InstanceHandle,
     source_timestamp: Option<Time>,
-    data_value: DynamicData<'static>,
+    data_value: Option<DynamicData<'static>>,
     sample_state: SampleStateKind,
     disposed_generation_count: i32,
     no_writers_generation_count: i32,
@@ -2053,7 +2052,7 @@ impl DataReaderEntity {
 
             let (data, valid_data) = match cache_change.kind {
                 ChangeKind::Alive | ChangeKind::AliveFiltered => {
-                    (Some(cache_change.data_value.clone()), true)
+                    (cache_change.data_value.clone(), true)
                 }
                 ChangeKind::NotAliveDisposed
                 | ChangeKind::NotAliveUnregistered
@@ -2159,61 +2158,29 @@ impl DataReaderEntity {
         }
     }
 
-    fn convert_cache_change_to_sample(
+    fn add_reader_change(
         &mut self,
-        cache_change: &CacheChange,
-    ) -> DdsResult<ReaderSample> {
-        let (data_value, instance_handle) = match cache_change.kind {
-            ChangeKind::Alive | ChangeKind::AliveFiltered => {
-                let data_value: DynamicData<'static> = deserialize_top_level_type(
-                    self.type_support,
-                    cache_change.data_value.as_ref(),
-                )?;
-                let instance_handle = get_instance_handle_from_dynamic_data(data_value.clone())?;
-                (data_value, instance_handle)
-            }
-            ChangeKind::NotAliveDisposed
-            | ChangeKind::NotAliveUnregistered
-            | ChangeKind::NotAliveDisposedUnregistered => match cache_change.instance_handle {
-                Some(i) => {
-                    let data_value = DynamicDataFactory::create_data(self.type_support);
-                    let instance_handle = InstanceHandle::new(i);
-                    (data_value, instance_handle)
-                }
-                None => {
-                    let mut dispose_data_type_key_holder = self.type_support;
-                    let mut member_list = self.type_support.member_list.to_vec();
-                    member_list.retain(|f| f.descriptor.is_key);
-                    dispose_data_type_key_holder.member_list = &member_list;
-
-                    let data_value = deserialize_top_level_type(
-                        dispose_data_type_key_holder,
-                        cache_change.data_value.as_ref(),
-                    )?;
-
-                    let instance_handle =
-                        get_instance_handle_from_dynamic_data(data_value.clone())?;
-                    (
-                        DynamicDataFactory::create_data(self.type_support),
-                        instance_handle,
-                    )
-                }
-            },
-        };
-
+        writer_guid: Guid,
+        data_value: Option<DynamicData<'static>>,
+        change_kind: ChangeKind,
+        change_instance_handle: [u8; 16],
+        change_source_timestamp: Option<Time>,
+        reception_timestamp: Time,
+    ) -> DdsResult<AddChangeResult> {
+        let instance_handle = InstanceHandle::new(change_instance_handle);
         // Update the state of the instance before creating since this has direct impact on
         // the information that is stored on the sample
-        match cache_change.kind {
+        match change_kind {
             ChangeKind::Alive | ChangeKind::AliveFiltered => {
                 match self
                     .instances
                     .iter_mut()
                     .find(|x| x.handle() == &instance_handle)
                 {
-                    Some(x) => x.update_state(cache_change.kind),
+                    Some(x) => x.update_state(change_kind),
                     None => {
                         let mut s = InstanceState::new(instance_handle);
-                        s.update_state(cache_change.kind);
+                        s.update_state(change_kind);
                         self.instances.push(s);
                     }
                 }
@@ -2228,7 +2195,7 @@ impl DataReaderEntity {
                     .find(|x| x.handle() == &instance_handle)
                 {
                     Some(instance) => {
-                        instance.update_state(cache_change.kind);
+                        instance.update_state(change_kind);
                         Ok(())
                     }
                     None => Err(DdsError::Error(
@@ -2242,24 +2209,17 @@ impl DataReaderEntity {
             .iter()
             .find(|x| x.handle() == &instance_handle)
             .expect("Sample with handle must exist");
-        Ok(ReaderSample {
-            kind: cache_change.kind,
-            writer_guid: cache_change.writer_guid.into(),
+        let sample = ReaderSample {
+            kind: change_kind,
+            writer_guid: writer_guid.into(),
             instance_handle,
-            source_timestamp: cache_change.source_timestamp.map(Into::into),
+            source_timestamp: change_source_timestamp,
             data_value,
             sample_state: SampleStateKind::NotRead,
             disposed_generation_count: instance.most_recent_disposed_generation_count,
             no_writers_generation_count: instance.most_recent_no_writers_generation_count,
-        })
-    }
+        };
 
-    fn add_reader_change(
-        &mut self,
-        cache_change: &CacheChange,
-        reception_timestamp: Time,
-    ) -> DdsResult<AddChangeResult> {
-        let sample = self.convert_cache_change_to_sample(cache_change)?;
         let change_instance_handle = sample.instance_handle;
         // data_reader exclusive access if the writer is not the allowed to write the sample do an early return
         if self.qos.ownership.kind == OwnershipQosPolicyKind::Exclusive {

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -577,7 +577,13 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
                 },
                 TypeKind::ENUM => deserializer.deserialize_enum_type(dynamic_type, dynamic_data),
 
-                TypeKind::UNION => todo!(),
+                TypeKind::UNION => match dynamic_type.get_descriptor().extensibility_kind {
+                    ExtensibilityKind::Final => {
+                        deserializer._deserialize_funion_type(dynamic_type, dynamic_data)
+                    }
+                    ExtensibilityKind::Appendable => todo!(),
+                    ExtensibilityKind::Mutable => todo!(),
+                },
                 kind => {
                     debug!("Expected structure, enum or union. Got kind {kind:?} ");
                     Err(XTypesError::InvalidType)
@@ -659,7 +665,10 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
                 member.get_id(),
                 self.deserialize_as_nested(member.descriptor.r#type)?,
             ),
-            TypeKind::UNION => todo!(),
+            TypeKind::UNION => dynamic_data.set_complex_value(
+                member.get_id(),
+                self.deserialize_as_nested(member.descriptor.r#type)?,
+            ),
             TypeKind::BITSET => todo!(),
             TypeKind::SEQUENCE => {
                 if is_element_type_kind_primitive(member)? {
@@ -779,8 +788,29 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     }
 
     /// Serialization Rule (26)
-    fn _deserialize_funion_type(&mut self) -> XTypesResult<DynamicData<'_>> {
-        todo!()
+    fn _deserialize_funion_type(
+        &mut self,
+        dynamic_type: DynamicType,
+        dynamic_data: &mut DynamicData<'_>,
+    ) -> XTypesResult<()> {
+        // Deserialize the discriminator
+        let disc_member = dynamic_type.get_member_by_index(0)?;
+        self.deserialize_nopt_fmember(disc_member, dynamic_data)?;
+
+        // The discriminator value represents the id of a member
+        let disc_id = match dynamic_data.get_value(disc_member.get_id())? {
+            crate::xtypes::data_storage::DataStorage::UInt8(x) => *x as u32,
+            crate::xtypes::data_storage::DataStorage::Int8(x) => *x as u32,
+            crate::xtypes::data_storage::DataStorage::UInt16(x) => *x as u32,
+            crate::xtypes::data_storage::DataStorage::Int16(x) => *x as u32,
+            crate::xtypes::data_storage::DataStorage::Int32(x) => *x as u32,
+            crate::xtypes::data_storage::DataStorage::UInt32(x) => *x as u32,
+            _ => return Err(XTypesError::InvalidType),
+        };
+
+        // Deserialize the member based on its discriminator
+        let m = dynamic_type.get_member(disc_id)?;
+        self.deserialize_nopt_fmember(m, dynamic_data)
     }
 }
 

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -804,7 +804,7 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
             crate::xtypes::data_storage::DataStorage::UInt16(x) => *x as u32,
             crate::xtypes::data_storage::DataStorage::Int16(x) => *x as u32,
             crate::xtypes::data_storage::DataStorage::Int32(x) => *x as u32,
-            crate::xtypes::data_storage::DataStorage::UInt32(x) => *x as u32,
+            crate::xtypes::data_storage::DataStorage::UInt32(x) => *x,
             _ => return Err(XTypesError::InvalidType),
         };
 

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -1568,13 +1568,14 @@ mod tests {
             serialize_cdr2_be(&v).unwrap(),
             vec![
                 0x00, 0x08, 0x00, 0x00, // D_CDR2_BE
-                0, 0, 0, 28, // Dheader
+                0, 0, 0, 32, // Dheader
                 0, 0, 0, 5, // color: length
                 b'B', b'L', b'U', b'E', // color
                 0, 0, 0, 0, // color: terminating 0 | padding
                 0, 0, 0, 10, // x
                 0, 0, 0, 20, // y
                 0, 0, 0, 30, // shapesize
+                0, 0, 0, 4, // additional_payload_size: dheader
                 0, 0, 0, 0, // additional_payload_size: length
             ]
         );
@@ -1582,13 +1583,14 @@ mod tests {
             serialize_cdr2_le(&v).unwrap(),
             vec![
                 0x00, 0x09, 0x00, 0x00, // D_CDR2_LE
-                28, 0, 0, 0, // Dheader
+                32, 0, 0, 0, // Dheader
                 5, 0, 0, 0, // color: length
                 b'B', b'L', b'U', b'E', // color
                 0, 0, 0, 0, // color: terminating 0 | padding
                 10, 0, 0, 0, // x
                 20, 0, 0, 0, // y
                 30, 0, 0, 0, // shapesize
+                4, 0, 0, 0, // additional_payload_size: dheader
                 0, 0, 0, 0, // additional_payload_size: length
             ]
         );

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -224,7 +224,7 @@ trait XTypesSerializer<'a> {
             TypeKind::ENUM => self.serialize_enum_type(v.get_complex_value(member_id)?)?,
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
-            TypeKind::STRUCTURE => self.serialize_t_as_nested(v.get_complex_value(member_id)?)?,
+            TypeKind::STRUCTURE => self.serialize_fstruct_type(v.get_complex_value(member_id)?)?,
             TypeKind::UNION => self.serialize_funion_type(v.get_complex_value(member_id)?)?,
             TypeKind::BITSET => todo!(),
             TypeKind::SEQUENCE => self.serialize_sequence_type(v, member_id)?,

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -142,22 +142,23 @@ trait XTypesSerializer<'a> {
             writer: CdrWriter::new(&mut byte_conter, LittleEndian),
         };
         byte_conter_serializer.serialize_m_value(dynamic_data, member_id)?;
+        let m_flag = 0;
         let length = byte_conter.0;
-        if length == 1 || length == 2 || length == 4 || length == 8 {
-            let m_flag = 0;
-            let lc = match length {
-                1 => 0,
-                2 => 1,
-                4 => 2,
-                8 => 3,
-                _ => unreachable!(),
-            } as u32;
-            let emheader = (m_flag << 31) + (lc << 28) + (member_id & 0x0fffffff);
-            self.serialize_primitive_type(&emheader);
-        } else {
-            self.serialize_primitive_type(&member_id);
-            //todo!("LC (length code) not yet supproted")
-        };
+        let lc = match length {
+            1 => 0,
+            2 => 1,
+            4 => 2,
+            8 => 3,
+            _ => 4,
+        } as u32;
+
+        let emheader = (m_flag << 31) + (lc << 28) + (member_id & 0x0fffffff);
+        self.serialize_primitive_type(&emheader);
+
+        if lc == 4 {
+            self.serialize_primitive_type(&(length as u32));
+        }
+
         Ok(())
     }
 
@@ -224,8 +225,8 @@ trait XTypesSerializer<'a> {
             TypeKind::ENUM => self.serialize_enum_type(v.get_complex_value(member_id)?)?,
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
-            TypeKind::STRUCTURE => self.serialize_fstruct_type(v.get_complex_value(member_id)?)?,
-            TypeKind::UNION => self.serialize_funion_type(v.get_complex_value(member_id)?)?,
+            TypeKind::STRUCTURE => self.serialize_t_as_nested(v.get_complex_value(member_id)?)?,
+            TypeKind::UNION => self.serialize_t_as_nested(v.get_complex_value(member_id)?)?,
             TypeKind::BITSET => todo!(),
             TypeKind::SEQUENCE => self.serialize_sequence_type(v, member_id)?,
             TypeKind::ARRAY => self.serialize_array_type(v, member_id)?,
@@ -371,65 +372,7 @@ trait XTypesSerializer<'a> {
         &mut self,
         v: &DynamicData,
         member_id: u32,
-    ) -> Result<(), XTypesError> {
-        let member_descriptor = v.get_descriptor(member_id)?;
-        let element_type = member_descriptor
-            .r#type
-            .get_descriptor()
-            .element_type
-            .as_ref()
-            .expect("sequence has element type");
-        match element_type.get_descriptor().kind {
-            TypeKind::NONE => todo!(),
-            TypeKind::BOOLEAN => self.serialize_p_sequence_type(v.get_boolean_values(member_id)?),
-            TypeKind::BYTE => self.serialize_p_sequence_type(v.get_byte_values(member_id)?),
-            TypeKind::INT16 => self.serialize_p_sequence_type(v.get_int16_values(member_id)?),
-            TypeKind::INT32 => self.serialize_p_sequence_type(v.get_int32_values(member_id)?),
-            TypeKind::INT64 => self.serialize_p_sequence_type(v.get_int64_values(member_id)?),
-            TypeKind::UINT16 => self.serialize_p_sequence_type(v.get_uint16_values(member_id)?),
-            TypeKind::UINT32 => self.serialize_p_sequence_type(v.get_uint32_values(member_id)?),
-            TypeKind::UINT64 => self.serialize_p_sequence_type(v.get_uint64_values(member_id)?),
-            TypeKind::FLOAT32 => self.serialize_p_sequence_type(v.get_float32_values(member_id)?),
-            TypeKind::FLOAT64 => self.serialize_p_sequence_type(v.get_float64_values(member_id)?),
-            TypeKind::FLOAT128 => self.serialize_p_sequence_type(v.get_float128_values(member_id)?),
-            TypeKind::INT8 => self.serialize_p_sequence_type(v.get_int8_values(member_id)?),
-            TypeKind::UINT8 => self.serialize_p_sequence_type(v.get_uint8_values(member_id)?),
-            TypeKind::CHAR8 => todo!(),
-            TypeKind::CHAR16 => todo!(),
-            TypeKind::STRING8 => {
-                let list = v.get_string_values(member_id)?;
-                self.serialize_primitive_type(&(list.len() as u32));
-                for v in list {
-                    self.serialize_string_type(v);
-                }
-            }
-            TypeKind::STRING16 => todo!(),
-            TypeKind::ALIAS => todo!(),
-            TypeKind::ENUM => todo!(),
-            TypeKind::BITMASK => todo!(),
-            TypeKind::ANNOTATION => todo!(),
-            TypeKind::STRUCTURE => {
-                let list = v.get_complex_values(member_id)?;
-                self.serialize_primitive_type(&(list.len() as u32));
-                for v in list {
-                    self.serialize_t_as_nested(v)?;
-                }
-            }
-            TypeKind::UNION => {
-                let list = v.get_complex_values(member_id)?;
-                self.serialize_primitive_type(&(list.len() as u32));
-                for v in list {
-                    self.serialize_funion_type(v)?;
-                }
-            }
-            TypeKind::BITSET => todo!(),
-            TypeKind::SEQUENCE => todo!(),
-            TypeKind::ARRAY => todo!(),
-            TypeKind::MAP => todo!(),
-        }
-
-        Ok(())
-    }
+    ) -> Result<(), XTypesError>;
 
     /// Serialization Rule (14)
     fn _serialize_pmap_type(&mut self, _v: &DynamicData) -> Result<(), XTypesError> {
@@ -473,7 +416,38 @@ trait XTypesSerializer<'a> {
         v: &DynamicData,
         member_id: u32,
     ) -> Result<(), XTypesError> {
-        self.serialize_m_value(v, member_id)
+        let member_descriptor = v.get_descriptor(member_id)?;
+        match member_descriptor.r#type.get_kind() {
+            TypeKind::NONE => todo!(),
+            TypeKind::BOOLEAN => self.serialize_primitive_type(v.get_boolean_value(member_id)?),
+            TypeKind::BYTE => self.serialize_primitive_type(v.get_byte_value(member_id)?),
+            TypeKind::INT16 => self.serialize_primitive_type(v.get_int16_value(member_id)?),
+            TypeKind::INT32 => self.serialize_primitive_type(v.get_int32_value(member_id)?),
+            TypeKind::INT64 => self.serialize_primitive_type(v.get_int64_value(member_id)?),
+            TypeKind::UINT16 => self.serialize_primitive_type(v.get_uint16_value(member_id)?),
+            TypeKind::UINT32 => self.serialize_primitive_type(v.get_uint32_value(member_id)?),
+            TypeKind::UINT64 => self.serialize_primitive_type(v.get_uint64_value(member_id)?),
+            TypeKind::FLOAT32 => self.serialize_primitive_type(v.get_float32_value(member_id)?),
+            TypeKind::FLOAT64 => self.serialize_primitive_type(v.get_float64_value(member_id)?),
+            TypeKind::FLOAT128 => self.serialize_primitive_type(v.get_float128_value(member_id)?),
+            TypeKind::INT8 => self.serialize_primitive_type(v.get_int8_value(member_id)?),
+            TypeKind::UINT8 => self.serialize_primitive_type(v.get_uint8_value(member_id)?),
+            TypeKind::CHAR8 => self.serialize_primitive_type(v.get_char8_value(member_id)?),
+            TypeKind::CHAR16 => todo!(),
+            TypeKind::STRING8 => self.serialize_string_type(v.get_string_value(member_id)?),
+            TypeKind::STRING16 => todo!(),
+            TypeKind::ALIAS => todo!(),
+            TypeKind::ENUM => self.serialize_enum_type(v.get_complex_value(member_id)?)?,
+            TypeKind::BITMASK => todo!(),
+            TypeKind::ANNOTATION => todo!(),
+            TypeKind::STRUCTURE => self.serialize_fstruct_type(v.get_complex_value(member_id)?)?,
+            TypeKind::UNION => self.serialize_funion_type(v.get_complex_value(member_id)?)?,
+            TypeKind::BITSET => todo!(),
+            TypeKind::SEQUENCE => self.serialize_sequence_type(v, member_id)?,
+            TypeKind::ARRAY => self.serialize_array_type(v, member_id)?,
+            TypeKind::MAP => todo!(),
+        }
+        Ok(())
     }
 
     /// Serialization Rule (19) & (20)
@@ -570,6 +544,70 @@ impl<'a, W: Write, E: EndiannessWrite> XTypesSerializer<'a> for Xcdr1Serializer<
     fn serialize_appendable_type(&mut self, v: &DynamicData) -> Result<(), XTypesError> {
         self.serialize_t_as_final(v)
     }
+
+    fn serialize_sequence_type(
+        &mut self,
+        v: &DynamicData,
+        member_id: u32,
+    ) -> Result<(), XTypesError> {
+        let member_descriptor = v.get_descriptor(member_id)?;
+        let element_type = member_descriptor
+            .r#type
+            .get_descriptor()
+            .element_type
+            .as_ref()
+            .expect("sequence has element type");
+        match element_type.get_descriptor().kind {
+            TypeKind::NONE => todo!(),
+            TypeKind::BOOLEAN => self.serialize_p_sequence_type(v.get_boolean_values(member_id)?),
+            TypeKind::BYTE => self.serialize_p_sequence_type(v.get_byte_values(member_id)?),
+            TypeKind::INT16 => self.serialize_p_sequence_type(v.get_int16_values(member_id)?),
+            TypeKind::INT32 => self.serialize_p_sequence_type(v.get_int32_values(member_id)?),
+            TypeKind::INT64 => self.serialize_p_sequence_type(v.get_int64_values(member_id)?),
+            TypeKind::UINT16 => self.serialize_p_sequence_type(v.get_uint16_values(member_id)?),
+            TypeKind::UINT32 => self.serialize_p_sequence_type(v.get_uint32_values(member_id)?),
+            TypeKind::UINT64 => self.serialize_p_sequence_type(v.get_uint64_values(member_id)?),
+            TypeKind::FLOAT32 => self.serialize_p_sequence_type(v.get_float32_values(member_id)?),
+            TypeKind::FLOAT64 => self.serialize_p_sequence_type(v.get_float64_values(member_id)?),
+            TypeKind::FLOAT128 => self.serialize_p_sequence_type(v.get_float128_values(member_id)?),
+            TypeKind::INT8 => self.serialize_p_sequence_type(v.get_int8_values(member_id)?),
+            TypeKind::UINT8 => self.serialize_p_sequence_type(v.get_uint8_values(member_id)?),
+            TypeKind::CHAR8 => todo!(),
+            TypeKind::CHAR16 => todo!(),
+            TypeKind::STRING8 => {
+                let list = v.get_string_values(member_id)?;
+                self.serialize_primitive_type(&(list.len() as u32));
+                for v in list {
+                    self.serialize_string_type(v);
+                }
+            }
+            TypeKind::STRING16 => todo!(),
+            TypeKind::ALIAS => todo!(),
+            TypeKind::ENUM => todo!(),
+            TypeKind::BITMASK => todo!(),
+            TypeKind::ANNOTATION => todo!(),
+            TypeKind::STRUCTURE => {
+                let list = v.get_complex_values(member_id)?;
+                self.serialize_primitive_type(&(list.len() as u32));
+                for v in list {
+                    self.serialize_t_as_nested(v)?;
+                }
+            }
+            TypeKind::UNION => {
+                let list = v.get_complex_values(member_id)?;
+                self.serialize_primitive_type(&(list.len() as u32));
+                for v in list {
+                    self.serialize_funion_type(v)?;
+                }
+            }
+            TypeKind::BITSET => todo!(),
+            TypeKind::SEQUENCE => todo!(),
+            TypeKind::ARRAY => todo!(),
+            TypeKind::MAP => todo!(),
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a, W: Write, E: EndiannessWrite> XTypesSerializer<'a> for Xcdr2Serializer<'a, W, E> {
@@ -637,6 +675,110 @@ impl<'a, W: Write, E: EndiannessWrite> XTypesSerializer<'a> for Xcdr2Serializer<
         byte_counter_serializer.serialize_t_as_final(v)?;
         self.serialize_dheader(byte_counter.0);
         self.serialize_t_as_final(v)
+    }
+
+    fn serialize_sequence_type(
+        &mut self,
+        v: &DynamicData,
+        member_id: u32,
+    ) -> Result<(), XTypesError> {
+        fn serialize_this<'b, W: Write, E: EndiannessWrite>(
+            serializer: &mut Xcdr2Serializer<'b, W, E>,
+            v: &DynamicData,
+            member_id: u32,
+        ) -> Result<(), XTypesError> {
+            let member_descriptor = v.get_descriptor(member_id)?;
+            let element_type = member_descriptor
+                .r#type
+                .get_descriptor()
+                .element_type
+                .as_ref()
+                .expect("sequence has element type");
+            match element_type.get_descriptor().kind {
+                TypeKind::NONE => todo!(),
+                TypeKind::BOOLEAN => {
+                    serializer.serialize_p_sequence_type(v.get_boolean_values(member_id)?)
+                }
+                TypeKind::BYTE => {
+                    serializer.serialize_p_sequence_type(v.get_byte_values(member_id)?)
+                }
+                TypeKind::INT16 => {
+                    serializer.serialize_p_sequence_type(v.get_int16_values(member_id)?)
+                }
+                TypeKind::INT32 => {
+                    serializer.serialize_p_sequence_type(v.get_int32_values(member_id)?)
+                }
+                TypeKind::INT64 => {
+                    serializer.serialize_p_sequence_type(v.get_int64_values(member_id)?)
+                }
+                TypeKind::UINT16 => {
+                    serializer.serialize_p_sequence_type(v.get_uint16_values(member_id)?)
+                }
+                TypeKind::UINT32 => {
+                    serializer.serialize_p_sequence_type(v.get_uint32_values(member_id)?)
+                }
+                TypeKind::UINT64 => {
+                    serializer.serialize_p_sequence_type(v.get_uint64_values(member_id)?)
+                }
+                TypeKind::FLOAT32 => {
+                    serializer.serialize_p_sequence_type(v.get_float32_values(member_id)?)
+                }
+                TypeKind::FLOAT64 => {
+                    serializer.serialize_p_sequence_type(v.get_float64_values(member_id)?)
+                }
+                TypeKind::FLOAT128 => {
+                    serializer.serialize_p_sequence_type(v.get_float128_values(member_id)?)
+                }
+                TypeKind::INT8 => {
+                    serializer.serialize_p_sequence_type(v.get_int8_values(member_id)?)
+                }
+                TypeKind::UINT8 => {
+                    serializer.serialize_p_sequence_type(v.get_uint8_values(member_id)?)
+                }
+                TypeKind::CHAR8 => todo!(),
+                TypeKind::CHAR16 => todo!(),
+                TypeKind::STRING8 => {
+                    let list = v.get_string_values(member_id)?;
+                    serializer.serialize_primitive_type(&(list.len() as u32));
+                    for v in list {
+                        serializer.serialize_string_type(v);
+                    }
+                }
+                TypeKind::STRING16 => todo!(),
+                TypeKind::ALIAS => todo!(),
+                TypeKind::ENUM => todo!(),
+                TypeKind::BITMASK => todo!(),
+                TypeKind::ANNOTATION => todo!(),
+                TypeKind::STRUCTURE => {
+                    let list = v.get_complex_values(member_id)?;
+                    serializer.serialize_primitive_type(&(list.len() as u32));
+                    for v in list {
+                        serializer.serialize_t_as_nested(v)?;
+                    }
+                }
+                TypeKind::UNION => {
+                    let list = v.get_complex_values(member_id)?;
+                    serializer.serialize_primitive_type(&(list.len() as u32));
+                    for v in list {
+                        serializer.serialize_funion_type(v)?;
+                    }
+                }
+                TypeKind::BITSET => todo!(),
+                TypeKind::SEQUENCE => todo!(),
+                TypeKind::ARRAY => todo!(),
+                TypeKind::MAP => todo!(),
+            }
+
+            Ok(())
+        }
+
+        let mut byte_counter = ByteCounter::new();
+        let mut byte_counter_serializer = Xcdr2Serializer {
+            writer: CdrWriter::new(&mut byte_counter, LittleEndian),
+        };
+        serialize_this(&mut byte_counter_serializer, v, member_id)?;
+        self.serialize_dheader(byte_counter.0);
+        serialize_this(self, v, member_id)
     }
 }
 

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -436,7 +436,7 @@ trait XTypesSerializer<'a> {
             TypeKind::CHAR16 => todo!(),
             TypeKind::STRING8 => self.serialize_string_type(v.get_string_value(member_id)?),
             TypeKind::STRING16 => todo!(),
-            TypeKind::ALIAS => todo!(),
+            TypeKind::ALIAS => (), // TODO: This is used for box so it might have to be something different
             TypeKind::ENUM => self.serialize_enum_type(v.get_complex_value(member_id)?)?,
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -1885,6 +1885,29 @@ impl<'a> From<DynamicType<'a>> for MinimalTypeObject {
                 };
                 MinimalTypeObject::TkStructure { struct_type }
             }
+            TypeKind::ENUM => {
+                let mut enum_flags = match value.descriptor.extensibility_kind {
+                    ExtensibilityKind::Final => TYPE_FLAG_IS_FINAL,
+                    ExtensibilityKind::Appendable => TYPE_FLAG_IS_APPENDABLE,
+                    ExtensibilityKind::Mutable => TYPE_FLAG_IS_MUTABLE,
+                };
+                if value.descriptor.is_nested {
+                    enum_flags |= TYPE_FLAG_IS_NESTED;
+                };
+
+                let header = MinimalEnumeratedHeader {
+                    common: CommonEnumeratedHeader { bit_bound: 32 }, //TODO: Add correct bit_bound
+                };
+
+                let literal_seq = Vec::new(); // TODO: fill up
+
+                let enumerated_type = MinimalEnumeratedType {
+                    enum_flags,
+                    header,
+                    literal_seq,
+                };
+                MinimalTypeObject::TkEnum { enumerated_type }
+            }
             t => todo!("Not yet implemeneted for {t:?}"),
         }
     }
@@ -1920,6 +1943,34 @@ impl<'a> From<DynamicType<'a>> for CompleteTypeObject {
                 };
                 CompleteTypeObject::TkStructure { struct_type }
             }
+            TypeKind::ENUM => {
+                let mut enum_flags = match value.descriptor.extensibility_kind {
+                    ExtensibilityKind::Final => TYPE_FLAG_IS_FINAL,
+                    ExtensibilityKind::Appendable => TYPE_FLAG_IS_APPENDABLE,
+                    ExtensibilityKind::Mutable => TYPE_FLAG_IS_MUTABLE,
+                };
+                if value.descriptor.is_nested {
+                    enum_flags |= TYPE_FLAG_IS_NESTED;
+                };
+
+                let header = CompleteEnumeratedHeader {
+                    common: CommonEnumeratedHeader { bit_bound: 32 }, //TODO: Add correct bit_bound
+                    detail: CompleteTypeDetail {
+                        ann_builtin: None,
+                        ann_custom: None,
+                        type_name: value.descriptor.name.to_string(),
+                    },
+                };
+
+                let literal_seq = Vec::new(); // TODO: fill up
+
+                let enumerated_type = CompleteEnumeratedType {
+                    enum_flags,
+                    header,
+                    literal_seq,
+                };
+                CompleteTypeObject::TkEnum { enumerated_type }
+            }
             t => todo!("Not yet implemeneted for {t:?}"),
         }
     }
@@ -1954,10 +2005,54 @@ impl<'a> From<&DynamicType<'a>> for TypeIdentifier {
             TypeKind::ENUM => todo!(),
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
-            TypeKind::STRUCTURE => todo!(),
+            TypeKind::STRUCTURE => {
+                let complete_type_object = TypeObject::EkComplete {
+                    complete: CompleteTypeObject::from(*value),
+                };
+                let mut data = DynamicDataFactory::create_data(TypeObject::get_type());
+                complete_type_object.create_dynamic_sample(&mut data);
+                let serialized_complete_type_object =
+                    serialize_without_header_cdr2_le(Vec::new(), &data).expect("Not fallible");
+
+                let hash_complete_type_object = md5::compute(&serialized_complete_type_object);
+                TypeIdentifier::EkComplete {
+                    equivalence_hash: [
+                        hash_complete_type_object[0],
+                        hash_complete_type_object[1],
+                        hash_complete_type_object[2],
+                        hash_complete_type_object[3],
+                        hash_complete_type_object[4],
+                        hash_complete_type_object[5],
+                        hash_complete_type_object[6],
+                        hash_complete_type_object[7],
+                        hash_complete_type_object[8],
+                        hash_complete_type_object[9],
+                        hash_complete_type_object[10],
+                        hash_complete_type_object[11],
+                        hash_complete_type_object[12],
+                        hash_complete_type_object[13],
+                    ],
+                }
+            }
             TypeKind::UNION => todo!(),
             TypeKind::BITSET => todo!(),
-            TypeKind::SEQUENCE => todo!(),
+            TypeKind::SEQUENCE => TypeIdentifier::TiPlainSequenceLarge {
+                seq_ldefn: PlainSequenceLElemDefn {
+                    header: PlainCollectionHeader {
+                        equiv_kind: EK_MINIMAL,
+                        element_flags: MEMBER_FLAG_MINIMAL_MASK,
+                    },
+                    bound: u32::MAX,
+                    element_identifier: Box::new(
+                        value
+                            .descriptor
+                            .element_type
+                            .as_ref()
+                            .expect("Sequence must have element type")
+                            .into(),
+                    ),
+                },
+            },
             TypeKind::ARRAY => todo!(),
             TypeKind::MAP => todo!(),
         }

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -2015,26 +2015,14 @@ impl From<&DynamicTypeMember> for CompleteStructMember {
 
 impl<'a> From<DynamicType<'a>> for TypeInformation {
     fn from(value: DynamicType<'a>) -> Self {
-        fn pad_entire_serialization(buffer: &mut Vec<u8>) {
-            let padding = match buffer.len() % 4 {
-                1 => &[0, 0, 0][..],
-                2 => &[0, 0][..],
-                3 => &[0][..],
-                _ => &[][..],
-            };
-            buffer.extend_from_slice(padding);
-            buffer[3] = padding.len() as u8;
-        }
-
         let minimal_type_object = TypeObject::EkMinimal {
             minimal: MinimalTypeObject::from(value),
         };
         let mut data = DynamicDataFactory::create_data(TypeObject::get_type());
         minimal_type_object.create_dynamic_sample(&mut data);
 
-        let mut serialized_minimal_type_object =
+        let serialized_minimal_type_object =
             serialize_without_header_cdr2_le(Vec::new(), &data).expect("Not fallible");
-        pad_entire_serialization(&mut serialized_minimal_type_object);
         let hash_minimal_type_object = md5::compute(&serialized_minimal_type_object);
 
         let complete_type_object = TypeObject::EkComplete {
@@ -2042,9 +2030,9 @@ impl<'a> From<DynamicType<'a>> for TypeInformation {
         };
         let mut data = DynamicDataFactory::create_data(TypeObject::get_type());
         complete_type_object.create_dynamic_sample(&mut data);
-        let mut serialized_complete_type_object =
+        let serialized_complete_type_object =
             serialize_without_header_cdr2_le(Vec::new(), &data).expect("Not fallible");
-        pad_entire_serialization(&mut serialized_complete_type_object);
+
         let hash_complete_type_object = md5::compute(&serialized_complete_type_object);
 
         TypeInformation {

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -2203,7 +2203,7 @@ mod tests {
             shapesize: i32,
         }
 
-        let type_information = TypeInformation::try_from(ShapeType::get_type()).unwrap();
+        let type_information = TypeInformation::from(ShapeType::get_type());
         assert_eq!(
             type_information
                 .complete

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -3,7 +3,7 @@ use dust_dds_derive::DdsType;
 
 use crate::xtypes::{
     dynamic_type::{DynamicDataFactory, DynamicType, DynamicTypeMember},
-    serializer::serialize_cdr2_le,
+    serializer::serialize_without_header_cdr2_le,
     type_support::TypeSupport,
 };
 
@@ -2015,12 +2015,26 @@ impl From<&DynamicTypeMember> for CompleteStructMember {
 
 impl<'a> From<DynamicType<'a>> for TypeInformation {
     fn from(value: DynamicType<'a>) -> Self {
+        fn pad_entire_serialization(buffer: &mut Vec<u8>) {
+            let padding = match buffer.len() % 4 {
+                1 => &[0, 0, 0][..],
+                2 => &[0, 0][..],
+                3 => &[0][..],
+                _ => &[][..],
+            };
+            buffer.extend_from_slice(padding);
+            buffer[3] = padding.len() as u8;
+        }
+
         let minimal_type_object = TypeObject::EkMinimal {
             minimal: MinimalTypeObject::from(value),
         };
         let mut data = DynamicDataFactory::create_data(TypeObject::get_type());
         minimal_type_object.create_dynamic_sample(&mut data);
-        let serialized_minimal_type_object = serialize_cdr2_le(&data).expect("Not fallible");
+
+        let mut serialized_minimal_type_object =
+            serialize_without_header_cdr2_le(Vec::new(), &data).expect("Not fallible");
+        pad_entire_serialization(&mut serialized_minimal_type_object);
         let hash_minimal_type_object = md5::compute(&serialized_minimal_type_object);
 
         let complete_type_object = TypeObject::EkComplete {
@@ -2028,7 +2042,9 @@ impl<'a> From<DynamicType<'a>> for TypeInformation {
         };
         let mut data = DynamicDataFactory::create_data(TypeObject::get_type());
         complete_type_object.create_dynamic_sample(&mut data);
-        let serialized_complete_type_object = serialize_cdr2_le(&data).expect("Not fallible");
+        let mut serialized_complete_type_object =
+            serialize_without_header_cdr2_le(Vec::new(), &data).expect("Not fallible");
+        pad_entire_serialization(&mut serialized_complete_type_object);
         let hash_complete_type_object = md5::compute(&serialized_complete_type_object);
 
         TypeInformation {
@@ -2079,7 +2095,7 @@ impl<'a> From<DynamicType<'a>> for TypeInformation {
                     },
                     typeobject_serialized_size: serialized_complete_type_object.len() as u32,
                 },
-                dependent_typeid_count: -1,
+                dependent_typeid_count: 0,
                 dependent_typeids: Vec::new(),
             },
         }
@@ -2141,6 +2157,62 @@ mod tests {
     }
 
     #[test]
+    fn serialize_type_information() {
+        let mut dynamic_data = DynamicDataFactory::create_data(TypeInformation::TYPE);
+        TypeInformation {
+            minimal: TypeIdentifierWithDependencies {
+                typeid_with_size: TypeIdentifierWithSize {
+                    type_id: TypeIdentifier::EkComplete {
+                        equivalence_hash: [1; 14],
+                    },
+                    typeobject_serialized_size: 100,
+                },
+                dependent_typeid_count: 0,
+                dependent_typeids: Vec::new(),
+            },
+            complete: TypeIdentifierWithDependencies {
+                typeid_with_size: TypeIdentifierWithSize {
+                    type_id: TypeIdentifier::EkComplete {
+                        equivalence_hash: [1; 14],
+                    },
+                    typeobject_serialized_size: 100,
+                },
+                dependent_typeid_count: 0,
+                dependent_typeids: Vec::new(),
+            },
+        }
+        .create_dynamic_sample(&mut dynamic_data);
+        let buffer = serialize_without_header_cdr2_le(Vec::new(), &dynamic_data).unwrap();
+
+        let expected = [
+            88, 0, 0, 0, // dheader
+            0x01, 0x10, 0, 0b100_0000, // Emheader: minimal
+            36, 0, 0, 0, // EMheader: nextint
+            32, 0, 0, 0,    // DHeader
+            0xF2, // Discriminator
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
+            0, // Padding
+            100, 0, 0, 0, // typeobject_serialized_size
+            0, 0, 0, 0, //dependent_typeid_count
+            4, 0, 0, 0, // dependent_typeids: Dheader
+            0, 0, 0, 0, // dependent_typeids Length
+            // complete
+            0x02, 0x10, 0, 0b100_0000, // Emheader: minimal
+            36, 0, 0, 0, // EMheader: nextint
+            32, 0, 0, 0,    // DHeader
+            0xF2, // Discriminator
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
+            0, // Padding
+            100, 0, 0, 0, // typeobject_serialized_size
+            0, 0, 0, 0, //dependent_typeid_count
+            4, 0, 0, 0, // dependent_typeids: Dheader
+            0, 0, 0, 0, // dependent_typeids Length
+        ];
+
+        assert_eq!(buffer, expected.to_vec())
+    }
+
+    #[test]
     fn serialize_type_identifier_with_dependencies() {
         let mut dynamic_data =
             DynamicDataFactory::create_data(TypeIdentifierWithDependencies::TYPE);
@@ -2158,12 +2230,13 @@ mod tests {
         let buffer = serialize_without_header_cdr2_le(Vec::new(), &dynamic_data).unwrap();
 
         let expected = [
-            28, 0, 0, 0,    // DHeader
+            32, 0, 0, 0,    // DHeader
             0xF2, // Discriminator
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
             0, // Padding
             100, 0, 0, 0, // typeobject_serialized_size
             0, 0, 0, 0, //dependent_typeid_count
+            4, 0, 0, 0, // dependent_typeids Dheader
             0, 0, 0, 0, // dependent_typeids Length
         ];
 

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -1958,7 +1958,7 @@ impl<'a> From<DynamicType<'a>> for CompleteTypeObject {
                     detail: CompleteTypeDetail {
                         ann_builtin: None,
                         ann_custom: None,
-                        type_name: value.descriptor.name.to_string(),
+                        type_name: String::from(value.descriptor.name),
                     },
                 };
 

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -3,7 +3,6 @@ use dust_dds_derive::DdsType;
 
 use crate::xtypes::{
     dynamic_type::{DynamicDataFactory, DynamicType, DynamicTypeMember},
-    error::XTypesError,
     serializer::serialize_cdr2_le,
     type_support::TypeSupport,
 };
@@ -1861,8 +1860,8 @@ pub struct TypeInformation {
 /// Sequence of TypeInformation.
 pub type TypeInformationSeq = Vec<TypeInformation>;
 
-impl<'a> From<&DynamicType<'a>> for MinimalTypeObject {
-    fn from(value: &DynamicType<'a>) -> Self {
+impl<'a> From<DynamicType<'a>> for MinimalTypeObject {
+    fn from(value: DynamicType<'a>) -> Self {
         match value.get_kind() {
             TypeKind::STRUCTURE => {
                 let mut struct_flags = match value.descriptor.extensibility_kind {
@@ -1891,8 +1890,8 @@ impl<'a> From<&DynamicType<'a>> for MinimalTypeObject {
     }
 }
 
-impl<'a> From<&DynamicType<'a>> for CompleteTypeObject {
-    fn from(value: &DynamicType<'a>) -> Self {
+impl<'a> From<DynamicType<'a>> for CompleteTypeObject {
+    fn from(value: DynamicType<'a>) -> Self {
         match value.get_kind() {
             TypeKind::STRUCTURE => {
                 let mut struct_flags = match value.descriptor.extensibility_kind {
@@ -2014,16 +2013,14 @@ impl From<&DynamicTypeMember> for CompleteStructMember {
     }
 }
 
-impl<'a> TryFrom<&DynamicType<'a>> for TypeInformation {
-    type Error = XTypesError;
-
-    fn try_from(value: &DynamicType<'a>) -> Result<Self, Self::Error> {
+impl<'a> From<DynamicType<'a>> for TypeInformation {
+    fn from(value: DynamicType<'a>) -> Self {
         let minimal_type_object = TypeObject::EkMinimal {
             minimal: MinimalTypeObject::from(value),
         };
         let mut data = DynamicDataFactory::create_data(TypeObject::get_type());
         minimal_type_object.create_dynamic_sample(&mut data);
-        let serialized_minimal_type_object = serialize_cdr2_le(&data)?;
+        let serialized_minimal_type_object = serialize_cdr2_le(&data).expect("Not fallible");
         let hash_minimal_type_object = md5::compute(&serialized_minimal_type_object);
 
         let complete_type_object = TypeObject::EkComplete {
@@ -2031,10 +2028,10 @@ impl<'a> TryFrom<&DynamicType<'a>> for TypeInformation {
         };
         let mut data = DynamicDataFactory::create_data(TypeObject::get_type());
         complete_type_object.create_dynamic_sample(&mut data);
-        let serialized_complete_type_object = serialize_cdr2_le(&data)?;
+        let serialized_complete_type_object = serialize_cdr2_le(&data).expect("Not fallible");
         let hash_complete_type_object = md5::compute(&serialized_complete_type_object);
 
-        Ok(TypeInformation {
+        TypeInformation {
             minimal: TypeIdentifierWithDependencies {
                 typeid_with_size: TypeIdentifierWithSize {
                     type_id: TypeIdentifier::EkMinimal {
@@ -2085,12 +2082,14 @@ impl<'a> TryFrom<&DynamicType<'a>> for TypeInformation {
                 dependent_typeid_count: -1,
                 dependent_typeids: Vec::new(),
             },
-        })
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::xtypes::{serializer::serialize_without_header_cdr2_le, type_support::Type};
+
     use super::*;
     #[test]
     #[ignore]
@@ -2105,7 +2104,7 @@ mod tests {
             shapesize: i32,
         }
 
-        let type_information = TypeInformation::try_from(&ShapeType::get_type()).unwrap();
+        let type_information = TypeInformation::try_from(ShapeType::get_type()).unwrap();
         assert_eq!(
             type_information
                 .complete
@@ -2139,5 +2138,75 @@ mod tests {
         //         ]
         //     }
         // );
+    }
+
+    #[test]
+    fn serialize_type_identifier_with_dependencies() {
+        let mut dynamic_data =
+            DynamicDataFactory::create_data(TypeIdentifierWithDependencies::TYPE);
+        TypeIdentifierWithDependencies {
+            typeid_with_size: TypeIdentifierWithSize {
+                type_id: TypeIdentifier::EkComplete {
+                    equivalence_hash: [1; 14],
+                },
+                typeobject_serialized_size: 100,
+            },
+            dependent_typeid_count: 0,
+            dependent_typeids: Vec::new(),
+        }
+        .create_dynamic_sample(&mut dynamic_data);
+        let buffer = serialize_without_header_cdr2_le(Vec::new(), &dynamic_data).unwrap();
+
+        let expected = [
+            28, 0, 0, 0,    // DHeader
+            0xF2, // Discriminator
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
+            0, // Padding
+            100, 0, 0, 0, // typeobject_serialized_size
+            0, 0, 0, 0, //dependent_typeid_count
+            0, 0, 0, 0, // dependent_typeids Length
+        ];
+
+        assert_eq!(buffer, expected.to_vec())
+    }
+
+    #[test]
+    fn serialize_type_identifier_with_size() {
+        let mut dynamic_data = DynamicDataFactory::create_data(TypeIdentifierWithSize::TYPE);
+        TypeIdentifierWithSize {
+            type_id: TypeIdentifier::EkComplete {
+                equivalence_hash: [1; 14],
+            },
+            typeobject_serialized_size: 100,
+        }
+        .create_dynamic_sample(&mut dynamic_data);
+        let buffer = serialize_without_header_cdr2_le(Vec::new(), &dynamic_data).unwrap();
+
+        let expected = [
+            20, 0, 0, 0,    // DHeader
+            0xF2, // Discriminator
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
+            0, // Padding
+            100, 0, 0, 0, // typeobject_serialized_size
+        ];
+
+        assert_eq!(buffer, expected.to_vec())
+    }
+
+    #[test]
+    fn serialize_type_identifier() {
+        let mut dynamic_data = DynamicDataFactory::create_data(TypeIdentifier::TYPE);
+        TypeIdentifier::EkComplete {
+            equivalence_hash: [1; 14],
+        }
+        .create_dynamic_sample(&mut dynamic_data);
+        let buffer = serialize_without_header_cdr2_le(Vec::new(), &dynamic_data).unwrap();
+
+        let expected = [
+            0xF2, // Discriminator
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
+        ];
+
+        assert_eq!(buffer, expected.to_vec())
     }
 }

--- a/dds/src/xtypes/type_support.rs
+++ b/dds/src/xtypes/type_support.rs
@@ -262,21 +262,8 @@ impl<T> Type for Box<T> {
     };
 }
 
-impl<T> Type for Option<T> {
-    const TYPE: DynamicType<'static> = DynamicType {
-        descriptor: &TypeDescriptor {
-            kind: TypeKind::ALIAS,
-            name: "",
-            base_type: None,
-            discriminator_type: None,
-            bound: None,
-            element_type: None,
-            key_element_type: None,
-            extensibility_kind: ExtensibilityKind::Final,
-            is_nested: false,
-        },
-        member_list: &[],
-    };
+impl<T: Type> Type for Option<T> {
+    const TYPE: DynamicType<'static> = T::TYPE;
 }
 
 impl Type for String {

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -285,8 +285,11 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
 
                 let variant_ident = &variant.ident;
                 let variant_name = variant_ident.to_string();
-                let index = variant_index + 1;
                 let variant_index_unsuffixed = syn::Index::from(variant_index);
+                let disc_expr = match &variant_attributes.case {
+                    Some(e) => quote! {#e},
+                    None => quote! {#variant_index_unsuffixed},
+                };
 
                 match &variant.fields {
                     // If there is a single field we handle this as the single type wrapper which is the most common case
@@ -297,13 +300,14 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                                 "Field of named variant must have defined name",
                             ))?;
                         let variant_ty = &fields_named.named[0].ty;
+
                         variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
                                 name: #variant_name,
-                                id: #index as u32,
+                                id: #disc_expr as u32,
                                 r#type: <#variant_ty as dust_dds::xtypes::type_support::Type>::TYPE,
                                 default_value: None,
-                                index: #index as u32,
+                                index: 1 as u32,
                                 try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
                                 label: None,
                                 is_key: false,
@@ -317,13 +321,10 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                         });
                         let variant_sample = quote! {
                             Self::#variant_ident {#variant_field_name: <#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
-                              src.remove_value(#index as u32).expect("Must exist"),
+                              src.remove_value(#disc_expr as u32).expect("Must exist"),
                             ).expect("Must match")},
                         };
-                        let disc_expr = match &variant_attributes.case {
-                            Some(e) => quote! {#e},
-                            None => quote! {#variant_index_unsuffixed},
-                        };
+
                         variant_sample_seq.push(if variant_attributes.is_default {
                             quote! {_ => #variant_sample}
                         } else {
@@ -332,18 +333,19 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                         variant_dynamic_sample_seq
                             .push(quote! {Self::#variant_ident {#variant_field_name} => {
                                 data.set_value(0, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#disc_expr));
-                                data.set_value(#index as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(#variant_field_name));
+                                data.set_value(#disc_expr as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(#variant_field_name));
                             }});
                     }
                     Fields::Unnamed(fields_unnamed) if fields_unnamed.unnamed.len() == 1 => {
                         let variant_ty = &fields_unnamed.unnamed[0].ty;
+
                         variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
                                 name: #variant_name,
-                                id: #index as u32,
+                                id: #disc_expr as u32,
                                 r#type: <#variant_ty as dust_dds::xtypes::type_support::Type>::TYPE,
                                 default_value: None,
-                                index: #index as u32,
+                                index: 1 as u32,
                                 try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
                                 label: None,
                                 is_key: false,
@@ -357,13 +359,10 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                         });
                         let variant_sample = quote! {
                             Self::#variant_ident(<#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
-                              src.remove_value(#index as u32).expect("Must exist"),
+                              src.remove_value(#disc_expr as u32).expect("Must exist"),
                             ).expect("Must match")),
                         };
-                        let disc_expr = match &variant_attributes.case {
-                            Some(e) => quote! {#e},
-                            None => quote! {#variant_index_unsuffixed},
-                        };
+
                         variant_sample_seq.push(if variant_attributes.is_default {
                             quote! {_ => #variant_sample}
                         } else {
@@ -372,14 +371,14 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                         variant_dynamic_sample_seq
                             .push(quote! {Self::#variant_ident (a) => {
                                 data.set_value(0, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#disc_expr));
-                                data.set_value(#index as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(a));
+                                data.set_value(#disc_expr as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(a));
                             }});
                     }
                     Fields::Unit => {
                         variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
                                 name: #variant_name,
-                                id: #index as u32,
+                                id: #disc_expr as u32,
                                 r#type: dust_dds::xtypes::dynamic_type::DynamicType {
                                     descriptor: &dust_dds::xtypes::dynamic_type::TypeDescriptor {
                                         kind: dust_dds::xtypes::dynamic_type::TypeKind::NONE,
@@ -395,7 +394,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                                     member_list: &[],
                                 },
                                 default_value: None,
-                                index: #index as u32,
+                                index: 1 as u32,
                                 try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
                                 label: None,
                                 is_key: false,
@@ -410,10 +409,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                         let variant_sample = quote! {
                             Self::#variant_ident,
                         };
-                        let disc_expr = match &variant_attributes.case {
-                            Some(e) => quote! {#e},
-                            None => quote! {#variant_index_unsuffixed},
-                        };
+
                         variant_sample_seq.push(if variant_attributes.is_default {
                             quote! {_ => #variant_sample}
                         } else {


### PR DESCRIPTION
This PR adds the sending of type information as part of the topic announcement.

To be able to communicate these values we needed to adjust the serialization of the TypeInformation on the wire. This also requires the union deserialization to be adjusted. To do this all the union variants are now having the index 1 and the id corresponding to the discriminator. The deserialization takes the discriminator and then deserializes the member with the corresponding id.