### PR TITLE
Add function to explicitly shutdown the participant factory

### DIFF
--- a/dds/examples/tracing_opentelemetry.rs
+++ b/dds/examples/tracing_opentelemetry.rs
@@ -65,7 +65,8 @@ fn main() {
 
     let domain_id = 0;
 
-    let participant = DomainParticipantFactory::get_instance()
+    let participant_factory = DomainParticipantFactory::get_instance();
+    let participant = participant_factory
         .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
         .unwrap();
 
@@ -150,6 +151,7 @@ fn main() {
     assert_eq!(samples.len(), 1);
     assert_eq!(samples[0].data.as_ref().unwrap(), &data);
 
+    participant_factory.shutdown();
     provider.shutdown().unwrap();
     std::thread::sleep(std::time::Duration::from_secs(10));
 }

--- a/dds/src/dds/domain/domain_participant_factory.rs
+++ b/dds/src/dds/domain/domain_participant_factory.rs
@@ -128,6 +128,11 @@ impl<T: TransportParticipantFactory> DomainParticipantFactory<T> {
     pub fn get_mut_configuration(&self) -> impl DerefMut<Target = DustDdsConfiguration> + '_ {
         block_on(self.participant_factory_async.get_mut_configuration())
     }
+
+    #[doc(hidden)]
+    pub fn shutdown(&self) {
+        self.participant_factory_async.shutdown();
+    }
 }
 
 impl DomainParticipantFactory<RtpsUdpTransportParticipantFactory> {

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -64,6 +64,8 @@ pub struct DomainParticipantFactoryAsync<T: TransportParticipantFactory> {
     host_id: [u8; 4],
     transport: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, T>,
     configuration: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, DustDdsConfiguration>,
+    worker_task: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, Option<core::pin::Pin<alloc::boxed::Box<dyn core::future::Future<Output = ()> + Send + 'static>>>>,
+    run_loop: alloc::sync::Arc<core::sync::atomic::AtomicBool>,
 }
 
 impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
@@ -265,8 +267,10 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                 DCPS_CHANNEL.sender(),
             );
         let dcps_receiver = DCPS_CHANNEL.receiver();
-        spawner_handle.spawn(async move {
-            loop {
+        let run_loop = alloc::sync::Arc::new(core::sync::atomic::AtomicBool::new(true));
+        let run_loop_clone = run_loop.clone();
+        let worker_task = spawner_handle.spawn(async move {
+            while run_loop_clone.load(core::sync::atomic::Ordering::Relaxed) {
                 let poke_time = Duration::new(0, 50_000_000);
                 let next_task_time = domain_participant_factory
                     .time_until_stale_participant()
@@ -296,6 +300,8 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             entity_counter: core::sync::atomic::AtomicU32::new(0),
             transport: Mutex::new(transport),
             configuration: Mutex::new(configuration),
+            worker_task: Mutex::new(Some(alloc::boxed::Box::pin(worker_task))),
+            run_loop,
         }
     }
 
@@ -319,5 +325,15 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             instance_id[2],
             instance_id[3], // Instance ID
         ]
+    }
+}
+
+impl<T: TransportParticipantFactory> Drop for DomainParticipantFactoryAsync<T> {
+    fn drop(&mut self) {
+        self.run_loop.store(false, core::sync::atomic::Ordering::Relaxed);
+        if let Some(worker_task) = self.worker_task.get_mut().take() {
+            #[cfg(feature = "std")]
+            crate::std_runtime::executor::block_on(worker_task);
+        }
     }
 }

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -21,7 +21,7 @@ use crate::{
         status::StatusKind,
         time::Duration,
     },
-    runtime::{DdsRuntime, Either, Spawner, Timer, select_future},
+    runtime::{DdsRuntime, Either, Spawner, TaskHandle, Timer, select_future},
     transport::{
         interface::{TransportDataReceiver, TransportParticipantFactory},
         types::{ENTITYID_PARTICIPANT, Guid, GuidPrefix},
@@ -64,7 +64,7 @@ pub struct DomainParticipantFactoryAsync<T: TransportParticipantFactory> {
     host_id: [u8; 4],
     transport: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, T>,
     configuration: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, DustDdsConfiguration>,
-    worker_task: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, Option<core::pin::Pin<alloc::boxed::Box<dyn core::future::Future<Output = ()> + Send + 'static>>>>,
+    worker_task: alloc::boxed::Box<dyn TaskHandle>,
     run_loop: alloc::sync::Arc<core::sync::atomic::AtomicBool>,
 }
 
@@ -270,6 +270,8 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         let run_loop = alloc::sync::Arc::new(core::sync::atomic::AtomicBool::new(true));
         let run_loop_clone = run_loop.clone();
         let worker_task = spawner_handle.spawn(async move {
+            let span = tracing::trace_span!("dds_actor_loop");
+            let _enter = span.enter();
             while run_loop_clone.load(core::sync::atomic::Ordering::Relaxed) {
                 let poke_time = Duration::new(0, 50_000_000);
                 let next_task_time = domain_participant_factory
@@ -300,7 +302,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             entity_counter: core::sync::atomic::AtomicU32::new(0),
             transport: Mutex::new(transport),
             configuration: Mutex::new(configuration),
-            worker_task: Mutex::new(Some(alloc::boxed::Box::pin(worker_task))),
+            worker_task: Box::new(worker_task),
             run_loop,
         }
     }
@@ -326,14 +328,11 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             instance_id[3], // Instance ID
         ]
     }
-}
 
-impl<T: TransportParticipantFactory> Drop for DomainParticipantFactoryAsync<T> {
-    fn drop(&mut self) {
-        self.run_loop.store(false, core::sync::atomic::Ordering::Relaxed);
-        if let Some(worker_task) = self.worker_task.get_mut().take() {
-            #[cfg(feature = "std")]
-            crate::std_runtime::executor::block_on(worker_task);
-        }
+    #[doc(hidden)]
+    pub fn shutdown(&self) {
+        self.run_loop
+            .store(false, core::sync::atomic::Ordering::Relaxed);
+        self.worker_task.join();
     }
 }

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -1,4 +1,4 @@
-use alloc::borrow::ToOwned;
+use alloc::{borrow::ToOwned, boxed::Box};
 use core::ops::DerefMut;
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};

--- a/dds/src/runtime.rs
+++ b/dds/src/runtime.rs
@@ -18,11 +18,14 @@ pub trait Timer: Clone + Send + Sync + 'static {
 
 /// Provides task spawning capabilities for asynchronous execution.
 pub trait Spawner: Clone + Send + Sync + 'static {
+    /// The handle returned when spawning a task, allowing it to be joined.
+    type TaskHandle: Future<Output = ()> + Send;
+
     /// Spawns a new asynchronous task.
     ///
     /// # Arguments
     /// * `f` - Future to be spawned as a new task
-    fn spawn(&self, f: impl Future<Output = ()> + Send + 'static);
+    fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) -> Self::TaskHandle;
 }
 
 /// Main runtime trait for the DDS system, providing access to various async primitives

--- a/dds/src/runtime.rs
+++ b/dds/src/runtime.rs
@@ -16,10 +16,16 @@ pub trait Timer: Clone + Send + Sync + 'static {
     fn delay(&mut self, duration: core::time::Duration) -> impl Future<Output = ()> + Send;
 }
 
+/// Represents a handle to a spawned task.
+pub trait TaskHandle: Send + Sync + 'static {
+    /// Join the task, waiting for it to finish.
+    fn join(&self);
+}
+
 /// Provides task spawning capabilities for asynchronous execution.
 pub trait Spawner: Clone + Send + Sync + 'static {
     /// The handle returned when spawning a task, allowing it to be joined.
-    type TaskHandle: Future<Output = ()> + Send;
+    type TaskHandle: TaskHandle;
 
     /// Spawns a new asynchronous task.
     ///

--- a/dds/src/std_runtime/executor.rs
+++ b/dds/src/std_runtime/executor.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::{
     infrastructure::error::{DdsError, DdsResult},
-    runtime::Spawner,
+    runtime::{Spawner, TaskHandle},
 };
 
 pub fn block_timeout<T>(
@@ -83,24 +83,34 @@ pub struct Task {
     join_waker: Mutex<Option<Waker>>,
 }
 
-pub struct TaskHandle {
+pub struct ExecutorTaskHandle {
     task: Arc<Task>,
 }
 
-impl Future for TaskHandle {
-    type Output = ();
+impl TaskHandle for ExecutorTaskHandle {
+    fn join(&self) {
+        struct JoinFuture<'a> {
+            task: &'a Arc<Task>,
+        }
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.task.is_finished() {
-            Poll::Ready(())
-        } else {
-            *self.task.join_waker.lock().unwrap() = Some(cx.waker().clone());
-            if self.task.is_finished() {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
+        impl<'a> Future for JoinFuture<'a> {
+            type Output = ();
+
+            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+                if self.task.is_finished() {
+                    Poll::Ready(())
+                } else {
+                    *self.task.join_waker.lock().unwrap() = Some(cx.waker().clone());
+                    if self.task.is_finished() {
+                        Poll::Ready(())
+                    } else {
+                        Poll::Pending
+                    }
+                }
             }
         }
+
+        block_on(JoinFuture { task: &self.task });
     }
 }
 
@@ -130,7 +140,7 @@ pub struct ExecutorHandle {
 }
 
 impl ExecutorHandle {
-    pub fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) -> TaskHandle {
+    pub fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) -> ExecutorTaskHandle {
         let future = Box::pin(f);
         let task = Arc::new(Task {
             future: Mutex::new(future),
@@ -143,12 +153,12 @@ impl ExecutorHandle {
             .send(task.clone())
             .expect("Should never fail to send");
         self.thread_handle.unpark();
-        TaskHandle { task }
+        ExecutorTaskHandle { task }
     }
 }
 
 impl Spawner for ExecutorHandle {
-    type TaskHandle = TaskHandle;
+    type TaskHandle = ExecutorTaskHandle;
 
     fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) -> Self::TaskHandle {
         self.spawn(f)

--- a/dds/src/std_runtime/executor.rs
+++ b/dds/src/std_runtime/executor.rs
@@ -80,6 +80,28 @@ pub struct Task {
     task_sender: Sender<Arc<Task>>,
     thread_handle: Thread,
     finished: AtomicBool,
+    join_waker: Mutex<Option<Waker>>,
+}
+
+pub struct TaskHandle {
+    task: Arc<Task>,
+}
+
+impl Future for TaskHandle {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.task.is_finished() {
+            Poll::Ready(())
+        } else {
+            *self.task.join_waker.lock().unwrap() = Some(cx.waker().clone());
+            if self.task.is_finished() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        }
+    }
 }
 
 impl Task {
@@ -108,24 +130,28 @@ pub struct ExecutorHandle {
 }
 
 impl ExecutorHandle {
-    pub fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) {
+    pub fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) -> TaskHandle {
         let future = Box::pin(f);
         let task = Arc::new(Task {
             future: Mutex::new(future),
             task_sender: self.task_sender.clone(),
             thread_handle: self.thread_handle.clone(),
             finished: AtomicBool::new(false),
+            join_waker: Mutex::new(None),
         });
         self.task_sender
             .send(task.clone())
             .expect("Should never fail to send");
         self.thread_handle.unpark();
+        TaskHandle { task }
     }
 }
 
 impl Spawner for ExecutorHandle {
-    fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) {
-        self.spawn(f);
+    type TaskHandle = TaskHandle;
+
+    fn spawn(&self, f: impl Future<Output = ()> + Send + 'static) -> Self::TaskHandle {
+        self.spawn(f)
     }
 }
 
@@ -159,7 +185,10 @@ impl Executor {
                                     .as_mut()
                                     .poll(&mut cx);
                                 if matches!(poll_result, Poll::Ready(_)) {
-                                    task.finished.store(true, atomic::Ordering::Relaxed);
+                                    task.finished.store(true, atomic::Ordering::Release);
+                                    if let Some(waker) = task.join_waker.lock().unwrap().take() {
+                                        waker.wake();
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
This PR adds a function to explicitly shutdown the participant factory. This function doesn't need to be used except in cases where an elegant shutdown of the DDS loop is required. An example of this is when collecting logs on opentelemetry.