### PR TITLE
Serialize optional fields

### DIFF
--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -39,9 +39,9 @@ critical-section = { version = "1.2.0", default-features = false, features = [
 	"std",
 ] }
 
-opentelemetry = "0.31.0"
-opentelemetry-otlp = "0.31.0"
-opentelemetry_sdk = "0.31.0"
+opentelemetry = "0.31"
+opentelemetry-otlp = "0.31"
+opentelemetry_sdk = "0.31"
 tracing-opentelemetry = "0.32.0"
 
 [features]

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -226,8 +226,7 @@ impl DcpsDomainParticipant {
                         tracing::warn!("Failed to deserialize user defined data");
                         return;
                     };
-                    let Ok(instance_handle) =
-                        get_instance_handle_from_dynamic_data(data_value.clone())
+                    let Ok(instance_handle) = get_instance_handle_from_dynamic_data(&data_value)
                     else {
                         tracing::warn!("Failed to get instance handle from dynamic_data");
                         return;
@@ -256,7 +255,7 @@ impl DcpsDomainParticipant {
                         };
 
                         let Ok(instance_handle) =
-                            get_instance_handle_from_dynamic_data(data_value.clone())
+                            get_instance_handle_from_dynamic_data(&data_value)
                         else {
                             tracing::warn!("Failed to deserialize disposed key user defined data");
                             return;

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -159,7 +159,7 @@ impl DcpsDomainParticipant {
                 dynamic_data.set_complex_value(0, topic_key_data).unwrap();
 
                 dw.unregister_w_timestamp(
-                    dynamic_data,
+                    &dynamic_data,
                     timestamp,
                     self.transport.message_writer.as_ref(),
                     runtime,
@@ -303,7 +303,7 @@ impl DcpsDomainParticipant {
             dynamic_data.set_complex_value(0, topic_key_data).unwrap();
 
             dw.unregister_w_timestamp(
-                dynamic_data,
+                &dynamic_data,
                 timestamp,
                 self.transport.message_writer.as_ref(),
                 runtime,
@@ -445,7 +445,7 @@ impl DcpsDomainParticipant {
             .create_dynamic_sample(&mut topic_key_data);
             dynamic_data.set_complex_value(0, topic_key_data).unwrap();
             dw.unregister_w_timestamp(
-                dynamic_data,
+                &dynamic_data,
                 timestamp,
                 self.transport.message_writer.as_ref(),
                 runtime,

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -1422,7 +1422,7 @@ impl DcpsDomainParticipant {
                             .create_dynamic_sample(&mut dynamic_data);
                         let change_instance_handle = match cache_change.instance_handle {
                             Some(i) => i,
-                            None => get_instance_handle_from_dynamic_data(dynamic_data.clone())
+                            None => get_instance_handle_from_dynamic_data(&dynamic_data)
                                 .expect("Should not fail")
                                 .into(),
                         };
@@ -1553,7 +1553,7 @@ impl DcpsDomainParticipant {
                             .create_dynamic_sample(&mut dynamic_data);
                         let change_instance_handle = match cache_change.instance_handle {
                             Some(i) => i,
-                            None => get_instance_handle_from_dynamic_data(dynamic_data.clone())
+                            None => get_instance_handle_from_dynamic_data(&dynamic_data)
                                 .expect("Should not fail")
                                 .into(),
                         };
@@ -1730,7 +1730,7 @@ impl DcpsDomainParticipant {
                             .create_dynamic_sample(&mut dynamic_data);
                         let change_instance_handle = match cache_change.instance_handle {
                             Some(i) => i,
-                            None => get_instance_handle_from_dynamic_data(dynamic_data.clone())
+                            None => get_instance_handle_from_dynamic_data(&dynamic_data)
                                 .expect("Should not fail")
                                 .into(),
                         };

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -24,7 +24,9 @@ use crate::{
         listeners::domain_participant_listener::ListenerMail,
         status_condition::DcpsStatusCondition,
         status_mask::StatusMask,
-        xtypes_glue::key_and_instance_handle::get_instance_handle_from_dynamic_data,
+        xtypes_glue::key_and_instance_handle::{
+            KeyHolderData, get_instance_handle_from_key_holder_data,
+        },
     },
     dds_async::{
         content_filtered_topic::ContentFilteredTopicAsync, data_reader::DataReaderAsync,
@@ -1453,7 +1455,6 @@ struct DataWriterEntity {
     status_condition: DcpsStatusCondition,
     listener_sender: Option<MpscSender<ListenerMail>>,
     listener_mask: StatusMask,
-    max_seq_num: Option<i64>,
     last_change_sequence_number: i64,
     qos: DataWriterQos,
     registered_instance_list: Vec<InstanceHandle>,
@@ -1494,7 +1495,6 @@ impl DataWriterEntity {
             status_condition: DcpsStatusCondition::default(),
             listener_sender,
             listener_mask,
-            max_seq_num: None,
             last_change_sequence_number: 0,
             qos,
             registered_instance_list: Vec::new(),
@@ -1580,11 +1580,6 @@ impl DataWriterEntity {
             instance_handle: Some(sample_instance_handle.into()),
             data_value: serialized_data.into(),
         };
-        let seq_num = change.sequence_number;
-
-        if seq_num > self.max_seq_num.unwrap_or(0) {
-            self.max_seq_num = Some(seq_num)
-        }
 
         match self
             .instance_publication_time
@@ -1634,7 +1629,7 @@ impl DataWriterEntity {
 
     fn dispose_w_timestamp(
         &mut self,
-        mut dynamic_data: DynamicData<'static>,
+        dynamic_data: &DynamicData<'static>,
         timestamp: Time,
         message_writer: &(impl WriteMessage + ?Sized),
         runtime: &impl DdsRuntime,
@@ -1647,10 +1642,15 @@ impl DataWriterEntity {
             return Err(DdsError::IllegalOperation);
         }
 
-        let instance_handle = get_instance_handle_from_dynamic_data(&dynamic_data)?;
+        let key_holder_data = KeyHolderData::from_dynamic_data(&dynamic_data)?;
+        let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
+
         if !self.registered_instance_list.contains(&instance_handle) {
             return Err(DdsError::BadParameter);
         }
+
+        let serialized_key =
+            serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;
 
         if let Some(i) = self
             .instance_publication_time
@@ -1659,9 +1659,6 @@ impl DataWriterEntity {
         {
             self.instance_publication_time.remove(i);
         }
-
-        dynamic_data.clear_nonkey_values()?;
-        let serialized_key = serialize(&dynamic_data, &self.qos.representation)?;
 
         self.last_change_sequence_number += 1;
         let cache_change = CacheChange {
@@ -1680,7 +1677,7 @@ impl DataWriterEntity {
 
     fn unregister_w_timestamp(
         &mut self,
-        mut dynamic_data: DynamicData<'static>,
+        dynamic_data: &DynamicData<'static>,
         timestamp: Time,
         message_writer: &(impl WriteMessage + ?Sized),
         runtime: &impl DdsRuntime,
@@ -1693,7 +1690,8 @@ impl DataWriterEntity {
             return Err(DdsError::IllegalOperation);
         }
 
-        let instance_handle = get_instance_handle_from_dynamic_data(&dynamic_data)?;
+        let key_holder_data = KeyHolderData::from_dynamic_data(&dynamic_data)?;
+        let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
         if !self.registered_instance_list.contains(&instance_handle) {
             return Err(DdsError::BadParameter);
         }
@@ -1706,8 +1704,8 @@ impl DataWriterEntity {
             self.instance_publication_time.remove(i);
         }
 
-        dynamic_data.clear_nonkey_values()?;
-        let serialized_key = serialize(&dynamic_data, &self.qos.representation)?;
+        let serialized_key =
+            serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;
 
         self.last_change_sequence_number += 1;
         let kind = if self
@@ -2715,8 +2713,8 @@ impl DataReaderEntity {
     }
 }
 
-fn serialize(
-    dynamic_data: &DynamicData<'static>,
+fn serialize<'a>(
+    dynamic_data: &DynamicData<'a>,
     representation: &DataRepresentationQosPolicy,
 ) -> DdsResult<Vec<u8>> {
     Ok(

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -1647,7 +1647,7 @@ impl DataWriterEntity {
             return Err(DdsError::IllegalOperation);
         }
 
-        let instance_handle = get_instance_handle_from_dynamic_data(dynamic_data.clone())?;
+        let instance_handle = get_instance_handle_from_dynamic_data(&dynamic_data)?;
         if !self.registered_instance_list.contains(&instance_handle) {
             return Err(DdsError::BadParameter);
         }
@@ -1693,7 +1693,7 @@ impl DataWriterEntity {
             return Err(DdsError::IllegalOperation);
         }
 
-        let instance_handle = get_instance_handle_from_dynamic_data(dynamic_data.clone())?;
+        let instance_handle = get_instance_handle_from_dynamic_data(&dynamic_data)?;
         if !self.registered_instance_list.contains(&instance_handle) {
             return Err(DdsError::BadParameter);
         }

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -1642,7 +1642,7 @@ impl DataWriterEntity {
             return Err(DdsError::IllegalOperation);
         }
 
-        let key_holder_data = KeyHolderData::from_dynamic_data(&dynamic_data)?;
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data)?;
         let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
 
         if !self.registered_instance_list.contains(&instance_handle) {
@@ -1690,7 +1690,7 @@ impl DataWriterEntity {
             return Err(DdsError::IllegalOperation);
         }
 
-        let key_holder_data = KeyHolderData::from_dynamic_data(&dynamic_data)?;
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data)?;
         let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
         if !self.registered_instance_list.contains(&instance_handle) {
             return Err(DdsError::BadParameter);

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -8,7 +8,9 @@ use crate::{
         dcps_mail::{DcpsMail, EventServiceMail, MessageServiceMail, WriterServiceMail},
         listeners::data_writer_listener::DcpsDataWriterListener,
         status_mask::StatusMask,
-        xtypes_glue::key_and_instance_handle::get_instance_handle_from_dynamic_data,
+        xtypes_glue::key_and_instance_handle::{
+            KeyHolderData, get_instance_handle_from_key_holder_data,
+        },
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -173,7 +175,7 @@ impl DcpsDomainParticipant {
         &mut self,
         publisher_handle: &InstanceHandle,
         data_writer_handle: &InstanceHandle,
-        dynamic_data: DynamicData<'static>,
+        dynamic_data: &DynamicData<'static>,
         timestamp: Time,
         runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
@@ -194,7 +196,7 @@ impl DcpsDomainParticipant {
         };
 
         data_writer.unregister_w_timestamp(
-            dynamic_data,
+            &dynamic_data,
             timestamp,
             self.transport.message_writer.as_ref(),
             runtime,
@@ -228,7 +230,13 @@ impl DcpsDomainParticipant {
             return Err(DdsError::NotEnabled);
         }
 
-        let instance_handle = match get_instance_handle_from_dynamic_data(&dynamic_data) {
+        let key_holder_data = match KeyHolderData::from_dynamic_data(&dynamic_data) {
+            Ok(k) => k,
+            Err(e) => {
+                return Err(e.into());
+            }
+        };
+        let instance_handle = match get_instance_handle_from_key_holder_data(&key_holder_data) {
             Ok(k) => k,
             Err(e) => {
                 return Err(e.into());
@@ -282,7 +290,14 @@ impl DcpsDomainParticipant {
             }
         };
 
-        let instance_handle = match get_instance_handle_from_dynamic_data(&dynamic_data) {
+        let key_holder_data = match KeyHolderData::from_dynamic_data(&dynamic_data) {
+            Ok(h) => h,
+            Err(e) => {
+                reply_sender.send(Err(e.into()));
+                return;
+            }
+        };
+        let instance_handle = match get_instance_handle_from_key_holder_data(&key_holder_data) {
             Ok(h) => h,
             Err(e) => {
                 reply_sender.send(Err(e.into()));
@@ -448,7 +463,7 @@ impl DcpsDomainParticipant {
         &mut self,
         publisher_handle: &InstanceHandle,
         data_writer_handle: &InstanceHandle,
-        dynamic_data: DynamicData<'static>,
+        dynamic_data: &DynamicData<'static>,
         timestamp: Time,
         runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -228,7 +228,7 @@ impl DcpsDomainParticipant {
             return Err(DdsError::NotEnabled);
         }
 
-        let instance_handle = match get_instance_handle_from_dynamic_data(dynamic_data.clone()) {
+        let instance_handle = match get_instance_handle_from_dynamic_data(&dynamic_data) {
             Ok(k) => k,
             Err(e) => {
                 return Err(e.into());
@@ -282,7 +282,7 @@ impl DcpsDomainParticipant {
             }
         };
 
-        let instance_handle = match get_instance_handle_from_dynamic_data(dynamic_data.clone()) {
+        let instance_handle = match get_instance_handle_from_dynamic_data(&dynamic_data) {
             Ok(h) => h,
             Err(e) => {
                 reply_sender.send(Err(e.into()));

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -196,7 +196,7 @@ impl DcpsDomainParticipant {
         };
 
         data_writer.unregister_w_timestamp(
-            &dynamic_data,
+            dynamic_data,
             timestamp,
             self.transport.message_writer.as_ref(),
             runtime,
@@ -230,7 +230,7 @@ impl DcpsDomainParticipant {
             return Err(DdsError::NotEnabled);
         }
 
-        let key_holder_data = match KeyHolderData::from_dynamic_data(&dynamic_data) {
+        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data) {
             Ok(k) => k,
             Err(e) => {
                 return Err(e.into());
@@ -290,7 +290,7 @@ impl DcpsDomainParticipant {
             }
         };
 
-        let key_holder_data = match KeyHolderData::from_dynamic_data(&dynamic_data) {
+        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data) {
             Ok(h) => h,
             Err(e) => {
                 reply_sender.send(Err(e.into()));

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -583,7 +583,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.unregister_instance(
                     &publisher_handle,
                     &data_writer_handle,
-                    dynamic_data,
+                    &dynamic_data,
                     timestamp,
                     &self.runtime,
                 )),
@@ -638,7 +638,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.dispose_w_timestamp(
                     &publisher_handle,
                     &data_writer_handle,
-                    dynamic_data,
+                    &dynamic_data,
                     timestamp,
                     &self.runtime,
                 )),

--- a/dds/src/dcps/infrastructure/type_support.rs
+++ b/dds/src/dcps/infrastructure/type_support.rs
@@ -1,5 +1,3 @@
 /// This is a convenience derive to allow the user to easily derive all the different traits needed for a type to be used for
 /// communication with Dust DDS. If the individual traits are manually derived then this derive should not be used.
 pub use dust_dds_derive::DdsType;
-
-// pub trait DdsType : crate::xtypes::type_support::TypeSupport{}

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -1,40 +1,57 @@
 use crate::{
     infrastructure::instance::InstanceHandle,
     xtypes::{
-        dynamic_type::{DynamicData, DynamicDataFactory, DynamicTypeBuilderFactory, TypeKind},
-        error::XTypesError,
+        dynamic_type::{
+            DynamicData, DynamicDataFactory, DynamicType, DynamicTypeBuilderFactory, TypeKind,
+        },
+        error::{XTypesError, XTypesResult},
         serializer::serialize_final_without_header,
     },
 };
 use alloc::vec::Vec;
 
-pub fn get_instance_handle_from_dynamic_data<'a>(
-    dynamic_data: &DynamicData<'a>,
-) -> Result<InstanceHandle, XTypesError> {
-    let dynamic_type = dynamic_data.r#type();
-    let mut key_holder_type_builder =
-        DynamicTypeBuilderFactory::create_type(dynamic_data.r#type().descriptor.clone());
-    for member_index in 0..dynamic_type.get_member_count() {
-        let dynamic_type_member = dynamic_type.get_member_by_index(member_index)?;
-        if dynamic_type_member.get_descriptor()?.is_key {
-            key_holder_type_builder.add_member(dynamic_type_member.get_descriptor()?.clone())?;
+pub struct KeyHolderType<'a>(DynamicType<'a>);
+
+impl<'a> KeyHolderType<'a> {
+    pub fn from_dynamic_type(value: &DynamicType<'a>) -> XTypesResult<Self> {
+        let mut key_holder_type_builder =
+            DynamicTypeBuilderFactory::create_type(value.descriptor.clone());
+        for member_index in 0..value.get_member_count() {
+            let dynamic_type_member = value.get_member_by_index(member_index)?;
+            if dynamic_type_member.get_descriptor()?.is_key {
+                key_holder_type_builder
+                    .add_member(dynamic_type_member.get_descriptor()?.clone())?;
+            }
         }
+        Ok(Self(key_holder_type_builder.build()))
     }
-    let key_holder_type = key_holder_type_builder.build();
-    
-    let mut key_holder_data = DynamicDataFactory::create_data(key_holder_type);
-    for key_member_index in 0..key_holder_type.get_member_count() {
-        let key_member_id = key_holder_type
-            .get_member_by_index(key_member_index)?
-            .get_id();
-        key_holder_data.set_value(
-            key_member_id,
-            dynamic_data.get_value(key_member_id)?.clone(),
-        );
+}
+
+pub struct KeyHolderData<'a>(DynamicData<'a>);
+
+impl<'a> KeyHolderData<'a> {
+    pub fn from_dynamic_data(value: &DynamicData<'a>) -> XTypesResult<KeyHolderData<'a>> {
+        let key_holder_type = KeyHolderType::from_dynamic_type(&value.r#type())?.0;
+        let mut key_holder_data = DynamicDataFactory::create_data(key_holder_type);
+        for key_member_index in 0..key_holder_type.get_member_count() {
+            let key_member_id = key_holder_type
+                .get_member_by_index(key_member_index)?
+                .get_id();
+            key_holder_data.set_value(key_member_id, value.get_value(key_member_id)?.clone());
+        }
+        Ok(Self(key_holder_data))
     }
 
-    let key = if key_holder_data.r#type().get_kind() == TypeKind::STRUCTURE {
-        let data = serialize_final_without_header(Vec::new(), &key_holder_data)?;
+    pub fn as_dynamic_data(&self) -> &DynamicData<'a> {
+        &self.0
+    }
+}
+
+pub fn get_instance_handle_from_key_holder_data<'a>(
+    key_holder_data: &KeyHolderData<'a>,
+) -> Result<InstanceHandle, XTypesError> {
+    let key = if key_holder_data.0.r#type().get_kind() == TypeKind::STRUCTURE {
+        let data = serialize_final_without_header(Vec::new(), &key_holder_data.0)?;
         if data.len() <= 16 {
             let mut key = [0; 16];
             key[0..data.len()].copy_from_slice(&data);
@@ -46,4 +63,11 @@ pub fn get_instance_handle_from_dynamic_data<'a>(
         [0; 16]
     };
     Ok(InstanceHandle::new(key))
+}
+
+pub fn get_instance_handle_from_dynamic_data<'a>(
+    value: &DynamicData<'a>,
+) -> Result<InstanceHandle, XTypesError> {
+    let key_holder_data = KeyHolderData::from_dynamic_data(value)?;
+    get_instance_handle_from_key_holder_data(&key_holder_data)
 }

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -1,7 +1,7 @@
 use crate::{
     infrastructure::instance::InstanceHandle,
     xtypes::{
-        dynamic_type::{DynamicData, TypeKind},
+        dynamic_type::{DynamicData, DynamicDataFactory, DynamicTypeBuilderFactory, TypeKind},
         error::XTypesError,
         serializer::serialize_final_without_header,
     },
@@ -9,11 +9,32 @@ use crate::{
 use alloc::vec::Vec;
 
 pub fn get_instance_handle_from_dynamic_data<'a>(
-    mut dynamic_data: DynamicData<'a>,
+    dynamic_data: &DynamicData<'a>,
 ) -> Result<InstanceHandle, XTypesError> {
-    let key = if dynamic_data.r#type().get_kind() == TypeKind::STRUCTURE {
-        dynamic_data.clear_nonkey_values()?;
-        let data = serialize_final_without_header(Vec::new(), &dynamic_data)?;
+    let dynamic_type = dynamic_data.r#type();
+    let mut key_holder_type_builder =
+        DynamicTypeBuilderFactory::create_type(dynamic_data.r#type().descriptor.clone());
+    for member_index in 0..dynamic_type.get_member_count() {
+        let dynamic_type_member = dynamic_type.get_member_by_index(member_index)?;
+        if dynamic_type_member.get_descriptor()?.is_key {
+            key_holder_type_builder.add_member(dynamic_type_member.get_descriptor()?.clone())?;
+        }
+    }
+    let key_holder_type = key_holder_type_builder.build();
+    
+    let mut key_holder_data = DynamicDataFactory::create_data(key_holder_type);
+    for key_member_index in 0..key_holder_type.get_member_count() {
+        let key_member_id = key_holder_type
+            .get_member_by_index(key_member_index)?
+            .get_id();
+        key_holder_data.set_value(
+            key_member_id,
+            dynamic_data.get_value(key_member_id)?.clone(),
+        );
+    }
+
+    let key = if key_holder_data.r#type().get_kind() == TypeKind::STRUCTURE {
+        let data = serialize_final_without_header(Vec::new(), &key_holder_data)?;
         if data.len() <= 16 {
             let mut key = [0; 16];
             key[0..data.len()].copy_from_slice(&data);

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -1032,7 +1032,7 @@ mod tests {
         )
         .unwrap();
         let instance_handle =
-            get_instance_handle_from_dynamic_data(dispose_serialized_key_from_data_message)
+            get_instance_handle_from_dynamic_data(&dispose_serialized_key_from_data_message)
                 .unwrap();
         assert_eq!(
             instance_handle,

--- a/dds/src/xtypes/dynamic_type.rs
+++ b/dds/src/xtypes/dynamic_type.rs
@@ -16,7 +16,7 @@ pub type ObjectName<'a> = &'a str;
 
 // ---------- TypeKinds (begin) -------------------
 /// Represents the kind of a dynamic type (e.g., primitive, constructed, or collection type).
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum TypeKind {
     /// No type kind.
@@ -519,7 +519,7 @@ impl DynamicTypeBuilderFactory {
 pub type Parameters = BTreeMap<ObjectName<'static>, ObjectName<'static>>;
 
 /// Defines how a type can be extended or modified in future versions.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExtensibilityKind {
     /// Cannot be extended or modified.
     Final,
@@ -530,7 +530,7 @@ pub enum ExtensibilityKind {
 }
 
 /// Defines the behavior when constructing an object of a type that fails some validation or constraints.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TryConstructKind {
     /// Fall back to the default value.
     UseDefault,
@@ -541,6 +541,7 @@ pub enum TryConstructKind {
 }
 
 /// Describes the properties and characteristics of a [`DynamicType`].
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeDescriptor {
     /// The kind of the type.
     pub kind: TypeKind,
@@ -568,7 +569,7 @@ pub type MemberId = u32;
 pub type UnionCaseLabelSeq = Option<i32>;
 
 /// Describes a member of a constructed type.
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemberDescriptor {
     /// The name of the member.
     pub name: ObjectName<'static>,
@@ -599,7 +600,7 @@ pub struct MemberDescriptor {
 }
 
 /// Represents a member of a [`DynamicType`].
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DynamicTypeMember {
     /// The descriptor describing this member.
     pub descriptor: MemberDescriptor,
@@ -718,19 +719,12 @@ impl DynamicTypeBuilder {
 }
 
 /// Represents a data type's schema at runtime.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DynamicType<'a> {
     /// The type descriptor.
     pub descriptor: &'a TypeDescriptor,
     /// The list of members belonging to this type.
     pub member_list: &'a [DynamicTypeMember],
-}
-
-impl<'a> PartialEq for DynamicType<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        core::ptr::addr_eq(self.descriptor, other.descriptor)
-            && core::ptr::addr_eq(self.member_list, other.member_list)
-    }
 }
 
 impl<'a> DynamicType<'a> {

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -320,24 +320,25 @@ impl<'a, E: EndiannessWrite, V: EncodingVersion> XTypesSerializer<'a, E, V> {
     ///           XCDR
     ///           << { O.member[i] : FMEMBER }*
     fn serialize_fstruct_type(&mut self, v: &DynamicData) -> Result<(), XTypesError> {
-        for field_index in 0..v.get_item_count() {
-            let dynamic_type = v.r#type();
-            if let Ok(member_id) = v.get_member_id_at_index(field_index) {
-                if let Some(base_type) = dynamic_type.descriptor.base_type {
-                    let member_descriptor = &base_type.get_member(member_id)?.descriptor;
+        let dynamic_type = v.r#type();
 
-                    if member_descriptor.is_optional {
-                        V::serialize_opt_fmember(self, v, member_id)?;
-                    } else {
-                        self.serialize_nopt_fmember(v, member_id)?;
-                    }
+        for field_index in 0..dynamic_type.get_member_count() {
+            let member_id = dynamic_type.get_member_by_index(field_index)?.get_id();
+
+            if let Some(base_type) = dynamic_type.descriptor.base_type {
+                let member_descriptor = &base_type.get_member(member_id)?.descriptor;
+
+                if member_descriptor.is_optional {
+                    V::serialize_opt_fmember(self, v, member_id)?;
+                } else {
+                    self.serialize_nopt_fmember(v, member_id)?;
                 }
-                if let Ok(member) = &dynamic_type.get_member(member_id) {
-                    if member.descriptor.is_optional {
-                        V::serialize_opt_fmember(self, v, member_id)?;
-                    } else {
-                        self.serialize_nopt_fmember(v, member_id)?;
-                    }
+            }
+            if let Ok(member) = &dynamic_type.get_member(member_id) {
+                if member.descriptor.is_optional {
+                    V::serialize_opt_fmember(self, v, member_id)?;
+                } else {
+                    self.serialize_nopt_fmember(v, member_id)?;
                 }
             }
         }

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -2202,6 +2202,7 @@ mod tests {
 
     use super::*;
     #[test]
+    #[ignore]
     fn shape_type_hash() {
         #[derive(Debug, PartialEq, TypeSupport)]
         #[dust_dds(extensibility = "final")]

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -2202,7 +2202,6 @@ mod tests {
 
     use super::*;
     #[test]
-    #[ignore = "Optional fields are not yet handled"]
     fn shape_type_hash() {
         #[derive(Debug, PartialEq, TypeSupport)]
         #[dust_dds(extensibility = "final")]
@@ -2356,6 +2355,28 @@ mod tests {
         let expected = [
             0xF2, // Discriminator
             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // equivalence_hash
+        ];
+
+        assert_eq!(buffer, expected.to_vec())
+    }
+
+    #[test]
+    fn serialize_complete_member_detail() {
+        let mut dynamic_data = DynamicDataFactory::create_data(CompleteMemberDetail::TYPE);
+        CompleteMemberDetail {
+            name: String::from("a"),
+            ann_builtin: None,
+            ann_custom: None,
+        }
+        .create_dynamic_sample(&mut dynamic_data);
+
+        let buffer = serialize_without_header_cdr2_le(Vec::new(), &dynamic_data).unwrap();
+
+        let expected = [
+            2, 0, 0, 0, // Name length
+            b'a', 0, // Name
+            0, // ann_builtin optional not present
+            0, // ann_custom optional not present
         ];
 
         assert_eq!(buffer, expected.to_vec())

--- a/dds/src/xtypes/type_object.rs
+++ b/dds/src/xtypes/type_object.rs
@@ -2198,17 +2198,19 @@ impl<'a> From<DynamicType<'a>> for TypeInformation {
 
 #[cfg(test)]
 mod tests {
-    use crate::xtypes::{serializer::serialize_without_header_cdr2_le, type_support::Type};
+    use crate::xtypes::{
+        serializer::serialize_without_header_cdr2_le,
+        type_support::{BoundedString, Type},
+    };
 
     use super::*;
     #[test]
-    #[ignore]
     fn shape_type_hash() {
         #[derive(Debug, PartialEq, TypeSupport)]
-        #[dust_dds(extensibility = "final")]
+        #[dust_dds(extensibility = "appendable")]
         struct ShapeType {
             #[dust_dds(key)]
-            color: String,
+            color: BoundedString<128>,
             x: i32,
             y: i32,
             shapesize: i32,

--- a/dds/src/xtypes/type_support.rs
+++ b/dds/src/xtypes/type_support.rs
@@ -1,8 +1,12 @@
-use crate::xtypes::dynamic_type::{
-    DynamicData, DynamicType, ExtensibilityKind, TypeDescriptor, TypeKind,
+use crate::xtypes::{
+    data_storage::DataStorageMapping,
+    dynamic_type::{DynamicData, DynamicType, ExtensibilityKind, TypeDescriptor, TypeKind},
+    error::XTypesError,
 };
 use alloc::{boxed::Box, string::String, vec::Vec};
 pub use dust_dds_derive::TypeSupport;
+
+use super::{data_storage::DataStorage, error::XTypesResult};
 
 /// The Type trait represents static type information of Rust types
 pub trait Type {
@@ -536,6 +540,58 @@ impl Type for Vec<String> {
         },
         member_list: &[],
     };
+}
+
+/// Type used to represent bounded strings on DDS Types
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct BoundedString<const N: u32>(String);
+
+impl<const N: u32> TryFrom<String> for BoundedString<N> {
+    type Error = XTypesError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.len() < N as usize - 1 {
+            Ok(Self(value))
+        } else {
+            Err(XTypesError::InvalidData)
+        }
+    }
+}
+
+impl<const N: u32> From<BoundedString<N>> for String {
+    fn from(value: BoundedString<N>) -> Self {
+        value.0
+    }
+}
+
+impl<const N: u32> Type for BoundedString<N> {
+    const TYPE: DynamicType<'static> = DynamicType {
+        descriptor: &TypeDescriptor {
+            kind: TypeKind::STRING8,
+            name: "",
+            base_type: None,
+            discriminator_type: None,
+            bound: Some(N),
+            element_type: None,
+            key_element_type: None,
+            extensibility_kind: ExtensibilityKind::Final,
+            is_nested: false,
+        },
+        member_list: &[],
+    };
+}
+
+impl<const N: u32> DataStorageMapping for BoundedString<N> {
+    fn into_storage(self) -> DataStorage {
+        DataStorage::String(self.0)
+    }
+
+    fn try_from_storage(data_storage: DataStorage) -> XTypesResult<Self> {
+        match data_storage {
+            DataStorage::String(x) => Ok(Self(x)),
+            _ => Err(XTypesError::InvalidType),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR fixes the serialization of optional fields and add the possibility of using BoundedStrings as member types of structs. The consequence of this is that now all the pieces are in place to communicate the Complete type ID across the wire and enable XTypes interoperability with other vendors