### PR TITLE
Add types and methods for XTypes Type Information exchange

### DIFF
--- a/bindings/python/src/infrastructure/qos.rs
+++ b/bindings/python/src/infrastructure/qos.rs
@@ -7,8 +7,8 @@ use super::qos_policy::{
     HistoryQosPolicy, LatencyBudgetQosPolicy, LifespanQosPolicy, LivelinessQosPolicy,
     OwnershipQosPolicy, OwnershipStrengthQosPolicy, PartitionQosPolicy, PresentationQosPolicy,
     ReaderDataLifecycleQosPolicy, ReliabilityQosPolicy, ResourceLimitsQosPolicy,
-    TimeBasedFilterQosPolicy, TopicDataQosPolicy, TransportPriorityQosPolicy, UserDataQosPolicy,
-    WriterDataLifecycleQosPolicy,
+    TimeBasedFilterQosPolicy, TopicDataQosPolicy, TransportPriorityQosPolicy,
+    TypeConsistencyEnforcementQosPolicy, UserDataQosPolicy, WriterDataLifecycleQosPolicy,
 };
 
 #[pyclass(from_py_object)]
@@ -469,6 +469,7 @@ impl DataReaderQos {
         time_based_filter = TimeBasedFilterQosPolicy::default(),
         reader_data_lifecycle = ReaderDataLifecycleQosPolicy::default(),
         representation = DataRepresentationQosPolicy::default(),
+        type_consistency = TypeConsistencyEnforcementQosPolicy::default(),
     ))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -485,6 +486,7 @@ impl DataReaderQos {
         time_based_filter: TimeBasedFilterQosPolicy,
         reader_data_lifecycle: ReaderDataLifecycleQosPolicy,
         representation: DataRepresentationQosPolicy,
+        type_consistency: TypeConsistencyEnforcementQosPolicy,
     ) -> Self {
         Self(dust_dds::infrastructure::qos::DataReaderQos {
             durability: durability.into(),
@@ -500,7 +502,7 @@ impl DataReaderQos {
             time_based_filter: time_based_filter.into(),
             reader_data_lifecycle: reader_data_lifecycle.into(),
             representation: representation.into(),
-            type_consistency: todo!(),
+            type_consistency: type_consistency.into(),
         })
     }
 
@@ -550,5 +552,13 @@ impl DataReaderQos {
 
     fn get_reader_data_lifecycle(&self) -> ReaderDataLifecycleQosPolicy {
         self.0.reader_data_lifecycle.clone().into()
+    }
+
+    fn get_representation(&self) -> DataRepresentationQosPolicy {
+        self.0.representation.clone().into()
+    }
+
+    fn get_type_consistency(&self) -> TypeConsistencyEnforcementQosPolicy {
+        self.0.type_consistency.clone().into()
     }
 }

--- a/bindings/python/src/infrastructure/qos.rs
+++ b/bindings/python/src/infrastructure/qos.rs
@@ -500,6 +500,7 @@ impl DataReaderQos {
             time_based_filter: time_based_filter.into(),
             reader_data_lifecycle: reader_data_lifecycle.into(),
             representation: representation.into(),
+            type_consistency: todo!(),
         })
     }
 

--- a/bindings/python/src/infrastructure/qos_policy.rs
+++ b/bindings/python/src/infrastructure/qos_policy.rs
@@ -1137,3 +1137,27 @@ impl From<dust_dds::infrastructure::qos_policy::DataRepresentationQosPolicy>
         Self(value)
     }
 }
+
+#[pyclass(from_py_object)]
+#[derive(Clone, Default)]
+pub struct TypeConsistencyEnforcementQosPolicy(
+    dust_dds::infrastructure::qos_policy::TypeConsistencyEnforcementQosPolicy,
+);
+
+impl From<TypeConsistencyEnforcementQosPolicy>
+    for dust_dds::infrastructure::qos_policy::TypeConsistencyEnforcementQosPolicy
+{
+    fn from(value: TypeConsistencyEnforcementQosPolicy) -> Self {
+        value.0
+    }
+}
+
+impl From<dust_dds::infrastructure::qos_policy::TypeConsistencyEnforcementQosPolicy>
+    for TypeConsistencyEnforcementQosPolicy
+{
+    fn from(
+        value: dust_dds::infrastructure::qos_policy::TypeConsistencyEnforcementQosPolicy,
+    ) -> Self {
+        Self(value)
+    }
+}

--- a/dds/src/dcps/builtin_topics.rs
+++ b/dds/src/dcps/builtin_topics.rs
@@ -78,31 +78,31 @@ pub struct TopicBuiltinTopicData {
     pub(crate) type_name: _String,
     #[dust_dds(id=PID_TYPE_INFORMATION as u32, optional)]
     pub(crate) type_information: Option<TypeInformation>,
-    #[dust_dds(id=PID_DURABILITY as u32)]
+    #[dust_dds(id=PID_DURABILITY as u32, optional)]
     pub(crate) durability: DurabilityQosPolicy,
-    #[dust_dds(id=PID_DEADLINE as u32)]
+    #[dust_dds(id=PID_DEADLINE as u32, optional)]
     pub(crate) deadline: DeadlineQosPolicy,
-    #[dust_dds(id=PID_LATENCY_BUDGET as u32)]
+    #[dust_dds(id=PID_LATENCY_BUDGET as u32, optional)]
     pub(crate) latency_budget: LatencyBudgetQosPolicy,
-    #[dust_dds(id=PID_LIVELINESS as u32)]
+    #[dust_dds(id=PID_LIVELINESS as u32, optional)]
     pub(crate) liveliness: LivelinessQosPolicy,
-    #[dust_dds(id=PID_RELIABILITY as u32, default_value=DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS)]
+    #[dust_dds(id=PID_RELIABILITY as u32, optional, default_value=DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS)]
     pub(crate) reliability: ReliabilityQosPolicy,
-    #[dust_dds(id=PID_TRANSPORT_PRIORITY as u32)]
+    #[dust_dds(id=PID_TRANSPORT_PRIORITY as u32, optional)]
     pub(crate) transport_priority: TransportPriorityQosPolicy,
-    #[dust_dds(id=PID_LIFESPAN as u32)]
+    #[dust_dds(id=PID_LIFESPAN as u32, optional)]
     pub(crate) lifespan: LifespanQosPolicy,
-    #[dust_dds(id=PID_DESTINATION_ORDER as u32)]
+    #[dust_dds(id=PID_DESTINATION_ORDER as u32, optional)]
     pub(crate) destination_order: DestinationOrderQosPolicy,
-    #[dust_dds(id=PID_HISTORY as u32)]
+    #[dust_dds(id=PID_HISTORY as u32, optional)]
     pub(crate) history: HistoryQosPolicy,
-    #[dust_dds(id=PID_RESOURCE_LIMITS as u32)]
+    #[dust_dds(id=PID_RESOURCE_LIMITS as u32, optional)]
     pub(crate) resource_limits: ResourceLimitsQosPolicy,
-    #[dust_dds(id=PID_OWNERSHIP as u32)]
+    #[dust_dds(id=PID_OWNERSHIP as u32, optional)]
     pub(crate) ownership: OwnershipQosPolicy,
-    #[dust_dds(id=PID_TOPIC_DATA as u32)]
+    #[dust_dds(id=PID_TOPIC_DATA as u32, optional)]
     pub(crate) topic_data: TopicDataQosPolicy,
-    #[dust_dds(id=PID_DATA_REPRESENTATION as u32)]
+    #[dust_dds(id=PID_DATA_REPRESENTATION as u32, optional)]
     pub(crate) representation: DataRepresentationQosPolicy,
 }
 
@@ -202,35 +202,35 @@ pub struct PublicationBuiltinTopicData {
     pub(crate) type_name: _String,
     #[dust_dds(id=PID_TYPE_INFORMATION as u32, optional)]
     pub(crate) type_information: Option<TypeInformation>,
-    #[dust_dds(id=PID_DURABILITY as u32)]
+    #[dust_dds(id=PID_DURABILITY as u32, optional)]
     pub(crate) durability: DurabilityQosPolicy,
-    #[dust_dds(id=PID_DEADLINE as u32)]
+    #[dust_dds(id=PID_DEADLINE as u32, optional)]
     pub(crate) deadline: DeadlineQosPolicy,
-    #[dust_dds(id=PID_LATENCY_BUDGET as u32)]
+    #[dust_dds(id=PID_LATENCY_BUDGET as u32, optional)]
     pub(crate) latency_budget: LatencyBudgetQosPolicy,
-    #[dust_dds(id=PID_LIVELINESS as u32)]
+    #[dust_dds(id=PID_LIVELINESS as u32, optional)]
     pub(crate) liveliness: LivelinessQosPolicy,
-    #[dust_dds(id=PID_RELIABILITY as u32, default_value=DEFAULT_RELIABILITY_QOS_POLICY_DATA_WRITER)]
+    #[dust_dds(id=PID_RELIABILITY as u32, optional, default_value=DEFAULT_RELIABILITY_QOS_POLICY_DATA_WRITER)]
     pub(crate) reliability: ReliabilityQosPolicy,
-    #[dust_dds(id=PID_LIFESPAN as u32)]
+    #[dust_dds(id=PID_LIFESPAN as u32, optional)]
     pub(crate) lifespan: LifespanQosPolicy,
-    #[dust_dds(id=PID_USER_DATA as u32)]
+    #[dust_dds(id=PID_USER_DATA as u32, optional)]
     pub(crate) user_data: UserDataQosPolicy,
-    #[dust_dds(id=PID_OWNERSHIP as u32)]
+    #[dust_dds(id=PID_OWNERSHIP as u32, optional)]
     pub(crate) ownership: OwnershipQosPolicy,
-    #[dust_dds(id=PID_OWNERSHIP_STRENGTH as u32)]
+    #[dust_dds(id=PID_OWNERSHIP_STRENGTH as u32, optional)]
     pub(crate) ownership_strength: OwnershipStrengthQosPolicy,
-    #[dust_dds(id=PID_DESTINATION_ORDER as u32)]
+    #[dust_dds(id=PID_DESTINATION_ORDER as u32, optional)]
     pub(crate) destination_order: DestinationOrderQosPolicy,
-    #[dust_dds(id=PID_PRESENTATION as u32)]
+    #[dust_dds(id=PID_PRESENTATION as u32, optional)]
     pub(crate) presentation: PresentationQosPolicy,
-    #[dust_dds(id=PID_PARTITION as u32)]
+    #[dust_dds(id=PID_PARTITION as u32, optional)]
     pub(crate) partition: PartitionQosPolicy,
-    #[dust_dds(id=PID_TOPIC_DATA as u32)]
+    #[dust_dds(id=PID_TOPIC_DATA as u32, optional)]
     pub(crate) topic_data: TopicDataQosPolicy,
-    #[dust_dds(id=PID_GROUP_DATA as u32)]
+    #[dust_dds(id=PID_GROUP_DATA as u32, optional)]
     pub(crate) group_data: GroupDataQosPolicy,
-    #[dust_dds(id=PID_DATA_REPRESENTATION as u32)]
+    #[dust_dds(id=PID_DATA_REPRESENTATION as u32, optional)]
     pub(crate) representation: DataRepresentationQosPolicy,
 }
 
@@ -345,35 +345,35 @@ pub struct SubscriptionBuiltinTopicData {
     pub(crate) type_name: _String,
     #[dust_dds(id=PID_TYPE_INFORMATION as u32, optional)]
     pub(crate) type_information: Option<TypeInformation>,
-    #[dust_dds(id=PID_DURABILITY as u32)]
+    #[dust_dds(id=PID_DURABILITY as u32, optional)]
     pub(crate) durability: DurabilityQosPolicy,
-    #[dust_dds(id=PID_DEADLINE as u32)]
+    #[dust_dds(id=PID_DEADLINE as u32, optional)]
     pub(crate) deadline: DeadlineQosPolicy,
-    #[dust_dds(id=PID_LATENCY_BUDGET as u32)]
+    #[dust_dds(id=PID_LATENCY_BUDGET as u32, optional)]
     pub(crate) latency_budget: LatencyBudgetQosPolicy,
-    #[dust_dds(id=PID_LIVELINESS as u32)]
+    #[dust_dds(id=PID_LIVELINESS as u32, optional)]
     pub(crate) liveliness: LivelinessQosPolicy,
-    #[dust_dds(id=PID_RELIABILITY as u32, default_value=DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS)]
+    #[dust_dds(id=PID_RELIABILITY as u32, optional, default_value=DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS)]
     pub(crate) reliability: ReliabilityQosPolicy,
-    #[dust_dds(id=PID_OWNERSHIP as u32)]
+    #[dust_dds(id=PID_OWNERSHIP as u32, optional)]
     pub(crate) ownership: OwnershipQosPolicy,
-    #[dust_dds(id=PID_DESTINATION_ORDER as u32)]
+    #[dust_dds(id=PID_DESTINATION_ORDER as u32, optional)]
     pub(crate) destination_order: DestinationOrderQosPolicy,
-    #[dust_dds(id=PID_USER_DATA as u32)]
+    #[dust_dds(id=PID_USER_DATA as u32, optional)]
     pub(crate) user_data: UserDataQosPolicy,
-    #[dust_dds(id=PID_TIME_BASED_FILTER as u32)]
+    #[dust_dds(id=PID_TIME_BASED_FILTER as u32, optional)]
     pub(crate) time_based_filter: TimeBasedFilterQosPolicy,
-    #[dust_dds(id=PID_PRESENTATION as u32)]
+    #[dust_dds(id=PID_PRESENTATION as u32, optional)]
     pub(crate) presentation: PresentationQosPolicy,
-    #[dust_dds(id=PID_PARTITION as u32)]
+    #[dust_dds(id=PID_PARTITION as u32, optional)]
     pub(crate) partition: PartitionQosPolicy,
-    #[dust_dds(id=PID_TOPIC_DATA as u32)]
+    #[dust_dds(id=PID_TOPIC_DATA as u32, optional)]
     pub(crate) topic_data: TopicDataQosPolicy,
-    #[dust_dds(id=PID_GROUP_DATA as u32)]
+    #[dust_dds(id=PID_GROUP_DATA as u32, optional)]
     pub(crate) group_data: GroupDataQosPolicy,
-    #[dust_dds(id=PID_DATA_REPRESENTATION as u32)]
+    #[dust_dds(id=PID_DATA_REPRESENTATION as u32, optional)]
     pub(crate) representation: DataRepresentationQosPolicy,
-    #[dust_dds(id=PID_TYPE_CONSISTENCY_ENFORCEMENT as u32)]
+    #[dust_dds(id=PID_TYPE_CONSISTENCY_ENFORCEMENT as u32, optional)]
     pub(crate) type_consistency: TypeConsistencyEnforcementQosPolicy,
 }
 
@@ -466,5 +466,10 @@ impl SubscriptionBuiltinTopicData {
     /// Get the data representation QoS policy of the discovered reader.
     pub fn representation(&self) -> &DataRepresentationQosPolicy {
         &self.representation
+    }
+
+    /// Get the type consistency enforcement QoS policy of the discovered reader
+    pub fn type_consistency(&self) -> &TypeConsistencyEnforcementQosPolicy {
+        &self.type_consistency
     }
 }

--- a/dds/src/dcps/builtin_topics.rs
+++ b/dds/src/dcps/builtin_topics.rs
@@ -11,12 +11,12 @@ use crate::{
         PID_ENDPOINT_GUID, PID_GROUP_DATA, PID_HISTORY, PID_LATENCY_BUDGET, PID_LIFESPAN,
         PID_LIVELINESS, PID_OWNERSHIP, PID_OWNERSHIP_STRENGTH, PID_PARTICIPANT_GUID, PID_PARTITION,
         PID_PRESENTATION, PID_RELIABILITY, PID_RESOURCE_LIMITS, PID_TIME_BASED_FILTER,
-        PID_TOPIC_DATA, PID_TOPIC_NAME, PID_TRANSPORT_PRIORITY, PID_TYPE_INFORMATION,
-        PID_TYPE_NAME, PID_USER_DATA,
+        PID_TOPIC_DATA, PID_TOPIC_NAME, PID_TRANSPORT_PRIORITY, PID_TYPE_CONSISTENCY_ENFORCEMENT,
+        PID_TYPE_INFORMATION, PID_TYPE_NAME, PID_USER_DATA,
     },
     infrastructure::qos_policy::{
         DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS,
-        DEFAULT_RELIABILITY_QOS_POLICY_DATA_WRITER,
+        DEFAULT_RELIABILITY_QOS_POLICY_DATA_WRITER, TypeConsistencyEnforcementQosPolicy,
     },
     xtypes::{
         type_object::TypeInformation,
@@ -373,6 +373,8 @@ pub struct SubscriptionBuiltinTopicData {
     pub(crate) group_data: GroupDataQosPolicy,
     #[dust_dds(id=PID_DATA_REPRESENTATION as u32)]
     pub(crate) representation: DataRepresentationQosPolicy,
+    #[dust_dds(id=PID_TYPE_CONSISTENCY_ENFORCEMENT as u32)]
+    pub(crate) type_consistency: TypeConsistencyEnforcementQosPolicy,
 }
 
 impl SubscriptionBuiltinTopicData {

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -16,8 +16,7 @@ use crate::{
         DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS, DataRepresentationQosPolicy,
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
         LatencyBudgetQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy, PartitionQosPolicy,
-        PresentationQosPolicy, TimeBasedFilterQosPolicy, TopicDataQosPolicy,
-        TypeConsistencyEnforcementQosPolicy, UserDataQosPolicy,
+        PresentationQosPolicy, TimeBasedFilterQosPolicy, TopicDataQosPolicy, UserDataQosPolicy,
     },
     transport::types::{ENTITYID_UNKNOWN, EntityId, Guid, Locator},
 };

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -16,7 +16,8 @@ use crate::{
         DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS, DataRepresentationQosPolicy,
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
         LatencyBudgetQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy, PartitionQosPolicy,
-        PresentationQosPolicy, TimeBasedFilterQosPolicy, TopicDataQosPolicy, UserDataQosPolicy,
+        PresentationQosPolicy, TimeBasedFilterQosPolicy, TopicDataQosPolicy,
+        TypeConsistencyEnforcementQosPolicy, UserDataQosPolicy,
     },
     transport::types::{ENTITYID_UNKNOWN, EntityId, Guid, Locator},
 };
@@ -110,10 +111,14 @@ impl DiscoveredReaderData {
             );
         }
 
-        pl.write_xcdr1_parameter(
-            PID_TYPE_CONSISTENCY_ENFORCEMENT,
-            self.dds_subscription_data.type_consistency,
-        );
+        if self.dds_subscription_data.type_consistency
+            != TypeConsistencyEnforcementQosPolicy::default()
+        {
+            pl.write_xcdr1_parameter(
+                PID_TYPE_CONSISTENCY_ENFORCEMENT,
+                self.dds_subscription_data.type_consistency,
+            );
+        }
 
         if self.reader_proxy.remote_group_entity_id != ENTITYID_UNKNOWN {
             pl.write_cdr_parameter(PID_GROUP_ENTITYID, self.reader_proxy.remote_group_entity_id);
@@ -263,9 +268,6 @@ mod tests {
             0x07, 0x00, 0x08, 0x00, // PID_TYPE_NAME, Length: 8
             3, 0x00, 0x00, 0x00, // string length (incl. terminator)
             b'c', b'd', 0, 0x00, // string + padding (1 byte)
-            0x74, 0x00, 0x08, 0x00, // PID_TYPE_CONSISTENCY, Length: 8
-            0x01, 0x00, 0x01, 0x01, // Type Consistency
-            0x00, 0x00, 0x00, 0x00, // Type Consistency
             0x53, 0x00, 4, 0, //PID_GROUP_ENTITYID
             21, 22, 23, 0xc2, //
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL, length
@@ -345,9 +347,6 @@ mod tests {
             b'o', b'n', b'e', 0, // String
             4, 0, 0, 0, // String length
             b't', b'w', b'o', 0, // String
-            0x74, 0x00, 0x08, 0x00, // PID_TYPE_CONSISTENCY, Length: 8
-            0x01, 0x00, 0x01, 0x01, // Type Consistency
-            0x00, 0x00, 0x00, 0x00, // Type Consistency
             0x53, 0x00, 4, 0, //PID_GROUP_ENTITYID
             21, 22, 23, 0xc2, //
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL, length

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -8,7 +8,7 @@ use super::parameter_id_values::{
 use crate::{
     builtin_topics::SubscriptionBuiltinTopicData,
     dcps::data_representation_builtin_endpoints::{
-        parameter_id_values::PID_TYPE_INFORMATION,
+        parameter_id_values::{PID_TYPE_CONSISTENCY_ENFORCEMENT, PID_TYPE_INFORMATION},
         rtps_data_representation::{CdrResult, ParameterList},
         rtps_data_representation_serialization::ParameterListSerializer,
     },
@@ -16,7 +16,8 @@ use crate::{
         DEFAULT_RELIABILITY_QOS_POLICY_DATA_READER_AND_TOPICS, DataRepresentationQosPolicy,
         DeadlineQosPolicy, DestinationOrderQosPolicy, DurabilityQosPolicy, GroupDataQosPolicy,
         LatencyBudgetQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy, PartitionQosPolicy,
-        PresentationQosPolicy, TimeBasedFilterQosPolicy, TopicDataQosPolicy, UserDataQosPolicy,
+        PresentationQosPolicy, TimeBasedFilterQosPolicy, TopicDataQosPolicy,
+        TypeConsistencyEnforcementQosPolicy, UserDataQosPolicy,
     },
     transport::types::{ENTITYID_UNKNOWN, EntityId, Guid, Locator},
 };
@@ -109,6 +110,14 @@ impl DiscoveredReaderData {
                 self.dds_subscription_data.representation,
             );
         }
+        if self.dds_subscription_data.type_consistency
+            != TypeConsistencyEnforcementQosPolicy::default()
+        {
+            pl.write_xcdr1_parameter(
+                PID_TYPE_CONSISTENCY_ENFORCEMENT,
+                self.dds_subscription_data.type_consistency,
+            );
+        }
 
         if self.reader_proxy.remote_group_entity_id != ENTITYID_UNKNOWN {
             pl.write_cdr_parameter(PID_GROUP_ENTITYID, self.reader_proxy.remote_group_entity_id);
@@ -160,6 +169,10 @@ impl DiscoveredReaderData {
             group_data: pl.get_optional_parameter_xdcr(PID_GROUP_DATA, Default::default())?,
             representation: pl
                 .get_optional_parameter_xdcr(PID_DATA_REPRESENTATION, Default::default())?,
+            type_consistency: pl.get_optional_parameter_xdcr(
+                PID_TYPE_CONSISTENCY_ENFORCEMENT,
+                Default::default(),
+            )?,
         };
 
         let reader_proxy = ReaderProxy {
@@ -221,6 +234,7 @@ mod tests {
                 topic_data: Default::default(),
                 group_data: Default::default(),
                 representation: Default::default(),
+                type_consistency: Default::default(),
             },
             reader_proxy: ReaderProxy {
                 remote_reader_guid: Guid::new(
@@ -293,6 +307,7 @@ mod tests {
                 topic_data: Default::default(),
                 group_data: Default::default(),
                 representation: Default::default(),
+                type_consistency: Default::default(),
             },
             reader_proxy: ReaderProxy {
                 remote_reader_guid: Guid::new(
@@ -379,6 +394,7 @@ mod tests {
                 topic_data: Default::default(),
                 group_data: Default::default(),
                 representation: Default::default(),
+                type_consistency: Default::default(),
             },
         };
 
@@ -449,6 +465,7 @@ mod tests {
                 topic_data: Default::default(),
                 group_data: Default::default(),
                 representation: Default::default(),
+                type_consistency: Default::default(),
             },
         };
 

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -110,14 +110,11 @@ impl DiscoveredReaderData {
                 self.dds_subscription_data.representation,
             );
         }
-        if self.dds_subscription_data.type_consistency
-            != TypeConsistencyEnforcementQosPolicy::default()
-        {
-            pl.write_xcdr1_parameter(
-                PID_TYPE_CONSISTENCY_ENFORCEMENT,
-                self.dds_subscription_data.type_consistency,
-            );
-        }
+
+        pl.write_xcdr1_parameter(
+            PID_TYPE_CONSISTENCY_ENFORCEMENT,
+            self.dds_subscription_data.type_consistency,
+        );
 
         if self.reader_proxy.remote_group_entity_id != ENTITYID_UNKNOWN {
             pl.write_cdr_parameter(PID_GROUP_ENTITYID, self.reader_proxy.remote_group_entity_id);

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -263,6 +263,9 @@ mod tests {
             0x07, 0x00, 0x08, 0x00, // PID_TYPE_NAME, Length: 8
             3, 0x00, 0x00, 0x00, // string length (incl. terminator)
             b'c', b'd', 0, 0x00, // string + padding (1 byte)
+            0x74, 0x00, 0x08, 0x00, // PID_TYPE_CONSISTENCY, Length: 8
+            0x01, 0x00, 0x01, 0x01, // Type Consistency
+            0x00, 0x00, 0x00, 0x00, // Type Consistency
             0x53, 0x00, 4, 0, //PID_GROUP_ENTITYID
             21, 22, 23, 0xc2, //
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL, length
@@ -342,6 +345,9 @@ mod tests {
             b'o', b'n', b'e', 0, // String
             4, 0, 0, 0, // String length
             b't', b'w', b'o', 0, // String
+            0x74, 0x00, 0x08, 0x00, // PID_TYPE_CONSISTENCY, Length: 8
+            0x01, 0x00, 0x01, 0x01, // Type Consistency
+            0x00, 0x00, 0x00, 0x00, // Type Consistency
             0x53, 0x00, 4, 0, //PID_GROUP_ENTITYID
             21, 22, 23, 0xc2, //
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL, length

--- a/dds/src/dcps/data_representation_builtin_endpoints/parameter_id_values.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/parameter_id_values.rs
@@ -60,6 +60,7 @@ pub const _PID_DATA_MAX_SIZE_SERIALIZED: ParameterId = _PID_TYPE_MAX_SIZE_SERIAL
 // also in "Table 9.14 - ParameterId mapping and default values"
 pub const PID_GROUP_ENTITYID: ParameterId = 0x0053;
 pub const PID_DATA_REPRESENTATION: ParameterId = 0x0073;
+pub const PID_TYPE_CONSISTENCY_ENFORCEMENT: ParameterId = 0x0074;
 
 #[allow(overflowing_literals)]
 pub const _PID_TYPE_REPRESENTATION: ParameterId = 0x8010;

--- a/dds/src/dcps/data_representation_builtin_endpoints/type_lookup.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/type_lookup.rs
@@ -1,14 +1,29 @@
 use dust_dds_derive::DdsType;
 
 use crate::{
-    transport::types::{Guid, SequenceNumber},
+    transport::types::Guid,
     xtypes::type_object::{
         TypeIdentifier, TypeIdentifierPair, TypeIdentifierTypeObjectPair, TypeIdentifierWithSize,
     },
 };
 use alloc::{string::String, vec::Vec};
 
-// // computed from @hashid("getTypes")
+#[derive(DdsType)]
+pub struct SequenceNumber {
+    pub high: i32,
+    pub low: u32,
+}
+
+impl From<i64> for SequenceNumber {
+    fn from(value: i64) -> Self {
+        Self {
+            high: ((value as u64 & 0xFFFFFFFF00000000u64) >> 32) as i32,
+            low: value as u32,
+        }
+    }
+}
+
+// computed from @hashid("getTypes")
 pub const TYPE_LOOKUP_GET_TYPES_HASH_ID: i32 = 0x018252d3;
 // computed from @hashid("getDependencies");
 pub const TYPE_LOOKUP_GET_DEPENDENCIES_HASH_ID: i32 = 0x05aafb31;
@@ -67,7 +82,7 @@ pub enum TypeLookupGetTypeDependenciesResult {
 
 // Service Request
 #[derive(DdsType)]
-#[dust_dds(switch(i32))]
+#[dust_dds(switch(i32), extensibility = "appendable")]
 pub enum TypeLookupCall {
     #[dust_dds(case=TYPE_LOOKUP_GET_TYPES_HASH_ID)]
     TypeLookupGetTypesHashId { get_types: TypeLookupGetTypesIn },
@@ -78,6 +93,7 @@ pub enum TypeLookupCall {
 }
 
 #[derive(DdsType)]
+#[dust_dds(extensibility = "final")]
 pub struct TypeLookupRequest {
     pub header: RequestHeader,
     pub call: TypeLookupCall,
@@ -96,6 +112,7 @@ pub enum TypeLookupReturn {
 }
 
 #[derive(DdsType)]
+#[dust_dds(extensibility = "final")]
 pub struct TypeLookupReply {
     pub header: RequestHeader,
     pub r#return: TypeLookupReturn,
@@ -103,17 +120,20 @@ pub struct TypeLookupReply {
 
 // DDS RPC Types
 #[derive(DdsType)]
+#[dust_dds(extensibility = "final")]
 pub struct RequestHeader {
     pub request_id: SampleIdentity,
     pub instance_name: InstanceName,
 }
 
 #[derive(DdsType)]
+#[dust_dds(extensibility = "final")]
 pub struct ReplyHeader {
     pub related_request_id: SampleIdentity,
 }
 
 #[derive(DdsType)]
+#[dust_dds(extensibility = "final")]
 pub struct SampleIdentity {
     pub writer_guid: Guid,
     pub sequence_number: SequenceNumber,

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -57,7 +57,7 @@ use crate::{
     xtypes::{
         deserializer::deserialize_top_level_type,
         dynamic_type::DynamicDataFactory,
-        serializer::serialize_cdr1_le,
+        serializer::serialize_cdr2_le,
         type_object::TypeIdentifier,
         type_support::{_String, Type, TypeSupport},
     },
@@ -2701,9 +2701,9 @@ impl DcpsDomainParticipant {
                 header: RequestHeader {
                     request_id: SampleIdentity {
                         writer_guid: w.transport_writer.guid(),
-                        sequence_number: w.last_change_sequence_number + 1,
+                        sequence_number: (w.last_change_sequence_number + 1).into(),
                     },
-                    instance_name: String::new(),
+                    instance_name: String::from(""),
                 },
                 call: TypeLookupCall::TypeLookupGetTypesHashId {
                     get_types: TypeLookupGetTypesIn { type_ids },
@@ -2713,7 +2713,7 @@ impl DcpsDomainParticipant {
 
             let timestamp = runtime.clock().now();
             let sample_instance_handle = self.domain_participant.instance_handle;
-            let serialized_data = serialize_cdr1_le(&dynamic_data).unwrap();
+            let serialized_data = serialize_cdr2_le(&dynamic_data).unwrap();
             let sample_timestamp = timestamp;
             let now = timestamp;
             w.write_w_timestamp(

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -1706,6 +1706,19 @@ impl DcpsDomainParticipant {
                         self.domain_participant.add_discovered_topic(reader_topic);
                     }
 
+                    if let Some(t) = &discovered_reader_data
+                        .dds_subscription_data
+                        .type_information
+                    {
+                        let type_identifiers = t
+                            .complete
+                            .dependent_typeids
+                            .iter()
+                            .map(|x| x.type_id.clone())
+                            .collect();
+                        self._request_type_lookup(type_identifiers, runtime);
+                    }
+
                     self.domain_participant
                         .add_discovered_reader(discovered_reader_data.clone());
                     let mut handle_list = Vec::new();

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -1520,10 +1520,6 @@ impl DcpsDomainParticipant {
                         };
                         self.domain_participant.add_discovered_topic(writer_topic);
                     }
-                    if let Some(t) = &discovered_writer_data.dds_publication_data.type_information {
-                        let type_identifiers = vec![t.complete.typeid_with_size.type_id.clone()];
-                        self._request_type_lookup(type_identifiers, runtime);
-                    }
 
                     self.domain_participant
                         .add_discovered_writer(discovered_writer_data.clone());
@@ -1700,14 +1696,6 @@ impl DcpsDomainParticipant {
                                 .clone(),
                         };
                         self.domain_participant.add_discovered_topic(reader_topic);
-                    }
-
-                    if let Some(t) = &discovered_reader_data
-                        .dds_subscription_data
-                        .type_information
-                    {
-                        let type_identifiers = vec![t.complete.typeid_with_size.type_id.clone()];
-                        self._request_type_lookup(type_identifiers, runtime);
                     }
 
                     self.domain_participant

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -2703,7 +2703,7 @@ impl DcpsDomainParticipant {
                         writer_guid: w.transport_writer.guid(),
                         sequence_number: w.last_change_sequence_number + 1,
                     },
-                    instance_name: String::from("Some name"),
+                    instance_name: String::new(),
                 },
                 call: TypeLookupCall::TypeLookupGetTypesHashId {
                     get_types: TypeLookupGetTypesIn { type_ids },

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -1521,12 +1521,7 @@ impl DcpsDomainParticipant {
                         self.domain_participant.add_discovered_topic(writer_topic);
                     }
                     if let Some(t) = &discovered_writer_data.dds_publication_data.type_information {
-                        let type_identifiers = t
-                            .complete
-                            .dependent_typeids
-                            .iter()
-                            .map(|x| x.type_id.clone())
-                            .collect();
+                        let type_identifiers = vec![t.complete.typeid_with_size.type_id.clone()];
                         self._request_type_lookup(type_identifiers, runtime);
                     }
 
@@ -1711,12 +1706,7 @@ impl DcpsDomainParticipant {
                         .dds_subscription_data
                         .type_information
                     {
-                        let type_identifiers = t
-                            .complete
-                            .dependent_typeids
-                            .iter()
-                            .map(|x| x.type_id.clone())
-                            .collect();
+                        let type_identifiers = vec![t.complete.typeid_with_size.type_id.clone()];
                         self._request_type_lookup(type_identifiers, runtime);
                     }
 

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -385,6 +385,7 @@ impl DcpsDomainParticipant {
             topic_data: topic.qos.topic_data.clone(),
             group_data: subscriber.qos.group_data.clone(),
             representation: data_reader.qos.representation.clone(),
+            type_consistency: data_reader.qos.type_consistency.clone(),
         };
         let reader_proxy = ReaderProxy {
             remote_reader_guid: data_reader.transport_reader.guid(),

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -58,6 +58,7 @@ use crate::{
         deserializer::deserialize_top_level_type,
         dynamic_type::DynamicDataFactory,
         serializer::serialize_cdr1_le,
+        type_object::TypeIdentifier,
         type_support::{_String, Type, TypeSupport},
     },
 };
@@ -1518,6 +1519,15 @@ impl DcpsDomainParticipant {
                         };
                         self.domain_participant.add_discovered_topic(writer_topic);
                     }
+                    if let Some(t) = &discovered_writer_data.dds_publication_data.type_information {
+                        let type_identifiers = t
+                            .complete
+                            .dependent_typeids
+                            .iter()
+                            .map(|x| x.type_id.clone())
+                            .collect();
+                        self._request_type_lookup(type_identifiers, runtime);
+                    }
 
                     self.domain_participant
                         .add_discovered_writer(discovered_writer_data.clone());
@@ -2660,7 +2670,11 @@ impl DcpsDomainParticipant {
     }
 
     #[tracing::instrument(skip(self, runtime))]
-    pub fn _request_type_lookup(&mut self, runtime: &impl DdsRuntime) {
+    pub fn _request_type_lookup(
+        &mut self,
+        type_ids: Vec<TypeIdentifier>,
+        runtime: &impl DdsRuntime,
+    ) {
         if let Some(w) = self
             .domain_participant
             .builtin_publisher
@@ -2678,9 +2692,7 @@ impl DcpsDomainParticipant {
                     instance_name: String::from("Some name"),
                 },
                 call: TypeLookupCall::TypeLookupGetTypesHashId {
-                    get_types: TypeLookupGetTypesIn {
-                        type_ids: Vec::new(),
-                    },
+                    get_types: TypeLookupGetTypesIn { type_ids },
                 },
             };
             type_lookup_request.create_dynamic_sample(&mut dynamic_data);

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -47,8 +47,9 @@ use crate::{
             LifespanQosPolicy, LivelinessQosPolicy, OwnershipQosPolicy, OwnershipQosPolicyKind,
             OwnershipStrengthQosPolicy, QosPolicyId, ReaderDataLifecycleQosPolicy,
             ReliabilityQosPolicy, ReliabilityQosPolicyKind, ResourceLimitsQosPolicy,
-            TimeBasedFilterQosPolicy, TransportPriorityQosPolicy, UserDataQosPolicy,
-            WriterDataLifecycleQosPolicy, XCDR_DATA_REPRESENTATION, XCDR2_DATA_REPRESENTATION,
+            TimeBasedFilterQosPolicy, TransportPriorityQosPolicy,
+            TypeConsistencyEnforcementQosPolicy, UserDataQosPolicy, WriterDataLifecycleQosPolicy,
+            XCDR_DATA_REPRESENTATION, XCDR2_DATA_REPRESENTATION,
         },
         sample_info::{InstanceStateKind, SampleInfo, SampleStateKind, ViewStateKind},
         status::{
@@ -163,6 +164,7 @@ const SPDP_READER_QOS: DataReaderQos = DataReaderQos {
     time_based_filter: TimeBasedFilterQosPolicy::const_default(),
     reader_data_lifecycle: ReaderDataLifecycleQosPolicy::const_default(),
     representation: DataRepresentationQosPolicy::const_default(),
+    type_consistency: TypeConsistencyEnforcementQosPolicy::const_default(),
 };
 
 const SEDP_DATA_READER_QOS: DataReaderQos = DataReaderQos {
@@ -186,6 +188,7 @@ const SEDP_DATA_READER_QOS: DataReaderQos = DataReaderQos {
     time_based_filter: TimeBasedFilterQosPolicy::const_default(),
     reader_data_lifecycle: ReaderDataLifecycleQosPolicy::const_default(),
     representation: DataRepresentationQosPolicy::const_default(),
+    type_consistency: TypeConsistencyEnforcementQosPolicy::const_default(),
 };
 
 fn spdp_writer_qos() -> DataWriterQos {
@@ -244,6 +247,7 @@ const TYPE_LOOKUP_READER_QOS: DataReaderQos = DataReaderQos {
     time_based_filter: TimeBasedFilterQosPolicy::const_default(),
     reader_data_lifecycle: ReaderDataLifecycleQosPolicy::const_default(),
     representation: DataRepresentationQosPolicy::const_default(),
+    type_consistency: TypeConsistencyEnforcementQosPolicy::const_default(),
 };
 
 const TYPE_LOOKUP_WRITER_QOS: DataWriterQos = DataWriterQos {

--- a/dds/src/dcps/infrastructure/qos.rs
+++ b/dds/src/dcps/infrastructure/qos.rs
@@ -1,6 +1,6 @@
 use crate::{
     dcps::infrastructure::error::{DdsError, DdsResult},
-    infrastructure::time::Duration,
+    infrastructure::{qos_policy::TypeConsistencyEnforcementQosPolicy, time::Duration},
 };
 
 use super::{
@@ -249,6 +249,8 @@ pub struct DataReaderQos {
     pub reader_data_lifecycle: ReaderDataLifecycleQosPolicy,
     /// Value of the data representation QoS policy.
     pub representation: DataRepresentationQosPolicy,
+    /// Value of the type consistency enforcement QoS policy,
+    pub type_consistency: TypeConsistencyEnforcementQosPolicy,
 }
 
 impl DataReaderQos {
@@ -273,6 +275,7 @@ impl DataReaderQos {
             time_based_filter: TimeBasedFilterQosPolicy::const_default(),
             reader_data_lifecycle: ReaderDataLifecycleQosPolicy::const_default(),
             representation: DataRepresentationQosPolicy::const_default(),
+            type_consistency: TypeConsistencyEnforcementQosPolicy::const_default(),
         }
     }
 }

--- a/dds/src/dcps/infrastructure/qos_policy.rs
+++ b/dds/src/dcps/infrastructure/qos_policy.rs
@@ -141,6 +141,7 @@ const TRANSPORTPRIORITY_QOS_POLICY_NAME: &str = "TransportPriority";
 const GROUPDATA_QOS_POLICY_NAME: &str = "GroupData";
 const LIFESPAN_QOS_POLICY_NAME: &str = "Lifespan";
 const DATA_REPRESENTATION_QOS_POLICY_NAME: &str = "DataRepresentation";
+const TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_NAME: &str = "TypeConsistencyEnforcement";
 
 /// QosPolicy Id representing an invalid QoS policy
 pub const INVALID_QOS_POLICY_ID: QosPolicyId = 0;
@@ -190,6 +191,8 @@ pub const LIFESPAN_QOS_POLICY_ID: QosPolicyId = 21;
 pub const DURABILITYSERVICE_QOS_POLICY_ID: QosPolicyId = 22;
 /// Id for the DataRepresentationQosPolicy
 pub const DATA_REPRESENTATION_QOS_POLICY_ID: QosPolicyId = 23;
+/// Id for the TypeConsistencyEnforcementQosPolicy
+pub const TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_ID: QosPolicyId = 24;
 
 /// This policy allows the application to attach additional information to the created Entity objects such that when
 /// a remote application discovers their existence it can access that information and use it for its own purposes.
@@ -1523,6 +1526,49 @@ impl QosPolicy for DataRepresentationQosPolicy {
 }
 
 impl Default for DataRepresentationQosPolicy {
+    fn default() -> Self {
+        Self::const_default()
+    }
+}
+
+/// Enumeration representing the different types of Type Consistency QoS policies.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, TypeSupport)]
+#[dust_dds(bit_bound = "16")]
+pub enum TypeConsistencyKind {
+    DisallowTypeCoercion,
+    AllowTypeCoercion,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, TypeSupport)]
+#[dust_dds(extensibility = "appendable", nested)]
+pub struct TypeConsistencyEnforcementQosPolicy {
+    pub kind: TypeConsistencyKind,
+    pub ignore_sequence_bounds: bool,
+    pub ignore_string_bounds: bool,
+    pub ignore_member_names: bool,
+    pub prevent_type_widening: bool,
+    pub force_type_validation: bool,
+}
+
+impl TypeConsistencyEnforcementQosPolicy {
+    pub const fn const_default() -> Self {
+        Self {
+            kind: TypeConsistencyKind::AllowTypeCoercion,
+            ignore_sequence_bounds: true,
+            ignore_string_bounds: true,
+            ignore_member_names: false,
+            prevent_type_widening: false,
+            force_type_validation: false,
+        }
+    }
+}
+
+impl QosPolicy for TypeConsistencyEnforcementQosPolicy {
+    fn name(&self) -> &str {
+        TYPE_CONSISTENCY_ENFORCEMENT_QOS_POLICY_NAME
+    }
+}
+impl Default for TypeConsistencyEnforcementQosPolicy {
     fn default() -> Self {
         Self::const_default()
     }

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -717,6 +717,10 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
                 let value = self.deserialize_primitive_type::<i8>()?;
                 dynamic_data.set_int8_value(0, value)
             }
+            TypeKind::INT16 => {
+                let value = self.deserialize_primitive_type::<i16>()?;
+                dynamic_data.set_int16_value(0, value)
+            }
             TypeKind::INT32 => {
                 let value = self.deserialize_primitive_type::<i32>()?;
                 dynamic_data.set_int32_value(0, value)

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -543,7 +543,13 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
                 }
                 dynamic_data.set_complex_values(member.get_id(), values)
             }
-            TypeKind::UNION => todo!(),
+            TypeKind::UNION => {
+                let mut values = Vec::with_capacity(length);
+                for _ in 0..length {
+                    values.push(self.deserialize_as_nested(element_type)?);
+                }
+                dynamic_data.set_complex_values(member.get_id(), values)
+            }
             TypeKind::BITSET => todo!(),
             TypeKind::SEQUENCE => todo!(),
             TypeKind::ARRAY => todo!(),
@@ -579,9 +585,12 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
 
                 TypeKind::UNION => match dynamic_type.get_descriptor().extensibility_kind {
                     ExtensibilityKind::Final => {
-                        deserializer._deserialize_funion_type(dynamic_type, dynamic_data)
+                        deserializer.deserialize_funion_type(dynamic_type, dynamic_data)
                     }
-                    ExtensibilityKind::Appendable => todo!(),
+                    ExtensibilityKind::Appendable => {
+                        let _dheader = deserializer.deserialize_primitive_type::<u32>()?;
+                        deserializer.deserialize_funion_type(dynamic_type, dynamic_data)
+                    }
                     ExtensibilityKind::Mutable => todo!(),
                 },
                 kind => {
@@ -792,7 +801,7 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     }
 
     /// Serialization Rule (26)
-    fn _deserialize_funion_type(
+    fn deserialize_funion_type(
         &mut self,
         dynamic_type: DynamicType,
         dynamic_data: &mut DynamicData<'_>,
@@ -979,8 +988,21 @@ impl<'a> Reader<'a> {
 mod tests {
     use super::*;
     use crate::{
-        dcps::xtypes_glue::key_and_instance_handle::get_instance_handle_from_dynamic_data,
-        xtypes::type_support::{Type, TypeSupport},
+        dcps::{
+            data_representation_builtin_endpoints::type_lookup::{
+                RequestHeader, SampleIdentity, TypeLookupCall, TypeLookupGetTypesIn,
+                TypeLookupRequest,
+            },
+            xtypes_glue::key_and_instance_handle::get_instance_handle_from_dynamic_data,
+        },
+        transport::types::{EntityId, Guid},
+        xtypes::{
+            type_object::{
+                TypeIdentifier, TypeIdentifierWithDependencies, TypeIdentifierWithSize,
+                TypeInformation,
+            },
+            type_support::{Type, TypeSupport},
+        },
     };
 
     #[test]
@@ -1568,6 +1590,148 @@ mod tests {
                     0, 0, 0, 30, // shapesize
                     0, 0, 0, 0, // additional_payload_size: length
                 ],
+            )
+            .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_type_lookup_get_types_in() {
+        let mut expected = DynamicDataFactory::create_data(TypeLookupCall::TYPE);
+        TypeLookupCall::TypeLookupGetTypesHashId {
+            get_types: TypeLookupGetTypesIn {
+                type_ids: vec![TypeIdentifier::EkComplete {
+                    equivalence_hash: [5; 14],
+                }],
+            },
+        }
+        .create_dynamic_sample(&mut expected);
+
+        assert_eq!(
+            deserialize_top_level_type(
+                TypeLookupCall::TYPE,
+                &[
+                    0x00u8, 0x09, 0x00, 0x01, // D_CDR2_LE + padding
+                    35, 0, 0, 0, // TypeLookupCall DHEADER
+                    0xd3, 0x52, 0x82, 0x01, // TypeLookupGetTypesHashId DISCRIMINATOR
+                    27, 0, 0, 0, // type_ids: DHEADER
+                    101, 96, 83, 92, // type_ids EMHEADER
+                    // 23, 0, 0, 0, // type_ids NEXTINT
+                    19, 0, 0, 0, // type_ids: DHEADER
+                    1, 0, 0, 0,   // type_ids: Length
+                    242, //EK_COMPLETE
+                    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // equivalence_hash
+                    0, // padding
+                ]
+            )
+            .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_type_lookup_request() {
+        let mut expected = DynamicDataFactory::create_data(TypeLookupRequest::TYPE);
+        TypeLookupRequest {
+            header: RequestHeader {
+                request_id: SampleIdentity {
+                    writer_guid: Guid::new([1; 12], EntityId::new([1; 3], 1)),
+                    sequence_number: 5.into(),
+                },
+                instance_name: String::from(""),
+            },
+            call: TypeLookupCall::TypeLookupGetTypesHashId {
+                get_types: TypeLookupGetTypesIn { type_ids: vec![] },
+            },
+        }
+        .create_dynamic_sample(&mut expected);
+
+        assert_eq!(
+            deserialize_top_level_type(
+                TypeLookupRequest::TYPE,
+                &[
+                    0x00u8, 0x07, 0x00, 0x00, // CDR2_LE + padding
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // writer_guid
+                    0, 0, 0, 0, // sequence_number: high
+                    5, 0, 0, 0, // sequence_number: low
+                    1, 0, 0, 0, // instance_name: length
+                    0, // instance_name: length
+                    0, 0, 0, // Padding
+                    20, 0, 0, 0, //TypeLookupCall DHEADER
+                    211, 82, 130, 1, // TypeLookupGetTypesHashId Discriminator
+                    12, 0, 0, 0, // type_ids: DHEADER
+                    101, 96, 83, 92, // type_ids EMHEADER
+                    // 19, 0, 0, 0, // type_ids NEXTINT (skipped, replaced by DHEADER)
+                    4, 0, 0, 0, // type_ids: DHEADER
+                    0, 0, 0,
+                    0, // type_ids: Length
+                       // 242, //EK_COMPLETE
+                       // 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // equivalence_hash
+                       // 0, // padding
+                ]
+            )
+            .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_type_identifier() {
+        let mut expected = DynamicDataFactory::create_data(TypeInformation::TYPE);
+        TypeInformation {
+            minimal: TypeIdentifierWithDependencies {
+                typeid_with_size: TypeIdentifierWithSize {
+                    type_id: TypeIdentifier::EkMinimal {
+                        equivalence_hash: [5; 14],
+                    },
+                    typeobject_serialized_size: 10,
+                },
+                dependent_typeid_count: 0,
+                dependent_typeids: Vec::new(),
+            },
+            complete: TypeIdentifierWithDependencies {
+                typeid_with_size: TypeIdentifierWithSize {
+                    type_id: TypeIdentifier::EkComplete {
+                        equivalence_hash: [5; 14],
+                    },
+                    typeobject_serialized_size: 10,
+                },
+                dependent_typeid_count: 0,
+                dependent_typeids: Vec::new(),
+            },
+        }
+        .create_dynamic_sample(&mut expected);
+
+        assert_eq!(
+            deserialize_top_level_type(
+                TypeInformation::TYPE,
+                &[
+                    0x00u8, 0x0B, 0x00, 0x00, // PL_CDR2_LE + 0 padding
+                    88, 0, 0, 0, // DHEADER
+                    0x01, 0x10, 0, 80, // EMHEADER
+                    // 40, 0, 0, 0, // NEXTINT (Reused in the EMHEADER)
+                    36, 0, 0, 0, // DHEADER
+                    20, 0, 0, 0,   // DHEADER
+                    241, //EK_MINIMAL
+                    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // equivalence_hash
+                    0, // padding
+                    10, 0, 0, 0, // typeobject_serialized_size
+                    0, 0, 0, 0, // dependent_typeid_count
+                    4, 0, 0, 0, // Sequence DHEADER
+                    0, 0, 0, 0, // Sequence length
+                    0x02, 0x10, 0, 80, // EMHEADER
+                    // 40, 0, 0, 0, // NEXTINT (Reused in the EMHEADER)
+                    36, 0, 0, 0, // DHEADER
+                    20, 0, 0, 0,   // DHEADER
+                    242, //EK_COMPLETE
+                    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // equivalence_hash
+                    0, // padding
+                    10, 0, 0, 0, // typeobject_serialized_size
+                    0, 0, 0, 0, // dependent_typeid_count
+                    4, 0, 0, 0, // Sequence DHEADER
+                    0, 0, 0, 0, // Sequence length
+                ]
             )
             .unwrap(),
             expected

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -320,23 +320,24 @@ impl<'a, E: EndiannessWrite, V: EncodingVersion> XTypesSerializer<'a, E, V> {
     ///           XCDR
     ///           << { O.member[i] : FMEMBER }*
     fn serialize_fstruct_type(&mut self, v: &DynamicData) -> Result<(), XTypesError> {
-        let dynamic_type = v.r#type();
-        for field_index in 0..dynamic_type.get_member_count() {
-            let member_id = dynamic_type.get_member_by_index(field_index)?.get_id();
-            if let Some(base_type) = dynamic_type.descriptor.base_type {
-                let member_descriptor = &base_type.get_member(member_id)?.descriptor;
+        for field_index in 0..v.get_item_count() {
+            let dynamic_type = v.r#type();
+            if let Ok(member_id) = v.get_member_id_at_index(field_index) {
+                if let Some(base_type) = dynamic_type.descriptor.base_type {
+                    let member_descriptor = &base_type.get_member(member_id)?.descriptor;
 
-                if member_descriptor.is_optional {
-                    V::serialize_opt_fmember(self, v, member_id)?;
-                } else {
-                    self.serialize_nopt_fmember(v, member_id)?;
+                    if member_descriptor.is_optional {
+                        V::serialize_opt_fmember(self, v, member_id)?;
+                    } else {
+                        self.serialize_nopt_fmember(v, member_id)?;
+                    }
                 }
-            }
-            if let Ok(member) = &dynamic_type.get_member(member_id) {
-                if member.descriptor.is_optional {
-                    V::serialize_opt_fmember(self, v, member_id)?;
-                } else {
-                    self.serialize_nopt_fmember(v, member_id)?;
+                if let Ok(member) = &dynamic_type.get_member(member_id) {
+                    if member.descriptor.is_optional {
+                        V::serialize_opt_fmember(self, v, member_id)?;
+                    } else {
+                        self.serialize_nopt_fmember(v, member_id)?;
+                    }
                 }
             }
         }

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -1851,7 +1851,7 @@ mod tests {
                 0, 0, 0, 13, // DHEADER (length)
                 0b001_0000, 0, 0x80, 0x81, // EMHEADER1 incl. LC 0b001 (2 bytes)
                 0x08, 0x09, 0, 0, // two_bytes | padding (2 bytes)
-                0, 0, 0x90, 0x91, // EMHEADER1 incl. LC 0b000 (1 bytes)
+                128, 0, 0x90, 0x91, // EMHEADER1 incl. LC 0b000 (1 bytes)
                 7, 0, 0, 0 // one_byte | padding 3 bytes
             ]
         );
@@ -1862,7 +1862,7 @@ mod tests {
                 13, 0, 0, 0, // DHEADER (length)
                 0x81, 0x80, 0, 0b001_0000, // EMHEADER1 incl. LC 0b001 (2 bytes)
                 0x09, 0x08, 0, 0, // two_bytes | padding (2 bytes)
-                0x91, 0x90, 0, 0, // EMHEADER1 incl. LC 0b000 (1 bytes)
+                0x91, 0x90, 0, 128, // EMHEADER1 incl. LC 0b000 (1 bytes)
                 7, 0, 0, 0 // one_byte | padding 3 bytes
             ]
         );

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -380,8 +380,8 @@ impl<'a, E: EndiannessWrite, V: EncodingVersion> XTypesSerializer<'a, E, V> {
             TypeKind::ENUM => self.serialize_enum_type(v.get_complex_value(member_id)?)?,
             TypeKind::BITMASK => todo!(),
             TypeKind::ANNOTATION => todo!(),
-            TypeKind::STRUCTURE => self.serialize_fstruct_type(v.get_complex_value(member_id)?)?,
-            TypeKind::UNION => self.serialize_funion_type(v.get_complex_value(member_id)?)?,
+            TypeKind::STRUCTURE => self.serialize_t_as_nested(v.get_complex_value(member_id)?)?,
+            TypeKind::UNION => self.serialize_t_as_nested(v.get_complex_value(member_id)?)?,
             TypeKind::BITSET => todo!(),
             TypeKind::SEQUENCE => V::serialize_sequence_type(self, v, member_id)?,
             TypeKind::ARRAY => V::serialize_array_type(self, v, member_id)?,
@@ -474,16 +474,28 @@ impl<'a, 'b, E: EndiannessWrite, V: EncodingVersion> EMheader1<'a, 'b, E, V> {
             initial_pos,
         }
     }
-    fn write_header(self, member_id: u32) {
+    fn write_header(self, member_id: u32, v: &DynamicData) -> XTypesResult<()> {
         let ssize = (self.serializer.writer.buffer.len() - self.initial_pos) as u32;
-
-        let m_flag = 0;
-        let lc = match ssize {
-            1 => 0,
-            2 => 1,
-            4 => 2,
-            8 => 3,
-            _ => 4,
+        let member_descriptor = v.get_descriptor(member_id)?;
+        let m_flag = member_descriptor.is_must_understand as u32;
+        let is_next_member_having_dheader = (matches!(
+            member_descriptor.r#type.get_kind(),
+            TypeKind::STRUCTURE | TypeKind::UNION
+        ) && matches!(
+            member_descriptor.r#type.descriptor.extensibility_kind,
+            ExtensibilityKind::Appendable | ExtensibilityKind::Mutable
+        )) || member_descriptor.r#type.get_kind()
+            == TypeKind::SEQUENCE;
+        let lc = if is_next_member_having_dheader {
+            5
+        } else {
+            match ssize {
+                1 => 0,
+                2 => 1,
+                4 => 2,
+                8 => 3,
+                _ => 4,
+            }
         } as u32;
 
         let emheader = (m_flag << 31) + (lc << 28) + (member_id & 0x0fffffff);
@@ -499,6 +511,8 @@ impl<'a, 'b, E: EndiannessWrite, V: EncodingVersion> EMheader1<'a, 'b, E, V> {
                 .splice(self.initial_pos..self.initial_pos, E::to_bytes_u32(ssize));
             self.serializer.writer.position += 4;
         }
+
+        Ok(())
     }
 }
 
@@ -1123,7 +1137,7 @@ impl EncodingVersion for EncodingVersion2 {
     ) -> Result<(), XTypesError> {
         let emheader = EMheader1::new(serializer);
         emheader.serializer.serialize_value(v, member_id).unwrap();
-        emheader.write_header(member_id);
+        emheader.write_header(member_id, v)?;
         Ok(())
     }
 
@@ -1395,7 +1409,10 @@ mod tests {
         transport::types::{EntityId, Guid},
         xtypes::{
             dynamic_type::DynamicDataFactory,
-            type_object::TypeIdentifier,
+            type_object::{
+                TypeIdentifier, TypeIdentifierWithDependencies, TypeIdentifierWithSize,
+                TypeInformation,
+            },
             type_support::{Type, TypeSupport},
         },
     };
@@ -2216,9 +2233,8 @@ mod tests {
             serialize_cdr2_le(&data).unwrap(),
             vec![
                 0x00, 0x0b, 0x00, 0x00, // PL_CDR2_LE
-                28, 0, 0, 0, // Struct DHEADER
-                0, 0, 0, 64, // my_sequence EMHEADER
-                20, 0, 0, 0, // my_sequence: NEXTINT
+                24, 0, 0, 0, // Struct DHEADER
+                0, 0, 0, 80, // my_sequence EMHEADER
                 16, 0, 0, 0, // Vec DHEADER
                 3, 0, 0, 0, // Vec length
                 1, 0, 0, 0, // Vec[0]
@@ -2256,15 +2272,45 @@ mod tests {
             serialize_cdr2_le(&data).unwrap(),
             vec![
                 0x00, 0x09, 0x00, 0x00, // D_CDR2_LE
-                36, 0, 0, 0, //AppendableUnion DHEADER
+                32, 0, 0, 0, //AppendableUnion DHEADER
                 10, 0, 0, 0, // MyVariant discriminator
-                0, 0, 0, 64, // my_sequence EMHEADER
-                20, 0, 0, 0, // my_sequence: NEXTINT
+                24, 0, 0, 0, // MutableTypeWithSequence DHEADER
+                0, 0, 0, 80, // my_sequence EMHEADER
                 16, 0, 0, 0, // Vec DHEADER
                 3, 0, 0, 0, // Vec length
                 1, 0, 0, 0, // Vec[0]
                 2, 0, 0, 0, // Vec[1]
                 3, 0, 0, 0, // Vec[2]
+            ]
+        );
+    }
+
+    #[test]
+    fn serialize_type_lookup_get_types_in() {
+        let mut data = DynamicDataFactory::create_data(TypeLookupCall::TYPE);
+        TypeLookupCall::TypeLookupGetTypesHashId {
+            get_types: TypeLookupGetTypesIn {
+                type_ids: vec![TypeIdentifier::EkComplete {
+                    equivalence_hash: [5; 14],
+                }],
+            },
+        }
+        .create_dynamic_sample(&mut data);
+
+        assert_eq!(
+            serialize_cdr2_le(&data).unwrap(),
+            vec![
+                0x00u8, 0x09, 0x00, 0x01, // D_CDR2_LE + padding
+                35, 0, 0, 0, // TypeLookupCall DHEADER
+                0xd3, 0x52, 0x82, 0x01, // TypeLookupGetTypesHashId DISCRIMINATOR
+                27, 0, 0, 0, // type_ids: DHEADER
+                101, 96, 83, 92, // type_ids EMHEADER
+                // 23, 0, 0, 0, // type_ids NEXTINT
+                19, 0, 0, 0, // type_ids: DHEADER
+                1, 0, 0, 0,   // type_ids: Length
+                242, //EK_COMPLETE
+                5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // equivalence_hash
+                0, // padding
             ]
         );
     }
@@ -2278,13 +2324,14 @@ mod tests {
                     writer_guid: Guid::new([1; 12], EntityId::new([1; 3], 1)),
                     sequence_number: 5.into(),
                 },
-                instance_name: String::from("abc"),
+                instance_name: String::from(""),
             },
             call: TypeLookupCall::TypeLookupGetTypesHashId {
                 get_types: TypeLookupGetTypesIn {
-                    type_ids: vec![TypeIdentifier::EkComplete {
-                        equivalence_hash: [5; 14],
-                    }],
+                    type_ids: vec![],
+                    //TypeIdentifier::EkComplete {
+                    // equivalence_hash: [5; 14],
+                    // }
                 },
             },
         }
@@ -2293,27 +2340,84 @@ mod tests {
         assert_eq!(
             serialize_cdr2_le(&data).unwrap(),
             vec![
-                0x00u8, 0x07, 0x00, 0x01, // CDR2_LE + padding
+                0x00u8, 0x07, 0x00, 0x00, // CDR2_LE + padding
                 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // writer_guid
                 0, 0, 0, 0, // sequence_number: high
                 5, 0, 0, 0, // sequence_number: low
-                4, 0, 0, 0, // instance_name: length
-                b'a', b'b', b'c', 0, // instance_name: length
-                39, 0, 0, 0, //TypeLookupCall DHEADER
+                1, 0, 0, 0, // instance_name: length
+                0, // instance_name: length
+                0, 0, 0, // Padding
+                20, 0, 0, 0, //TypeLookupCall DHEADER
                 211, 82, 130, 1, // TypeLookupGetTypesHashId Discriminator
-                101, 96, 83, 76, // type_ids EMHEADER
-                23, 0, 0, 0, // type_ids NEXTINT
-                19, 0, 0, 0, // type_ids: DHEADER
-                1, 0, 0, 0,   // type_ids: Length
+                12, 0, 0, 0, // type_ids: DHEADER
+                101, 96, 83, 92, // type_ids EMHEADER
+                // 19, 0, 0, 0, // type_ids NEXTINT (skipped, replaced by DHEADER)
+                4, 0, 0, 0, // type_ids: DHEADER
+                0, 0, 0,
+                0, // type_ids: Length
+                   // 242, //EK_COMPLETE
+                   // 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // equivalence_hash
+                   // 0, // padding
+            ]
+        );
+    }
+
+    #[test]
+    fn serialize_type_identifier() {
+        let mut data = DynamicDataFactory::create_data(TypeInformation::TYPE);
+        TypeInformation {
+            minimal: TypeIdentifierWithDependencies {
+                typeid_with_size: TypeIdentifierWithSize {
+                    type_id: TypeIdentifier::EkMinimal {
+                        equivalence_hash: [5; 14],
+                    },
+                    typeobject_serialized_size: 10,
+                },
+                dependent_typeid_count: 0,
+                dependent_typeids: Vec::new(),
+            },
+            complete: TypeIdentifierWithDependencies {
+                typeid_with_size: TypeIdentifierWithSize {
+                    type_id: TypeIdentifier::EkComplete {
+                        equivalence_hash: [5; 14],
+                    },
+                    typeobject_serialized_size: 10,
+                },
+                dependent_typeid_count: 0,
+                dependent_typeids: Vec::new(),
+            },
+        }
+        .create_dynamic_sample(&mut data);
+
+        let buffer = serialize_without_header_cdr2_le(Vec::new(), &data).unwrap();
+        assert_eq!(
+            buffer,
+            vec![
+                // 0x00u8, 0x0B, 0x00, 0x00, // PL_CDR2_LE + 0 padding
+                88, 0, 0, 0, // DHEADER
+                0x01, 0x10, 0, 80, // EMHEADER
+                // 40, 0, 0, 0, // NEXTINT (Reused in the EMHEADER)
+                36, 0, 0, 0, // DHEADER
+                20, 0, 0, 0,   // DHEADER
+                241, //EK_MINIMAL
+                5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // equivalence_hash
+                0, // padding
+                10, 0, 0, 0, // typeobject_serialized_size
+                0, 0, 0, 0, // dependent_typeid_count
+                4, 0, 0, 0, // Sequence DHEADER
+                0, 0, 0, 0, // Sequence length
+                0x02, 0x10, 0, 80, // EMHEADER
+                // 40, 0, 0, 0, // NEXTINT (Reused in the EMHEADER)
+                36, 0, 0, 0, // DHEADER
+                20, 0, 0, 0,   // DHEADER
                 242, //EK_COMPLETE
                 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // equivalence_hash
                 0, // padding
+                10, 0, 0, 0, // typeobject_serialized_size
+                0, 0, 0, 0, // dependent_typeid_count
+                4, 0, 0, 0, // Sequence DHEADER
+                0, 0, 0, 0, // Sequence length
             ]
         );
-
-        // 0xd3, 0x52, 0x82, 0x01 // Discriminator (GET_TYPES)
-        // 0x00, 0x00, 0x00, 0x00 //
-        // 0x07, 0x01, 0x1c, 0x00
-        // 00 03 00 c4
     }
 }

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -1388,9 +1388,16 @@ impl<'a> CdrWriter<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::xtypes::{
-        dynamic_type::DynamicDataFactory,
-        type_support::{Type, TypeSupport},
+    use crate::{
+        dcps::data_representation_builtin_endpoints::type_lookup::{
+            RequestHeader, SampleIdentity, TypeLookupCall, TypeLookupGetTypesIn, TypeLookupRequest,
+        },
+        transport::types::{EntityId, Guid},
+        xtypes::{
+            dynamic_type::DynamicDataFactory,
+            type_object::TypeIdentifier,
+            type_support::{Type, TypeSupport},
+        },
     };
     extern crate std;
 
@@ -2188,5 +2195,125 @@ mod tests {
                 .id,
             22
         );
+    }
+
+    #[test]
+    fn serialize_mutable_struct_with_sequence() {
+        #[derive(Debug, PartialEq, TypeSupport)]
+        #[dust_dds(extensibility = "mutable")]
+        struct MutableTypeWithSequence {
+            #[dust_dds(hash_id)]
+            my_sequence: Vec<u32>,
+        }
+
+        let mut data = DynamicDataFactory::create_data(MutableTypeWithSequence::TYPE);
+        MutableTypeWithSequence {
+            my_sequence: vec![1, 2, 3],
+        }
+        .create_dynamic_sample(&mut data);
+
+        assert_eq!(
+            serialize_cdr2_le(&data).unwrap(),
+            vec![
+                0x00, 0x0b, 0x00, 0x00, // PL_CDR2_LE
+                28, 0, 0, 0, // Struct DHEADER
+                0, 0, 0, 64, // my_sequence EMHEADER
+                20, 0, 0, 0, // my_sequence: NEXTINT
+                16, 0, 0, 0, // Vec DHEADER
+                3, 0, 0, 0, // Vec length
+                1, 0, 0, 0, // Vec[0]
+                2, 0, 0, 0, // Vec[1]
+                3, 0, 0, 0, // Vec[2]
+            ]
+        );
+    }
+
+    #[test]
+    fn serialize_appendable_union_with_mutable_struct() {
+        #[derive(Debug, PartialEq, TypeSupport)]
+        #[dust_dds(extensibility = "mutable")]
+        struct MutableTypeWithSequence {
+            #[dust_dds(hash_id)]
+            my_sequence: Vec<u32>,
+        }
+
+        #[derive(Debug, PartialEq, TypeSupport)]
+        #[dust_dds(switch(i32), extensibility = "appendable")]
+        pub enum AppendableUnion {
+            #[dust_dds(case = 10)]
+            MyVariant { a: MutableTypeWithSequence },
+        }
+
+        let mut data = DynamicDataFactory::create_data(AppendableUnion::TYPE);
+        AppendableUnion::MyVariant {
+            a: MutableTypeWithSequence {
+                my_sequence: vec![1, 2, 3],
+            },
+        }
+        .create_dynamic_sample(&mut data);
+
+        assert_eq!(
+            serialize_cdr2_le(&data).unwrap(),
+            vec![
+                0x00, 0x09, 0x00, 0x00, // D_CDR2_LE
+                36, 0, 0, 0, //AppendableUnion DHEADER
+                10, 0, 0, 0, // MyVariant discriminator
+                0, 0, 0, 64, // my_sequence EMHEADER
+                20, 0, 0, 0, // my_sequence: NEXTINT
+                16, 0, 0, 0, // Vec DHEADER
+                3, 0, 0, 0, // Vec length
+                1, 0, 0, 0, // Vec[0]
+                2, 0, 0, 0, // Vec[1]
+                3, 0, 0, 0, // Vec[2]
+            ]
+        );
+    }
+
+    #[test]
+    fn serialize_type_lookup_request() {
+        let mut data = DynamicDataFactory::create_data(TypeLookupRequest::TYPE);
+        TypeLookupRequest {
+            header: RequestHeader {
+                request_id: SampleIdentity {
+                    writer_guid: Guid::new([1; 12], EntityId::new([1; 3], 1)),
+                    sequence_number: 5.into(),
+                },
+                instance_name: String::from("abc"),
+            },
+            call: TypeLookupCall::TypeLookupGetTypesHashId {
+                get_types: TypeLookupGetTypesIn {
+                    type_ids: vec![TypeIdentifier::EkComplete {
+                        equivalence_hash: [5; 14],
+                    }],
+                },
+            },
+        }
+        .create_dynamic_sample(&mut data);
+
+        assert_eq!(
+            serialize_cdr2_le(&data).unwrap(),
+            vec![
+                0x00u8, 0x07, 0x00, 0x01, // CDR2_LE + padding
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // writer_guid
+                0, 0, 0, 0, // sequence_number: high
+                5, 0, 0, 0, // sequence_number: low
+                4, 0, 0, 0, // instance_name: length
+                b'a', b'b', b'c', 0, // instance_name: length
+                39, 0, 0, 0, //TypeLookupCall DHEADER
+                211, 82, 130, 1, // TypeLookupGetTypesHashId Discriminator
+                101, 96, 83, 76, // type_ids EMHEADER
+                23, 0, 0, 0, // type_ids NEXTINT
+                19, 0, 0, 0, // type_ids: DHEADER
+                1, 0, 0, 0,   // type_ids: Length
+                242, //EK_COMPLETE
+                5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // equivalence_hash
+                0, // padding
+            ]
+        );
+
+        // 0xd3, 0x52, 0x82, 0x01 // Discriminator (GET_TYPES)
+        // 0x00, 0x00, 0x00, 0x00 //
+        // 0x07, 0x01, 0x1c, 0x00
+        // 00 03 00 c4
     }
 }

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -320,24 +320,23 @@ impl<'a, E: EndiannessWrite, V: EncodingVersion> XTypesSerializer<'a, E, V> {
     ///           XCDR
     ///           << { O.member[i] : FMEMBER }*
     fn serialize_fstruct_type(&mut self, v: &DynamicData) -> Result<(), XTypesError> {
-        for field_index in 0..v.get_item_count() {
-            let dynamic_type = v.r#type();
-            if let Ok(member_id) = v.get_member_id_at_index(field_index) {
-                if let Some(base_type) = dynamic_type.descriptor.base_type {
-                    let member_descriptor = &base_type.get_member(member_id)?.descriptor;
+        let dynamic_type = v.r#type();
+        for field_index in 0..dynamic_type.get_member_count() {
+            let member_id = dynamic_type.get_member_by_index(field_index)?.get_id();
+            if let Some(base_type) = dynamic_type.descriptor.base_type {
+                let member_descriptor = &base_type.get_member(member_id)?.descriptor;
 
-                    if member_descriptor.is_optional {
-                        V::serialize_opt_fmember(self, v, member_id)?;
-                    } else {
-                        self.serialize_nopt_fmember(v, member_id)?;
-                    }
+                if member_descriptor.is_optional {
+                    V::serialize_opt_fmember(self, v, member_id)?;
+                } else {
+                    self.serialize_nopt_fmember(v, member_id)?;
                 }
-                if let Ok(member) = &dynamic_type.get_member(member_id) {
-                    if member.descriptor.is_optional {
-                        V::serialize_opt_fmember(self, v, member_id)?;
-                    } else {
-                        self.serialize_nopt_fmember(v, member_id)?;
-                    }
+            }
+            if let Ok(member) = &dynamic_type.get_member(member_id) {
+                if member.descriptor.is_optional {
+                    V::serialize_opt_fmember(self, v, member_id)?;
+                } else {
+                    self.serialize_nopt_fmember(v, member_id)?;
                 }
             }
         }
@@ -1095,7 +1094,13 @@ impl EncodingVersion for EncodingVersion2 {
         v: &DynamicData,
         member_id: u32,
     ) -> Result<(), XTypesError> {
-        Self::serialize_mmember(serializer, v, member_id)
+        let is_present = v.get_data_kind(member_id).is_ok();
+        serializer.serialize_primitive_type(&is_present);
+        if is_present {
+            serializer.serialize_value(v, member_id)?;
+        }
+
+        Ok(())
     }
 
     /// Structures with extensibility MUTABLE, version 2 encoding

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -2153,7 +2153,7 @@ impl<'a> From<DynamicType<'a>> for TypeInformation {
                     },
                     typeobject_serialized_size: serialized_minimal_type_object.len() as u32,
                 },
-                dependent_typeid_count: -1,
+                dependent_typeid_count: 0,
                 dependent_typeids: Vec::new(),
             },
             complete: TypeIdentifierWithDependencies {

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -2269,9 +2269,9 @@ mod tests {
 
         let expected = [
             88, 0, 0, 0, // dheader
-            0x01, 0x10, 0, 0b100_0000, // Emheader: minimal
-            36, 0, 0, 0, // EMheader: nextint
-            32, 0, 0, 0,    // DHeader
+            0x01, 0x10, 0, 0b101_0000, // Emheader: minimal
+            36, 0, 0, 0, // DHeader (replaces nextint)
+            20, 0, 0, 0,    // DHeader
             0xF2, // Discriminator
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
             0, // Padding
@@ -2280,9 +2280,9 @@ mod tests {
             4, 0, 0, 0, // dependent_typeids: Dheader
             0, 0, 0, 0, // dependent_typeids Length
             // complete
-            0x02, 0x10, 0, 0b100_0000, // Emheader: minimal
-            36, 0, 0, 0, // EMheader: nextint
-            32, 0, 0, 0,    // DHeader
+            0x02, 0x10, 0, 0b101_0000, // Emheader: minimal
+            36, 0, 0, 0, // DHeader (replaces nextint)
+            20, 0, 0, 0,    // DHeader
             0xF2, // Discriminator
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
             0, // Padding
@@ -2313,7 +2313,8 @@ mod tests {
         let buffer = serialize_without_header_cdr2_le(Vec::new(), &dynamic_data).unwrap();
 
         let expected = [
-            32, 0, 0, 0,    // DHeader
+            36, 0, 0, 0, // DHeader
+            20, 0, 0, 0,    // DHeader
             0xF2, // Discriminator
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
             0, // Padding

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -1995,12 +1995,24 @@ impl<'a> From<&DynamicType<'a>> for TypeIdentifier {
             TypeKind::UINT8 => TypeIdentifier::TkUint8Type,
             TypeKind::CHAR8 => TypeIdentifier::TkChar8Type,
             TypeKind::CHAR16 => TypeIdentifier::TkChar16Type,
-            TypeKind::STRING8 => TypeIdentifier::TiString8Large {
-                string_ldefn: StringLTypeDefn { bound: u32::MAX },
-            },
-            TypeKind::STRING16 => TypeIdentifier::TiString16Small {
-                string_sdefn: StringSTypeDefn { bound: u8::MAX },
-            },
+            TypeKind::STRING8 => {
+                if let Some(b) = value.descriptor.bound {
+                    if b <= u8::MAX as u32 {
+                        TypeIdentifier::TiString8Small {
+                            string_sdefn: StringSTypeDefn { bound: b as u8 },
+                        }
+                    } else {
+                        TypeIdentifier::TiString8Large {
+                            string_ldefn: StringLTypeDefn { bound: b },
+                        }
+                    }
+                } else {
+                    TypeIdentifier::TiString8Large {
+                        string_ldefn: StringLTypeDefn { bound: u32::MAX },
+                    }
+                }
+            }
+            TypeKind::STRING16 => todo!(),
             TypeKind::ALIAS => todo!(),
             TypeKind::ENUM => todo!(),
             TypeKind::BITMASK => todo!(),
@@ -2100,7 +2112,6 @@ impl From<&DynamicTypeMember> for CompleteStructMember {
         let common = value.into();
         let detail = CompleteMemberDetail {
             name: String::from(value.get_name()),
-            // TODO: Applied builtin and custom annotations
             ann_builtin: None,
             ann_custom: None,
         };
@@ -2191,7 +2202,7 @@ mod tests {
 
     use super::*;
     #[test]
-    #[ignore]
+    #[ignore = "Optional fields are not yet handled"]
     fn shape_type_hash() {
         #[derive(Debug, PartialEq, TypeSupport)]
         #[dust_dds(extensibility = "final")]
@@ -2211,32 +2222,15 @@ mod tests {
                 .typeobject_serialized_size,
             132
         );
-        // assert_eq!(
-        //     type_information.complete.typeid_with_size.type_id,
-        //     TypeIdentifier::EkComplete {
-        //         equivalence_hash: [
-        //             0xce, 0x6d, 0x79, 0x13, 0x05, 0x8d, 0xaa, 0x30, 0x78, 0xa8, 0x8f, 0x98, 0x21,
-        //             0x96
-        //         ]
-        //     }
-        // );
-
         assert_eq!(
-            type_information
-                .minimal
-                .typeid_with_size
-                .typeobject_serialized_size,
-            92
+            type_information.complete.typeid_with_size.type_id,
+            TypeIdentifier::EkComplete {
+                equivalence_hash: [
+                    0xce, 0x6d, 0x79, 0x13, 0x05, 0x8d, 0xaa, 0x30, 0x78, 0xa8, 0x8f, 0x98, 0x21,
+                    0x96
+                ]
+            }
         );
-        // assert_eq!(
-        //     type_information.minimal.typeid_with_size.type_id,
-        //     TypeIdentifier::EkMinimal {
-        //         equivalence_hash: [
-        //             0xd3, 0xd5, 0x89, 0xfb, 0x12, 0x8b, 0x55, 0xdb, 0x4b, 0x83, 0x3d, 0x99, 0xa4,
-        //             0x02
-        //         ]
-        //     }
-        // );
     }
 
     #[test]

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -140,8 +140,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 } else {
                     match &member.ident {
                         Some(member_ident) => {
-                            // In Mutable structs every member is optional even when not explicitly marked as such
-                            if r#struct.extensibility == Extensibility::Mutable || is_optional {
+                            if is_optional {
                                 member_sample_seq.push(quote! {
                                     #member_ident: src.remove_value(#member_id).map_or(#member_default_value, |x| {
                                         dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(x).expect("Must match")

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -112,7 +112,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                                 label: None,
                                 is_key: #is_key,
                                 is_optional: #is_optional,
-                                is_must_understand: false,
+                                is_must_understand: #is_key,
                                 is_shared: false,
                                 is_default_label: false,
                                 is_external: #is_external,


### PR DESCRIPTION
This PR is a step towards being able to exchange type information as defined in XTypes. For this purpose the following changes are done:
- TypeConsistencyEnforcementQosPolicy is added
- Fix some type inconsistencies on type_lookup.rs
- Fix serialization errors for unions, emheader and optional fields