### PR TITLE
626 feat shared ownership policy

### DIFF
--- a/bindings/python/src/publication/data_writer.rs
+++ b/bindings/python/src/publication/data_writer.rs
@@ -51,7 +51,7 @@ impl DataWriter {
     ) -> PyResult<Option<InstanceHandle>> {
         Ok(self
             .0
-            .register_instance(&convert_python_instance_to_dynamic_data(instance)?.into())
+            .register_instance(convert_python_instance_to_dynamic_data(instance)?.into())
             .map_err(into_pyerr)?
             .map(InstanceHandle::from))
     }
@@ -64,7 +64,7 @@ impl DataWriter {
         Ok(self
             .0
             .register_instance_w_timestamp(
-                &convert_python_instance_to_dynamic_data(instance)?.into(),
+                convert_python_instance_to_dynamic_data(instance)?.into(),
                 timestamp.into(),
             )
             .map_err(into_pyerr)?

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -353,12 +353,17 @@ impl DcpsDomainParticipant {
         for publisher in &mut self.domain_participant.user_defined_publisher_list {
             for data_writer in &mut publisher.data_writer_list {
                 if let DurationKind::Finite(deadline) = data_writer.qos.deadline.period {
-                    for instance_publication_time in data_writer
-                        .instance_publication_time
+                    for instance in data_writer
+                        .registered_instance_info
                         .iter_mut()
-                        .filter(|x| now - x.last_write_time > deadline)
+                        .filter(|x| match x.last_write_time {
+                            Some(t) => now - t > deadline,
+                            None => false,
+                        })
                     {
-                        instance_publication_time.last_write_time += deadline;
+                        if let Some(t) = &mut instance.last_write_time {
+                            *t += deadline;
+                        }
                         let the_participant = DomainParticipantAsync::new(
                             self.dcps_sender,
                             self.domain_participant.domain_id,
@@ -385,7 +390,7 @@ impl DcpsDomainParticipant {
                         );
                         data_writer
                             .offered_deadline_missed_status
-                            .last_instance_handle = instance_publication_time.instance;
+                            .last_instance_handle = instance.instance_handle;
                         data_writer.offered_deadline_missed_status.total_count += 1;
                         data_writer
                             .offered_deadline_missed_status

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -353,14 +353,12 @@ impl DcpsDomainParticipant {
         for publisher in &mut self.domain_participant.user_defined_publisher_list {
             for data_writer in &mut publisher.data_writer_list {
                 if let DurationKind::Finite(deadline) = data_writer.qos.deadline.period {
-                    for instance in data_writer
-                        .registered_instance_info
-                        .iter_mut()
-                        .filter(|x| match x.last_write_time {
+                    for instance in data_writer.registered_instance_info.iter_mut().filter(|x| {
+                        match x.last_write_time {
                             Some(t) => now - t > deadline,
                             None => false,
-                        })
-                    {
+                        }
+                    }) {
                         if let Some(t) = &mut instance.last_write_time {
                             *t += deadline;
                         }

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -674,9 +674,10 @@ impl DcpsDomainParticipant {
             .filter_map(|data_writer| {
                 if let DurationKind::Finite(deadline) = data_writer.qos.deadline.period {
                     data_writer
-                        .instance_publication_time
+                        .registered_instance_info
                         .iter()
-                        .map(|instance| deadline - (now - instance.last_write_time))
+                        .filter_map(|instance| instance.last_write_time)
+                        .map(|last_write_time| deadline - (now - last_write_time))
                         .min()
                 } else {
                     None
@@ -1108,13 +1109,9 @@ impl RtpsWriterKind {
     }
 }
 
-struct InstancePublicationTime {
-    instance: InstanceHandle,
-    last_write_time: Time,
-}
-
-struct InstanceSamples {
-    instance: InstanceHandle,
+struct RegisteredInstanceInfo {
+    instance_handle: InstanceHandle,
+    last_write_time: Option<Time>,
     samples: VecDeque<i64>,
 }
 
@@ -1139,10 +1136,8 @@ struct DataWriterEntity {
     listener_mask: StatusMask,
     last_change_sequence_number: i64,
     qos: DataWriterQos,
-    registered_instance_list: Vec<InstanceHandle>,
+    registered_instance_info: Vec<RegisteredInstanceInfo>,
     offered_deadline_missed_status: OfferedDeadlineMissedStatus,
-    instance_publication_time: Vec<InstancePublicationTime>,
-    instance_samples: Vec<InstanceSamples>,
     /// Member used for notifying reliable writers which are waiting to send
     /// their samples without losing data
     acknowledgement_notification: Option<OneshotSender<()>>,
@@ -1178,10 +1173,8 @@ impl DataWriterEntity {
             listener_mask,
             last_change_sequence_number: 0,
             qos,
-            registered_instance_list: Vec::new(),
+            registered_instance_info: Vec::new(),
             offered_deadline_missed_status: OfferedDeadlineMissedStatus::const_default(),
-            instance_publication_time: Vec::new(),
-            instance_samples: Vec::new(),
             acknowledgement_notification: None,
             wait_for_acknowledgments_notification: Vec::new(),
         }
@@ -1197,23 +1190,17 @@ impl DataWriterEntity {
         runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         if !self
-            .registered_instance_list
-            .contains(&sample_instance_handle)
+            .registered_instance_info
+            .iter()
+            .any(|x| x.instance_handle == sample_instance_handle)
         {
-            if self.registered_instance_list.len() < self.qos.resource_limits.max_instances {
-                self.registered_instance_list.push(sample_instance_handle);
+            if self.registered_instance_info.len() < self.qos.resource_limits.max_instances {
+                self.registered_instance_info.push(RegisteredInstanceInfo {
+                    instance_handle: sample_instance_handle,
+                    last_write_time: None,
+                    samples: VecDeque::new(),
+                });
             } else {
-                return Err(DdsError::OutOfResources);
-            }
-        }
-
-        if let Length::Limited(max_instances) = self.qos.resource_limits.max_instances {
-            if !self
-                .instance_samples
-                .iter()
-                .any(|x| x.instance == sample_instance_handle)
-                && self.instance_samples.len() == max_instances as usize
-            {
                 return Err(DdsError::OutOfResources);
             }
         }
@@ -1228,9 +1215,9 @@ impl DataWriterEntity {
                     if depth as i32 <= max_samples_per_instance => {}
                 _ => {
                     if let Some(s) = self
-                        .instance_samples
+                        .registered_instance_info
                         .iter()
-                        .find(|x| x.instance == sample_instance_handle)
+                        .find(|x| x.instance_handle == sample_instance_handle)
                     {
                         // Only Alive changes count towards the resource limits
                         if s.samples.len() >= max_samples_per_instance as usize {
@@ -1243,7 +1230,7 @@ impl DataWriterEntity {
 
         if let Length::Limited(max_samples) = self.qos.resource_limits.max_samples {
             let total_samples = self
-                .instance_samples
+                .registered_instance_info
                 .iter()
                 .fold(0, |acc, x| acc + x.samples.len());
 
@@ -1262,38 +1249,24 @@ impl DataWriterEntity {
             data_value: serialized_data.into(),
         };
 
-        match self
-            .instance_publication_time
+        let instance_info = self
+            .registered_instance_info
             .iter_mut()
-            .find(|x| x.instance == sample_instance_handle)
-        {
-            Some(x) => {
-                if x.last_write_time < sample_timestamp {
-                    x.last_write_time = sample_timestamp;
+            .find(|x| x.instance_handle == sample_instance_handle)
+            .expect("Instance info must exist");
+
+        match &mut instance_info.last_write_time {
+            Some(last_write_time) => {
+                if *last_write_time < sample_timestamp {
+                    *last_write_time = sample_timestamp;
                 }
             }
-            None => self
-                .instance_publication_time
-                .push(InstancePublicationTime {
-                    instance: sample_instance_handle,
-                    last_write_time: sample_timestamp,
-                }),
-        }
-
-        match self
-            .instance_samples
-            .iter_mut()
-            .find(|x| x.instance == sample_instance_handle)
-        {
-            Some(s) => s.samples.push_back(change.sequence_number),
             None => {
-                let s = InstanceSamples {
-                    instance: sample_instance_handle,
-                    samples: VecDeque::from([change.sequence_number]),
-                };
-                self.instance_samples.push(s);
+                instance_info.last_write_time = Some(sample_timestamp);
             }
         }
+
+        instance_info.samples.push_back(change.sequence_number);
 
         if let DurationKind::Finite(lifespan_duration) = self.qos.lifespan.duration {
             let duration_until_expired = sample_timestamp - now + lifespan_duration;
@@ -1327,20 +1300,18 @@ impl DataWriterEntity {
 
         let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
 
-        if !self.registered_instance_list.contains(&instance_handle) {
+        let Some(instance_info) = self
+            .registered_instance_info
+            .iter_mut()
+            .find(|x| x.instance_handle == instance_handle)
+        else {
             return Err(DdsError::BadParameter);
-        }
+        };
+
+        instance_info.last_write_time = None;
 
         let serialized_key =
             serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;
-
-        if let Some(i) = self
-            .instance_publication_time
-            .iter()
-            .position(|x| x.instance == instance_handle)
-        {
-            self.instance_publication_time.remove(i);
-        }
 
         self.last_change_sequence_number += 1;
         let cache_change = CacheChange {
@@ -1374,22 +1345,22 @@ impl DataWriterEntity {
 
         let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
 
-        if !self.registered_instance_list.contains(&instance_handle) {
-            self.registered_instance_list.push(instance_handle);
-        }
-
-        if let Some(i) = self
-            .instance_publication_time
+        if let Some(instance_info) = self
+            .registered_instance_info
             .iter_mut()
-            .find(|x| x.instance == instance_handle)
+            .find(|x| x.instance_handle == instance_handle)
         {
-            i.last_write_time = timestamp;
+            instance_info.last_write_time = Some(timestamp);
         } else {
-            self.instance_publication_time
-                .push(InstancePublicationTime {
-                    instance: instance_handle,
-                    last_write_time: timestamp,
+            if self.registered_instance_info.len() < self.qos.resource_limits.max_instances {
+                self.registered_instance_info.push(RegisteredInstanceInfo {
+                    instance_handle,
+                    last_write_time: Some(timestamp),
+                    samples: VecDeque::new(),
                 });
+            } else {
+                return Err(DdsError::OutOfResources);
+            }
         }
 
         Ok(Some(instance_handle))
@@ -1413,17 +1384,15 @@ impl DataWriterEntity {
         }
 
         let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
-        if !self.registered_instance_list.contains(&instance_handle) {
+        let Some(instance_info) = self
+            .registered_instance_info
+            .iter_mut()
+            .find(|x| x.instance_handle == instance_handle)
+        else {
             return Err(DdsError::BadParameter);
-        }
+        };
 
-        if let Some(i) = self
-            .instance_publication_time
-            .iter()
-            .position(|x| x.instance == instance_handle)
-        {
-            self.instance_publication_time.remove(i);
-        }
+        instance_info.last_write_time = None;
 
         let serialized_key =
             serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -1351,16 +1351,14 @@ impl DataWriterEntity {
             .find(|x| x.instance_handle == instance_handle)
         {
             instance_info.last_write_time = Some(timestamp);
+        } else if self.registered_instance_info.len() < self.qos.resource_limits.max_instances {
+            self.registered_instance_info.push(RegisteredInstanceInfo {
+                instance_handle,
+                last_write_time: Some(timestamp),
+                samples: VecDeque::new(),
+            });
         } else {
-            if self.registered_instance_info.len() < self.qos.resource_limits.max_instances {
-                self.registered_instance_info.push(RegisteredInstanceInfo {
-                    instance_handle,
-                    last_write_time: Some(timestamp),
-                    samples: VecDeque::new(),
-                });
-            } else {
-                return Err(DdsError::OutOfResources);
-            }
+            return Err(DdsError::OutOfResources);
         }
 
         Ok(Some(instance_handle))

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -1357,6 +1357,44 @@ impl DataWriterEntity {
         Ok(())
     }
 
+    fn register_w_timestamp(
+        &mut self,
+        dynamic_data: &DynamicData<'static>,
+        timestamp: Time,
+    ) -> DdsResult<Option<InstanceHandle>> {
+        if !self.enabled {
+            return Err(DdsError::NotEnabled);
+        }
+
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data)?;
+
+        if key_holder_data.get_topic_kind() == TopicKind::NoKey {
+            return Err(DdsError::IllegalOperation);
+        }
+
+        let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
+
+        if !self.registered_instance_list.contains(&instance_handle) {
+            self.registered_instance_list.push(instance_handle);
+        }
+
+        if let Some(i) = self
+            .instance_publication_time
+            .iter_mut()
+            .find(|x| x.instance == instance_handle)
+        {
+            i.last_write_time = timestamp;
+        } else {
+            self.instance_publication_time
+                .push(InstancePublicationTime {
+                    instance: instance_handle,
+                    last_write_time: timestamp,
+                });
+        }
+
+        Ok(Some(instance_handle))
+    }
+
     fn unregister_w_timestamp(
         &mut self,
         dynamic_data: &DynamicData<'static>,

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -271,8 +271,9 @@ impl DcpsDomainParticipant {
         };
 
         Ok(data_writer
-            .registered_instance_list
-            .contains(&instance_handle)
+            .registered_instance_info
+            .iter()
+            .any(|x| x.instance_handle == instance_handle)
             .then_some(instance_handle))
     }
 
@@ -334,9 +335,9 @@ impl DcpsDomainParticipant {
 
         if let HistoryQosPolicyKind::KeepLast(depth) = data_writer.qos.history.kind {
             if let Some(s) = data_writer
-                .instance_samples
+                .registered_instance_info
                 .iter_mut()
-                .find(|x| x.instance == instance_handle)
+                .find(|x| x.instance_handle == instance_handle)
             {
                 if s.samples.len() == depth as usize {
                     if let Some(&smallest_seq_num_instance) = s.samples.front() {

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -170,6 +170,33 @@ impl DcpsDomainParticipant {
             .cloned()
     }
 
+    #[tracing::instrument(skip(self))]
+    pub fn register_instance(
+        &mut self,
+        publisher_handle: &InstanceHandle,
+        data_writer_handle: &InstanceHandle,
+        dynamic_data: &DynamicData<'static>,
+        timestamp: Time,
+    ) -> DdsResult<Option<InstanceHandle>> {
+        let Some(publisher) = self
+            .domain_participant
+            .user_defined_publisher_list
+            .iter_mut()
+            .find(|x| &x.instance_handle == publisher_handle)
+        else {
+            return Err(DdsError::AlreadyDeleted);
+        };
+        let Some(data_writer) = publisher
+            .data_writer_list
+            .iter_mut()
+            .find(|x| &x.instance_handle == data_writer_handle)
+        else {
+            return Err(DdsError::AlreadyDeleted);
+        };
+
+        data_writer.register_w_timestamp(dynamic_data, timestamp)
+    }
+
     #[tracing::instrument(skip(self, runtime))]
     pub fn unregister_instance(
         &mut self,

--- a/dds/src/dcps/dcps_mail.rs
+++ b/dds/src/dcps/dcps_mail.rs
@@ -404,6 +404,14 @@ pub enum WriterServiceMail {
         data_writer_handle: InstanceHandle,
         reply_sender: OneshotSender<DdsResult<PublicationMatchedStatus>>,
     },
+    RegisterInstance {
+        participant_handle: InstanceHandle,
+        publisher_handle: InstanceHandle,
+        data_writer_handle: InstanceHandle,
+        dynamic_data: DynamicData<'static>,
+        timestamp: Time,
+        reply_sender: OneshotSender<DdsResult<Option<InstanceHandle>>>,
+    },
     UnregisterInstance {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -571,6 +571,27 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .send(p.get_publication_matched_status(&publisher_handle, &data_writer_handle)),
                 Err(e) => reply_sender.send(Err(e)),
             },
+            DcpsMail::Writer(WriterServiceMail::RegisterInstance {
+                participant_handle,
+                publisher_handle,
+                data_writer_handle,
+                dynamic_data,
+                timestamp,
+                reply_sender,
+            }) => match self
+                .domain_participant_list
+                .iter_mut()
+                .find(|x| x.get_instance_handle() == &participant_handle)
+                .ok_or(DdsError::AlreadyDeleted)
+            {
+                Ok(p) => reply_sender.send(p.register_instance(
+                    &publisher_handle,
+                    &data_writer_handle,
+                    &dynamic_data,
+                    timestamp,
+                )),
+                Err(e) => reply_sender.send(Err(e)),
+            },
             DcpsMail::Writer(WriterServiceMail::UnregisterInstance {
                 participant_handle,
                 publisher_handle,

--- a/dds/src/dds/publication/data_writer.rs
+++ b/dds/src/dds/publication/data_writer.rs
@@ -66,7 +66,7 @@ where
     /// The explicit use of this operation is optional as the application may call directly [`DataWriter::write`]
     /// and specify no [`InstanceHandle`] to indicate that the *key* should be examined to identify the instance.
     #[tracing::instrument(skip(self, instance))]
-    pub fn register_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
+    pub fn register_instance(&self, instance: Foo) -> DdsResult<Option<InstanceHandle>> {
         block_on(self.writer_async.register_instance(instance))
     }
 
@@ -77,7 +77,7 @@ where
     #[tracing::instrument(skip(self, instance))]
     pub fn register_instance_w_timestamp(
         &self,
-        instance: &Foo,
+        instance: Foo,
         timestamp: Time,
     ) -> DdsResult<Option<InstanceHandle>> {
         block_on(

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -81,7 +81,7 @@ where
 {
     /// Async version of [`register_instance`](crate::publication::data_writer::DataWriter::register_instance).
     #[tracing::instrument(skip(self, instance))]
-    pub async fn register_instance(&self, instance: &Foo) -> DdsResult<Option<InstanceHandle>> {
+    pub async fn register_instance(&self, instance: Foo) -> DdsResult<Option<InstanceHandle>> {
         let timestamp = self
             .get_publisher()
             .get_participant()
@@ -92,13 +92,25 @@ where
     }
 
     /// Async version of [`register_instance_w_timestamp`](crate::publication::data_writer::DataWriter::register_instance_w_timestamp).
-    #[tracing::instrument(skip(self, _instance))]
+    #[tracing::instrument(skip(self, instance))]
     pub async fn register_instance_w_timestamp(
         &self,
-        _instance: &Foo,
+        instance: Foo,
         timestamp: Time,
     ) -> DdsResult<Option<InstanceHandle>> {
-        todo!()
+        let (reply_sender, reply_receiver) = oneshot();
+        let dynamic_data = instance.create_dynamic_sample();
+        self.dcps_sender()
+            .send(DcpsMail::Writer(WriterServiceMail::RegisterInstance {
+                participant_handle: self.publisher.get_participant().get_instance_handle(),
+                publisher_handle: self.publisher.get_instance_handle(),
+                data_writer_handle: self.handle,
+                dynamic_data,
+                timestamp,
+                reply_sender,
+            }))
+            .await;
+        reply_receiver.await?
     }
 
     /// Async version of [`unregister_instance`](crate::publication::data_writer::DataWriter::unregister_instance).

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -3758,3 +3758,148 @@ fn samples_are_transfered_between_two_participants() {
     assert_eq!(samples.len(), 1);
     assert_eq!(samples[0].data.as_ref().unwrap(), &data);
 }
+
+#[test]
+fn shared_ownership_writer1_should_write_and_writer2_should_dispose_same_data() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer1_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Shared,
+        },
+        ..Default::default()
+    };
+    let writer1 = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer1_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+    let writer2_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Shared,
+        },
+        ..Default::default()
+    };
+    let writer2 = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer2_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Shared,
+        },
+        ..Default::default()
+    };
+
+    let reader = subscriber
+        .create_datareader::<KeyedData>(
+            &topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let start_time = std::time::Instant::now();
+    while std::time::Instant::now().duration_since(start_time) < std::time::Duration::from_secs(10)
+    {
+        if reader.get_matched_publications().unwrap().len() >= 2 {
+            break;
+        }
+    }
+    assert_eq!(
+        reader.get_matched_publications().unwrap().len(),
+        2,
+        "Reader must have 2 matched writers"
+    );
+
+    let cond = writer1.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let cond = writer2.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let data = KeyedData { id: 1, value: 10 };
+    writer1.write(data.clone(), None).unwrap();
+    writer1
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data);
+    assert_eq!(
+        samples[0].sample_info.instance_state,
+        InstanceStateKind::Alive
+    );
+
+    let _handle = writer2.register_instance(data.clone()).unwrap();
+    writer2.dispose(data, None).unwrap();
+    writer2
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+    assert_eq!(samples.len(), 1);
+    assert!(samples[0].data.is_none());
+    assert_eq!(
+        samples[0].sample_info.instance_state,
+        InstanceStateKind::NotAliveDisposed
+    );
+}


### PR DESCRIPTION
Implement register_instance functionality on the DataWriter to allow a second writer to dispose of an instance without having to write data to it first.