### PR TITLE
Move try construct checks out of deserializer

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/reader_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/reader_methods.rs
@@ -55,7 +55,11 @@ pub fn deserialize_topic_type<'a>(
             .ok(),
         _ => deserialize_top_level_type(type_support, data).ok(),
     };
-
+    if let Some(dynamic_data) = dynamic_data.as_mut() {
+        if !dynamic_data.validate_dynamic_data() {
+            return None;
+        }
+    }
     dynamic_data
 }
 

--- a/dds/src/dcps/dcps_domain_participant/reader_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/reader_methods.rs
@@ -40,7 +40,7 @@ pub fn deserialize_topic_type<'a>(
     type_support: DynamicType<'a>,
     data: &[u8],
 ) -> Option<DynamicData<'a>> {
-    match topic_name {
+    let mut dynamic_data = match topic_name {
         DCPS_PARTICIPANT => SpdpDiscoveredParticipantData::from_bytes(data)
             .map(|x| x.dds_participant_data.create_dynamic_sample())
             .ok(),
@@ -54,7 +54,9 @@ pub fn deserialize_topic_type<'a>(
             .map(|x| x.topic_builtin_topic_data.create_dynamic_sample())
             .ok(),
         _ => deserialize_top_level_type(type_support, data).ok(),
-    }
+    };
+
+    dynamic_data
 }
 
 impl DcpsDomainParticipant {

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -674,21 +674,6 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
         dynamic_data: &mut DynamicData,
         length: usize,
     ) -> XTypesResult<()> {
-        let (read_len, store_len) =
-            if let Some(&bound) = member.descriptor.r#type.descriptor.bound.first() {
-                if bound > 0 && length > bound as usize {
-                    match member.descriptor.try_construct_kind {
-                        TryConstructKind::Trim => (length, bound as usize),
-                        TryConstructKind::UseDefault => (length, 0),
-                        TryConstructKind::Discard => return Err(XTypesError::InvalidData),
-                    }
-                } else {
-                    (length, length)
-                }
-            } else {
-                (length, length)
-            };
-
         fn deserialize_primitive_sequence_elements<
             'a,
             O: AsBytes + Align,
@@ -696,15 +681,11 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
             V: EncodingVersion,
         >(
             deserializer: &mut XTypesDeserializer<'a, E, V>,
-            read_length: usize,
-            store_length: usize,
+            length: usize,
         ) -> XTypesResult<Vec<O>> {
-            let mut sequence = Vec::with_capacity(store_length);
-            for i in 0..read_length {
-                let val = deserializer.deserialize_primitive_type()?;
-                if i < store_length {
-                    sequence.push(val);
-                }
+            let mut sequence = Vec::with_capacity(length);
+            for _ in 0..length {
+                sequence.push(deserializer.deserialize_primitive_type()?);
             }
             Ok(sequence)
         }
@@ -719,80 +700,72 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
             TypeKind::NONE => todo!(),
             TypeKind::BOOLEAN => dynamic_data.set_boolean_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::BYTE => {
-                let bytes = self.reader.read_bytes(read_len)?;
-                dynamic_data.set_byte_values(member.get_id(), bytes[..store_len].to_vec())
+                let bytes = self.reader.read_bytes(length)?;
+                dynamic_data.set_byte_values(member.get_id(), bytes.to_vec())
             }
             TypeKind::INT16 => dynamic_data.set_int16_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::INT32 => dynamic_data.set_int32_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::INT64 => dynamic_data.set_int64_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::UINT16 => dynamic_data.set_uint16_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::UINT32 => dynamic_data.set_uint32_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::UINT64 => dynamic_data.set_uint64_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::FLOAT32 => dynamic_data.set_float32_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::FLOAT64 => dynamic_data.set_float64_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::FLOAT128 => dynamic_data.set_float128_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::INT8 => dynamic_data.set_int8_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::UINT8 => {
-                let bytes = self.reader.read_bytes(read_len)?;
-                dynamic_data.set_uint8_values(member.get_id(), bytes[..store_len].to_vec())
+                let bytes = self.reader.read_bytes(length)?;
+                dynamic_data.set_uint8_values(member.get_id(), bytes.to_vec())
             }
             TypeKind::CHAR8 => dynamic_data.set_char8_values(
                 member.get_id(),
-                deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                deserialize_primitive_sequence_elements(self, length)?,
             ),
             TypeKind::CHAR16 => todo!(),
             TypeKind::STRING8 => {
-                let bound = element_type.descriptor.bound.first().copied().unwrap_or(0);
-                let mut values = Vec::with_capacity(store_len);
-                for i in 0..read_len {
-                    let val = self.deserialize_string_type(bound)?;
-                    if i < store_len {
-                        values.push(val);
-                    }
+                let mut values = Vec::with_capacity(length);
+                for _ in 0..length {
+                    values.push(self.deserialize_string_type()?);
                 }
                 dynamic_data.set_string_values(member.get_id(), values)
             }
             TypeKind::STRING16 => {
-                let bound = element_type.descriptor.bound.first().copied().unwrap_or(0);
-                let mut values = Vec::with_capacity(store_len);
-                for i in 0..read_len {
-                    let val = self.deserialize_wstring_type(bound)?;
-                    if i < store_len {
-                        values.push(val);
-                    }
+                let mut values = Vec::with_capacity(length);
+                for _ in 0..length {
+                    values.push(self.deserialize_wstring_type()?);
                 }
                 dynamic_data.set_string_values(member.get_id(), values)
             }
@@ -802,30 +775,28 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
                 match bound {
                     1..=8 => dynamic_data.set_uint8_values(
                         member.get_id(),
-                        deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                        deserialize_primitive_sequence_elements(self, length)?,
                     ),
                     9..=16 => dynamic_data.set_uint16_values(
                         member.get_id(),
-                        deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                        deserialize_primitive_sequence_elements(self, length)?,
                     ),
                     17..=32 => dynamic_data.set_uint32_values(
                         member.get_id(),
-                        deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                        deserialize_primitive_sequence_elements(self, length)?,
                     ),
                     _ => dynamic_data.set_uint64_values(
                         member.get_id(),
-                        deserialize_primitive_sequence_elements(self, read_len, store_len)?,
+                        deserialize_primitive_sequence_elements(self, length)?,
                     ),
                 }
             }
             TypeKind::ANNOTATION => todo!(),
             TypeKind::ENUM | TypeKind::STRUCTURE | TypeKind::UNION => {
-                let mut values = Vec::with_capacity(store_len);
-                for i in 0..read_len {
-                    let val = self.deserialize_as_nested(element_type)?;
-                    if i < store_len {
-                        values.push(val);
-                    }
+                let mut values = Vec::with_capacity(length);
+                for _ in 0..length {
+                        values.push(self.deserialize_as_nested(element_type)?);
+
                 }
                 dynamic_data.set_complex_values(member.get_id(), values)
             }
@@ -915,12 +886,12 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
             TypeKind::CHAR16 => todo!(),
             TypeKind::STRING8 => {
                 let bound = member_type.descriptor.bound.first().copied().unwrap_or(0);
-                dynamic_data.set_string_value(member.get_id(), self.deserialize_string_type(bound)?)
+                dynamic_data.set_string_value(member.get_id(), self.deserialize_string_type()?)
             }
             TypeKind::STRING16 => {
                 let bound = member_type.descriptor.bound.first().copied().unwrap_or(0);
                 dynamic_data
-                    .set_string_value(member.get_id(), self.deserialize_wstring_type(bound)?)
+                    .set_string_value(member.get_id(), self.deserialize_wstring_type()?)
             }
             TypeKind::ALIAS => todo!(),
             TypeKind::ENUM | TypeKind::STRUCTURE | TypeKind::UNION => dynamic_data
@@ -989,11 +960,8 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     ///               XCDR
     ///                << { O.ssize : UInt32 } // includes NUL
     ///                << { O[i] : Byte }* // includes NUL
-    fn deserialize_string_type(&mut self, bound: u32) -> XTypesResult<String> {
+    fn deserialize_string_type(&mut self) -> XTypesResult<String> {
         let length = self.deserialize_primitive_type::<u32>()?;
-        if bound > 0 && length.saturating_sub(1) > bound {
-            return Err(XTypesError::InvalidData);
-        }
         let values = self
             .reader
             .read_bytes(length.saturating_sub(1) as usize)?
@@ -1002,13 +970,10 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
         String::from_utf8(values).map_err(|_| XTypesError::InvalidData)
     }
 
-    fn deserialize_wstring_type(&mut self, bound: u32) -> XTypesResult<String> {
+    fn deserialize_wstring_type(&mut self) -> XTypesResult<String> {
         let length = self.deserialize_primitive_type::<u32>()?;
         if length == 0 {
             return Ok(String::new());
-        }
-        if bound > 0 && length.saturating_sub(1) > bound {
-            return Err(XTypesError::InvalidData);
         }
         let num_units = length.saturating_sub(1) as usize;
         let mut units = Vec::with_capacity(num_units);

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -795,8 +795,7 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
             TypeKind::ENUM | TypeKind::STRUCTURE | TypeKind::UNION => {
                 let mut values = Vec::with_capacity(length);
                 for _ in 0..length {
-                        values.push(self.deserialize_as_nested(element_type)?);
-
+                    values.push(self.deserialize_as_nested(element_type)?);
                 }
                 dynamic_data.set_complex_values(member.get_id(), values)
             }
@@ -885,13 +884,10 @@ impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
                 .set_char8_value(member.get_id(), self.deserialize_primitive_type::<char>()?),
             TypeKind::CHAR16 => todo!(),
             TypeKind::STRING8 => {
-                let bound = member_type.descriptor.bound.first().copied().unwrap_or(0);
                 dynamic_data.set_string_value(member.get_id(), self.deserialize_string_type()?)
             }
             TypeKind::STRING16 => {
-                let bound = member_type.descriptor.bound.first().copied().unwrap_or(0);
-                dynamic_data
-                    .set_string_value(member.get_id(), self.deserialize_wstring_type()?)
+                dynamic_data.set_string_value(member.get_id(), self.deserialize_wstring_type()?)
             }
             TypeKind::ALIAS => todo!(),
             TypeKind::ENUM | TypeKind::STRUCTURE | TypeKind::UNION => dynamic_data

--- a/dds/src/xtypes/dynamic_type.rs
+++ b/dds/src/xtypes/dynamic_type.rs
@@ -1647,7 +1647,6 @@ impl<'a> DynamicData<'a> {
     }
 
     pub(crate) fn validate_dynamic_data(&mut self) -> bool {
-        let mut values_to_insert = Vec::new();
         let kind = self.r#type.descriptor.kind;
         let extensibility = self.r#type.descriptor.extensibility_kind;
 
@@ -1657,16 +1656,16 @@ impl<'a> DynamicData<'a> {
                 Ok(m) => m,
                 Err(_) => return false,
             };
-            match self.abstract_data.get_mut(&0) {
-                None => return false, // Discriminator is always required
-                Some(val) => {
-                    if !validate_member_value(
-                        val,
-                        &disc_member.descriptor.r#type,
-                        disc_member.descriptor.try_construct_kind,
-                    ) {
-                        return false;
-                    }
+            if !self.abstract_data.contains_key(&0) {
+                return false; // Discriminator is always required
+            } else {
+                let val = self.abstract_data.get_mut(&0).unwrap();
+                if !validate_member_value(
+                    val,
+                    &disc_member.descriptor.r#type,
+                    disc_member.descriptor.try_construct_kind,
+                ) {
+                    return false;
                 }
             }
 
@@ -1674,31 +1673,29 @@ impl<'a> DynamicData<'a> {
             if let Some(active_member) = get_active_union_member(self) {
                 let member_id = active_member.get_id();
                 let try_construct_kind = active_member.descriptor.try_construct_kind;
-                match self.abstract_data.get_mut(&member_id) {
-                    None => match try_construct_kind {
+                if !self.abstract_data.contains_key(&member_id) {
+                    match try_construct_kind {
                         TryConstructKind::Discard => return false,
                         TryConstructKind::UseDefault => {
                             let default_val =
                                 default_storage_for_type(active_member.descriptor.r#type);
-                            values_to_insert.push((member_id, default_val));
+                            self.abstract_data.insert(member_id, default_val);
                         }
                         TryConstructKind::Trim => return false,
-                    },
-                    Some(val) => {
-                        if !validate_member_value(
-                            val,
-                            &active_member.descriptor.r#type,
-                            try_construct_kind,
-                        ) {
-                            match try_construct_kind {
-                                TryConstructKind::Discard => return false,
-                                TryConstructKind::UseDefault => {
-                                    let default_val =
-                                        default_storage_for_type(active_member.descriptor.r#type);
-                                    values_to_insert.push((member_id, default_val));
-                                }
-                                TryConstructKind::Trim => return false,
+                    }
+                } else {
+                    let val = self.abstract_data.get_mut(&member_id).unwrap();
+                    if !validate_member_value(
+                        val,
+                        &active_member.descriptor.r#type,
+                        try_construct_kind,
+                    ) {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                *val = default_storage_for_type(active_member.descriptor.r#type);
                             }
+                            TryConstructKind::Trim => return false,
                         }
                     }
                 }
@@ -1723,44 +1720,37 @@ impl<'a> DynamicData<'a> {
                 let is_required =
                     !member.descriptor.is_optional && extensibility == ExtensibilityKind::Final;
 
-                match self.abstract_data.get_mut(&member_id) {
-                    None => {
-                        if is_required {
-                            match try_construct_kind {
-                                TryConstructKind::Discard => return false,
-                                TryConstructKind::UseDefault => {
-                                    let default_val =
-                                        default_storage_for_type(member.descriptor.r#type);
-                                    values_to_insert.push((member_id, default_val));
-                                }
-                                TryConstructKind::Trim => return false,
+                if !self.abstract_data.contains_key(&member_id) {
+                    if is_required {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                let default_val =
+                                    default_storage_for_type(member.descriptor.r#type);
+                                self.abstract_data.insert(member_id, default_val);
                             }
+                            TryConstructKind::Trim => return false,
                         }
                     }
-                    Some(val) => {
-                        if !validate_member_value(
-                            val,
-                            &member.descriptor.r#type,
-                            try_construct_kind,
-                        ) {
-                            match try_construct_kind {
-                                TryConstructKind::Discard => return false,
-                                TryConstructKind::UseDefault => {
-                                    let default_val =
-                                        default_storage_for_type(member.descriptor.r#type);
-                                    values_to_insert.push((member_id, default_val));
-                                }
-                                TryConstructKind::Trim => return false,
+                } else {
+                    let val = self.abstract_data.get_mut(&member_id).unwrap();
+                    if !validate_member_value(
+                        val,
+                        &member.descriptor.r#type,
+                        try_construct_kind,
+                    ) {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                *val = default_storage_for_type(member.descriptor.r#type);
                             }
+                            TryConstructKind::Trim => return false,
                         }
                     }
                 }
             }
         }
 
-        for (k, v) in values_to_insert {
-            self.abstract_data.insert(k, v);
-        }
         true
     }
 }

--- a/dds/src/xtypes/dynamic_type.rs
+++ b/dds/src/xtypes/dynamic_type.rs
@@ -1645,6 +1645,124 @@ impl<'a> DynamicData<'a> {
             .remove(&id)
             .ok_or(XTypesError::InvalidId(id))
     }
+
+    pub(crate) fn validate_dynamic_data(&mut self) -> bool {
+        let mut values_to_insert = Vec::new();
+        let kind = self.r#type.descriptor.kind;
+        let extensibility = self.r#type.descriptor.extensibility_kind;
+
+        if kind == TypeKind::UNION {
+            // Discriminator check (member 0)
+            let disc_member = match self.r#type.get_member(0) {
+                Ok(m) => m,
+                Err(_) => return false,
+            };
+            match self.abstract_data.get_mut(&0) {
+                None => return false, // Discriminator is always required
+                Some(val) => {
+                    if !validate_member_value(
+                        val,
+                        &disc_member.descriptor.r#type,
+                        disc_member.descriptor.try_construct_kind,
+                    ) {
+                        return false;
+                    }
+                }
+            }
+
+            // Active case member check
+            if let Some(active_member) = get_active_union_member(self) {
+                let member_id = active_member.get_id();
+                let try_construct_kind = active_member.descriptor.try_construct_kind;
+                match self.abstract_data.get_mut(&member_id) {
+                    None => match try_construct_kind {
+                        TryConstructKind::Discard => return false,
+                        TryConstructKind::UseDefault => {
+                            let default_val =
+                                default_storage_for_type(active_member.descriptor.r#type);
+                            values_to_insert.push((member_id, default_val));
+                        }
+                        TryConstructKind::Trim => return false,
+                    },
+                    Some(val) => {
+                        if !validate_member_value(
+                            val,
+                            &active_member.descriptor.r#type,
+                            try_construct_kind,
+                        ) {
+                            match try_construct_kind {
+                                TryConstructKind::Discard => return false,
+                                TryConstructKind::UseDefault => {
+                                    let default_val =
+                                        default_storage_for_type(active_member.descriptor.r#type);
+                                    values_to_insert.push((member_id, default_val));
+                                }
+                                TryConstructKind::Trim => return false,
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Clean up inactive union members
+            let active_id = get_active_union_member(self).map(|m| m.get_id());
+            let mut keys_to_remove = Vec::new();
+            for key in self.abstract_data.keys() {
+                if *key != 0 && Some(*key) != active_id {
+                    keys_to_remove.push(*key);
+                }
+            }
+            for k in keys_to_remove {
+                self.abstract_data.remove(&k);
+            }
+        } else if kind == TypeKind::STRUCTURE {
+            // Structure check
+            for member in self.r#type.member_list {
+                let member_id = member.get_id();
+                let try_construct_kind = member.descriptor.try_construct_kind;
+                let is_required =
+                    !member.descriptor.is_optional && extensibility == ExtensibilityKind::Final;
+
+                match self.abstract_data.get_mut(&member_id) {
+                    None => {
+                        if is_required {
+                            match try_construct_kind {
+                                TryConstructKind::Discard => return false,
+                                TryConstructKind::UseDefault => {
+                                    let default_val =
+                                        default_storage_for_type(member.descriptor.r#type);
+                                    values_to_insert.push((member_id, default_val));
+                                }
+                                TryConstructKind::Trim => return false,
+                            }
+                        }
+                    }
+                    Some(val) => {
+                        if !validate_member_value(
+                            val,
+                            &member.descriptor.r#type,
+                            try_construct_kind,
+                        ) {
+                            match try_construct_kind {
+                                TryConstructKind::Discard => return false,
+                                TryConstructKind::UseDefault => {
+                                    let default_val =
+                                        default_storage_for_type(member.descriptor.r#type);
+                                    values_to_insert.push((member_id, default_val));
+                                }
+                                TryConstructKind::Trim => return false,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        for (k, v) in values_to_insert {
+            self.abstract_data.insert(k, v);
+        }
+        true
+    }
 }
 
 impl Type for DynamicData<'static> {
@@ -1665,12 +1783,7 @@ impl Type for DynamicData<'static> {
 }
 impl TypeSupport for DynamicData<'static> {
     fn create_sample(src: &mut DynamicData<'static>) -> Option<Self> {
-        let mut clone = src.clone();
-        if validate_dynamic_data(&mut clone) {
-            Some(clone)
-        } else {
-            None
-        }
+        Some(src.clone())
     }
 
     fn create_dynamic_sample(self) -> DynamicData<'static> {
@@ -1782,16 +1895,16 @@ fn default_storage_for_type(t: DynamicType<'static>) -> DataStorage {
                     TypeKind::FLOAT128 => DataStorage::SequenceFloat128(Vec::new()),
                     TypeKind::CHAR8 => DataStorage::SequenceChar8(Vec::new()),
                     TypeKind::CHAR16 => DataStorage::SequenceChar8(Vec::new()),
-                    TypeKind::STRING8 | TypeKind::STRING16 => DataStorage::SequenceString(Vec::new()),
+                    TypeKind::STRING8 | TypeKind::STRING16 => {
+                        DataStorage::SequenceString(Vec::new())
+                    }
                     _ => DataStorage::SequenceComplexValue(Vec::new()),
                 }
             } else {
                 DataStorage::SequenceComplexValue(Vec::new())
             }
         }
-        TypeKind::ARRAY => {
-            DataStorage::SequenceComplexValue(Vec::new())
-        }
+        TypeKind::ARRAY => DataStorage::SequenceComplexValue(Vec::new()),
         _ => DataStorage::Boolean(false),
     }
 }
@@ -1822,109 +1935,6 @@ fn get_active_union_member<'a>(data: &DynamicData<'a>) -> Option<&'a DynamicType
     default_member
 }
 
-fn validate_dynamic_data(data: &mut DynamicData<'static>) -> bool {
-    let mut values_to_insert = Vec::new();
-    let kind = data.r#type.descriptor.kind;
-    let extensibility = data.r#type.descriptor.extensibility_kind;
-
-    if kind == TypeKind::UNION {
-        // Discriminator check (member 0)
-        let disc_member = match data.r#type.get_member(0) {
-            Ok(m) => m,
-            Err(_) => return false,
-        };
-        match data.abstract_data.get_mut(&0) {
-            None => return false, // Discriminator is always required
-            Some(val) => {
-                if !validate_member_value(val, &disc_member.descriptor.r#type, disc_member.descriptor.try_construct_kind) {
-                    return false;
-                }
-            }
-        }
-
-        // Active case member check
-        if let Some(active_member) = get_active_union_member(data) {
-            let member_id = active_member.get_id();
-            let try_construct_kind = active_member.descriptor.try_construct_kind;
-            match data.abstract_data.get_mut(&member_id) {
-                None => {
-                    match try_construct_kind {
-                        TryConstructKind::Discard => return false,
-                        TryConstructKind::UseDefault => {
-                            let default_val = default_storage_for_type(active_member.descriptor.r#type);
-                            values_to_insert.push((member_id, default_val));
-                        }
-                        TryConstructKind::Trim => return false,
-                    }
-                }
-                Some(val) => {
-                    if !validate_member_value(val, &active_member.descriptor.r#type, try_construct_kind) {
-                        match try_construct_kind {
-                            TryConstructKind::Discard => return false,
-                            TryConstructKind::UseDefault => {
-                                let default_val = default_storage_for_type(active_member.descriptor.r#type);
-                                values_to_insert.push((member_id, default_val));
-                            }
-                            TryConstructKind::Trim => return false,
-                        }
-                    }
-                }
-            }
-        }
-
-        // Clean up inactive union members
-        let active_id = get_active_union_member(data).map(|m| m.get_id());
-        let mut keys_to_remove = Vec::new();
-        for key in data.abstract_data.keys() {
-            if *key != 0 && Some(*key) != active_id {
-                keys_to_remove.push(*key);
-            }
-        }
-        for k in keys_to_remove {
-            data.abstract_data.remove(&k);
-        }
-    } else {
-        // Structure check
-        for member in data.r#type.member_list {
-            let member_id = member.get_id();
-            let try_construct_kind = member.descriptor.try_construct_kind;
-            let is_required = !member.descriptor.is_optional && extensibility != ExtensibilityKind::Mutable;
-
-            match data.abstract_data.get_mut(&member_id) {
-                None => {
-                    if is_required {
-                        match try_construct_kind {
-                            TryConstructKind::Discard => return false,
-                            TryConstructKind::UseDefault => {
-                                let default_val = default_storage_for_type(member.descriptor.r#type);
-                                values_to_insert.push((member_id, default_val));
-                            }
-                            TryConstructKind::Trim => return false,
-                        }
-                    }
-                }
-                Some(val) => {
-                    if !validate_member_value(val, &member.descriptor.r#type, try_construct_kind) {
-                        match try_construct_kind {
-                            TryConstructKind::Discard => return false,
-                            TryConstructKind::UseDefault => {
-                                let default_val = default_storage_for_type(member.descriptor.r#type);
-                                values_to_insert.push((member_id, default_val));
-                            }
-                            TryConstructKind::Trim => return false,
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    for (k, v) in values_to_insert {
-        data.abstract_data.insert(k, v);
-    }
-    true
-}
-
 fn validate_member_value(
     val: &mut DataStorage,
     member_type: &DynamicType<'static>,
@@ -1934,16 +1944,19 @@ fn validate_member_value(
     match kind {
         TypeKind::STRUCTURE | TypeKind::UNION | TypeKind::ANNOTATION => {
             if let DataStorage::ComplexValue(inner) = val {
-                validate_dynamic_data(inner)
+                inner.validate_dynamic_data()
             } else {
                 false
             }
         }
         TypeKind::SEQUENCE => {
             if let DataStorage::SequenceComplexValue(vec) = val {
-                let element_type = member_type.descriptor.element_type.expect("sequence must have element type");
+                let element_type = member_type
+                    .descriptor
+                    .element_type
+                    .expect("sequence must have element type");
                 for elem in vec.iter_mut() {
-                    if !validate_dynamic_data(elem) {
+                    if !elem.validate_dynamic_data() {
                         match try_construct_kind {
                             TryConstructKind::Discard => return false,
                             TryConstructKind::UseDefault => {
@@ -1977,9 +1990,12 @@ fn validate_member_value(
         }
         TypeKind::ARRAY => {
             if let DataStorage::SequenceComplexValue(vec) = val {
-                let element_type = member_type.descriptor.element_type.expect("array must have element type");
+                let element_type = member_type
+                    .descriptor
+                    .element_type
+                    .expect("array must have element type");
                 for elem in vec.iter_mut() {
-                    if !validate_dynamic_data(elem) {
+                    if !elem.validate_dynamic_data() {
                         match try_construct_kind {
                             TryConstructKind::Discard => return false,
                             TryConstructKind::UseDefault => {
@@ -2006,7 +2022,8 @@ fn validate_member_value(
                                 s.clear();
                             }
                             TryConstructKind::Trim => {
-                                let trim_idx = s.char_indices().nth(bound).map_or(s.len(), |(idx, _)| idx);
+                                let trim_idx =
+                                    s.char_indices().nth(bound).map_or(s.len(), |(idx, _)| idx);
                                 s.truncate(trim_idx);
                             }
                         }

--- a/dds/src/xtypes/dynamic_type.rs
+++ b/dds/src/xtypes/dynamic_type.rs
@@ -1665,11 +1665,357 @@ impl Type for DynamicData<'static> {
 }
 impl TypeSupport for DynamicData<'static> {
     fn create_sample(src: &mut DynamicData<'static>) -> Option<Self> {
-        Some(src.clone())
+        let mut clone = src.clone();
+        if validate_dynamic_data(&mut clone) {
+            Some(clone)
+        } else {
+            None
+        }
     }
 
     fn create_dynamic_sample(self) -> DynamicData<'static> {
         self
+    }
+}
+
+fn get_sequence_len(storage: &DataStorage) -> Option<usize> {
+    match storage {
+        DataStorage::SequenceUInt8(v) => Some(v.len()),
+        DataStorage::SequenceInt8(v) => Some(v.len()),
+        DataStorage::SequenceUInt16(v) => Some(v.len()),
+        DataStorage::SequenceInt16(v) => Some(v.len()),
+        DataStorage::SequenceInt32(v) => Some(v.len()),
+        DataStorage::SequenceUInt32(v) => Some(v.len()),
+        DataStorage::SequenceInt64(v) => Some(v.len()),
+        DataStorage::SequenceUInt64(v) => Some(v.len()),
+        DataStorage::SequenceFloat32(v) => Some(v.len()),
+        DataStorage::SequenceFloat64(v) => Some(v.len()),
+        DataStorage::SequenceFloat128(v) => Some(v.len()),
+        DataStorage::SequenceChar8(v) => Some(v.len()),
+        DataStorage::SequenceBoolean(v) => Some(v.len()),
+        DataStorage::SequenceString(v) => Some(v.len()),
+        DataStorage::SequenceComplexValue(v) => Some(v.len()),
+        _ => None,
+    }
+}
+
+fn reset_sequence_to_empty(storage: &mut DataStorage) {
+    match storage {
+        DataStorage::SequenceUInt8(v) => v.clear(),
+        DataStorage::SequenceInt8(v) => v.clear(),
+        DataStorage::SequenceUInt16(v) => v.clear(),
+        DataStorage::SequenceInt16(v) => v.clear(),
+        DataStorage::SequenceInt32(v) => v.clear(),
+        DataStorage::SequenceUInt32(v) => v.clear(),
+        DataStorage::SequenceInt64(v) => v.clear(),
+        DataStorage::SequenceUInt64(v) => v.clear(),
+        DataStorage::SequenceFloat32(v) => v.clear(),
+        DataStorage::SequenceFloat64(v) => v.clear(),
+        DataStorage::SequenceFloat128(v) => v.clear(),
+        DataStorage::SequenceChar8(v) => v.clear(),
+        DataStorage::SequenceBoolean(v) => v.clear(),
+        DataStorage::SequenceString(v) => v.clear(),
+        DataStorage::SequenceComplexValue(v) => v.clear(),
+        _ => {}
+    }
+}
+
+fn truncate_sequence(storage: &mut DataStorage, bound: usize) {
+    match storage {
+        DataStorage::SequenceUInt8(v) => v.truncate(bound),
+        DataStorage::SequenceInt8(v) => v.truncate(bound),
+        DataStorage::SequenceUInt16(v) => v.truncate(bound),
+        DataStorage::SequenceInt16(v) => v.truncate(bound),
+        DataStorage::SequenceInt32(v) => v.truncate(bound),
+        DataStorage::SequenceUInt32(v) => v.truncate(bound),
+        DataStorage::SequenceInt64(v) => v.truncate(bound),
+        DataStorage::SequenceUInt64(v) => v.truncate(bound),
+        DataStorage::SequenceFloat32(v) => v.truncate(bound),
+        DataStorage::SequenceFloat64(v) => v.truncate(bound),
+        DataStorage::SequenceFloat128(v) => v.truncate(bound),
+        DataStorage::SequenceChar8(v) => v.truncate(bound),
+        DataStorage::SequenceBoolean(v) => v.truncate(bound),
+        DataStorage::SequenceString(v) => v.truncate(bound),
+        DataStorage::SequenceComplexValue(v) => v.truncate(bound),
+        _ => {}
+    }
+}
+
+fn default_storage_for_type(t: DynamicType<'static>) -> DataStorage {
+    match t.get_kind() {
+        TypeKind::BOOLEAN => DataStorage::Boolean(false),
+        TypeKind::BYTE => DataStorage::UInt8(0),
+        TypeKind::INT8 => DataStorage::Int8(0),
+        TypeKind::UINT8 => DataStorage::UInt8(0),
+        TypeKind::INT16 => DataStorage::Int16(0),
+        TypeKind::UINT16 => DataStorage::UInt16(0),
+        TypeKind::INT32 => DataStorage::Int32(0),
+        TypeKind::UINT32 => DataStorage::UInt32(0),
+        TypeKind::INT64 => DataStorage::Int64(0),
+        TypeKind::UINT64 => DataStorage::UInt64(0),
+        TypeKind::FLOAT32 => DataStorage::Float32(0.0),
+        TypeKind::FLOAT64 => DataStorage::Float64(0.0),
+        TypeKind::FLOAT128 => DataStorage::Float128(0),
+        TypeKind::CHAR8 => DataStorage::Char8('\0'),
+        TypeKind::CHAR16 => DataStorage::Char8('\0'),
+        TypeKind::STRING8 => DataStorage::String(String::new()),
+        TypeKind::STRING16 => DataStorage::String(String::new()),
+        TypeKind::ENUM => DataStorage::Int32(0),
+        TypeKind::BITMASK => DataStorage::UInt32(0),
+        TypeKind::STRUCTURE | TypeKind::UNION | TypeKind::ANNOTATION => {
+            DataStorage::ComplexValue(DynamicDataFactory::create_data(t))
+        }
+        TypeKind::SEQUENCE => {
+            if let Some(elem_t) = t.descriptor.element_type {
+                match elem_t.get_kind() {
+                    TypeKind::BOOLEAN => DataStorage::SequenceBoolean(Vec::new()),
+                    TypeKind::BYTE | TypeKind::UINT8 => DataStorage::SequenceUInt8(Vec::new()),
+                    TypeKind::INT8 => DataStorage::SequenceInt8(Vec::new()),
+                    TypeKind::INT16 => DataStorage::SequenceInt16(Vec::new()),
+                    TypeKind::UINT16 => DataStorage::SequenceUInt16(Vec::new()),
+                    TypeKind::INT32 => DataStorage::SequenceInt32(Vec::new()),
+                    TypeKind::UINT32 => DataStorage::SequenceUInt32(Vec::new()),
+                    TypeKind::INT64 => DataStorage::SequenceInt64(Vec::new()),
+                    TypeKind::UINT64 => DataStorage::SequenceUInt64(Vec::new()),
+                    TypeKind::FLOAT32 => DataStorage::SequenceFloat32(Vec::new()),
+                    TypeKind::FLOAT64 => DataStorage::SequenceFloat64(Vec::new()),
+                    TypeKind::FLOAT128 => DataStorage::SequenceFloat128(Vec::new()),
+                    TypeKind::CHAR8 => DataStorage::SequenceChar8(Vec::new()),
+                    TypeKind::CHAR16 => DataStorage::SequenceChar8(Vec::new()),
+                    TypeKind::STRING8 | TypeKind::STRING16 => DataStorage::SequenceString(Vec::new()),
+                    _ => DataStorage::SequenceComplexValue(Vec::new()),
+                }
+            } else {
+                DataStorage::SequenceComplexValue(Vec::new())
+            }
+        }
+        TypeKind::ARRAY => {
+            DataStorage::SequenceComplexValue(Vec::new())
+        }
+        _ => DataStorage::Boolean(false),
+    }
+}
+
+fn get_discriminator_value_as_i32(data: &DynamicData) -> Option<i32> {
+    match data.abstract_data.get(&0)? {
+        DataStorage::UInt8(x) => Some(*x as i32),
+        DataStorage::Int8(x) => Some(*x as i32),
+        DataStorage::UInt16(x) => Some(*x as i32),
+        DataStorage::Int16(x) => Some(*x as i32),
+        DataStorage::Int32(x) => Some(*x),
+        DataStorage::UInt32(x) => Some(*x as i32),
+        _ => None,
+    }
+}
+
+fn get_active_union_member<'a>(data: &DynamicData<'a>) -> Option<&'a DynamicTypeMember> {
+    let disc_id = get_discriminator_value_as_i32(data)?;
+    let mut default_member = None;
+    for member in data.r#type.member_list {
+        if member.descriptor.label.contains(&disc_id) {
+            return Some(member);
+        }
+        if member.descriptor.is_default_label {
+            default_member = Some(member);
+        }
+    }
+    default_member
+}
+
+fn validate_dynamic_data(data: &mut DynamicData<'static>) -> bool {
+    let mut values_to_insert = Vec::new();
+    let kind = data.r#type.descriptor.kind;
+    let extensibility = data.r#type.descriptor.extensibility_kind;
+
+    if kind == TypeKind::UNION {
+        // Discriminator check (member 0)
+        let disc_member = match data.r#type.get_member(0) {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
+        match data.abstract_data.get_mut(&0) {
+            None => return false, // Discriminator is always required
+            Some(val) => {
+                if !validate_member_value(val, &disc_member.descriptor.r#type, disc_member.descriptor.try_construct_kind) {
+                    return false;
+                }
+            }
+        }
+
+        // Active case member check
+        if let Some(active_member) = get_active_union_member(data) {
+            let member_id = active_member.get_id();
+            let try_construct_kind = active_member.descriptor.try_construct_kind;
+            match data.abstract_data.get_mut(&member_id) {
+                None => {
+                    match try_construct_kind {
+                        TryConstructKind::Discard => return false,
+                        TryConstructKind::UseDefault => {
+                            let default_val = default_storage_for_type(active_member.descriptor.r#type);
+                            values_to_insert.push((member_id, default_val));
+                        }
+                        TryConstructKind::Trim => return false,
+                    }
+                }
+                Some(val) => {
+                    if !validate_member_value(val, &active_member.descriptor.r#type, try_construct_kind) {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                let default_val = default_storage_for_type(active_member.descriptor.r#type);
+                                values_to_insert.push((member_id, default_val));
+                            }
+                            TryConstructKind::Trim => return false,
+                        }
+                    }
+                }
+            }
+        }
+
+        // Clean up inactive union members
+        let active_id = get_active_union_member(data).map(|m| m.get_id());
+        let mut keys_to_remove = Vec::new();
+        for key in data.abstract_data.keys() {
+            if *key != 0 && Some(*key) != active_id {
+                keys_to_remove.push(*key);
+            }
+        }
+        for k in keys_to_remove {
+            data.abstract_data.remove(&k);
+        }
+    } else {
+        // Structure check
+        for member in data.r#type.member_list {
+            let member_id = member.get_id();
+            let try_construct_kind = member.descriptor.try_construct_kind;
+            let is_required = !member.descriptor.is_optional && extensibility != ExtensibilityKind::Mutable;
+
+            match data.abstract_data.get_mut(&member_id) {
+                None => {
+                    if is_required {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                let default_val = default_storage_for_type(member.descriptor.r#type);
+                                values_to_insert.push((member_id, default_val));
+                            }
+                            TryConstructKind::Trim => return false,
+                        }
+                    }
+                }
+                Some(val) => {
+                    if !validate_member_value(val, &member.descriptor.r#type, try_construct_kind) {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                let default_val = default_storage_for_type(member.descriptor.r#type);
+                                values_to_insert.push((member_id, default_val));
+                            }
+                            TryConstructKind::Trim => return false,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for (k, v) in values_to_insert {
+        data.abstract_data.insert(k, v);
+    }
+    true
+}
+
+fn validate_member_value(
+    val: &mut DataStorage,
+    member_type: &DynamicType<'static>,
+    try_construct_kind: TryConstructKind,
+) -> bool {
+    let kind = member_type.get_kind();
+    match kind {
+        TypeKind::STRUCTURE | TypeKind::UNION | TypeKind::ANNOTATION => {
+            if let DataStorage::ComplexValue(inner) = val {
+                validate_dynamic_data(inner)
+            } else {
+                false
+            }
+        }
+        TypeKind::SEQUENCE => {
+            if let DataStorage::SequenceComplexValue(vec) = val {
+                let element_type = member_type.descriptor.element_type.expect("sequence must have element type");
+                for elem in vec.iter_mut() {
+                    if !validate_dynamic_data(elem) {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                *elem = DynamicDataFactory::create_data(element_type);
+                            }
+                            TryConstructKind::Trim => {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+
+            let bound = member_type.descriptor.bound.first().copied().unwrap_or(0) as usize;
+            if bound > 0 && bound != u32::MAX as usize {
+                if let Some(len) = get_sequence_len(val) {
+                    if len > bound {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                reset_sequence_to_empty(val);
+                            }
+                            TryConstructKind::Trim => {
+                                truncate_sequence(val, bound);
+                            }
+                        }
+                    }
+                }
+            }
+            true
+        }
+        TypeKind::ARRAY => {
+            if let DataStorage::SequenceComplexValue(vec) = val {
+                let element_type = member_type.descriptor.element_type.expect("array must have element type");
+                for elem in vec.iter_mut() {
+                    if !validate_dynamic_data(elem) {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                *elem = DynamicDataFactory::create_data(element_type);
+                            }
+                            TryConstructKind::Trim => {
+                                return false;
+                            }
+                        }
+                    }
+                }
+            }
+            true
+        }
+        TypeKind::STRING8 | TypeKind::STRING16 => {
+            let bound = member_type.descriptor.bound.first().copied().unwrap_or(0) as usize;
+            if bound > 0 && bound != u32::MAX as usize {
+                if let DataStorage::String(s) = val {
+                    let len = s.chars().count();
+                    if len > bound {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                s.clear();
+                            }
+                            TryConstructKind::Trim => {
+                                let trim_idx = s.char_indices().nth(bound).map_or(s.len(), |(idx, _)| idx);
+                                s.truncate(trim_idx);
+                            }
+                        }
+                    }
+                }
+            }
+            true
+        }
+        _ => true,
     }
 }
 

--- a/dds/src/xtypes/dynamic_type.rs
+++ b/dds/src/xtypes/dynamic_type.rs
@@ -1955,7 +1955,7 @@ impl<'a> DynamicData<'a> {
                 let is_required =
                     !member.descriptor.is_optional && extensibility == ExtensibilityKind::Final;
 
-                if let std::collections::btree_map::Entry::Vacant(e) =
+                if let alloc::collections::btree_map::Entry::Vacant(e) =
                     self.abstract_data.entry(member_id)
                 {
                     if is_required {

--- a/dds/src/xtypes/dynamic_type.rs
+++ b/dds/src/xtypes/dynamic_type.rs
@@ -1817,10 +1817,7 @@ fn get_selected_union_member<'a>(data: &DynamicData<'a>) -> Option<&'a DynamicTy
     default_member
 }
 
-fn validate_member_value(
-    value: &mut DataStorage,
-    member_descriptor: &MemberDescriptor,
-) -> bool {
+fn validate_member_value(value: &mut DataStorage, member_descriptor: &MemberDescriptor) -> bool {
     match member_descriptor.r#type.get_kind() {
         TypeKind::STRUCTURE | TypeKind::UNION | TypeKind::ANNOTATION => {
             if let DataStorage::ComplexValue(inner) = value {
@@ -1831,7 +1828,8 @@ fn validate_member_value(
         }
         TypeKind::SEQUENCE => {
             if let DataStorage::SequenceComplexValue(vec) = value {
-                let element_type = member_descriptor.r#type
+                let element_type = member_descriptor
+                    .r#type
                     .descriptor
                     .element_type
                     .expect("sequence must have element type");
@@ -1850,7 +1848,13 @@ fn validate_member_value(
                 }
             }
 
-            let bound = member_descriptor.r#type.descriptor.bound.first().copied().unwrap_or(0) as usize;
+            let bound = member_descriptor
+                .r#type
+                .descriptor
+                .bound
+                .first()
+                .copied()
+                .unwrap_or(0) as usize;
             if bound > 0 && bound != u32::MAX as usize {
                 if let Some(len) = get_sequence_len(value) {
                     if len > bound {
@@ -1870,7 +1874,8 @@ fn validate_member_value(
         }
         TypeKind::ARRAY => {
             if let DataStorage::SequenceComplexValue(vec) = value {
-                let element_type = member_descriptor.r#type
+                let element_type = member_descriptor
+                    .r#type
                     .descriptor
                     .element_type
                     .expect("array must have element type");
@@ -1891,7 +1896,13 @@ fn validate_member_value(
             true
         }
         TypeKind::STRING8 | TypeKind::STRING16 => {
-            let bound = member_descriptor.r#type.descriptor.bound.first().copied().unwrap_or(0) as usize;
+            let bound = member_descriptor
+                .r#type
+                .descriptor
+                .bound
+                .first()
+                .copied()
+                .unwrap_or(0) as usize;
             if bound > 0 && bound != u32::MAX as usize {
                 if let DataStorage::String(s) = value {
                     let len = s.chars().count();
@@ -1917,7 +1928,7 @@ fn validate_member_value(
 }
 
 impl<'a> DynamicData<'a> {
-  pub(crate) fn validate_dynamic_data(&mut self) -> bool {
+    pub(crate) fn validate_dynamic_data(&mut self) -> bool {
         let kind = self.r#type.descriptor.kind;
         let extensibility = self.r#type.descriptor.extensibility_kind;
 
@@ -1944,14 +1955,16 @@ impl<'a> DynamicData<'a> {
                 let is_required =
                     !member.descriptor.is_optional && extensibility == ExtensibilityKind::Final;
 
-                if !self.abstract_data.contains_key(&member_id) {
+                if let std::collections::btree_map::Entry::Vacant(e) =
+                    self.abstract_data.entry(member_id)
+                {
                     if is_required {
                         match try_construct_kind {
                             TryConstructKind::Discard => return false,
                             TryConstructKind::UseDefault => {
                                 let default_val =
                                     default_storage_for_type(member.descriptor.r#type);
-                                self.abstract_data.insert(member_id, default_val);
+                                e.insert(default_val);
                             }
                             TryConstructKind::Trim => return false,
                         }
@@ -1974,7 +1987,6 @@ impl<'a> DynamicData<'a> {
         true
     }
 }
-
 
 #[cfg(feature = "xtypes-xml")]
 impl<'a> DynamicData<'a> {

--- a/dds/src/xtypes/dynamic_type.rs
+++ b/dds/src/xtypes/dynamic_type.rs
@@ -1645,114 +1645,6 @@ impl<'a> DynamicData<'a> {
             .remove(&id)
             .ok_or(XTypesError::InvalidId(id))
     }
-
-    pub(crate) fn validate_dynamic_data(&mut self) -> bool {
-        let kind = self.r#type.descriptor.kind;
-        let extensibility = self.r#type.descriptor.extensibility_kind;
-
-        if kind == TypeKind::UNION {
-            // Discriminator check (member 0)
-            let disc_member = match self.r#type.get_member(0) {
-                Ok(m) => m,
-                Err(_) => return false,
-            };
-            if !self.abstract_data.contains_key(&0) {
-                return false; // Discriminator is always required
-            } else {
-                let val = self.abstract_data.get_mut(&0).unwrap();
-                if !validate_member_value(
-                    val,
-                    &disc_member.descriptor.r#type,
-                    disc_member.descriptor.try_construct_kind,
-                ) {
-                    return false;
-                }
-            }
-
-            // Active case member check
-            if let Some(active_member) = get_active_union_member(self) {
-                let member_id = active_member.get_id();
-                let try_construct_kind = active_member.descriptor.try_construct_kind;
-                if !self.abstract_data.contains_key(&member_id) {
-                    match try_construct_kind {
-                        TryConstructKind::Discard => return false,
-                        TryConstructKind::UseDefault => {
-                            let default_val =
-                                default_storage_for_type(active_member.descriptor.r#type);
-                            self.abstract_data.insert(member_id, default_val);
-                        }
-                        TryConstructKind::Trim => return false,
-                    }
-                } else {
-                    let val = self.abstract_data.get_mut(&member_id).unwrap();
-                    if !validate_member_value(
-                        val,
-                        &active_member.descriptor.r#type,
-                        try_construct_kind,
-                    ) {
-                        match try_construct_kind {
-                            TryConstructKind::Discard => return false,
-                            TryConstructKind::UseDefault => {
-                                *val = default_storage_for_type(active_member.descriptor.r#type);
-                            }
-                            TryConstructKind::Trim => return false,
-                        }
-                    }
-                }
-            }
-
-            // Clean up inactive union members
-            let active_id = get_active_union_member(self).map(|m| m.get_id());
-            let mut keys_to_remove = Vec::new();
-            for key in self.abstract_data.keys() {
-                if *key != 0 && Some(*key) != active_id {
-                    keys_to_remove.push(*key);
-                }
-            }
-            for k in keys_to_remove {
-                self.abstract_data.remove(&k);
-            }
-        } else if kind == TypeKind::STRUCTURE {
-            // Structure check
-            for member in self.r#type.member_list {
-                let member_id = member.get_id();
-                let try_construct_kind = member.descriptor.try_construct_kind;
-                let is_required =
-                    !member.descriptor.is_optional && extensibility == ExtensibilityKind::Final;
-
-                if !self.abstract_data.contains_key(&member_id) {
-                    if is_required {
-                        match try_construct_kind {
-                            TryConstructKind::Discard => return false,
-                            TryConstructKind::UseDefault => {
-                                let default_val =
-                                    default_storage_for_type(member.descriptor.r#type);
-                                self.abstract_data.insert(member_id, default_val);
-                            }
-                            TryConstructKind::Trim => return false,
-                        }
-                    }
-                } else {
-                    let val = self.abstract_data.get_mut(&member_id).unwrap();
-                    if !validate_member_value(
-                        val,
-                        &member.descriptor.r#type,
-                        try_construct_kind,
-                    ) {
-                        match try_construct_kind {
-                            TryConstructKind::Discard => return false,
-                            TryConstructKind::UseDefault => {
-                                *val = default_storage_for_type(member.descriptor.r#type);
-                            }
-                            TryConstructKind::Trim => return false,
-                        }
-                    }
-                }
-            }
-        }
-
-        true
-    }
 }
 
 impl Type for DynamicData<'static> {
@@ -1911,7 +1803,7 @@ fn get_discriminator_value_as_i32(data: &DynamicData) -> Option<i32> {
     }
 }
 
-fn get_active_union_member<'a>(data: &DynamicData<'a>) -> Option<&'a DynamicTypeMember> {
+fn get_selected_union_member<'a>(data: &DynamicData<'a>) -> Option<&'a DynamicTypeMember> {
     let disc_id = get_discriminator_value_as_i32(data)?;
     let mut default_member = None;
     for member in data.r#type.member_list {
@@ -1926,31 +1818,29 @@ fn get_active_union_member<'a>(data: &DynamicData<'a>) -> Option<&'a DynamicType
 }
 
 fn validate_member_value(
-    val: &mut DataStorage,
-    member_type: &DynamicType<'static>,
-    try_construct_kind: TryConstructKind,
+    value: &mut DataStorage,
+    member_descriptor: &MemberDescriptor,
 ) -> bool {
-    let kind = member_type.get_kind();
-    match kind {
+    match member_descriptor.r#type.get_kind() {
         TypeKind::STRUCTURE | TypeKind::UNION | TypeKind::ANNOTATION => {
-            if let DataStorage::ComplexValue(inner) = val {
+            if let DataStorage::ComplexValue(inner) = value {
                 inner.validate_dynamic_data()
             } else {
                 false
             }
         }
         TypeKind::SEQUENCE => {
-            if let DataStorage::SequenceComplexValue(vec) = val {
-                let element_type = member_type
+            if let DataStorage::SequenceComplexValue(vec) = value {
+                let element_type = member_descriptor.r#type
                     .descriptor
                     .element_type
                     .expect("sequence must have element type");
-                for elem in vec.iter_mut() {
-                    if !elem.validate_dynamic_data() {
-                        match try_construct_kind {
+                for element in vec.iter_mut() {
+                    if !element.validate_dynamic_data() {
+                        match member_descriptor.try_construct_kind {
                             TryConstructKind::Discard => return false,
                             TryConstructKind::UseDefault => {
-                                *elem = DynamicDataFactory::create_data(element_type);
+                                *element = DynamicDataFactory::create_data(element_type);
                             }
                             TryConstructKind::Trim => {
                                 return false;
@@ -1960,17 +1850,17 @@ fn validate_member_value(
                 }
             }
 
-            let bound = member_type.descriptor.bound.first().copied().unwrap_or(0) as usize;
+            let bound = member_descriptor.r#type.descriptor.bound.first().copied().unwrap_or(0) as usize;
             if bound > 0 && bound != u32::MAX as usize {
-                if let Some(len) = get_sequence_len(val) {
+                if let Some(len) = get_sequence_len(value) {
                     if len > bound {
-                        match try_construct_kind {
+                        match member_descriptor.try_construct_kind {
                             TryConstructKind::Discard => return false,
                             TryConstructKind::UseDefault => {
-                                reset_sequence_to_empty(val);
+                                reset_sequence_to_empty(value);
                             }
                             TryConstructKind::Trim => {
-                                truncate_sequence(val, bound);
+                                truncate_sequence(value, bound);
                             }
                         }
                     }
@@ -1979,14 +1869,14 @@ fn validate_member_value(
             true
         }
         TypeKind::ARRAY => {
-            if let DataStorage::SequenceComplexValue(vec) = val {
-                let element_type = member_type
+            if let DataStorage::SequenceComplexValue(vec) = value {
+                let element_type = member_descriptor.r#type
                     .descriptor
                     .element_type
                     .expect("array must have element type");
                 for elem in vec.iter_mut() {
                     if !elem.validate_dynamic_data() {
-                        match try_construct_kind {
+                        match member_descriptor.try_construct_kind {
                             TryConstructKind::Discard => return false,
                             TryConstructKind::UseDefault => {
                                 *elem = DynamicDataFactory::create_data(element_type);
@@ -2001,12 +1891,12 @@ fn validate_member_value(
             true
         }
         TypeKind::STRING8 | TypeKind::STRING16 => {
-            let bound = member_type.descriptor.bound.first().copied().unwrap_or(0) as usize;
+            let bound = member_descriptor.r#type.descriptor.bound.first().copied().unwrap_or(0) as usize;
             if bound > 0 && bound != u32::MAX as usize {
-                if let DataStorage::String(s) = val {
+                if let DataStorage::String(s) = value {
                     let len = s.chars().count();
                     if len > bound {
-                        match try_construct_kind {
+                        match member_descriptor.try_construct_kind {
                             TryConstructKind::Discard => return false,
                             TryConstructKind::UseDefault => {
                                 s.clear();
@@ -2025,6 +1915,66 @@ fn validate_member_value(
         _ => true,
     }
 }
+
+impl<'a> DynamicData<'a> {
+  pub(crate) fn validate_dynamic_data(&mut self) -> bool {
+        let kind = self.r#type.descriptor.kind;
+        let extensibility = self.r#type.descriptor.extensibility_kind;
+
+        if kind == TypeKind::UNION {
+            let Some(selected_member) = get_selected_union_member(self) else {
+                return false;
+            };
+            let Some(value) = self.abstract_data.get_mut(&selected_member.get_id()) else {
+                return false;
+            };
+            if !validate_member_value(value, &selected_member.descriptor) {
+                match selected_member.descriptor.try_construct_kind {
+                    TryConstructKind::Discard => return false,
+                    TryConstructKind::UseDefault => {
+                        *value = default_storage_for_type(selected_member.descriptor.r#type);
+                    }
+                    TryConstructKind::Trim => return false,
+                }
+            }
+        } else if kind == TypeKind::STRUCTURE {
+            for member in self.r#type.member_list {
+                let member_id = member.get_id();
+                let try_construct_kind = member.descriptor.try_construct_kind;
+                let is_required =
+                    !member.descriptor.is_optional && extensibility == ExtensibilityKind::Final;
+
+                if !self.abstract_data.contains_key(&member_id) {
+                    if is_required {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                let default_val =
+                                    default_storage_for_type(member.descriptor.r#type);
+                                self.abstract_data.insert(member_id, default_val);
+                            }
+                            TryConstructKind::Trim => return false,
+                        }
+                    }
+                } else {
+                    let value = self.abstract_data.get_mut(&member_id).unwrap();
+                    if !validate_member_value(value, &member.descriptor) {
+                        match try_construct_kind {
+                            TryConstructKind::Discard => return false,
+                            TryConstructKind::UseDefault => {
+                                *value = default_storage_for_type(member.descriptor.r#type);
+                            }
+                            TryConstructKind::Trim => return false,
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    }
+}
+
 
 #[cfg(feature = "xtypes-xml")]
 impl<'a> DynamicData<'a> {

--- a/dds/tests/xtypes.rs
+++ b/dds/tests/xtypes.rs
@@ -4329,3 +4329,155 @@ fn xtypes_v2_tryconstruct_test_suite_tryc_union_seq_1() {
 
     assert!(reader.read_next_sample().unwrap().data.is_some());
 }
+
+/// 'tryc_enum_2' : {
+///     'common_args' : ['--type-folder types --type-file try_construct'],
+///     'apps' : ['pub-exe -P -t test -y Test::struct_enum_1 --data-folder data --data-file tryconstruct/enum_val3',
+///               'sub-exe -S -t test -y Test::struct_enum_2_default --data-folder data --data-file tryconstruct/enum_val1'],
+///     'expected_codes' : [ReturnCode.OK, ReturnCode.OK],
+///     'check_function' : tsf.data_is_correct,
+///     'title' : 'Communication between struct_enum_1 and struct_enum_2_default',
+///     'description' : 'Verifies enum with `@try_construct(use_default)` replaces unrepresentable literals with default:\n\n'
+///                     ' * Publisher uses `struct_enum_1` from `try_construct`.\n'
+///                     ' * Subscriber uses `struct_enum_2_default` from `try_construct`.\n'
+///                     ' * Publisher uses `E1` (4 literals: VAL0-VAL3).\n'
+///                     ' * Subscriber uses `E2` (3 literals: VAL0-VAL2) with `@try_construct(use_default)`.\n'
+///                     ' * Literal `VAL3` is replaced with `E2`\'s default literal (`VAL1`).\n'
+///                     '**Test passes if:** Discovery succeeds and the subscriber receives the sample.\n'
+/// },
+#[test]
+#[ignore = "Enums for discriminant and defaultLiteral to be implemented"]
+fn xtypes_v2_tryconstruct_test_suite_tryc_enum_2() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let publisher_participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let type_xml = r#"
+    <dds>
+        <types>
+            <module name="Test">
+                <enum name="E1" bitBound="32" extensibility="appendable">
+                    <enumerator name="VAL0" value="0"/>
+                    <enumerator name="VAL1" value="1"/>
+                    <enumerator name="VAL2" value="2"/>
+                    <enumerator name="VAL3" value="3"/>
+                </enum>
+                <enum name="E2" bitBound="32" extensibility="appendable">
+                    <enumerator name="VAL0" value="0"/>
+                    <enumerator name="VAL1" value="1" defaultLiteral="true"/>
+                    <enumerator name="VAL2" value="2"/>
+                </enum>
+                <struct name="struct_enum_1"   extensibility="mutable">
+                    <member name="x1" type="nonBasic" nonBasicTypeName="E1" />
+                </struct>
+                <struct name="struct_enum_2_default"   extensibility="mutable">
+                    <member name="x1" type="nonBasic" nonBasicTypeName="E2" tryConstruct="use_default"/>
+                </struct>
+            </module>
+        </types>
+    </dds>
+    "#;
+    let publisher_dynamic_type =
+        DynamicTypeBuilderFactory::create_type_w_document(type_xml, "Test::struct_enum_1", vec![])
+            .unwrap()
+            .build();
+    let publisher_topic = publisher_participant
+        .create_dynamic_topic(
+            "test",
+            "Test::struct_enum_1",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+            publisher_dynamic_type,
+        )
+        .unwrap();
+    let publisher = publisher_participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer = publisher
+        .create_datawriter(
+            &publisher_topic,
+            QosKind::Specific(writer_qos()),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber_participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let subscriber_dynamic_type = DynamicTypeBuilderFactory::create_type_w_document(
+        type_xml,
+        "Test::struct_enum_2_default",
+        vec![],
+    )
+    .unwrap()
+    .build();
+    let subscriber_topic = subscriber_participant
+        .create_dynamic_topic(
+            "test",
+            "Test::struct_enum_2_default",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+            subscriber_dynamic_type,
+        )
+        .unwrap();
+    let subscriber = subscriber_participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader = subscriber
+        .create_datareader::<DynamicData<'static>>(
+            &subscriber_topic,
+            QosKind::Specific(reader_qos()),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let writer_condition = writer.get_statuscondition();
+    writer_condition
+        .set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut writer_wait_set = WaitSet::new();
+    writer_wait_set
+        .attach_condition(Condition::StatusCondition(writer_condition))
+        .unwrap();
+    let reader_condition = reader.get_statuscondition();
+    reader_condition
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut reader_wait_set = WaitSet::new();
+    reader_wait_set
+        .attach_condition(Condition::StatusCondition(reader_condition))
+        .unwrap();
+    writer_wait_set.wait(Duration::new(10, 0)).unwrap();
+    reader_wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let mut data = DynamicDataFactory::create_data(publisher_dynamic_type);
+    data.from_xml(
+        "<struct>
+            <x1>VAL3</x1>
+        </struct>
+        ",
+    )
+    .unwrap();
+
+    writer.write(data, None).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let mut expected_received = DynamicDataFactory::create_data(subscriber_dynamic_type);
+    expected_received
+        .from_xml(
+            "<struct>
+                <x1>VAL1</x1>
+            </struct>",
+        )
+        .unwrap();
+    assert_eq!(
+        reader.read_next_sample().unwrap().data.unwrap(),
+        expected_received
+    );
+}


### PR DESCRIPTION
Move try construct checks out of deserializer into a check on the DynamicData itself