### PR TITLE
Refactor: Remove task spawn

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -493,6 +493,7 @@ impl DcpsDomainParticipant {
                                 &runtime.clock(),
                             );
                         }
+                        self.process_pending_write_samples(runtime);
                     }
                     RtpsSubmessageReadKind::NackFrag(nack_frag_submessage) => {
                         for dw in self

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -87,9 +87,19 @@ use alloc::{format, string::String, vec, vec::Vec};
 use regex::Regex;
 
 impl DcpsDomainParticipant {
+    pub fn announce_participant_if_needed(&mut self, runtime: &impl DdsRuntime) {
+        let now = runtime.clock().now();
+        if let Some(time_until) = self.time_until_participant_announcement(now) {
+            if time_until == Duration::new(0, 0) {
+                self.announce_participant(runtime);
+            }
+        }
+    }
+
     #[tracing::instrument(skip(self, runtime))]
     pub fn announce_participant(&mut self, runtime: &impl DdsRuntime) {
         if self.domain_participant.enabled {
+            self.domain_participant.last_announcement_timestamp = Some(runtime.clock().now());
             let builtin_topic_key = *self.domain_participant.instance_handle.as_ref();
             let guid = Guid::from(builtin_topic_key);
             let participant_builtin_topic_data = ParticipantBuiltinTopicData {

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -74,6 +74,7 @@ impl DcpsDomainParticipant {
         listener_mask: StatusMask,
         transport: RtpsTransportParticipant,
         dcps_sender: DcpsSender,
+        participant_announcement_interval: core::time::Duration,
     ) -> Self {
         let guid = Guid::new(guid_prefix, ENTITYID_PARTICIPANT);
 
@@ -91,6 +92,7 @@ impl DcpsDomainParticipant {
             builtin_publisher,
             builtin_subscriber,
             domain_tag,
+            Duration::from(participant_announcement_interval),
         );
 
         Self {
@@ -106,6 +108,11 @@ impl DcpsDomainParticipant {
 
     pub fn domain_id(&self) -> DomainId {
         self.domain_participant.domain_id
+    }
+
+    pub fn time_until_participant_announcement(&self, now: Time) -> Option<Duration> {
+        self.domain_participant
+            .time_until_participant_announcement(now)
     }
 
     pub fn time_until_stale_participant(&self, now: Time) -> Option<Duration> {
@@ -224,6 +231,8 @@ pub struct DomainParticipantEntity {
     pub listener_sender: Option<MpscSender<ListenerMail>>,
     pub listener_mask: StatusMask,
     pub find_topic_sender_list: Vec<FindTopicNotification>,
+    pub last_announcement_timestamp: Option<Time>,
+    pub participant_announcement_interval: Duration,
 }
 
 impl DomainParticipantEntity {
@@ -237,6 +246,7 @@ impl DomainParticipantEntity {
         builtin_publisher: BuiltinPublisher,
         builtin_subscriber: BuiltinSubscriber,
         domain_tag: String,
+        participant_announcement_interval: Duration,
     ) -> Self {
         Self {
             domain_id,
@@ -265,6 +275,26 @@ impl DomainParticipantEntity {
             listener_mask,
             domain_tag,
             find_topic_sender_list: Vec::new(),
+            last_announcement_timestamp: None,
+            participant_announcement_interval,
+        }
+    }
+
+    pub fn time_until_participant_announcement(&self, now: Time) -> Option<Duration> {
+        if self.enabled {
+            match self.last_announcement_timestamp {
+                Some(last_announcement) => {
+                    let elapsed = now - last_announcement;
+                    if elapsed >= self.participant_announcement_interval {
+                        Some(Duration::new(0, 0))
+                    } else {
+                        Some(self.participant_announcement_interval - elapsed)
+                    }
+                }
+                None => Some(Duration::new(0, 0)),
+            }
+        } else {
+            None
         }
     }
 
@@ -440,5 +470,64 @@ mod tests {
 
         let remaining = Time::from(source_timestamp) + lifespan - now;
         assert_eq!(remaining, Duration::new(5, 0));
+    }
+
+    #[test]
+    fn test_time_until_participant_announcement() {
+        struct MockWriter;
+        impl crate::transport::interface::WriteMessage for MockWriter {
+            fn write_message(&self, _buf: &[u8], _locators: &[Locator]) {}
+        }
+
+        let transport = RtpsTransportParticipant {
+            message_writer: Box::new(MockWriter),
+            default_unicast_locator_list: Vec::new(),
+            metatraffic_unicast_locator_list: Vec::new(),
+            metatraffic_multicast_locator_list: Vec::new(),
+            default_multicast_locator_list: Vec::new(),
+            fragment_size: 65536,
+        };
+
+        let mut entity = DomainParticipantEntity::new(
+            0,
+            DomainParticipantQos::default(),
+            None,
+            StatusMask::default(),
+            InstanceHandle::new([0; 16]),
+            BuiltinPublisher::new(GuidPrefix::default(), &transport),
+            BuiltinSubscriber::new(GuidPrefix::default()),
+            String::new(),
+            Duration::new(5, 0),
+        );
+
+        // Disabled entity returns None
+        assert_eq!(entity.time_until_participant_announcement(Time::new(10, 0)), None);
+
+        entity.enabled = true;
+
+        // Enabled entity without previous announcement returns 0
+        assert_eq!(
+            entity.time_until_participant_announcement(Time::new(10, 0)),
+            Some(Duration::new(0, 0))
+        );
+
+        // After announcement at t=10s, remaining time at t=12s should be 3s
+        entity.last_announcement_timestamp = Some(Time::new(10, 0));
+        assert_eq!(
+            entity.time_until_participant_announcement(Time::new(12, 0)),
+            Some(Duration::new(3, 0))
+        );
+
+        // At t=15s (5s elapsed), remaining time should be 0s
+        assert_eq!(
+            entity.time_until_participant_announcement(Time::new(15, 0)),
+            Some(Duration::new(0, 0))
+        );
+
+        // Past interval (e.g. t=16s), remaining time should still be 0s
+        assert_eq!(
+            entity.time_until_participant_announcement(Time::new(16, 0)),
+            Some(Duration::new(0, 0))
+        );
     }
 }

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -183,6 +183,29 @@ impl DcpsDomainParticipant {
             .min()
     }
 
+    pub fn time_until_pending_writer_sample_timeout(&self, now: Time) -> Option<Duration> {
+        self.domain_participant
+            .user_defined_publisher_list
+            .iter()
+            .flat_map(|publisher| publisher.data_writer_list.iter())
+            .filter_map(|data_writer| {
+                if let Some(pending) = &data_writer.pending_write_sample {
+                    if let Some(expiration_time) = pending.expiration_time {
+                        if expiration_time > now {
+                            Some(expiration_time - now)
+                        } else {
+                            Some(Duration::new(0, 0))
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .min()
+    }
+
     pub fn get_instance_handle(&self) -> &InstanceHandle {
         &self.domain_participant.instance_handle
     }
@@ -501,7 +524,10 @@ mod tests {
         );
 
         // Disabled entity returns None
-        assert_eq!(entity.time_until_participant_announcement(Time::new(10, 0)), None);
+        assert_eq!(
+            entity.time_until_participant_announcement(Time::new(10, 0)),
+            None
+        );
 
         entity.enabled = true;
 

--- a/dds/src/dcps/dcps_domain_participant/user_defined_data_writer.rs
+++ b/dds/src/dcps/dcps_domain_participant/user_defined_data_writer.rs
@@ -14,11 +14,20 @@ use crate::{
         instance::InstanceHandle,
         qos::DataWriterQos,
         status::{OfferedDeadlineMissedStatus, PublicationMatchedStatus, StatusKind},
+        time::Time,
     },
     rtps::stateful_writer::RtpsStatefulWriter,
+    xtypes::dynamic_type::DynamicData,
 };
 use alloc::{string::String, vec::Vec};
 use core::ops::{Deref, DerefMut};
+
+pub struct PendingWriteSample {
+    pub dynamic_data: DynamicData<'static>,
+    pub timestamp: Time,
+    pub reply_sender: OneshotSender<DdsResult<()>>,
+    pub expiration_time: Option<Time>,
+}
 
 pub struct UserDefinedDataWriter {
     pub writer: DataWriterEntity<RtpsStatefulWriter>,
@@ -35,6 +44,7 @@ pub struct UserDefinedDataWriter {
     /// Member used to notify the external user which called the
     /// wait_for_acknowledgments method
     pub wait_for_acknowledgments_notification: Vec<OneshotSender<DdsResult<()>>>,
+    pub pending_write_sample: Option<PendingWriteSample>,
 }
 
 impl Deref for UserDefinedDataWriter {
@@ -71,6 +81,7 @@ impl UserDefinedDataWriter {
             offered_deadline_missed_status: OfferedDeadlineMissedStatus::const_default(),
             acknowledgement_notification: None,
             wait_for_acknowledgments_notification: Vec::new(),
+            pending_write_sample: None,
         }
     }
 

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -3,11 +3,11 @@ use alloc::{string::String, vec::Vec};
 use crate::{
     builtin_topics::SubscriptionBuiltinTopicData,
     dcps::{
-        channels::oneshot::{OneshotSender, oneshot},
+        channels::oneshot::OneshotSender,
         dcps_domain_participant::{
             data_writer_entity::serialize, participant_entity::DcpsDomainParticipant,
+            user_defined_data_writer::PendingWriteSample,
         },
-        dcps_mail::{DcpsMail, WriterServiceMail},
         listeners::data_writer_listener::DcpsDataWriterListener,
         status_mask::StatusMask,
         xtypes_glue::key_and_instance_handle::{
@@ -22,7 +22,7 @@ use crate::{
         status::{OfferedDeadlineMissedStatus, PublicationMatchedStatus, StatusKind},
         time::{DurationKind, Time},
     },
-    runtime::{Clock, DdsRuntime, Either, Spawner, Timer, select_future},
+    runtime::{Clock, DdsRuntime},
     xtypes::dynamic_type::DynamicData,
 };
 
@@ -373,61 +373,21 @@ impl DcpsDomainParticipant {
                         .transport_writer
                         .is_change_acknowledged(smallest_seq_num_instance)
                 {
-                    if data_writer.acknowledgement_notification.is_some() {
+                    if data_writer.pending_write_sample.is_some() {
                         reply_sender.send(Err(DdsError::Error(String::from(
                             "Another writer already waiting for acknowledgements.",
                         ))));
                         return;
                     }
-                    let max_blocking_time = data_writer.qos.reliability.max_blocking_time;
-                    let (acknowledgment_notification_sender, acknowledgment_notification_receiver) =
-                        oneshot::<()>();
-                    data_writer.acknowledgement_notification =
-                        Some(acknowledgment_notification_sender);
-                    let participant_handle = self.domain_participant.instance_handle;
-                    let dcps_sender = self.dcps_sender;
-                    let mut timer_handle = runtime.timer();
-                    let publisher_handle = *publisher_handle;
-                    let data_writer_handle = *data_writer_handle;
-                    let dynamic_data = dynamic_data.clone();
-                    runtime.spawner().spawn(async move {
-                        if let DurationKind::Finite(t) = max_blocking_time {
-                            let max_blocking_time_wait = timer_handle.delay(t.into());
-                            match select_future(
-                                acknowledgment_notification_receiver,
-                                max_blocking_time_wait,
-                            )
-                            .await
-                            {
-                                Either::A(_) => {
-                                    dcps_sender
-                                        .send(DcpsMail::Writer(
-                                            WriterServiceMail::WriteWTimestamp {
-                                                participant_handle,
-                                                publisher_handle,
-                                                data_writer_handle,
-                                                dynamic_data,
-                                                timestamp,
-                                                reply_sender,
-                                            },
-                                        ))
-                                        .await;
-                                }
-                                Either::B(_) => reply_sender.send(Err(DdsError::Timeout)),
-                            };
-                        } else {
-                            acknowledgment_notification_receiver.await.ok();
-                            dcps_sender
-                                .send(DcpsMail::Writer(WriterServiceMail::WriteWTimestamp {
-                                    participant_handle,
-                                    publisher_handle,
-                                    data_writer_handle,
-                                    dynamic_data,
-                                    timestamp,
-                                    reply_sender,
-                                }))
-                                .await;
-                        }
+                    let expiration_time = match data_writer.qos.reliability.max_blocking_time {
+                        DurationKind::Finite(t) => Some(runtime.clock().now() + t.into()),
+                        DurationKind::Infinite => None,
+                    };
+                    data_writer.pending_write_sample = Some(PendingWriteSample {
+                        dynamic_data: dynamic_data.clone(),
+                        timestamp,
+                        reply_sender,
+                        expiration_time,
                     });
                     return;
                 }
@@ -633,6 +593,117 @@ impl DcpsDomainParticipant {
             data_writer
                 .wait_for_acknowledgments_notification
                 .push(notify_sender);
+        }
+    }
+
+    pub fn process_pending_write_samples(&mut self, runtime: &impl DdsRuntime) {
+        let now = runtime.clock().now();
+        for publisher in &mut self.domain_participant.user_defined_publisher_list {
+            for data_writer in &mut publisher.data_writer_list {
+                if let Some(pending) = &data_writer.pending_write_sample {
+                    if !data_writer.enabled {
+                        continue;
+                    }
+                    let mut member_list = Vec::new();
+                    let Ok(key_holder_data) =
+                        KeyHolderData::from_dynamic_data(&pending.dynamic_data, &mut member_list)
+                    else {
+                        continue;
+                    };
+                    let Ok(instance_handle) =
+                        get_instance_handle_from_key_holder_data(&key_holder_data)
+                    else {
+                        continue;
+                    };
+
+                    let can_write = if let HistoryQosPolicyKind::KeepLast(depth) =
+                        data_writer.qos.history.kind
+                    {
+                        let smallest_seq_num_instance = data_writer
+                            .registered_instance_info
+                            .iter()
+                            .find(|x| x.instance_handle == instance_handle)
+                            .and_then(|s| {
+                                if s.samples.len() == depth as usize {
+                                    s.samples.front().copied()
+                                } else {
+                                    None
+                                }
+                            });
+
+                        if let Some(smallest_seq_num_instance) = smallest_seq_num_instance {
+                            !(data_writer.qos.reliability.kind
+                                == ReliabilityQosPolicyKind::Reliable
+                                && !data_writer
+                                    .transport_writer
+                                    .is_change_acknowledged(smallest_seq_num_instance))
+                        } else {
+                            true
+                        }
+                    } else {
+                        true
+                    };
+
+                    if can_write {
+                        let pending = data_writer.pending_write_sample.take().unwrap();
+                        let serialized_data =
+                            match serialize(&pending.dynamic_data, &data_writer.qos.representation)
+                            {
+                                Ok(s) => s,
+                                Err(e) => {
+                                    pending.reply_sender.send(Err(e));
+                                    continue;
+                                }
+                            };
+
+                        if let HistoryQosPolicyKind::KeepLast(depth) = data_writer.qos.history.kind
+                        {
+                            if let Some(s) = data_writer
+                                .registered_instance_info
+                                .iter_mut()
+                                .find(|x| x.instance_handle == instance_handle)
+                            {
+                                if s.samples.len() == depth as usize {
+                                    if let Some(smallest_seq_num_instance) = s.samples.pop_front() {
+                                        data_writer
+                                            .transport_writer
+                                            .remove_change(smallest_seq_num_instance);
+                                    }
+                                }
+                            }
+                        }
+
+                        let write_result = data_writer.write_w_timestamp(
+                            instance_handle,
+                            serialized_data,
+                            pending.timestamp,
+                            now,
+                            self.transport.message_writer.as_ref(),
+                            runtime,
+                        );
+                        if write_result.is_err() {
+                            pending.reply_sender.send(write_result);
+                        } else {
+                            pending.reply_sender.send(Ok(()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn check_pending_writer_sample_timeout(&mut self, now: Time) {
+        for publisher in &mut self.domain_participant.user_defined_publisher_list {
+            for data_writer in &mut publisher.data_writer_list {
+                if let Some(pending) = &data_writer.pending_write_sample {
+                    if let Some(expiration_time) = pending.expiration_time {
+                        if now >= expiration_time {
+                            let pending = data_writer.pending_write_sample.take().unwrap();
+                            pending.reply_sender.send(Err(DdsError::Timeout));
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -380,7 +380,7 @@ impl DcpsDomainParticipant {
                         return;
                     }
                     let expiration_time = match data_writer.qos.reliability.max_blocking_time {
-                        DurationKind::Finite(t) => Some(runtime.clock().now() + t.into()),
+                        DurationKind::Finite(t) => Some(runtime.clock().now() + t),
                         DurationKind::Infinite => None,
                     };
                     data_writer.pending_write_sample = Some(PendingWriteSample {

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -633,10 +633,10 @@ impl DcpsDomainParticipant {
 
                         if let Some(smallest_seq_num_instance) = smallest_seq_num_instance {
                             !(data_writer.qos.reliability.kind
-                                == ReliabilityQosPolicyKind::Reliable
-                                && !data_writer
+                                == ReliabilityQosPolicyKind::Reliable)
+                                || data_writer
                                     .transport_writer
-                                    .is_change_acknowledged(smallest_seq_num_instance))
+                                    .is_change_acknowledged(smallest_seq_num_instance)
                         } else {
                             true
                         }

--- a/dds/src/dcps/dcps_mail.rs
+++ b/dds/src/dcps/dcps_mail.rs
@@ -47,7 +47,6 @@ pub enum DcpsMail {
     Reader(ReaderServiceMail),
     StatusCondition(StatusConditionMail),
     Message(MessageServiceMail),
-    Discovery(DiscoveryServiceMail),
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -602,8 +601,4 @@ pub enum MessageServiceMail {
         participant_handle: InstanceHandle,
         data_message: Vec<u8>,
     },
-}
-
-pub enum DiscoveryServiceMail {
-    AnnounceParticipant { participant_handle: InstanceHandle },
 }

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -1,9 +1,9 @@
 use crate::{
     dcps::{
         dcps_mail::{
-            DcpsMail, DiscoveryServiceMail, MessageServiceMail, ParticipantFactoryMail,
-            ParticipantServiceMail, PublisherServiceMail, ReaderServiceMail, StatusConditionMail,
-            SubscriberServiceMail, TopicServiceMail, WriterServiceMail,
+            DcpsMail, MessageServiceMail, ParticipantFactoryMail, ParticipantServiceMail,
+            PublisherServiceMail, ReaderServiceMail, StatusConditionMail, SubscriberServiceMail,
+            TopicServiceMail, WriterServiceMail,
         },
         dcps_participant_factory::DcpsParticipantFactory,
     },
@@ -1084,19 +1084,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .ok_or(DdsError::AlreadyDeleted)
                 {
                     p.handle_data(data_message.as_slice(), &self.runtime);
-                }
-            }
-
-            DcpsMail::Discovery(DiscoveryServiceMail::AnnounceParticipant {
-                participant_handle,
-            }) => {
-                if let Ok(p) = self
-                    .domain_participant_list
-                    .iter_mut()
-                    .find(|x| x.get_instance_handle() == &participant_handle)
-                    .ok_or(DdsError::AlreadyDeleted)
-                {
-                    p.announce_participant(&self.runtime)
                 }
             }
         }

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -167,6 +167,14 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             .min()
     }
 
+    pub(crate) fn time_until_pending_writer_sample_timeout(&self) -> Option<Duration> {
+        let now = self.runtime.clock().now();
+        self.domain_participant_list
+            .iter()
+            .filter_map(|x| x.time_until_pending_writer_sample_timeout(now))
+            .min()
+    }
+
     pub(crate) fn time_until_participant_announcement(&self) -> Option<Duration> {
         let now = self.runtime.clock().now();
         self.domain_participant_list

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -1,7 +1,6 @@
 use crate::{
     dcps::{
         dcps_domain_participant::participant_entity::DcpsDomainParticipant,
-        dcps_mail::{DcpsMail, DiscoveryServiceMail},
         listeners::domain_participant_listener::DcpsDomainParticipantListener,
         status_mask::StatusMask,
     },
@@ -13,7 +12,7 @@ use crate::{
         qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
         time::Duration,
     },
-    runtime::{Clock, DdsRuntime, Spawner, Timer},
+    runtime::{Clock, DdsRuntime},
     transport::{interface::RtpsTransportParticipant, types::GuidPrefix},
 };
 use alloc::{string::String, vec::Vec};
@@ -54,8 +53,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             QosKind::Specific(q) => q,
         };
 
-        let spawner_handle = self.runtime.spawner();
-
         let listener_sender = dcps_listener.map(|l| l.spawn(&self.runtime.spawner()));
 
         let mut dcps_participant = DcpsDomainParticipant::new(
@@ -67,26 +64,9 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             listener_mask,
             transport_participant,
             self.dcps_sender,
+            participant_announcement_interval,
         );
         let participant_handle = *dcps_participant.get_instance_handle();
-
-        //****** Spawn the participant actor and tasks **********//
-
-        // Start the regular participant announcement task
-        let dcps_sender_clone = self.dcps_sender;
-        let mut timer_handle = self.runtime.timer().clone();
-
-        spawner_handle.spawn(async move {
-            loop {
-                dcps_sender_clone
-                    .send(DcpsMail::Discovery(
-                        DiscoveryServiceMail::AnnounceParticipant { participant_handle },
-                    ))
-                    .await;
-
-                timer_handle.delay(participant_announcement_interval).await;
-            }
-        });
 
         if self.qos.entity_factory.autoenable_created_entities {
             dcps_participant.enable_domain_participant(&self.runtime)?;
@@ -184,6 +164,14 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         self.domain_participant_list
             .iter()
             .filter_map(|x| x.time_until_stale_writer_sample(now))
+            .min()
+    }
+
+    pub(crate) fn time_until_participant_announcement(&self) -> Option<Duration> {
+        let now = self.runtime.clock().now();
+        self.domain_participant_list
+            .iter()
+            .filter_map(|x| x.time_until_participant_announcement(now))
             .min()
     }
 }

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -293,6 +293,8 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     domain_participant_factory.time_until_stale_participant();
                 let time_until_stale_writer_sample =
                     domain_participant_factory.time_until_stale_writer_sample();
+                let time_until_pending_writer_sample_timeout =
+                    domain_participant_factory.time_until_pending_writer_sample_timeout();
                 let time_until_participant_announcement =
                     domain_participant_factory.time_until_participant_announcement();
                 let next_task_time = poke_time
@@ -300,6 +302,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     .min(time_until_missed_writer_deadline.unwrap_or(poke_time))
                     .min(time_until_stale_participant.unwrap_or(poke_time))
                     .min(time_until_stale_writer_sample.unwrap_or(poke_time))
+                    .min(time_until_pending_writer_sample_timeout.unwrap_or(poke_time))
                     .min(time_until_participant_announcement.unwrap_or(poke_time));
 
                 match select_future(
@@ -344,6 +347,10 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     dp.remove_stale_writer_samples(
                         domain_participant_factory.runtime.clock().now(),
                     );
+                    dp.check_pending_writer_sample_timeout(
+                        domain_participant_factory.runtime.clock().now(),
+                    );
+                    dp.process_pending_write_samples(&domain_participant_factory.runtime);
                     dp.announce_participant_if_needed(&domain_participant_factory.runtime);
                     dp.notify_find_topic_senders(domain_participant_factory.runtime.clock().now());
                     dp.poke(&domain_participant_factory.runtime.clock());

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -293,11 +293,14 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     domain_participant_factory.time_until_stale_participant();
                 let time_until_stale_writer_sample =
                     domain_participant_factory.time_until_stale_writer_sample();
+                let time_until_participant_announcement =
+                    domain_participant_factory.time_until_participant_announcement();
                 let next_task_time = poke_time
                     .min(time_until_missed_reader_deadline.unwrap_or(poke_time))
                     .min(time_until_missed_writer_deadline.unwrap_or(poke_time))
                     .min(time_until_stale_participant.unwrap_or(poke_time))
-                    .min(time_until_stale_writer_sample.unwrap_or(poke_time));
+                    .min(time_until_stale_writer_sample.unwrap_or(poke_time))
+                    .min(time_until_participant_announcement.unwrap_or(poke_time));
 
                 match select_future(
                     dcps_receiver.receive(),
@@ -341,6 +344,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     dp.remove_stale_writer_samples(
                         domain_participant_factory.runtime.clock().now(),
                     );
+                    dp.announce_participant_if_needed(&domain_participant_factory.runtime);
                     dp.notify_find_topic_senders(domain_participant_factory.runtime.clock().now());
                     dp.poke(&domain_participant_factory.runtime.clock());
                 }


### PR DESCRIPTION
Remove task spawn on the internal implementation of the DCPS. After this change only the listeners and the main task stay.