### PR TITLE
Fix memory leak on key generation due to using type builder

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -234,9 +234,11 @@ impl DcpsDomainParticipant {
                             ChangeKind::NotAliveDisposed
                             | ChangeKind::NotAliveUnregistered
                             | ChangeKind::NotAliveDisposedUnregistered => {
-                                let Ok(key_holder) =
-                                    KeyHolderType::from_dynamic_type(&data_reader.type_support)
-                                else {
+                                let mut dynamic_members = Vec::new();
+                                let Ok(key_holder) = KeyHolderType::from_dynamic_type(
+                                    &data_reader.type_support,
+                                    &mut dynamic_members,
+                                ) else {
                                     tracing::warn!("Failed to create key holder");
                                     return;
                                 };

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use tracing::info;
 
 use crate::{

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -1327,7 +1327,8 @@ impl DataWriterEntity {
             return Err(DdsError::NotEnabled);
         }
 
-        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data)?;
+        let mut member_list = Vec::new();
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)?;
 
         if TopicKind::from(&self.type_support) == TopicKind::NoKey {
             return Err(DdsError::IllegalOperation);
@@ -1372,7 +1373,8 @@ impl DataWriterEntity {
             return Err(DdsError::NotEnabled);
         }
 
-        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data)?;
+        let mut member_list = Vec::new();
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)?;
 
         if TopicKind::from(&self.type_support) == TopicKind::NoKey {
             return Err(DdsError::IllegalOperation);
@@ -1410,7 +1412,8 @@ impl DataWriterEntity {
             return Err(DdsError::NotEnabled);
         }
 
-        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data)?;
+        let mut member_list = Vec::new();
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)?;
 
         if TopicKind::from(&self.type_support) == TopicKind::NoKey {
             return Err(DdsError::IllegalOperation);

--- a/dds/src/dcps/dcps_domain_participant/mod.rs
+++ b/dds/src/dcps/dcps_domain_participant/mod.rs
@@ -1329,7 +1329,7 @@ impl DataWriterEntity {
 
         let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data)?;
 
-        if key_holder_data.get_topic_kind() == TopicKind::NoKey {
+        if TopicKind::from(&self.type_support) == TopicKind::NoKey {
             return Err(DdsError::IllegalOperation);
         }
 
@@ -1374,7 +1374,7 @@ impl DataWriterEntity {
 
         let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data)?;
 
-        if key_holder_data.get_topic_kind() == TopicKind::NoKey {
+        if TopicKind::from(&self.type_support) == TopicKind::NoKey {
             return Err(DdsError::IllegalOperation);
         }
 
@@ -1412,7 +1412,7 @@ impl DataWriterEntity {
 
         let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data)?;
 
-        if key_holder_data.get_topic_kind() == TopicKind::NoKey {
+        if TopicKind::from(&self.type_support) == TopicKind::NoKey {
             return Err(DdsError::IllegalOperation);
         }
 

--- a/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
@@ -7,7 +7,6 @@ use crate::{
             data_writer_listener::DcpsDataWriterListener, publisher_listener::DcpsPublisherListener,
         },
         status_mask::StatusMask,
-        xtypes_glue::key_and_instance_handle::KeyHolderType,
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -42,7 +41,7 @@ impl DcpsDomainParticipant {
             return Err(DdsError::AlreadyDeleted);
         };
 
-        let topic_kind = KeyHolderType::from_dynamic_type(&topic.type_support)?.get_topic_kind();
+        let topic_kind = TopicKind::from(&topic.type_support);
         let type_support = topic.type_support;
         let type_name = topic.type_name.clone();
 

--- a/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
@@ -10,7 +10,6 @@ use crate::{
             subscriber_listener::DcpsSubscriberListener,
         },
         status_mask::StatusMask,
-        xtypes_glue::key_and_instance_handle::KeyHolderType,
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -65,7 +64,7 @@ impl DcpsDomainParticipant {
             topic
         };
 
-        let topic_kind = KeyHolderType::from_dynamic_type(&topic.type_support)?.get_topic_kind();
+        let topic_kind = TopicKind::from(&topic.type_support);
 
         let type_support = topic.type_support;
         let Some(subscriber) = self

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -258,7 +258,8 @@ impl DcpsDomainParticipant {
         }
 
         let mut member_list = Vec::new();
-        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list) {
+        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)
+        {
             Ok(k) => k,
             Err(e) => {
                 return Err(e.into());
@@ -320,7 +321,8 @@ impl DcpsDomainParticipant {
         };
 
         let mut member_list = Vec::new();
-        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list) {
+        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)
+        {
             Ok(h) => h,
             Err(e) => {
                 reply_sender.send(Err(e.into()));

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -257,7 +257,8 @@ impl DcpsDomainParticipant {
             return Err(DdsError::NotEnabled);
         }
 
-        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data) {
+        let mut member_list = Vec::new();
+        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list) {
             Ok(k) => k,
             Err(e) => {
                 return Err(e.into());
@@ -318,7 +319,8 @@ impl DcpsDomainParticipant {
             }
         };
 
-        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data) {
+        let mut member_list = Vec::new();
+        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list) {
             Ok(h) => h,
             Err(e) => {
                 reply_sender.send(Err(e.into()));

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -3,8 +3,8 @@ use crate::{
     transport::types::TopicKind,
     xtypes::{
         dynamic_type::{
-            DynamicData, DynamicDataFactory, DynamicType, DynamicTypeBuilder,
-            DynamicTypeBuilderFactory, TypeKind,
+            DynamicData, DynamicDataFactory, DynamicType,
+            DynamicTypeMember, TypeKind,
         },
         error::{XTypesError, XTypesResult},
         serializer::serialize_final_without_header,
@@ -15,34 +15,33 @@ use alloc::vec::Vec;
 pub struct KeyHolderType<'a>(DynamicType<'a>);
 
 impl<'a> KeyHolderType<'a> {
-    pub fn from_dynamic_type(value: &DynamicType<'a>) -> XTypesResult<Self> {
+    pub fn from_dynamic_type(
+        value: &DynamicType<'a>,
+        member_list: &'a mut Vec<DynamicTypeMember>,
+    ) -> XTypesResult<Self> {
         fn fill_struct_key_holder_type<'a>(
             value: &DynamicType<'a>,
-            builder: &mut DynamicTypeBuilder,
+            member_list: &'a mut Vec<DynamicTypeMember>,
         ) -> XTypesResult<()> {
             if value.get_kind() == TypeKind::STRUCTURE {
-                for member_index in 0..value.get_member_count() {
-                    let dynamic_type_member = value.get_member_by_index(member_index)?;
-                    if dynamic_type_member.get_descriptor()?.is_key {
-                        builder.add_member(dynamic_type_member.get_descriptor()?.clone())?;
-                    } else if dynamic_type_member.descriptor.r#type.descriptor.kind
-                        == TypeKind::STRUCTURE
-                        && !dynamic_type_member.descriptor.is_optional
+                for member in value.member_list {
+                    if member.descriptor.is_key {
+                        member_list.push(member.clone());
+                    } else if member.descriptor.r#type.descriptor.kind == TypeKind::STRUCTURE
+                        && !member.descriptor.is_optional
                     {
-                        fill_struct_key_holder_type(
-                            &dynamic_type_member.descriptor.r#type,
-                            builder,
-                        )?;
+                        fill_struct_key_holder_type(&member.descriptor.r#type, member_list)?;
                     }
                 }
             }
             Ok(())
         }
 
-        let mut key_holder_type_builder =
-            DynamicTypeBuilderFactory::create_type(value.descriptor.clone());
-        fill_struct_key_holder_type(value, &mut key_holder_type_builder)?;
-        Ok(Self(key_holder_type_builder.build()))
+        fill_struct_key_holder_type(value, member_list)?;
+        Ok(Self(DynamicType {
+            descriptor: value.descriptor,
+            member_list: member_list.as_slice(),
+        }))
     }
 
     pub fn as_dynamic_type(&self) -> &DynamicType<'a> {
@@ -73,7 +72,10 @@ impl From<&DynamicType<'_>> for TopicKind {
 pub struct KeyHolderData<'a>(DynamicData<'a>);
 
 impl<'a> KeyHolderData<'a> {
-    pub fn from_dynamic_data(value: &DynamicData<'a>) -> XTypesResult<KeyHolderData<'a>> {
+    pub fn from_dynamic_data(
+        value: &DynamicData<'a>,
+        member_list: &'a mut Vec<DynamicTypeMember>,
+    ) -> XTypesResult<KeyHolderData<'a>> {
         fn fill_struct_key_holder_data<'a>(
             value: &DynamicData<'a>,
             key_holder_data: &mut DynamicData,
@@ -99,7 +101,7 @@ impl<'a> KeyHolderData<'a> {
             }
             Ok(())
         }
-        let key_holder_type = KeyHolderType::from_dynamic_type(&value.r#type())?.0;
+        let key_holder_type = KeyHolderType::from_dynamic_type(&value.r#type(), member_list)?.0;
         let mut key_holder_data = DynamicDataFactory::create_data(key_holder_type);
         fill_struct_key_holder_data(value, &mut key_holder_data)?;
         Ok(Self(key_holder_data))
@@ -128,7 +130,8 @@ pub fn get_instance_handle_from_key_holder_data<'a>(
 pub fn get_instance_handle_from_dynamic_data<'a>(
     value: &DynamicData<'a>,
 ) -> Result<InstanceHandle, XTypesError> {
-    let key_holder_data = KeyHolderData::from_dynamic_data(value)?;
+    let mut member_list = Vec::new();
+    let key_holder_data = KeyHolderData::from_dynamic_data(value, &mut member_list)?;
     get_instance_handle_from_key_holder_data(&key_holder_data)
 }
 

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -2,10 +2,7 @@ use crate::{
     infrastructure::instance::InstanceHandle,
     transport::types::TopicKind,
     xtypes::{
-        dynamic_type::{
-            DynamicData, DynamicDataFactory, DynamicType,
-            DynamicTypeMember, TypeKind,
-        },
+        dynamic_type::{DynamicData, DynamicDataFactory, DynamicType, DynamicTypeMember, TypeKind},
         error::{XTypesError, XTypesResult},
         serializer::serialize_final_without_header,
     },

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -48,13 +48,25 @@ impl<'a> KeyHolderType<'a> {
     pub fn as_dynamic_type(&self) -> &DynamicType<'a> {
         &self.0
     }
+}
 
-    pub fn get_topic_kind(&self) -> TopicKind {
-        if self.0.member_list.is_empty() {
-            TopicKind::NoKey
-        } else {
-            TopicKind::WithKey
+impl From<&DynamicType<'_>> for TopicKind {
+    fn from(value: &DynamicType<'_>) -> Self {
+        if value.get_kind() == TypeKind::STRUCTURE {
+            for member in value.member_list {
+                if member.descriptor.is_key {
+                    return TopicKind::WithKey;
+                } else if member.descriptor.r#type.descriptor.kind == TypeKind::STRUCTURE
+                    && !member.descriptor.is_optional
+                {
+                    let member_topic_kind = TopicKind::from(&member.descriptor.r#type);
+                    if member_topic_kind == TopicKind::WithKey {
+                        return TopicKind::WithKey;
+                    }
+                }
+            }
         }
+        TopicKind::NoKey
     }
 }
 
@@ -95,10 +107,6 @@ impl<'a> KeyHolderData<'a> {
 
     pub fn as_dynamic_data(&self) -> &DynamicData<'a> {
         &self.0
-    }
-
-    pub fn get_topic_kind(&self) -> TopicKind {
-        KeyHolderType(self.0.r#type()).get_topic_kind()
     }
 }
 


### PR DESCRIPTION
Fix memory leak on key generation due to using type builder. This is replaced instead by directly creating the KeyHolderType. This fixes #634 