### PR TITLE
Modify create_sample to make the conversion from DynamicData to Foo fallible

### DIFF
--- a/bindings/python/src/topic_definition/type_support.rs
+++ b/bindings/python/src/topic_definition/type_support.rs
@@ -273,8 +273,10 @@ impl Type for PythonDdsData {
         <u8 as dust_dds::xtypes::type_support::Type>::TYPE;
 }
 impl TypeSupport for PythonDdsData {
-    fn create_sample(src: &mut dust_dds::xtypes::dynamic_type::DynamicData<'static>) -> Self {
-        Self(src.clone())
+    fn create_sample(
+        src: &mut dust_dds::xtypes::dynamic_type::DynamicData<'static>,
+    ) -> Option<Self> {
+        Some(Self(src.clone()))
     }
 
     fn create_dynamic_sample(self) -> dust_dds::xtypes::dynamic_type::DynamicData<'static> {

--- a/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation.rs
@@ -141,7 +141,7 @@ impl<'a> ParameterList<'a> {
                 representation_identifier,
                 pid_data,
             )?;
-            Ok(Some(T::create_sample(&mut dynamic_data)))
+            Ok(T::create_sample(&mut dynamic_data))
         } else {
             Ok(None)
         }
@@ -158,7 +158,7 @@ impl<'a> ParameterList<'a> {
                 [self.data[0], self.data[1]],
                 pid_data,
             )?;
-            Ok(T::create_sample(&mut dynamic_data))
+            Ok(T::create_sample(&mut dynamic_data).unwrap_or(default))
         } else {
             Ok(default)
         }
@@ -174,7 +174,7 @@ impl<'a> ParameterList<'a> {
             [self.data[0], self.data[1]],
             pid_data,
         )?;
-        Ok(T::create_sample(&mut dynamic_data))
+        T::create_sample(&mut dynamic_data).ok_or(CdrError::InvalidData)
     }
 
     pub(crate) fn get_locator_list(&self, pid: ParameterId) -> CdrResult<Vec<Locator>> {

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -2161,10 +2161,11 @@ impl DcpsDomainParticipant {
                 &None,
             ) {
                 for (sample_data, _sample_info) in samples {
-                    if let Ok(mut d) =
+                    if let Some(type_lookup_request) =
                         deserialize_top_level_type(TypeLookupRequest::TYPE, &sample_data)
+                            .ok()
+                            .and_then(|mut d| TypeLookupRequest::create_sample(&mut d))
                     {
-                        let type_lookup_request = TypeLookupRequest::create_sample(&mut d);
                         match type_lookup_request.call {
                             TypeLookupCall::TypeLookupGetTypesHashId { get_types } => {
                                 for type_id in get_types.type_ids {
@@ -2256,10 +2257,11 @@ impl DcpsDomainParticipant {
                 &None,
             ) {
                 for (sample_data, _sample_info) in samples {
-                    if let Ok(mut d) =
+                    if let Some(type_lookup_reply) =
                         deserialize_top_level_type(TypeLookupReply::TYPE, &sample_data)
+                            .ok()
+                            .and_then(|mut d| TypeLookupReply::create_sample(&mut d))
                     {
-                        let type_lookup_reply = TypeLookupReply::create_sample(&mut d);
                         if let TypeLookupReturn::TypeLookupGetTypesHash { get_type } =
                             &type_lookup_reply.r#return
                         {

--- a/dds/src/dcps/infrastructure/qos_policy.rs
+++ b/dds/src/dcps/infrastructure/qos_policy.rs
@@ -1079,13 +1079,13 @@ impl Type for HistoryQosPolicyKind {
 }
 
 impl TypeSupport for HistoryQosPolicyKind {
-    fn create_sample(src: &mut DynamicData<'static>) -> Self {
-        let discriminant = src.get_int32_value(0).unwrap();
+    fn create_sample(src: &mut DynamicData<'static>) -> Option<Self> {
+        let discriminant = src.get_int32_value(0).ok()?;
 
         match discriminant {
-            0 => Self::KeepLast(1),
-            1 => Self::KeepAll,
-            d => panic!("Discriminant not valid: {d}"),
+            0 => Some(Self::KeepLast(1)),
+            1 => Some(Self::KeepAll),
+            _ => None,
         }
     }
 
@@ -1186,18 +1186,18 @@ impl Type for HistoryQosPolicy {
 }
 
 impl TypeSupport for HistoryQosPolicy {
-    fn create_sample(src: &mut DynamicData<'static>) -> Self {
-        let mut kind = src.get_complex_value(0).cloned().unwrap();
-        let kind = HistoryQosPolicyKind::create_sample(&mut kind);
-        let depth = src.get_int32_value(1).unwrap();
+    fn create_sample(src: &mut DynamicData<'static>) -> Option<Self> {
+        let mut kind = src.get_complex_value(0).cloned().ok()?;
+        let kind = HistoryQosPolicyKind::create_sample(&mut kind)?;
+        let depth = src.get_int32_value(1).ok()?;
 
         match kind {
-            HistoryQosPolicyKind::KeepLast(_) => Self {
+            HistoryQosPolicyKind::KeepLast(_) => Some(Self {
                 kind: HistoryQosPolicyKind::KeepLast(*depth as u32),
-            },
-            HistoryQosPolicyKind::KeepAll => Self {
+            }),
+            HistoryQosPolicyKind::KeepAll => Some(Self {
                 kind: HistoryQosPolicyKind::KeepAll,
-            },
+            }),
         }
     }
 
@@ -1260,12 +1260,12 @@ pub struct ResourceLimitsQosPolicy {
 
 #[automatically_derived]
 impl TypeSupport for ResourceLimitsQosPolicy {
-    fn create_sample(src: &mut DynamicData) -> Self {
-        Self {
-            max_samples: (*src.get_int32_value(0).expect("Must exist")).into(),
-            max_instances: (*src.get_int32_value(1).expect("Must exist")).into(),
-            max_samples_per_instance: (*src.get_int32_value(2).expect("Must exist")).into(),
-        }
+    fn create_sample(src: &mut DynamicData) -> Option<Self> {
+        Some(Self {
+            max_samples: (*src.get_int32_value(0).ok()?).into(),
+            max_instances: (*src.get_int32_value(1).ok()?).into(),
+            max_samples_per_instance: (*src.get_int32_value(2).ok()?).into(),
+        })
     }
     fn create_dynamic_sample(self) -> DynamicData<'static> {
         let mut data = DynamicDataFactory::create_data(Self::TYPE);

--- a/dds/src/dcps/infrastructure/sample_info.rs
+++ b/dds/src/dcps/infrastructure/sample_info.rs
@@ -18,7 +18,7 @@ where
 {
     pub(crate) fn new(mut data: Option<DynamicData<'static>>, sample_info: SampleInfo) -> Self {
         Self {
-            data: data.as_mut().map(Foo::create_sample),
+            data: data.as_mut().and_then(Foo::create_sample),
             sample_info,
         }
     }

--- a/dds/src/dcps/infrastructure/time.rs
+++ b/dds/src/dcps/infrastructure/time.rs
@@ -17,11 +17,11 @@ impl Type for DurationKind {
     const TYPE: crate::xtypes::dynamic_type::DynamicType<'static> = Duration::TYPE;
 }
 impl TypeSupport for DurationKind {
-    fn create_sample(src: &mut crate::xtypes::dynamic_type::DynamicData<'static>) -> Self {
-        let duration = Duration::create_sample(src);
+    fn create_sample(src: &mut crate::xtypes::dynamic_type::DynamicData<'static>) -> Option<Self> {
+        let duration = Duration::create_sample(src)?;
         match duration {
-            DURATION_INFINITE => DurationKind::Infinite,
-            d => DurationKind::Finite(d),
+            DURATION_INFINITE => Some(DurationKind::Infinite),
+            d => Some(DurationKind::Finite(d)),
         }
     }
 

--- a/dds/src/xtypes/data_storage.rs
+++ b/dds/src/xtypes/data_storage.rs
@@ -628,9 +628,11 @@ impl<T: TypeSupport> DataStorageMapping for Vec<T> {
 
     fn try_from_storage(mut data_storage: DataStorage) -> XTypesResult<Self> {
         match &mut data_storage {
-            DataStorage::SequenceComplexValue(x) => {
-                Ok(x.iter_mut().map(T::create_sample).collect())
-            }
+            DataStorage::SequenceComplexValue(x) => x
+                .iter_mut()
+                .map(T::create_sample)
+                .collect::<Option<Vec<_>>>()
+                .ok_or(XTypesError::InvalidData),
             _ => Err(XTypesError::InvalidType),
         }
     }
@@ -648,8 +650,12 @@ impl<T: TypeSupport, const N: usize> DataStorageMapping for [T; N] {
     fn try_from_storage(mut data_storage: DataStorage) -> XTypesResult<Self> {
         match &mut data_storage {
             DataStorage::SequenceComplexValue(x) => {
-                Self::try_from(x.iter_mut().map(T::create_sample).collect::<Vec<_>>())
-                    .map_err(|_| XTypesError::InvalidType)
+                let vec = x
+                    .iter_mut()
+                    .map(T::create_sample)
+                    .collect::<Option<Vec<_>>>()
+                    .ok_or(XTypesError::InvalidData)?;
+                Self::try_from(vec).map_err(|_| XTypesError::InvalidType)
             }
             _ => Err(XTypesError::InvalidType),
         }
@@ -673,7 +679,7 @@ impl<T: TypeSupport> DataStorageMapping for T {
 
     fn try_from_storage(mut data_storage: DataStorage) -> XTypesResult<Self> {
         match &mut data_storage {
-            DataStorage::ComplexValue(x) => Ok(T::create_sample(x)),
+            DataStorage::ComplexValue(x) => T::create_sample(x).ok_or(XTypesError::InvalidData),
             _ => Err(XTypesError::InvalidType),
         }
     }

--- a/dds/src/xtypes/dynamic_type.rs
+++ b/dds/src/xtypes/dynamic_type.rs
@@ -1664,8 +1664,8 @@ impl Type for DynamicData<'static> {
     };
 }
 impl TypeSupport for DynamicData<'static> {
-    fn create_sample(src: &mut DynamicData<'static>) -> Self {
-        src.clone()
+    fn create_sample(src: &mut DynamicData<'static>) -> Option<Self> {
+        Some(src.clone())
     }
 
     fn create_dynamic_sample(self) -> DynamicData<'static> {

--- a/dds/src/xtypes/type_support.rs
+++ b/dds/src/xtypes/type_support.rs
@@ -22,7 +22,9 @@ pub trait TypeSupport: Type {
     }
 
     /// Create a sample of the TypeSupport’s data type with the contents of an input DynamicData object.
-    fn create_sample(src: &mut DynamicData<'static>) -> Self;
+    fn create_sample(src: &mut DynamicData<'static>) -> Option<Self>
+    where
+        Self: Sized;
 
     /// Create a 'DynamicData' object with the contents of an input sample of the TypeSupport’s data type.
     fn create_dynamic_sample(self) -> DynamicData<'static>;
@@ -254,8 +256,8 @@ impl<T: Type> Type for Box<T> {
 }
 
 impl<T: TypeSupport> TypeSupport for Box<T> {
-    fn create_sample(src: &mut DynamicData<'static>) -> Self {
-        Box::new(T::create_sample(src))
+    fn create_sample(src: &mut DynamicData<'static>) -> Option<Self> {
+        T::create_sample(src).map(Box::new)
     }
 
     fn create_dynamic_sample(self) -> DynamicData<'static> {

--- a/dds_derive/src/derive/type_support.rs
+++ b/dds_derive/src/derive/type_support.rs
@@ -215,9 +215,10 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                         Some(member_ident) => {
                             if is_optional {
                                 member_sample_seq.push(quote! {
-                                    #member_ident: src.remove_value(#member_id).map_or(#member_default_value, |x| {
-                                        dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(x).expect("Must match")
-                                    }),
+                                    #member_ident: src.remove_value(#member_id).ok().map_or(
+                                        Some(#member_default_value),
+                                        |x| dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(x).ok()
+                                    )?,
                                 });
 
                                 member_dynamic_sample_seq
@@ -230,13 +231,14 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                                 member_sample_seq.push(
                                     if struct_member_attributes.try_construct == Some(TryConstructKind::UseDefault) {
                                         quote! {
-                                            #member_ident: src.remove_value(#member_id).map_or(#member_default_value, |x| {
-                                                dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(x).expect("Must match")
-                                            }),
+                                            #member_ident: src.remove_value(#member_id).ok().map_or(
+                                                #member_default_value,
+                                                |x| dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(x).unwrap_or(#member_default_value)
+                                            ),
                                         }
                                     } else {
                                         quote! {
-                                    #member_ident: dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(src.remove_value(#member_id).expect("Must exist")).expect("Must match"),
+                                            #member_ident: dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(src.remove_value(#member_id).ok()?).ok()?,
                                         }
                                     }
                                     );
@@ -250,9 +252,10 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                             // In Mutable structs every member is optional even when not explicitly marked as such
                             if r#struct.extensibility == Extensibility::Mutable || is_optional {
                                 member_sample_seq.push(quote! {
-                                    src.remove_value(#member_id).map_or(#member_default_value, |x| {
-                                        DataStorageMapping::try_from_storage(x).expect("Must match")
-                                    }),
+                                    src.remove_value(#member_id).ok().map_or(
+                                        Some(#member_default_value),
+                                        |x| dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(x).ok()
+                                    )?,
                                 });
                                 member_dynamic_sample_seq.push(quote! {
                                     if self.#index != #member_default_value {
@@ -262,12 +265,13 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                             } else {
                                 member_sample_seq.push(if struct_member_attributes.try_construct == Some(TryConstructKind::UseDefault) {
                                     quote! {
-                                        src.remove_value(#member_id).map_or(#member_default_value, |x| {
-                                            DataStorageMapping::try_from_storage(x).expect("Must match")
-                                        }),
+                                        src.remove_value(#member_id).ok().map_or(
+                                            #member_default_value,
+                                            |x| dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(x).unwrap_or(#member_default_value)
+                                        ),
                                     }
                                 } else {
-                                     quote! { dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(src.remove_value(#member_id).expect("Must exist")).expect("Must match"),}
+                                     quote! { dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(src.remove_value(#member_id).ok()?).ok()?,}
                                 });
 
                                 member_dynamic_sample_seq.push(quote! {
@@ -295,9 +299,9 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                 #(#member_dynamic_sample_seq)*
             };
             let create_sample_quote = if is_tuple {
-                quote! {Self(#(#member_sample_seq)*)}
+                quote! {Some(Self(#(#member_sample_seq)*))}
             } else {
-                quote! {Self{#(#member_sample_seq)*}}
+                quote! {Some(Self{#(#member_sample_seq)*})}
             };
             Ok((
                 get_type_quote,
@@ -453,8 +457,8 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
                         });
                         let variant_sample = quote! {
                             Self::#variant_ident(<#variant_ty as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
-                              src.remove_value(#variant_index_unsuffixed as u32).expect("Must exist"),
-                            ).expect("Must match")),
+                              src.remove_value(#variant_index_unsuffixed as u32).ok()?
+                            ).ok()?),
                         };
 
                         variant_sample_seq.push(if variant_attributes.is_default {
@@ -523,7 +527,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
             }
 
             if !has_default {
-                variant_sample_seq.push(quote! {_ => panic!("Invalid discriminator"),});
+                variant_sample_seq.push(quote! {_ => return None,});
             }
 
             let get_type_quote = quote! {
@@ -543,12 +547,12 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
             let create_sample_quote = quote! {
                 let disc =
                     <#discriminator_type as ::dust_dds::xtypes::data_storage::DataStorageMapping>::try_from_storage(
-                        src.remove_value(0).expect("Must exist"),
+                        src.remove_value(0).ok()?,
                     )
-                    .expect("Must match");
-                match disc {
+                    .ok()?;
+                Some(match disc {
                     #(#variant_sample_seq)*
-                }
+                })
             };
             Ok((
                 get_type_quote,
@@ -581,9 +585,9 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
             };
 
             let discriminator_sample = match enum_type_attributes.bit_bound {
-                BitBound::I8 => quote! {src.get_int8_value(0).expect("Must exist");},
-                BitBound::I16 => quote! {src.get_int16_value(0).expect("Must exist");},
-                BitBound::I32 => quote! {src.get_int32_value(0).expect("Must exist");},
+                BitBound::I8 => quote! {*src.get_int8_value(0).ok()?},
+                BitBound::I16 => quote! {*src.get_int16_value(0).ok()?},
+                BitBound::I32 => quote! {*src.get_int32_value(0).ok()?},
             };
 
             let enum_descriptor = quote! {
@@ -618,10 +622,10 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
             }
             let create_sample_quote = quote! {
                     let discriminator = #discriminator_sample;
-                    match discriminator {
+                    Some(match discriminator {
                         #(#create_sample_quote_variants)*
-                        d => panic!("Invalid discriminator {d:?}"),
-                    }
+                        _ => return None,
+                    })
             };
 
             Ok((
@@ -639,7 +643,7 @@ pub fn expand_type_support(input: &DeriveInput) -> Result<TokenStream> {
     Ok(quote! {
         #[automatically_derived]
         impl #impl_generics dust_dds::xtypes::type_support::TypeSupport for #ident #type_generics #where_clause {
-            fn create_sample(src: &mut dust_dds::xtypes::dynamic_type::DynamicData) -> Self {
+            fn create_sample(src: &mut dust_dds::xtypes::dynamic_type::DynamicData) -> ::core::option::Option<Self> {
                 #create_sample_quote
             }
 


### PR DESCRIPTION
Modify create_sample to make the conversion from DynamicData to Foo fallible by returning an Option as specified in the DDS standard.