### PR TITLE
Add type information to built-in topics

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -201,6 +201,9 @@ jobs:
   interoperability_tests:
     docker:
       - image: s2esystems/dust_dds_interoperability:1.87.0
+    # CycloneDDS sends incompatible TypeInformation message which appear on Wireshark as malformed. This is explicitly ignore to allow interoperability
+    environment:
+      CYCLONEDDS_URI: <CycloneDDS><Domain Id="any"><Compatibility><IgnoreTypeInformation>1.20</IgnoreTypeInformation></Compatibility></Domain></CycloneDDS>
     steps:
       - checkout
       - run:

--- a/dds/src/dcps/builtin_topics.rs
+++ b/dds/src/dcps/builtin_topics.rs
@@ -200,6 +200,8 @@ pub struct PublicationBuiltinTopicData {
     pub(crate) topic_name: _String,
     #[dust_dds(id=PID_TYPE_NAME as u32)]
     pub(crate) type_name: _String,
+    #[dust_dds(id=PID_TYPE_INFORMATION as u32, optional)]
+    pub(crate) type_information: Option<TypeInformation>,
     #[dust_dds(id=PID_DURABILITY as u32)]
     pub(crate) durability: DurabilityQosPolicy,
     #[dust_dds(id=PID_DEADLINE as u32)]

--- a/dds/src/dcps/builtin_topics.rs
+++ b/dds/src/dcps/builtin_topics.rs
@@ -343,6 +343,8 @@ pub struct SubscriptionBuiltinTopicData {
     pub(crate) topic_name: _String,
     #[dust_dds(id=PID_TYPE_NAME as u32)]
     pub(crate) type_name: _String,
+    #[dust_dds(id=PID_TYPE_INFORMATION as u32, optional)]
+    pub(crate) type_information: Option<TypeInformation>,
     #[dust_dds(id=PID_DURABILITY as u32)]
     pub(crate) durability: DurabilityQosPolicy,
     #[dust_dds(id=PID_DEADLINE as u32)]

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -133,7 +133,9 @@ impl DiscoveredReaderData {
                 .get_optional_parameter_xdcr(PID_PARTICIPANT_GUID, Default::default())?,
             topic_name: pl.get_optional_parameter_xdcr(PID_TOPIC_NAME, Default::default())?,
             type_name: pl.get_optional_parameter_xdcr(PID_TYPE_NAME, Default::default())?,
-            type_information: pl.get_optional_parameter_xdcr2(PID_TYPE_INFORMATION)?,
+            type_information: pl
+                .get_optional_parameter_xdcr2(PID_TYPE_INFORMATION)
+                .unwrap_or_default(),
             durability: pl.get_optional_parameter_xdcr(PID_DURABILITY, Default::default())?,
             deadline: pl.get_optional_parameter_xdcr(PID_DEADLINE, Default::default())?,
             latency_budget: pl

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -8,6 +8,7 @@ use super::parameter_id_values::{
 use crate::{
     builtin_topics::SubscriptionBuiltinTopicData,
     dcps::data_representation_builtin_endpoints::{
+        parameter_id_values::PID_TYPE_INFORMATION,
         rtps_data_representation::{CdrResult, ParameterList},
         rtps_data_representation_serialization::ParameterListSerializer,
     },
@@ -132,6 +133,7 @@ impl DiscoveredReaderData {
                 .get_optional_parameter_xdcr(PID_PARTICIPANT_GUID, Default::default())?,
             topic_name: pl.get_optional_parameter_xdcr(PID_TOPIC_NAME, Default::default())?,
             type_name: pl.get_optional_parameter_xdcr(PID_TYPE_NAME, Default::default())?,
+            type_information: pl.get_optional_parameter_xdcr2(PID_TYPE_INFORMATION)?,
             durability: pl.get_optional_parameter_xdcr(PID_DURABILITY, Default::default())?,
             deadline: pl.get_optional_parameter_xdcr(PID_DEADLINE, Default::default())?,
             latency_budget: pl
@@ -199,6 +201,7 @@ mod tests {
                 type_name: _String {
                     value: "cd".to_string(),
                 },
+                type_information: None,
                 durability: Default::default(),
                 deadline: Default::default(),
                 latency_budget: Default::default(),
@@ -268,6 +271,7 @@ mod tests {
                 type_name: _String {
                     value: "cd".to_string(),
                 },
+                type_information: None,
                 durability: Default::default(),
                 deadline: Default::default(),
                 latency_budget: Default::default(),
@@ -355,6 +359,7 @@ mod tests {
                 type_name: _String {
                     value: "cd".to_string(),
                 },
+                type_information: None,
                 durability: Default::default(),
                 deadline: Default::default(),
                 latency_budget: Default::default(),
@@ -424,6 +429,7 @@ mod tests {
                 type_name: _String {
                     value: "cd".to_string(),
                 },
+                type_information: None,
                 durability: Default::default(),
                 deadline: Default::default(),
                 latency_budget: Default::default(),

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -50,6 +50,9 @@ impl DiscoveredReaderData {
         pl.write_xcdr1_parameter(PID_TOPIC_NAME, self.dds_subscription_data.topic_name);
         pl.write_xcdr1_parameter(PID_TYPE_NAME, self.dds_subscription_data.type_name);
 
+        if let Some(type_information) = self.dds_subscription_data.type_information {
+            pl.write_xcdr2_parameter(PID_TYPE_INFORMATION, type_information);
+        }
         if self.dds_subscription_data.durability != DurabilityQosPolicy::default() {
             pl.write_xcdr1_parameter(PID_DURABILITY, self.dds_subscription_data.durability);
         }

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_topic_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_topic_data.rs
@@ -103,7 +103,7 @@ impl DiscoveredTopicData {
             key: pl.get_optional_parameter_xdcr(PID_ENDPOINT_GUID, Default::default())?,
             name: pl.get_optional_parameter_xdcr(PID_TOPIC_NAME, Default::default())?,
             type_name: pl.get_optional_parameter_xdcr(PID_TYPE_NAME, Default::default())?,
-            type_information: None, //pl.get_optional_parameter_xdcr(PID_TYPE_INFORMATION, Default::default())?,
+            type_information: pl.get_optional_parameter_xdcr2(PID_TYPE_INFORMATION)?,
             durability: pl.get_optional_parameter_xdcr(PID_DURABILITY, Default::default())?,
             deadline: pl.get_optional_parameter_xdcr(PID_DEADLINE, Default::default())?,
             latency_budget: pl

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -128,7 +128,9 @@ impl DiscoveredWriterData {
                 .get_optional_parameter_xdcr(PID_PARTICIPANT_GUID, Default::default())?,
             topic_name: pl.get_optional_parameter_xdcr(PID_TOPIC_NAME, Default::default())?,
             type_name: pl.get_optional_parameter_xdcr(PID_TYPE_NAME, Default::default())?,
-            type_information: pl.get_optional_parameter_xdcr2(PID_TYPE_INFORMATION)?,
+            type_information: pl
+                .get_optional_parameter_xdcr2(PID_TYPE_INFORMATION)
+                .unwrap_or_default(),
             durability: pl.get_optional_parameter_xdcr(PID_DURABILITY, Default::default())?,
             deadline: pl.get_optional_parameter_xdcr(PID_DEADLINE, Default::default())?,
             latency_budget: pl

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -8,7 +8,7 @@ use super::parameter_id_values::{
 use crate::{
     builtin_topics::PublicationBuiltinTopicData,
     dcps::data_representation_builtin_endpoints::{
-        parameter_id_values::PID_TYPE_NAME,
+        parameter_id_values::{PID_TYPE_INFORMATION, PID_TYPE_NAME},
         rtps_data_representation::{CdrResult, ParameterList},
         rtps_data_representation_serialization::ParameterListSerializer,
     },
@@ -48,7 +48,9 @@ impl DiscoveredWriterData {
         );
         pl.write_xcdr1_parameter(PID_TOPIC_NAME, self.dds_publication_data.topic_name);
         pl.write_xcdr1_parameter(PID_TYPE_NAME, self.dds_publication_data.type_name);
-
+        if let Some(type_information) = self.dds_publication_data.type_information {
+            pl.write_xcdr2_parameter(PID_TYPE_INFORMATION, type_information);
+        }
         if self.dds_publication_data.durability != DurabilityQosPolicy::default() {
             pl.write_xcdr1_parameter(PID_DURABILITY, self.dds_publication_data.durability);
         }
@@ -126,6 +128,7 @@ impl DiscoveredWriterData {
                 .get_optional_parameter_xdcr(PID_PARTICIPANT_GUID, Default::default())?,
             topic_name: pl.get_optional_parameter_xdcr(PID_TOPIC_NAME, Default::default())?,
             type_name: pl.get_optional_parameter_xdcr(PID_TYPE_NAME, Default::default())?,
+            type_information: pl.get_optional_parameter_xdcr2(PID_TYPE_INFORMATION)?,
             durability: pl.get_optional_parameter_xdcr(PID_DURABILITY, Default::default())?,
             deadline: pl.get_optional_parameter_xdcr(PID_DEADLINE, Default::default())?,
             latency_budget: pl
@@ -191,6 +194,7 @@ mod tests {
                 },
                 topic_name: "ab".to_string().into(),
                 type_name: "cd".to_string().into(),
+                type_information: None,
                 durability: Default::default(),
                 deadline: Default::default(),
                 latency_budget: Default::default(),
@@ -257,6 +261,7 @@ mod tests {
                 },
                 topic_name: "ab".to_string().into(),
                 type_name: "cd".to_string().into(),
+                type_information: None,
                 durability: Default::default(),
                 deadline: Default::default(),
                 latency_budget: Default::default(),
@@ -328,6 +333,7 @@ mod tests {
                 },
                 topic_name: "ab".to_string().into(),
                 type_name: "cd".to_string().into(),
+                type_information: None,
                 durability: Default::default(),
                 deadline: Default::default(),
                 latency_budget: Default::default(),

--- a/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation.rs
@@ -14,11 +14,24 @@ use alloc::{string::String, vec::Vec};
 
 pub type CdrResult<T> = Result<T, CdrError>;
 
+type RepresentationIdentifier = [u8; 2];
+const CDR_BE: RepresentationIdentifier = [0x00, 0x00];
+const CDR_LE: RepresentationIdentifier = [0x00, 0x01];
+const CDR2_BE: RepresentationIdentifier = [0x00, 0x06];
+const CDR2_LE: RepresentationIdentifier = [0x00, 0x07];
+const D_CDR2_BE: RepresentationIdentifier = [0x00, 0x08];
+const D_CDR2_LE: RepresentationIdentifier = [0x00, 0x09];
+const PL_CDR_BE: RepresentationIdentifier = [0x00, 0x02];
+const PL_CDR_LE: RepresentationIdentifier = [0x00, 0x03];
+const PL_CDR2_BE: RepresentationIdentifier = [0x00, 0x0a];
+const PL_CDR2_LE: RepresentationIdentifier = [0x00, 0x0b];
+
 #[derive(Debug, PartialEq)]
 pub enum CdrError {
     InvalidData,
     PidNotFound(i16),
     NotEnoughData,
+    Unsupported(RepresentationIdentifier),
     XTypes(XTypesError),
 }
 impl From<XTypesError> for CdrError {
@@ -111,6 +124,27 @@ impl<'a> ParameterList<'a> {
             self.seek_to_pid(pid)?.ok_or(CdrError::PidNotFound(pid))?,
             self.endianness()?,
         ))
+    }
+
+    pub(crate) fn get_optional_parameter_xdcr2<T: TypeSupport>(
+        &self,
+        pid: ParameterId,
+    ) -> CdrResult<Option<T>> {
+        if let Some(pid_data) = self.seek_to_pid(pid)? {
+            let representation_identifier = match [self.data[0], self.data[1]] {
+                CDR_BE | CDR2_BE| PL_CDR_BE | D_CDR2_BE | PL_CDR2_BE => CDR2_BE,
+                CDR_LE | CDR2_LE| PL_CDR_LE | D_CDR2_LE | PL_CDR2_LE => CDR2_LE,
+                unsupported => Err(CdrError::Unsupported(unsupported))?
+            };
+            let mut dynamic_data = deserialize_top_level_type_from_representation_identifier(
+                T::TYPE,
+                representation_identifier,
+                pid_data,
+            )?;
+            Ok(Some(T::create_sample(&mut dynamic_data)))
+        } else {
+            Ok(None)
+        }
     }
 
     pub(crate) fn get_optional_parameter_xdcr<T: TypeSupport>(

--- a/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation.rs
@@ -132,9 +132,9 @@ impl<'a> ParameterList<'a> {
     ) -> CdrResult<Option<T>> {
         if let Some(pid_data) = self.seek_to_pid(pid)? {
             let representation_identifier = match [self.data[0], self.data[1]] {
-                CDR_BE | CDR2_BE| PL_CDR_BE | D_CDR2_BE | PL_CDR2_BE => CDR2_BE,
-                CDR_LE | CDR2_LE| PL_CDR_LE | D_CDR2_LE | PL_CDR2_LE => CDR2_LE,
-                unsupported => Err(CdrError::Unsupported(unsupported))?
+                CDR_BE | CDR2_BE | PL_CDR_BE | D_CDR2_BE | PL_CDR2_BE => CDR2_BE,
+                CDR_LE | CDR2_LE | PL_CDR_LE | D_CDR2_LE | PL_CDR2_LE => CDR2_LE,
+                unsupported => Err(CdrError::Unsupported(unsupported))?,
             };
             let mut dynamic_data = deserialize_top_level_type_from_representation_identifier(
                 T::TYPE,

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -336,8 +336,8 @@ impl DcpsDomainParticipant {
             return;
         };
 
-        let (topic_name, type_name, topic_qos) = match topic {
-            TopicDescriptionKind::Topic(t) => (&t.topic_name, &t.type_name, &t.qos),
+        let topic = match topic {
+            TopicDescriptionKind::Topic(t) => t,
             TopicDescriptionKind::ContentFilteredTopic(t) => {
                 if let Some(TopicDescriptionKind::Topic(topic)) = self
                     .domain_participant
@@ -345,7 +345,7 @@ impl DcpsDomainParticipant {
                     .iter()
                     .find(|x| x.topic_name() == t.related_topic_name)
                 {
-                    (&topic.topic_name, &topic.type_name, &topic.qos)
+                    topic
                 } else {
                     return;
                 }
@@ -358,11 +358,12 @@ impl DcpsDomainParticipant {
                 value: self.domain_participant.instance_handle.into(),
             },
             topic_name: _String {
-                value: topic_name.clone(),
+                value: topic.topic_name.clone(),
             },
             type_name: _String {
-                value: type_name.clone(),
+                value: topic.type_name.clone(),
             },
+            type_information: Some(topic.type_support.into()),
             durability: data_reader.qos.durability.clone(),
             deadline: data_reader.qos.deadline.clone(),
             latency_budget: data_reader.qos.latency_budget.clone(),
@@ -374,7 +375,7 @@ impl DcpsDomainParticipant {
             time_based_filter: data_reader.qos.time_based_filter.clone(),
             presentation: subscriber.qos.presentation.clone(),
             partition: subscriber.qos.partition.clone(),
-            topic_data: topic_qos.topic_data.clone(),
+            topic_data: topic.qos.topic_data.clone(),
             group_data: subscriber.qos.group_data.clone(),
             representation: data_reader.qos.representation.clone(),
         };

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -221,6 +221,7 @@ impl DcpsDomainParticipant {
             },
             topic_name: data_writer.topic_name.clone().into(),
             type_name: data_writer.type_name.clone().into(),
+            type_information: Some(topic.type_support.into()),
             durability: data_writer.qos.durability.clone(),
             deadline: data_writer.qos.deadline.clone(),
             latency_budget: data_writer.qos.latency_budget.clone(),

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -162,7 +162,7 @@ pub type SBoundSeq = Vec<SBound>;
 pub const INVALID_SBOUND: SBound = 0;
 
 /// Unique identifier for a TypeObject based on its equivalence hash.
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested, switch(u8))]
 pub enum TypeObjectHashId {
     /// The hash for a complete TypeObject representation.
@@ -185,7 +185,7 @@ pub enum TypeObjectHashId {
 // When not all, the applicable member types are listed
 
 /// Flags that apply to struct/union/collection/enum/bitmask/bitset members/elements and affect type assignability.
-#[derive(Debug, Clone, Copy, DdsType)]
+#[derive(Debug, Clone, Copy, DdsType, Eq)]
 pub struct MemberFlag(u16);
 
 impl PartialEq for MemberFlag {
@@ -193,6 +193,7 @@ impl PartialEq for MemberFlag {
         self.0 & other.0 == other.0
     }
 }
+
 
 impl core::ops::BitOr for MemberFlag {
     type Output = MemberFlag;
@@ -310,7 +311,7 @@ pub const TYPE_FLAG_MINIMAL_MASK: TypeFlag = TypeFlag(0x0007); // Selects M, A, 
 
 // 1 Byte
 /// Definition of a small string type (bound <= 255).
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct StringSTypeDefn {
     /// The short bound (maximum length) of the string.
@@ -318,7 +319,7 @@ pub struct StringSTypeDefn {
 }
 // 4 Bytes
 /// Definition of a large string type (bound > 255).
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct StringLTypeDefn {
     /// The long bound (maximum length) of the string.
@@ -326,7 +327,7 @@ pub struct StringLTypeDefn {
 }
 
 /// Common header for plain collection types (sequence, array, map).
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainCollectionHeader {
     /// The equivalence kind of the collection.
@@ -336,7 +337,7 @@ pub struct PlainCollectionHeader {
 }
 
 /// Definition of a plain sequence with a small bound.
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainSequenceSElemDefn {
     /// The header containing collection properties.
@@ -349,7 +350,7 @@ pub struct PlainSequenceSElemDefn {
 }
 
 /// Definition of a plain sequence with a large bound.
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainSequenceLElemDefn {
     /// The header containing collection properties.
@@ -362,7 +363,7 @@ pub struct PlainSequenceLElemDefn {
 }
 
 /// Definition of a plain array with small bounds.
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainArraySElemDefn {
     /// The header containing collection properties.
@@ -375,7 +376,7 @@ pub struct PlainArraySElemDefn {
 }
 
 /// Definition of a plain array with large bounds.
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainArrayLElemDefn {
     /// The header containing collection properties.
@@ -388,7 +389,7 @@ pub struct PlainArrayLElemDefn {
 }
 
 /// Definition of a plain map with a small bound.
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainMapSTypeDefn {
     /// The header containing collection properties.
@@ -406,7 +407,7 @@ pub struct PlainMapSTypeDefn {
 }
 
 /// Definition of a plain map with a large bound.
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested)]
 pub struct PlainMapLTypeDefn {
     /// The header containing collection properties.
@@ -424,7 +425,7 @@ pub struct PlainMapLTypeDefn {
 }
 
 /// Identifier for a type that belongs to a strongly connected component (has cyclic dependencies).
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct StronglyConnectedComponentId {
     /// The hash of the strongly connected component.
@@ -460,7 +461,7 @@ pub struct ExtendedTypeDefn {
 /// - COMMON indicates the TypeIdentifier identifies equivalent types
 ///   according to both the MINIMAL and the COMMON equivalence relation.
 ///   This means the TypeIdentifier is the same for both relationships
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "final", nested, switch(u8))]
 pub enum TypeIdentifier {
     /// No type.
@@ -1690,7 +1691,7 @@ pub enum CompleteTypeObject {
 }
 
 /// Minimal extended type representation for future extensions.
-#[derive(DdsType, Debug, Clone, PartialEq, Default)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq, Default)]
 #[dust_dds(extensibility = "mutable", nested)]
 pub struct MinimalExtendedType {
     // Empty. Available for future extension
@@ -1821,7 +1822,7 @@ pub struct TypeIdentifierPair {
 pub type TypeIdentifierPairSeq = Vec<TypeIdentifierPair>;
 
 /// A TypeIdentifier packaged with the serialized size of its corresponding TypeObject.
-#[derive(DdsType, Debug, Clone, PartialEq, Default)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq, Default)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct TypeIdentifierWithSize {
     /// The TypeIdentifier.
@@ -1833,7 +1834,7 @@ pub struct TypeIdentifierWithSize {
 pub type TypeIdentfierWithSizeSeq = Vec<TypeIdentifierWithSize>;
 
 /// A TypeIdentifier packaged with its size and all the dependent type identifiers it relies on.
-#[derive(DdsType, Debug, Clone, PartialEq, Default)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq, Default)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct TypeIdentifierWithDependencies {
     /// The TypeIdentifier with its serialized size.
@@ -1847,7 +1848,7 @@ pub struct TypeIdentifierWithDependencies {
 pub type TypeIdentifierWithDependenciesSeq = Vec<TypeIdentifierWithDependencies>;
 
 /// Complete type information containing both complete and minimal representations with their dependencies.
-#[derive(DdsType, Debug, Clone, PartialEq)]
+#[derive(DdsType, Debug, Clone, PartialEq, Eq)]
 #[dust_dds(extensibility = "mutable", nested)]
 pub struct TypeInformation {
     /// Minimal type representation with dependencies.

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -194,7 +194,6 @@ impl PartialEq for MemberFlag {
     }
 }
 
-
 impl core::ops::BitOr for MemberFlag {
     type Output = MemberFlag;
 


### PR DESCRIPTION
Add type information to built-in topics. 

The data format used by Cyclone DDS is not correct so we explicitly set the TypeInformation to be ignored for interoperability.