### PR TITLE
Refactor: Make the internal implementation dcps mod private

### DIFF
--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_reader_data.rs
@@ -39,7 +39,7 @@ pub struct DiscoveredReaderData {
 }
 
 impl DiscoveredReaderData {
-    pub fn to_bytes(self) -> Vec<u8> {
+    pub fn into_bytes(self) -> Vec<u8> {
         let mut buffer = Vec::new();
         let mut pl = ParameterListSerializer::new(&mut buffer);
         pl.write_header();
@@ -248,7 +248,7 @@ mod tests {
                 expects_inline_qos: false,
             },
         }
-        .to_bytes();
+        .into_bytes();
 
         let expected = [
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
@@ -321,7 +321,7 @@ mod tests {
                 expects_inline_qos: false,
             },
         }
-        .to_bytes();
+        .into_bytes();
 
         let expected = [
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_topic_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_topic_data.rs
@@ -25,7 +25,7 @@ pub struct DiscoveredTopicData {
 }
 
 impl DiscoveredTopicData {
-    pub fn to_bytes(self) -> Vec<u8> {
+    pub fn into_bytes(self) -> Vec<u8> {
         let mut buffer = Vec::new();
         let mut pl = ParameterListSerializer::new(&mut buffer);
         pl.write_header();
@@ -163,7 +163,7 @@ mod tests {
                 representation: topic_qos.representation,
             },
         }
-        .to_bytes();
+        .into_bytes();
 
         let expected = [
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE

--- a/dds/src/dcps/data_representation_builtin_endpoints/discovered_writer_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/discovered_writer_data.rs
@@ -37,7 +37,7 @@ pub struct DiscoveredWriterData {
 }
 
 impl DiscoveredWriterData {
-    pub fn to_bytes(self) -> Vec<u8> {
+    pub fn into_bytes(self) -> Vec<u8> {
         let mut buffer = Vec::new();
         let mut pl = ParameterListSerializer::new(&mut buffer);
         pl.write_header();
@@ -223,7 +223,7 @@ mod tests {
                 multicast_locator_list: vec![],
             },
         }
-        .to_bytes();
+        .into_bytes();
 
         let expected = [
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE

--- a/dds/src/dcps/data_representation_builtin_endpoints/parameter_id_values.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/parameter_id_values.rs
@@ -7,7 +7,7 @@ pub type ParameterId = Short;
 
 // Constant value from Table 9.13 - ParameterId Values
 pub const _PID_PAD: ParameterId = 0x0000;
-pub const PID_SENTINEL: ParameterId = 0x0001;
+pub const _PID_SENTINEL: ParameterId = 0x0001;
 pub const PID_USER_DATA: ParameterId = 0x002c;
 pub const PID_TOPIC_NAME: ParameterId = 0x0005;
 pub const PID_TYPE_NAME: ParameterId = 0x0007;
@@ -65,7 +65,7 @@ pub const PID_TYPE_CONSISTENCY_ENFORCEMENT: ParameterId = 0x0074;
 #[allow(overflowing_literals)]
 pub const _PID_TYPE_REPRESENTATION: ParameterId = 0x8010;
 #[allow(overflowing_literals)]
-pub const PID_DISCOVERED_PARTICIPANT: ParameterId = 0x8020;
+pub const _PID_DISCOVERED_PARTICIPANT: ParameterId = 0x8020;
 
 // Constant value from Table 9.14 - ParameterId mapping and default values
 // that are not N/A and not See DDS specification

--- a/dds/src/dcps/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/spdp_discovered_participant_data.rs
@@ -143,7 +143,7 @@ pub struct SpdpDiscoveredParticipantData {
 }
 
 impl SpdpDiscoveredParticipantData {
-    pub fn to_bytes(self) -> Vec<u8> {
+    pub fn into_bytes(self) -> Vec<u8> {
         let mut buffer = Vec::new();
 
         let mut pl = ParameterListSerializer::new(&mut buffer);
@@ -298,7 +298,7 @@ mod tests {
             lease_duration: Duration::new(10, 11),
             discovered_participant_list: vec![],
         }
-        .to_bytes();
+        .into_bytes();
 
         let expected = [
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
@@ -399,7 +399,7 @@ mod tests {
             lease_duration: DEFAULT_PARTICIPANT_LEASE_DURATION,
             discovered_participant_list: Vec::new(),
         }
-        .to_bytes();
+        .into_bytes();
 
         let expected = [
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE

--- a/dds/src/dcps/data_representation_builtin_endpoints/type_lookup.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/type_lookup.rs
@@ -128,7 +128,7 @@ pub struct RequestHeader {
 
 #[derive(DdsType)]
 #[dust_dds(extensibility = "final")]
-pub struct ReplyHeader {
+pub struct _ReplyHeader {
     pub related_request_id: SampleIdentity,
 }
 

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -122,7 +122,7 @@ impl DcpsDomainParticipant {
             {
                 let timestamp = runtime.clock().now();
                 let sample_instance_handle = self.domain_participant.instance_handle;
-                let serialized_data = spdp_discovered_participant_data.to_bytes();
+                let serialized_data = spdp_discovered_participant_data.into_bytes();
                 let sample_timestamp = timestamp;
                 let now = timestamp;
                 w.write_w_timestamp(
@@ -264,7 +264,7 @@ impl DcpsDomainParticipant {
         {
             let now = runtime.clock().now();
             let sample_instance_handle = data_writer.transport_writer.guid().into();
-            let serialized_data = discovered_writer_data.to_bytes();
+            let serialized_data = discovered_writer_data.into_bytes();
             let sample_timestamp = now;
             let message_writer = self.transport.message_writer.as_ref();
             dw.write_w_timestamp(
@@ -406,7 +406,7 @@ impl DcpsDomainParticipant {
         {
             let now = runtime.clock().now();
             let sample_instance_handle = data_reader.transport_reader.guid().into();
-            let serialized_data = discovered_reader_data.to_bytes();
+            let serialized_data = discovered_reader_data.into_bytes();
             let sample_timestamp = now;
             let message_writer = self.transport.message_writer.as_ref();
             dw.write_w_timestamp(
@@ -494,7 +494,7 @@ impl DcpsDomainParticipant {
             .find(|x| x.topic_name == DCPS_TOPIC)
         {
             let sample_instance_handle = topic.instance_handle;
-            let serialized_data = discovered_topic_data.to_bytes();
+            let serialized_data = discovered_topic_data.into_bytes();
             let now = runtime.clock().now();
             let sample_timestamp = now;
             let message_writer = self.transport.message_writer.as_ref();

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -766,10 +766,6 @@ impl DcpsDomainParticipant {
         &self.domain_participant.instance_handle
     }
 
-    pub fn get_builtin_subscriber_status_condition(&self) -> &DcpsStatusCondition {
-        &self.domain_participant.builtin_subscriber.status_condition
-    }
-
     #[tracing::instrument(skip(self, runtime))]
     pub fn offered_deadline_missed(
         &mut self,

--- a/dds/src/dcps/infrastructure/qos.rs
+++ b/dds/src/dcps/infrastructure/qos.rs
@@ -55,6 +55,7 @@ pub struct PublisherQos {
 }
 
 impl PublisherQos {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             presentation: PresentationQosPolicy::const_default(),
@@ -107,6 +108,7 @@ pub struct DataWriterQos {
 }
 
 impl DataWriterQos {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             reliability: ReliabilityQosPolicy {
@@ -197,6 +199,7 @@ pub struct SubscriberQos {
 }
 
 impl SubscriberQos {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             presentation: PresentationQosPolicy::const_default(),
@@ -254,6 +257,7 @@ pub struct DataReaderQos {
 }
 
 impl DataReaderQos {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             reliability: ReliabilityQosPolicy {
@@ -362,6 +366,7 @@ pub struct TopicQos {
 }
 
 impl TopicQos {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             reliability: ReliabilityQosPolicy {

--- a/dds/src/dcps/infrastructure/qos_policy.rs
+++ b/dds/src/dcps/infrastructure/qos_policy.rs
@@ -204,6 +204,7 @@ pub struct UserDataQosPolicy {
 }
 
 impl UserDataQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self { value: Vec::new() }
     }
@@ -230,6 +231,7 @@ pub struct TopicDataQosPolicy {
 }
 
 impl TopicDataQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self { value: Vec::new() }
     }
@@ -261,6 +263,7 @@ pub struct GroupDataQosPolicy {
 }
 
 impl GroupDataQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self { value: Vec::new() }
     }
@@ -295,6 +298,7 @@ pub struct TransportPriorityQosPolicy {
 }
 
 impl TransportPriorityQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self { value: 0 }
     }
@@ -333,6 +337,7 @@ pub struct LifespanQosPolicy {
 }
 
 impl LifespanQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             duration: DurationKind::Infinite,
@@ -417,6 +422,7 @@ pub struct DurabilityQosPolicy {
 }
 
 impl DurabilityQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             kind: DurabilityQosPolicyKind::Volatile,
@@ -509,6 +515,7 @@ pub struct PresentationQosPolicy {
 }
 
 impl PresentationQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             access_scope: PresentationQosPolicyAccessScopeKind::Instance,
@@ -552,6 +559,7 @@ pub struct DeadlineQosPolicy {
 }
 
 impl DeadlineQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             period: DurationKind::Infinite,
@@ -585,6 +593,7 @@ pub struct LatencyBudgetQosPolicy {
 }
 
 impl LatencyBudgetQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             duration: DurationKind::Finite(Duration::new(DURATION_ZERO_SEC, DURATION_ZERO_NSEC)),
@@ -630,6 +639,7 @@ pub struct OwnershipQosPolicy {
 }
 
 impl OwnershipQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             kind: OwnershipQosPolicyKind::Shared,
@@ -686,6 +696,7 @@ pub struct OwnershipStrengthQosPolicy {
 }
 
 impl OwnershipStrengthQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self { value: 0 }
     }
@@ -771,6 +782,7 @@ pub struct LivelinessQosPolicy {
 }
 
 impl LivelinessQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             kind: LivelinessQosPolicyKind::Automatic,
@@ -821,6 +833,7 @@ pub struct TimeBasedFilterQosPolicy {
 }
 
 impl TimeBasedFilterQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             minimum_separation: DurationKind::Finite(Duration::new(
@@ -872,6 +885,7 @@ pub struct PartitionQosPolicy {
 }
 
 impl PartitionQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self { name: Vec::new() }
     }
@@ -1018,6 +1032,7 @@ pub struct DestinationOrderQosPolicy {
 }
 
 impl DestinationOrderQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             kind: DestinationOrderQosPolicyKind::ByReceptionTimestamp,
@@ -1108,6 +1123,7 @@ pub struct HistoryQosPolicy {
 }
 
 impl HistoryQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             kind: HistoryQosPolicyKind::KeepLast(1),
@@ -1333,6 +1349,7 @@ impl Type for ResourceLimitsQosPolicy {
 }
 
 impl ResourceLimitsQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             max_samples: Length::Unlimited,
@@ -1373,6 +1390,7 @@ pub struct EntityFactoryQosPolicy {
 }
 
 impl EntityFactoryQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             autoenable_created_entities: true,
@@ -1415,6 +1433,7 @@ pub struct WriterDataLifecycleQosPolicy {
 }
 
 impl WriterDataLifecycleQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             autodispose_unregistered_instances: true,
@@ -1463,6 +1482,7 @@ pub struct ReaderDataLifecycleQosPolicy {
 }
 
 impl ReaderDataLifecycleQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             autopurge_nowriter_samples_delay: DurationKind::Infinite,
@@ -1525,6 +1545,7 @@ pub struct DataRepresentationQosPolicy {
 }
 
 impl DataRepresentationQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             value: DataRepresentationIdSeq::new(),
@@ -1548,7 +1569,9 @@ impl Default for DataRepresentationQosPolicy {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, TypeSupport)]
 #[dust_dds(bit_bound = "16")]
 pub enum TypeConsistencyKind {
+    /// Disallow type coercion for matched types
     DisallowTypeCoercion,
+    /// Allow type coercion for matched types
     AllowTypeCoercion,
 }
 
@@ -1564,6 +1587,7 @@ pub struct TypeConsistencyEnforcementQosPolicy {
 }
 
 impl TypeConsistencyEnforcementQosPolicy {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             kind: TypeConsistencyKind::AllowTypeCoercion,

--- a/dds/src/dcps/infrastructure/qos_policy.rs
+++ b/dds/src/dcps/infrastructure/qos_policy.rs
@@ -1575,14 +1575,32 @@ pub enum TypeConsistencyKind {
     AllowTypeCoercion,
 }
 
+/// This policy defines the rules for determining whether the data type used by a [`DataWriter`](crate::publication::data_writer::DataWriter)
+/// is consistent with the type used by a [`DataReader`](crate::subscription::data_reader::DataReader).
+///
+/// This policy is a DDS-XTypes extension. It allows a [`DataReader`](crate::subscription::data_reader::DataReader) to define the rules
+/// for type consistency when matching with a [`DataWriter`](crate::publication::data_writer::DataWriter). It provides a mechanism
+/// to enforce stricter static type checking than the default assignability rules, ensuring that the data received by a consumer
+/// is compatible with its expected type.
 #[derive(Debug, PartialEq, Eq, Clone, TypeSupport)]
 #[dust_dds(extensibility = "appendable", nested)]
 pub struct TypeConsistencyEnforcementQosPolicy {
+    /// Type consistency kind that determines the coercion strategy (whether to allow type coercion or not).
     pub kind: TypeConsistencyKind,
+    /// Controls whether sequence bounds are ignored when determining type compatibility.
+    /// If true, sequences with different bounds are considered consistent.
     pub ignore_sequence_bounds: bool,
+    /// Controls whether string bounds are ignored when determining type compatibility.
+    /// If true, strings with different bounds are considered consistent.
     pub ignore_string_bounds: bool,
+    /// Controls whether member names are ignored when determining type compatibility.
+    /// If true, compatibility is determined solely by member IDs rather than names.
     pub ignore_member_names: bool,
+    /// Controls whether type widening is prohibited.
+    /// If true, prevents the reader from accepting a "wider" type (a type with more members) than expected.
     pub prevent_type_widening: bool,
+    /// Controls whether explicit type validation is required.
+    /// If true, requires the explicit type information (typically via `TypeObject`) to be available to complete the matching process.
     pub force_type_validation: bool,
 }
 

--- a/dds/src/dcps/infrastructure/status.rs
+++ b/dds/src/dcps/infrastructure/status.rs
@@ -60,6 +60,7 @@ pub struct InconsistentTopicStatus {
 }
 
 impl InconsistentTopicStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             total_count: 0,
@@ -84,6 +85,7 @@ pub struct SampleLostStatus {
 }
 
 impl SampleLostStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             total_count: 0,
@@ -125,6 +127,7 @@ pub struct SampleRejectedStatus {
 }
 
 impl SampleRejectedStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             total_count: 0,
@@ -185,6 +188,7 @@ pub struct LivelinessChangedStatus {
 }
 
 impl LivelinessChangedStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             alive_count: 0,
@@ -219,6 +223,7 @@ pub struct OfferedDeadlineMissedStatus {
 }
 
 impl OfferedDeadlineMissedStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             total_count: 0,
@@ -244,6 +249,7 @@ pub struct RequestedDeadlineMissedStatus {
 }
 
 impl RequestedDeadlineMissedStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             total_count: 0,
@@ -289,6 +295,7 @@ pub struct OfferedIncompatibleQosStatus {
 }
 
 impl OfferedIncompatibleQosStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             total_count: 0,
@@ -320,6 +327,7 @@ pub struct RequestedIncompatibleQosStatus {
 }
 
 impl RequestedIncompatibleQosStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             total_count: 0,
@@ -359,6 +367,7 @@ pub struct PublicationMatchedStatus {
 }
 
 impl PublicationMatchedStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             total_count: 0,
@@ -399,6 +408,7 @@ pub struct SubscriptionMatchedStatus {
 }
 
 impl SubscriptionMatchedStatus {
+    /// Default constructor usable in const contexts
     pub const fn const_default() -> Self {
         Self {
             total_count: 0,

--- a/dds/src/lib.rs
+++ b/dds/src/lib.rs
@@ -14,8 +14,7 @@ pub use dds::*;
 pub mod dds_async;
 
 /// Contains the DCPS logic which provides the behavior to the DDS API
-#[doc(hidden)]
-pub mod dcps;
+mod dcps;
 
 pub use dcps::{builtin_topics, infrastructure};
 


### PR DESCRIPTION
Make the internal implementation dcps mod private to avoid leaking implementation details to the library users.