### PR TITLE
Bugfix: Handle union with case 0

### DIFF
--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -937,19 +937,24 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
         self.deserialize_nopt_fmember(disc_member, dynamic_data)?;
 
         // The discriminator value represents the id of a member
-        let disc_id = match dynamic_data.get_value(disc_member.get_id())? {
-            crate::xtypes::data_storage::DataStorage::UInt8(x) => *x as u32,
-            crate::xtypes::data_storage::DataStorage::Int8(x) => *x as u32,
-            crate::xtypes::data_storage::DataStorage::UInt16(x) => *x as u32,
-            crate::xtypes::data_storage::DataStorage::Int16(x) => *x as u32,
-            crate::xtypes::data_storage::DataStorage::Int32(x) => *x as u32,
-            crate::xtypes::data_storage::DataStorage::UInt32(x) => *x,
+        let disc_id = match dynamic_data.get_value(0)? {
+            crate::xtypes::data_storage::DataStorage::UInt8(x) => *x as i32,
+            crate::xtypes::data_storage::DataStorage::Int8(x) => *x as i32,
+            crate::xtypes::data_storage::DataStorage::UInt16(x) => *x as i32,
+            crate::xtypes::data_storage::DataStorage::Int16(x) => *x as i32,
+            crate::xtypes::data_storage::DataStorage::Int32(x) => *x,
+            crate::xtypes::data_storage::DataStorage::UInt32(x) => *x as i32,
             _ => return Err(XTypesError::InvalidType),
         };
 
-        // Deserialize the member based on its discriminator
-        let member = dynamic_type.get_member(disc_id)?;
-        self.deserialize_fmember(member, dynamic_data)
+        for member_index in 0..dynamic_type.get_member_count() {
+            let member = dynamic_type.get_member_by_index(member_index)?;
+            // Deserialize the member based on its discriminator
+            if member.descriptor.label.contains(&disc_id) {
+                return self.deserialize_fmember(member, dynamic_data);
+            }
+        }
+        Err(XTypesError::InvalidData)
     }
 }
 

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -190,7 +190,7 @@ impl<'a, E: EndiannessWrite, V: EncodingVersion> XTypesSerializer<'a, E, V> {
     fn serialize_value(&mut self, v: &DynamicData, member_id: u32) -> Result<(), XTypesError> {
         let member_descriptor = v.get_descriptor(member_id)?;
         match member_descriptor.r#type.get_kind() {
-            TypeKind::NONE => todo!(),
+            TypeKind::NONE => (),
             TypeKind::BOOLEAN => self.serialize_primitive_type(v.get_boolean_value(member_id)?),
             TypeKind::BYTE => self.serialize_primitive_type(v.get_byte_value(member_id)?),
             TypeKind::INT16 => self.serialize_primitive_type(v.get_int16_value(member_id)?),
@@ -475,10 +475,26 @@ impl<'a, E: EndiannessWrite, V: EncodingVersion> XTypesSerializer<'a, E, V> {
     ///             << { O.selected_member : FMEMBER }?
     fn serialize_funion_type(&mut self, v: &DynamicData) -> Result<(), XTypesError> {
         self.serialize_nopt_fmember(v, 0)?;
-        if let Ok(member_id) = v.get_member_id_at_index(1) {
-            self.serialize_nopt_fmember(v, member_id)?;
+
+        // The discriminator value represents the id of a member
+        let disc_id = match v.get_value(0)? {
+            crate::xtypes::data_storage::DataStorage::UInt8(x) => *x as i32,
+            crate::xtypes::data_storage::DataStorage::Int8(x) => *x as i32,
+            crate::xtypes::data_storage::DataStorage::UInt16(x) => *x as i32,
+            crate::xtypes::data_storage::DataStorage::Int16(x) => *x as i32,
+            crate::xtypes::data_storage::DataStorage::Int32(x) => *x,
+            crate::xtypes::data_storage::DataStorage::UInt32(x) => *x as i32,
+            _ => return Err(XTypesError::InvalidType),
+        };
+        let dynamic_type = v.r#type();
+        for member_index in 0..dynamic_type.get_member_count() {
+            let member = dynamic_type.get_member_by_index(member_index)?;
+            if member.descriptor.label.contains(&disc_id) {
+                let member_id = member.get_id();
+                return self.serialize_nopt_fmember(v, member_id);
+            }
         }
-        Ok(())
+        Err(XTypesError::InvalidType)
     }
 }
 

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -309,7 +309,7 @@ fn foo_xtypes_union_should_read_and_write() {
     enum MyEnum {
         #[dust_dds(case = 5)]
         _VariantA(MyInnerType),
-        #[dust_dds(case = 6)]
+        #[dust_dds(case = 0)]
         VariantB { a: u32 },
         #[dust_dds(case = 7)]
         _VariantC,

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -281,7 +281,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
 
             for (variant_index, variant) in xtypes_union.variants.iter().enumerate() {
                 let variant_attributes = get_union_variant_attributes(variant)?;
-                let variant_index_unsuffixed = syn::Index::from(variant_index);
+                let variant_index_unsuffixed = syn::Index::from(variant_index + 1);
                 let is_default_label = variant_attributes.is_default;
 
                 if !has_default && variant_attributes.is_default {
@@ -292,28 +292,27 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 } else {
                     variant_attributes.case
                 };
+                let first_discriminator = case_list[0].clone();
+                let variant_ident = &variant.ident;
+                let variant_name = variant_ident.to_string();
 
-                for disc_expr in &case_list {
-                    let variant_ident = &variant.ident;
-                    let variant_name = variant_ident.to_string();
+                match &variant.fields {
+                    // If there is a single field we handle this as the single type wrapper which is the most common case
+                    Fields::Named(fields_named) if fields_named.named.len() == 1 => {
+                        let variant_field_name =
+                            fields_named.named[0].ident.as_ref().ok_or(syn::Error::new(
+                                fields_named.span(),
+                                "Field of named variant must have defined name",
+                            ))?;
+                        let variant_ty = &fields_named.named[0].ty;
 
-                    match &variant.fields {
-                        // If there is a single field we handle this as the single type wrapper which is the most common case
-                        Fields::Named(fields_named) if fields_named.named.len() == 1 => {
-                            let variant_field_name =
-                                fields_named.named[0].ident.as_ref().ok_or(syn::Error::new(
-                                    fields_named.span(),
-                                    "Field of named variant must have defined name",
-                                ))?;
-                            let variant_ty = &fields_named.named[0].ty;
-
-                            variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+                        variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
                                 name: #variant_name,
-                                id: #disc_expr as u32,
+                                id: #variant_index_unsuffixed as u32,
                                 r#type: <#variant_ty as dust_dds::xtypes::type_support::Type>::TYPE,
                                 default_value: None,
-                                index: 1 as u32,
+                                index: #variant_index_unsuffixed as u32,
                                 try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
                                 label: &[#(#case_list as i32,)*],
                                 is_key: false,
@@ -325,33 +324,33 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                             }
                         }
                         });
-                            let variant_sample = quote! {
-                                Self::#variant_ident {#variant_field_name: <#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
-                                  src.remove_value(#disc_expr as u32).expect("Must exist"),
-                                ).expect("Must match")},
-                            };
+                        let variant_sample = quote! {
+                            Self::#variant_ident {#variant_field_name: <#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
+                              src.remove_value(#variant_index_unsuffixed as u32).expect("Must exist"),
+                            ).expect("Must match")},
+                        };
 
-                            variant_sample_seq.push(if variant_attributes.is_default {
-                                quote! {_ => #variant_sample}
-                            } else {
-                                quote! {#disc_expr => #variant_sample}
-                            });
-                            variant_dynamic_sample_seq
+                        variant_sample_seq.push(if variant_attributes.is_default {
+                            quote! {_ => #variant_sample}
+                        } else {
+                            quote! {#first_discriminator => #variant_sample}
+                        });
+                        variant_dynamic_sample_seq
                             .push(quote! {Self::#variant_ident {#variant_field_name} => {
-                                data.set_value(0, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#disc_expr));
-                                data.set_value(#disc_expr as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(#variant_field_name));
+                                data.set_value(0, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#first_discriminator));
+                                data.set_value(#variant_index_unsuffixed as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(#variant_field_name));
                             }});
-                        }
-                        Fields::Unnamed(fields_unnamed) if fields_unnamed.unnamed.len() == 1 => {
-                            let variant_ty = &fields_unnamed.unnamed[0].ty;
+                    }
+                    Fields::Unnamed(fields_unnamed) if fields_unnamed.unnamed.len() == 1 => {
+                        let variant_ty = &fields_unnamed.unnamed[0].ty;
 
-                            variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+                        variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
                                 name: #variant_name,
-                                id: #disc_expr as u32,
+                                id: #variant_index_unsuffixed as u32,
                                 r#type: <#variant_ty as dust_dds::xtypes::type_support::Type>::TYPE,
                                 default_value: None,
-                                index: 1 as u32,
+                                index: #variant_index_unsuffixed as u32,
                                 try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
                                 label: &[#(#case_list as i32,)*],
                                 is_key: false,
@@ -363,28 +362,28 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                             }
                         }
                         });
-                            let variant_sample = quote! {
-                                Self::#variant_ident(<#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
-                                  src.remove_value(#disc_expr as u32).expect("Must exist"),
-                                ).expect("Must match")),
-                            };
+                        let variant_sample = quote! {
+                            Self::#variant_ident(<#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
+                              src.remove_value(#variant_index_unsuffixed as u32).expect("Must exist"),
+                            ).expect("Must match")),
+                        };
 
-                            variant_sample_seq.push(if variant_attributes.is_default {
-                                quote! {_ => #variant_sample}
-                            } else {
-                                quote! {#disc_expr => #variant_sample}
-                            });
-                            variant_dynamic_sample_seq
+                        variant_sample_seq.push(if variant_attributes.is_default {
+                            quote! {_ => #variant_sample}
+                        } else {
+                            quote! {#first_discriminator => #variant_sample}
+                        });
+                        variant_dynamic_sample_seq
                             .push(quote! {Self::#variant_ident (a) => {
-                                data.set_value(0, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#disc_expr));
-                                data.set_value(#disc_expr as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(a));
+                                data.set_value(0, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#first_discriminator));
+                                data.set_value(#variant_index_unsuffixed as u32, ::dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(a));
                             }});
-                        }
-                        Fields::Unit => {
-                            variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+                    }
+                    Fields::Unit => {
+                        variant_list.push(quote!{ dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
                                 name: #variant_name,
-                                id: #disc_expr as u32,
+                                id: #variant_index_unsuffixed as u32,
                                 r#type: dust_dds::xtypes::dynamic_type::DynamicType {
                                     descriptor: &dust_dds::xtypes::dynamic_type::TypeDescriptor {
                                         kind: dust_dds::xtypes::dynamic_type::TypeKind::NONE,
@@ -400,7 +399,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                                     member_list: &[],
                                 },
                                 default_value: None,
-                                index: 1 as u32,
+                                index: #variant_index_unsuffixed as u32,
                                 try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
                                 label: &[#(#case_list as i32,)*],
                                 is_key: false,
@@ -412,25 +411,24 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                             }
                         }
                         });
-                            let variant_sample = quote! {
-                                Self::#variant_ident,
-                            };
+                        let variant_sample = quote! {
+                            Self::#variant_ident,
+                        };
 
-                            variant_sample_seq.push(if variant_attributes.is_default {
-                                quote! {_ => #variant_sample}
-                            } else {
-                                quote! {#disc_expr => #variant_sample}
-                            });
-                            variant_dynamic_sample_seq.push(quote! {Self::#variant_ident => {
-                            data.set_value(0, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#disc_expr));
+                        variant_sample_seq.push(if variant_attributes.is_default {
+                            quote! {_ => #variant_sample}
+                        } else {
+                            quote! {#first_discriminator => #variant_sample}
+                        });
+                        variant_dynamic_sample_seq.push(quote! {Self::#variant_ident => {
+                            data.set_value(0, <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::into_storage(#first_discriminator));
                         },});
-                        }
-                        Fields::Named(_) | Fields::Unnamed(_) => {
-                            return Err(syn::Error::new(
-                                variant.span(),
-                                "Only variants with a single field are supported",
-                            ));
-                        }
+                    }
+                    Fields::Named(_) | Fields::Unnamed(_) => {
+                        return Err(syn::Error::new(
+                            variant.span(),
+                            "Only variants with a single field are supported",
+                        ));
                     }
                 }
             }


### PR DESCRIPTION
Handle union with case 0 by explicitly searching the discriminator in the label list. This avoid conflicts with the id numbers of the discriminator member being also 0