### PR TITLE
XTypes: External member support

### DIFF
--- a/dds/src/xtypes/data_storage.rs
+++ b/dds/src/xtypes/data_storage.rs
@@ -3,7 +3,7 @@ use crate::xtypes::{
     error::{XTypesError, XTypesResult},
     type_support::TypeSupport,
 };
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 /// Representation of data storage for dynamic types.
 #[derive(Debug, Clone, PartialEq)]
@@ -663,18 +663,6 @@ impl<T: DataStorageMapping> DataStorageMapping for Option<T> {
 
     fn try_from_storage(data_storage: DataStorage) -> XTypesResult<Self> {
         Ok(Some(T::try_from_storage(data_storage)?))
-    }
-}
-
-impl DataStorageMapping for Box<super::type_object::TypeIdentifier> {
-    fn into_storage(self) -> DataStorage {
-        super::type_object::TypeIdentifier::into_storage(*self)
-    }
-
-    fn try_from_storage(data_storage: DataStorage) -> XTypesResult<Self> {
-        Ok(Box::new(
-            super::type_object::TypeIdentifier::try_from_storage(data_storage)?,
-        ))
     }
 }
 

--- a/dds/src/xtypes/type_support.rs
+++ b/dds/src/xtypes/type_support.rs
@@ -249,6 +249,20 @@ impl Type for char {
     };
 }
 
+impl<T: Type> Type for Box<T> {
+    const TYPE: DynamicType<'static> = T::TYPE;
+}
+
+impl<T: TypeSupport> TypeSupport for Box<T> {
+    fn create_sample(src: &mut DynamicData<'static>) -> Self {
+        Box::new(T::create_sample(src))
+    }
+
+    fn create_dynamic_sample(self) -> DynamicData<'static> {
+        T::create_dynamic_sample(*self)
+    }
+}
+
 impl<T: Type> Type for Option<T> {
     const TYPE: DynamicType<'static> = T::TYPE;
 }

--- a/dds/src/xtypes/type_support.rs
+++ b/dds/src/xtypes/type_support.rs
@@ -3,7 +3,7 @@ use crate::xtypes::{
     dynamic_type::{DynamicData, DynamicType, ExtensibilityKind, TypeDescriptor, TypeKind},
     error::XTypesError,
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
 pub use dust_dds_derive::TypeSupport;
 
 use super::{data_storage::DataStorage, error::XTypesResult};

--- a/dds/src/xtypes/type_support.rs
+++ b/dds/src/xtypes/type_support.rs
@@ -3,7 +3,7 @@ use crate::xtypes::{
     dynamic_type::{DynamicData, DynamicType, ExtensibilityKind, TypeDescriptor, TypeKind},
     error::XTypesError,
 };
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 pub use dust_dds_derive::TypeSupport;
 
 use super::{data_storage::DataStorage, error::XTypesResult};
@@ -244,23 +244,6 @@ impl Type for char {
             key_element_type: None,
             extensibility_kind: ExtensibilityKind::Final,
             is_nested: true,
-        },
-        member_list: &[],
-    };
-}
-
-impl<T> Type for Box<T> {
-    const TYPE: DynamicType<'static> = DynamicType {
-        descriptor: &TypeDescriptor {
-            kind: TypeKind::ALIAS,
-            name: "",
-            base_type: None,
-            discriminator_type: None,
-            bound: None,
-            element_type: None,
-            key_element_type: None,
-            extensibility_kind: ExtensibilityKind::Final,
-            is_nested: false,
         },
         member_list: &[],
     };

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -212,7 +212,7 @@ fn nested_types_should_read_and_write() {
 
     #[derive(Clone, PartialEq, Eq, Debug, DdsType)]
     struct OuterType {
-        inner: InnerType,
+        inner: Box<InnerType>,
         flag: bool,
     }
 
@@ -281,7 +281,7 @@ fn nested_types_should_read_and_write() {
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
     let data = OuterType {
-        inner: InnerType { a: 20, b: 5 },
+        inner: Box::new(InnerType { a: 20, b: 5 }),
         flag: true,
     };
 

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -103,13 +103,26 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 let is_external = struct_member_attributes.external;
                 let default_value = struct_member_attributes.default_value.map(|x| quote! {#x});
 
+                let member_dynamic_type = if is_external {
+                    todo!("Check that the type of this member is Box<T>, otherwise return error message saying that Box<T> is expected for external");
+                    todo!("Retrieve the type T from the inside of the Box");
+                    quote! {
+                        dust_dds::xtypes::dynamic_type::DynamicType {
+                            descriptor: todo!("Use the descriptor of type T to fill up this information"),
+                            member_list: &[]
+                        }
+                    }
+                } else {
+                    quote! { <#member_type as dust_dds::xtypes::type_support::Type>::TYPE}
+                };
+
                 member_list.push(
                     quote! {
                          dust_dds::xtypes::dynamic_type::DynamicTypeMember {
                             descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
                                 name: #member_name,
                                 id: #member_id,
-                                r#type: <#member_type as dust_dds::xtypes::type_support::Type>::TYPE,
+                                r#type: #member_dynamic_type,
                                 default_value: None,
                                 index: #index as u32,
                                 try_construct_kind: dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -104,11 +104,57 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 let default_value = struct_member_attributes.default_value.map(|x| quote! {#x});
 
                 let member_dynamic_type = if is_external {
-                    todo!("Check that the type of this member is Box<T>, otherwise return error message saying that Box<T> is expected for external");
-                    todo!("Retrieve the type T from the inside of the Box");
+                    let inner_type = if let syn::Type::Path(type_path) = member_type {
+                        if let Some(segment) = type_path.path.segments.last() {
+                            if segment.ident == "Box" {
+                                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+                                {
+                                    if args.args.len() == 1 {
+                                        if let syn::GenericArgument::Type(inner_type) =
+                                            &args.args[0]
+                                        {
+                                            Some(inner_type)
+                                        } else {
+                                            None
+                                        }
+                                    } else {
+                                        None
+                                    }
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
+                    let inner_type = inner_type.ok_or_else(|| {
+                        syn::Error::new(
+                            member_type.span(),
+                            "#[dust_dds(external)] is only supported on Box<T> types",
+                        )
+                    })?;
+
+                    let member_type_name = quote::quote!(#inner_type).to_string().replace(" ", "");
+
                     quote! {
                         dust_dds::xtypes::dynamic_type::DynamicType {
-                            descriptor: todo!("Use the descriptor of type T to fill up this information"),
+                            descriptor: &dust_dds::xtypes::dynamic_type::TypeDescriptor {
+                                kind: dust_dds::xtypes::dynamic_type::TypeKind::NONE,
+                                name: #member_type_name,
+                                base_type: None,
+                                discriminator_type: None,
+                                bound: None,
+                                element_type: None,
+                                key_element_type: None,
+                                extensibility_kind: dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final,
+                                is_nested: false,
+                            },
                             member_list: &[]
                         }
                     }


### PR DESCRIPTION
Fix the support for members marked external and Box<T> as part of the structs to be sent on the wire