### PR TITLE
Optimization: Faster compile and execution performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ default-members = [
     "dds",
     "dds_derive",
     "dds_gen",
-    "bindings/python",
-    "bindings/c",
-    "nostd_test_project",
 ]
 resolver = "3"
 

--- a/dds/Cargo.toml
+++ b/dds/Cargo.toml
@@ -33,7 +33,7 @@ embassy-sync = { version = "0.8.0" }
 [dev-dependencies]
 dust_dds = { path = ".", features = ["xtypes-xml"] }
 tokio = { version = "1", features = ["rt", "macros"] }
-criterion = { version = "0.3", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 tracing-subscriber = "0.3.20"
 critical-section = { version = "1.2.0", default-features = false, features = [
 	"std",

--- a/dds/src/dcps/dcps_domain_participant/builtin_data_reader.rs
+++ b/dds/src/dcps/dcps_domain_participant/builtin_data_reader.rs
@@ -9,7 +9,6 @@ use crate::{
         },
     },
     infrastructure::{instance::InstanceHandle, qos::DataReaderQos, time::Time},
-    runtime::{Clock, DdsRuntime},
     transport::types::ChangeKind,
     xtypes::{deserializer::deserialize_top_level_type, type_support::Type},
 };
@@ -57,8 +56,11 @@ impl<R: RtpsReader, T: Type> BuiltinDataReader<R, T> {
         &mut self,
         discovered_participant_list: &mut [DiscoveredParticipantInfo],
         reception_timestamp: Time,
-        runtime: &impl DdsRuntime,
     ) {
+        if self.reader.transport_reader.changes_mut().is_empty() {
+            return;
+        }
+
         let changes = core::mem::take(self.reader.transport_reader.changes_mut());
         let data_reader_handle = &self.reader.instance_handle.clone();
         tracing::trace!(data_reader_handle=?data_reader_handle, "Processing {} reader cache changes", changes.len());
@@ -68,7 +70,7 @@ impl<R: RtpsReader, T: Type> BuiltinDataReader<R, T> {
                 .iter_mut()
                 .find(|x| x.guid_prefix == cache_change.writer_guid.prefix())
             {
-                matched_participant.last_communication_timestamp = runtime.clock().now();
+                matched_participant.last_communication_timestamp = reception_timestamp;
             }
 
             let change_instance_handle = if let Some(i) = cache_change.instance_handle {

--- a/dds/src/dcps/dcps_domain_participant/builtin_data_reader.rs
+++ b/dds/src/dcps/dcps_domain_participant/builtin_data_reader.rs
@@ -12,7 +12,7 @@ use crate::{
     transport::types::ChangeKind,
     xtypes::{deserializer::deserialize_top_level_type, type_support::Type},
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 use core::{
     marker::PhantomData,
     ops::{Deref, DerefMut},
@@ -27,7 +27,7 @@ impl<R, T> BuiltinDataReader<R, T> {
     pub fn new(
         instance_handle: InstanceHandle,
         qos: DataReaderQos,
-        topic_name: String,
+        topic_name: Arc<str>,
         transport_reader: R,
     ) -> Self {
         Self {

--- a/dds/src/dcps/dcps_domain_participant/builtin_publisher.rs
+++ b/dds/src/dcps/dcps_domain_participant/builtin_publisher.rs
@@ -16,7 +16,7 @@ use crate::{
         types::{Guid, GuidPrefix},
     },
 };
-use alloc::string::String;
+use alloc::sync::Arc;
 
 use super::builtin_constants::{
     ENTITYID_SEDP_BUILTIN_PUBLICATIONS_ANNOUNCER, ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_ANNOUNCER,
@@ -79,7 +79,7 @@ impl BuiltinPublisher {
         let dcps_participant_writer = DataWriterEntity::new(
             InstanceHandle::new(dcps_participant_transport_writer.guid().into()),
             dcps_participant_transport_writer,
-            String::from(DCPS_PARTICIPANT),
+            Arc::from(DCPS_PARTICIPANT),
             spdp_writer_qos(),
         );
 
@@ -90,7 +90,7 @@ impl BuiltinPublisher {
         let dcps_topics_writer = DataWriterEntity::new(
             InstanceHandle::new(dcps_topics_transport_writer.guid().into()),
             dcps_topics_transport_writer,
-            String::from(DCPS_TOPIC),
+            Arc::from(DCPS_TOPIC),
             sedp_data_writer_qos(),
         );
 
@@ -101,7 +101,7 @@ impl BuiltinPublisher {
         let dcps_publications_writer = DataWriterEntity::new(
             InstanceHandle::new(dcps_publications_transport_writer.guid().into()),
             dcps_publications_transport_writer,
-            String::from(DCPS_PUBLICATION),
+            Arc::from(DCPS_PUBLICATION),
             sedp_data_writer_qos(),
         );
 
@@ -112,7 +112,7 @@ impl BuiltinPublisher {
         let dcps_subscriptions_writer = DataWriterEntity::new(
             InstanceHandle::new(dcps_subscriptions_transport_writer.guid().into()),
             dcps_subscriptions_transport_writer,
-            String::from(DCPS_SUBSCRIPTION),
+            Arc::from(DCPS_SUBSCRIPTION),
             sedp_data_writer_qos(),
         );
 
@@ -123,7 +123,7 @@ impl BuiltinPublisher {
         let type_lookup_request_writer = DataWriterEntity::new(
             InstanceHandle::new(type_lookup_request_transport_writer.guid().into()),
             type_lookup_request_transport_writer,
-            String::from(TYPE_LOOKUP_REQUEST_TOPIC_NAME),
+            Arc::from(TYPE_LOOKUP_REQUEST_TOPIC_NAME),
             TYPE_LOOKUP_WRITER_QOS,
         );
 
@@ -134,7 +134,7 @@ impl BuiltinPublisher {
         let type_lookup_reply_writer = DataWriterEntity::new(
             InstanceHandle::new(type_lookup_reply_transport_writer.guid().into()),
             type_lookup_reply_transport_writer,
-            String::from(TYPE_LOOKUP_REPLY_TOPIC_NAME),
+            Arc::from(TYPE_LOOKUP_REPLY_TOPIC_NAME),
             TYPE_LOOKUP_WRITER_QOS,
         );
 

--- a/dds/src/dcps/dcps_domain_participant/builtin_subscriber.rs
+++ b/dds/src/dcps/dcps_domain_participant/builtin_subscriber.rs
@@ -15,7 +15,7 @@ use crate::{
     rtps::{stateful_reader::RtpsStatefulReader, stateless_reader::RtpsStatelessReader},
     transport::types::{Guid, GuidPrefix, ReliabilityKind},
 };
-use alloc::string::String;
+use alloc::sync::Arc;
 use core::ops::{Deref, DerefMut};
 
 use super::builtin_constants::{
@@ -66,7 +66,7 @@ impl BuiltinSubscriber {
         let dcps_participant_reader = BuiltinDataReader::new(
             InstanceHandle::new(rtps_stateless_reader.guid().into()),
             SPDP_READER_QOS,
-            String::from(DCPS_PARTICIPANT),
+            Arc::from(DCPS_PARTICIPANT),
             rtps_stateless_reader,
         );
 
@@ -77,7 +77,7 @@ impl BuiltinSubscriber {
         let dcps_topic_reader = BuiltinDataReader::new(
             InstanceHandle::new(dcps_topic_transport_reader.guid().into()),
             SEDP_DATA_READER_QOS,
-            String::from(DCPS_TOPIC),
+            Arc::from(DCPS_TOPIC),
             dcps_topic_transport_reader,
         );
 
@@ -88,7 +88,7 @@ impl BuiltinSubscriber {
         let dcps_publication_reader = BuiltinDataReader::new(
             InstanceHandle::new(dcps_publication_transport_reader.guid().into()),
             SEDP_DATA_READER_QOS,
-            String::from(DCPS_PUBLICATION),
+            Arc::from(DCPS_PUBLICATION),
             dcps_publication_transport_reader,
         );
 
@@ -99,7 +99,7 @@ impl BuiltinSubscriber {
         let dcps_subscription_reader = BuiltinDataReader::new(
             InstanceHandle::new(dcps_subscription_transport_reader.guid().into()),
             SEDP_DATA_READER_QOS,
-            String::from(DCPS_SUBSCRIPTION),
+            Arc::from(DCPS_SUBSCRIPTION),
             dcps_subscription_transport_reader,
         );
 
@@ -110,7 +110,7 @@ impl BuiltinSubscriber {
         let type_lookup_request_reader = BuiltinDataReader::new(
             InstanceHandle::new(type_lookup_request_transport_reader.guid().into()),
             TYPE_LOOKUP_READER_QOS,
-            String::from(TYPE_LOOKUP_REQUEST_TOPIC_NAME),
+            Arc::from(TYPE_LOOKUP_REQUEST_TOPIC_NAME),
             type_lookup_request_transport_reader,
         );
 
@@ -121,7 +121,7 @@ impl BuiltinSubscriber {
         let type_lookup_reply_reader = BuiltinDataReader::new(
             InstanceHandle::new(type_lookup_reply_transport_reader.guid().into()),
             TYPE_LOOKUP_READER_QOS,
-            String::from(TYPE_LOOKUP_REPLY_TOPIC_NAME),
+            Arc::from(TYPE_LOOKUP_REPLY_TOPIC_NAME),
             type_lookup_reply_transport_reader,
         );
 

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -16,7 +16,7 @@ use crate::{
         data_reader::DataReaderAsync, domain_participant::DomainParticipantAsync,
         subscriber::SubscriberAsync,
     },
-    infrastructure::{instance::InstanceHandle, status::StatusKind},
+    infrastructure::{instance::InstanceHandle, status::StatusKind, time::Time},
     rtps::message_receiver::MessageReceiver,
     rtps_messages::{
         overall_structure::{RtpsMessageRead, RtpsSubmessageReadKind},
@@ -31,9 +31,8 @@ use crate::{
 };
 
 impl DcpsDomainParticipant {
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn process_user_defined_received_cache_changes(&mut self, runtime: &impl DdsRuntime) {
-        let reception_timestamp = runtime.clock().now();
+    #[tracing::instrument(skip(self))]
+    pub fn process_user_defined_received_cache_changes(&mut self, reception_timestamp: Time) {
         let dcps_sender = self.dcps_sender;
         let domain_id = self.domain_participant.domain_id;
         let dp_instance_handle = self.domain_participant.instance_handle;
@@ -52,8 +51,53 @@ impl DcpsDomainParticipant {
                 &mut subscriber.data_reader_list,
             );
             'data_readers: for data_reader in data_reader_list {
+                if data_reader.transport_reader.changes_mut().is_empty() {
+                    continue;
+                }
+
+                let Some(type_support) = get_topic_type_support(
+                    &data_reader.topic_name,
+                    content_filtered_topic_list,
+                    locally_created_topic_list,
+                ) else {
+                    tracing::warn!(topic_name = ?data_reader.topic_name, "Failed to find type support for reader");
+                    continue 'data_readers;
+                };
+
+                let content_filtered_topic = content_filtered_topic_list
+                    .iter()
+                    .find(|t| t.topic_name == data_reader.topic_name);
+
+                let (topic_name, type_name) = if let Some(content_filtered_topic) =
+                    content_filtered_topic
+                {
+                    let Some(reader_topic) = locally_created_topic_list
+                        .iter()
+                        .find(|t| t.topic_name == content_filtered_topic.related_topic_name)
+                    else {
+                        tracing::warn!(topic_name = ?data_reader.topic_name, "Failed to find related_topic_name for reader");
+                        continue 'data_readers;
+                    };
+                    (
+                        reader_topic.topic_name.clone(),
+                        reader_topic.type_name.clone(),
+                    )
+                } else {
+                    let Some(reader_topic) = locally_created_topic_list
+                        .iter()
+                        .find(|t| t.topic_name == data_reader.topic_name)
+                    else {
+                        tracing::warn!(topic_name = ?data_reader.topic_name, "Failed to find topic for reader");
+                        continue 'data_readers;
+                    };
+                    (
+                        data_reader.topic_name.clone(),
+                        reader_topic.type_name.clone(),
+                    )
+                };
+
                 let changes = core::mem::take(data_reader.transport_reader.changes_mut());
-                let data_reader_handle = &data_reader.instance_handle.clone();
+                let data_reader_handle = data_reader.instance_handle;
                 tracing::trace!(subscriber_handle=?subscriber_handle, data_reader_handle=?data_reader_handle, "Processing {} reader cache changes", changes.len());
 
                 for cache_change in changes {
@@ -61,29 +105,10 @@ impl DcpsDomainParticipant {
                         .iter_mut()
                         .find(|x| x.guid_prefix == cache_change.writer_guid.prefix())
                     {
-                        matched_participant.last_communication_timestamp = runtime.clock().now();
+                        matched_participant.last_communication_timestamp = reception_timestamp;
                     }
-                    let Some(type_support) = get_topic_type_support(
-                        &data_reader.topic_name,
-                        content_filtered_topic_list,
-                        locally_created_topic_list,
-                    ) else {
-                        tracing::warn!(topic_name = ?data_reader.topic_name, "Failed to find type support for reader");
-                        continue 'data_readers;
-                    };
 
-                    let (topic_name, type_name) = if let Some(content_filtered_topic) =
-                        content_filtered_topic_list
-                            .iter()
-                            .find(|t| t.topic_name == data_reader.topic_name)
-                    {
-                        let Some(reader_topic) = locally_created_topic_list
-                            .iter()
-                            .find(|t| t.topic_name == content_filtered_topic.related_topic_name)
-                        else {
-                            tracing::warn!(topic_name = ?data_reader.topic_name, "Failed to find related_topic_name for reader");
-                            continue 'data_readers;
-                        };
+                    if let Some(content_filtered_topic) = content_filtered_topic {
                         if cache_change.kind == ChangeKind::Alive {
                             let Some(data) = deserialize_topic_type(
                                 &data_reader.topic_name,
@@ -197,23 +222,7 @@ impl DcpsDomainParticipant {
                                 continue 'data_readers;
                             };
                         }
-                        (
-                            reader_topic.type_name.clone(),
-                            reader_topic.topic_name.clone(),
-                        )
-                    } else {
-                        let Some(reader_topic) = locally_created_topic_list
-                            .iter()
-                            .find(|t| t.topic_name == data_reader.topic_name)
-                        else {
-                            tracing::warn!(topic_name = ?data_reader.topic_name, "Failed to find topic for reader");
-                            continue 'data_readers;
-                        };
-                        (
-                            data_reader.topic_name.clone(),
-                            reader_topic.type_name.clone(),
-                        )
-                    };
+                    }
 
                     let change_instance_handle = if let Some(i) = cache_change.instance_handle {
                         InstanceHandle::new(i)
@@ -273,18 +282,6 @@ impl DcpsDomainParticipant {
                         }
                     };
 
-                    let the_participant =
-                        DomainParticipantAsync::new(dcps_sender, domain_id, dp_instance_handle);
-                    let the_subscriber =
-                        SubscriberAsync::new(subscriber_handle, the_participant.clone());
-
-                    let the_reader = DataReaderAsync::new(
-                        *data_reader_handle,
-                        the_subscriber.clone(),
-                        topic_name,
-                        type_name,
-                    );
-
                     match data_reader.add_reader_change(
                         cache_change.writer_guid,
                         cache_change.data_value,
@@ -302,11 +299,35 @@ impl DcpsDomainParticipant {
 
                             if subscriber_listener_mask.is_enabled(&StatusKind::DataOnReaders) {
                                 if let Some(l) = &subscriber_listener_sender {
+                                    let the_participant = DomainParticipantAsync::new(
+                                        dcps_sender,
+                                        domain_id,
+                                        dp_instance_handle,
+                                    );
+                                    let the_subscriber = SubscriberAsync::new(
+                                        subscriber_handle,
+                                        the_participant,
+                                    );
                                     l.send(ListenerMail::DataOnReaders { the_subscriber }).ok();
                                 }
                             } else if data_reader_on_data_available_active {
                                 if let Some(l) = &data_reader.listener_sender {
                                     info!("Triggering data reader DataAvailable listener");
+                                    let the_participant = DomainParticipantAsync::new(
+                                        dcps_sender,
+                                        domain_id,
+                                        dp_instance_handle,
+                                    );
+                                    let the_subscriber = SubscriberAsync::new(
+                                        subscriber_handle,
+                                        the_participant,
+                                    );
+                                    let the_reader = DataReaderAsync::new(
+                                        data_reader_handle,
+                                        the_subscriber,
+                                        topic_name.clone(),
+                                        type_name.clone(),
+                                    );
                                     l.send(ListenerMail::DataAvailable { the_reader }).ok();
                                 }
                             }
@@ -329,29 +350,49 @@ impl DcpsDomainParticipant {
                                 sample_rejected_status_kind,
                             );
 
-                            if data_reader
+                            let is_listener_enabled = data_reader
                                 .listener_mask
                                 .is_enabled(&StatusKind::SampleRejected)
-                            {
+                                || subscriber_listener_mask
+                                    .is_enabled(&StatusKind::SampleRejected)
+                                || dp_listener_mask.is_enabled(&StatusKind::SampleRejected);
+
+                            if is_listener_enabled {
+                                let the_participant = DomainParticipantAsync::new(
+                                    dcps_sender,
+                                    domain_id,
+                                    dp_instance_handle,
+                                );
+                                let the_subscriber =
+                                    SubscriberAsync::new(subscriber_handle, the_participant);
+                                let the_reader = DataReaderAsync::new(
+                                    data_reader_handle,
+                                    the_subscriber,
+                                    topic_name.clone(),
+                                    type_name.clone(),
+                                );
                                 let status = data_reader.get_sample_rejected_status();
 
-                                if let Some(l) = &data_reader.listener_sender {
-                                    l.send(ListenerMail::SampleRejected { the_reader, status })
-                                        .ok();
-                                };
-                            } else if subscriber_listener_mask
-                                .is_enabled(&StatusKind::SampleRejected)
-                            {
-                                let status = data_reader.get_sample_rejected_status();
-                                if let Some(l) = &subscriber_listener_sender {
-                                    l.send(ListenerMail::SampleRejected { status, the_reader })
-                                        .ok();
-                                }
-                            } else if dp_listener_mask.is_enabled(&StatusKind::SampleRejected) {
-                                let status = data_reader.get_sample_rejected_status();
-                                if let Some(l) = dp_listener_sender {
-                                    l.send(ListenerMail::SampleRejected { status, the_reader })
-                                        .ok();
+                                if data_reader
+                                    .listener_mask
+                                    .is_enabled(&StatusKind::SampleRejected)
+                                {
+                                    if let Some(l) = &data_reader.listener_sender {
+                                        l.send(ListenerMail::SampleRejected { the_reader, status })
+                                            .ok();
+                                    };
+                                } else if subscriber_listener_mask
+                                    .is_enabled(&StatusKind::SampleRejected)
+                                {
+                                    if let Some(l) = &subscriber_listener_sender {
+                                        l.send(ListenerMail::SampleRejected { status, the_reader })
+                                            .ok();
+                                    }
+                                } else if dp_listener_mask.is_enabled(&StatusKind::SampleRejected) {
+                                    if let Some(l) = dp_listener_sender {
+                                        l.send(ListenerMail::SampleRejected { status, the_reader })
+                                            .ok();
+                                    }
                                 }
                             }
 
@@ -366,39 +407,38 @@ impl DcpsDomainParticipant {
         }
     }
 
-    pub fn process_builtin_cache_changes(&mut self, runtime: &impl DdsRuntime) {
-        let reception_timestamp = runtime.clock().now();
+    pub fn process_builtin_cache_changes(&mut self, reception_timestamp: Time) {
         let discovered_participant_list = &mut self.domain_participant.discovered_participant_list;
 
         self.domain_participant
             .builtin_subscriber
             .dcps_participant_reader
-            .process_cache_changes(discovered_participant_list, reception_timestamp, runtime);
+            .process_cache_changes(discovered_participant_list, reception_timestamp);
 
         self.domain_participant
             .builtin_subscriber
             .dcps_topic_reader
-            .process_cache_changes(discovered_participant_list, reception_timestamp, runtime);
+            .process_cache_changes(discovered_participant_list, reception_timestamp);
 
         self.domain_participant
             .builtin_subscriber
             .dcps_publication_reader
-            .process_cache_changes(discovered_participant_list, reception_timestamp, runtime);
+            .process_cache_changes(discovered_participant_list, reception_timestamp);
 
         self.domain_participant
             .builtin_subscriber
             .dcps_subscription_reader
-            .process_cache_changes(discovered_participant_list, reception_timestamp, runtime);
+            .process_cache_changes(discovered_participant_list, reception_timestamp);
 
         self.domain_participant
             .builtin_subscriber
             .type_lookup_request_reader
-            .process_cache_changes(discovered_participant_list, reception_timestamp, runtime);
+            .process_cache_changes(discovered_participant_list, reception_timestamp);
 
         self.domain_participant
             .builtin_subscriber
             .type_lookup_reply_reader
-            .process_cache_changes(discovered_participant_list, reception_timestamp, runtime);
+            .process_cache_changes(discovered_participant_list, reception_timestamp);
     }
 
     #[tracing::instrument(skip(self, data_message, runtime))]

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -304,10 +304,8 @@ impl DcpsDomainParticipant {
                                         domain_id,
                                         dp_instance_handle,
                                     );
-                                    let the_subscriber = SubscriberAsync::new(
-                                        subscriber_handle,
-                                        the_participant,
-                                    );
+                                    let the_subscriber =
+                                        SubscriberAsync::new(subscriber_handle, the_participant);
                                     l.send(ListenerMail::DataOnReaders { the_subscriber }).ok();
                                 }
                             } else if data_reader_on_data_available_active {
@@ -318,10 +316,8 @@ impl DcpsDomainParticipant {
                                         domain_id,
                                         dp_instance_handle,
                                     );
-                                    let the_subscriber = SubscriberAsync::new(
-                                        subscriber_handle,
-                                        the_participant,
-                                    );
+                                    let the_subscriber =
+                                        SubscriberAsync::new(subscriber_handle, the_participant);
                                     let the_reader = DataReaderAsync::new(
                                         data_reader_handle,
                                         the_subscriber,
@@ -353,8 +349,7 @@ impl DcpsDomainParticipant {
                             let is_listener_enabled = data_reader
                                 .listener_mask
                                 .is_enabled(&StatusKind::SampleRejected)
-                                || subscriber_listener_mask
-                                    .is_enabled(&StatusKind::SampleRejected)
+                                || subscriber_listener_mask.is_enabled(&StatusKind::SampleRejected)
                                 || dp_listener_mask.is_enabled(&StatusKind::SampleRejected);
 
                             if is_listener_enabled {

--- a/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
@@ -259,8 +259,7 @@ impl<T> DataReaderEntity<T> {
                         .instance_state
                         .most_recent_no_writers_generation_count);
 
-            instance_in_coll.most_recent_sample_absolute_generation_rank =
-                absolute_generation_rank;
+            instance_in_coll.most_recent_sample_absolute_generation_rank = absolute_generation_rank;
 
             let (data, valid_data) = match cache_change.kind {
                 ChangeKind::Alive | ChangeKind::AliveFiltered => {

--- a/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
@@ -11,11 +11,7 @@ use crate::{
     },
     transport::types::{ChangeKind, Guid},
 };
-use alloc::{
-    string::{String, ToString},
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::{string::ToString, sync::Arc, vec::Vec};
 
 pub type SampleList = Vec<(Arc<[u8]>, SampleInfo)>;
 
@@ -121,7 +117,7 @@ pub struct DataReaderEntity<T> {
     pub instance_handle: InstanceHandle,
     pub sample_list: Vec<ReaderSample>,
     pub qos: DataReaderQos,
-    pub topic_name: String,
+    pub topic_name: Arc<str>,
     pub matched_publication_list: Vec<PublicationBuiltinTopicData>,
     pub enabled: bool,
     pub instances: Vec<InstanceState>,
@@ -133,7 +129,7 @@ impl<T> DataReaderEntity<T> {
     pub fn new(
         instance_handle: InstanceHandle,
         qos: DataReaderQos,
-        topic_name: String,
+        topic_name: Arc<str>,
         transport_reader: T,
     ) -> Self {
         Self {

--- a/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
@@ -158,15 +158,33 @@ impl<T> DataReaderEntity<T> {
         specific_instance_handle: &Option<InstanceHandle>,
         take: bool,
     ) -> DdsResult<SampleList> {
+        if self.sample_list.is_empty() || max_samples <= 0 {
+            return Err(DdsError::NoData);
+        }
+
         if let Some(h) = specific_instance_handle {
             if !self.instances.iter().any(|x| x.handle() == h) {
                 return Err(DdsError::BadParameter);
             }
         };
 
-        let mut samples = Vec::new();
+        struct InstanceInCollection {
+            handle: InstanceHandle,
+            instance_index: usize,
+            instance_state: InstanceState,
+            most_recent_sample_absolute_generation_rank: i32,
+            sample_rank_counter: i32,
+        }
 
-        let mut instances_in_collection = Vec::<InstanceState>::new();
+        let match_all_sample_states = sample_states.len() >= 2;
+        let match_all_view_states = view_states.len() >= 2;
+        let match_all_instance_states = instance_states.len() >= 3;
+
+        let estimated_capacity = (max_samples as usize).min(self.sample_list.len());
+        let mut samples = Vec::with_capacity(estimated_capacity);
+        let mut instances_in_collection: Vec<InstanceInCollection> =
+            Vec::with_capacity(self.instances.len().min(4));
+
         self.sample_list.retain_mut(|cache_change| {
             if samples.len() as i32 == max_samples {
                 return true;
@@ -178,41 +196,71 @@ impl<T> DataReaderEntity<T> {
                 }
             };
 
-            let Some(instance) = self
-                .instances
-                .iter()
-                .find(|x| x.handle == cache_change.instance_handle)
-            else {
-                return true;
+            let (instance_idx, instance) = if self.instances.len() == 1
+                && self.instances[0].handle == cache_change.instance_handle
+            {
+                (0, &self.instances[0])
+            } else {
+                match self
+                    .instances
+                    .iter()
+                    .enumerate()
+                    .find(|(_, x)| x.handle == cache_change.instance_handle)
+                {
+                    Some(entry) => entry,
+                    None => return true,
+                }
             };
 
-            if !(sample_states.contains(&cache_change.sample_state)
-                && view_states.contains(&instance.view_state)
-                && instance_states.contains(&instance.instance_state))
+            if (!match_all_sample_states && !sample_states.contains(&cache_change.sample_state))
+                || (!match_all_view_states && !view_states.contains(&instance.view_state))
+                || (!match_all_instance_states
+                    && !instance_states.contains(&instance.instance_state))
             {
                 return true;
             }
 
-            if !instances_in_collection
-                .iter()
-                .any(|x| x.handle() == &cache_change.instance_handle)
+            let instance_in_coll = if instances_in_collection.len() == 1
+                && instances_in_collection[0].handle == cache_change.instance_handle
             {
-                instances_in_collection.push(InstanceState::new(cache_change.instance_handle));
-            }
+                &mut instances_in_collection[0]
+            } else {
+                match instances_in_collection
+                    .iter_mut()
+                    .find(|x| x.handle == cache_change.instance_handle)
+                {
+                    Some(entry) => entry,
+                    None => {
+                        instances_in_collection.push(InstanceInCollection {
+                            handle: cache_change.instance_handle,
+                            instance_index: instance_idx,
+                            instance_state: InstanceState::new(cache_change.instance_handle),
+                            most_recent_sample_absolute_generation_rank: 0,
+                            sample_rank_counter: 0,
+                        });
+                        instances_in_collection.last_mut().unwrap()
+                    }
+                }
+            };
 
-            let instance_from_collection = instances_in_collection
-                .iter_mut()
-                .find(|x| x.handle() == &cache_change.instance_handle)
-                .expect("Instance must exist");
-            instance_from_collection.update_state(cache_change.kind, None);
+            instance_in_coll
+                .instance_state
+                .update_state(cache_change.kind, None);
             let sample_state = cache_change.sample_state;
             let view_state = instance.view_state;
             let instance_state = instance.instance_state;
 
             let absolute_generation_rank = (instance.most_recent_disposed_generation_count
                 + instance.most_recent_no_writers_generation_count)
-                - (instance_from_collection.most_recent_disposed_generation_count
-                    + instance_from_collection.most_recent_no_writers_generation_count);
+                - (instance_in_coll
+                    .instance_state
+                    .most_recent_disposed_generation_count
+                    + instance_in_coll
+                        .instance_state
+                        .most_recent_no_writers_generation_count);
+
+            instance_in_coll.most_recent_sample_absolute_generation_rank =
+                absolute_generation_rank;
 
             let (data, valid_data) = match cache_change.kind {
                 ChangeKind::Alive | ChangeKind::AliveFiltered => {
@@ -250,36 +298,33 @@ impl<T> DataReaderEntity<T> {
             }
         });
 
-        // After the collection is created, update the relative generation rank values and mark the read instances as viewed
-        for handle in instances_in_collection.iter().map(|x| x.handle()) {
-            let most_recent_sample_absolute_generation_rank = samples
-                .iter()
-                .filter(|(_, sample_info)| &sample_info.instance_handle == handle)
-                .map(|(_, sample_info)| sample_info.absolute_generation_rank)
-                .next_back()
-                .expect("Instance handle must exist on collection");
+        // After the collection is created, update relative generation rank and sample rank in a single reverse pass
+        if instances_in_collection.len() == 1 {
+            let inst = &mut instances_in_collection[0];
+            let most_recent_rank = inst.most_recent_sample_absolute_generation_rank;
+            for (i, (_, sample_info)) in samples.iter_mut().rev().enumerate() {
+                sample_info.generation_rank =
+                    sample_info.absolute_generation_rank - most_recent_rank;
+                sample_info.sample_rank = i as i32;
+            }
+            self.instances[inst.instance_index].mark_viewed();
+        } else {
+            for (_, sample_info) in samples.iter_mut().rev() {
+                let instance_in_coll = instances_in_collection
+                    .iter_mut()
+                    .find(|x| x.handle == sample_info.instance_handle)
+                    .expect("Instance handle must exist on collection");
 
-            let mut total_instance_samples_in_collection = samples
-                .iter()
-                .filter(|(_, sample_info)| &sample_info.instance_handle == handle)
-                .count();
-
-            for (_, sample_info) in samples
-                .iter_mut()
-                .filter(|(_, sample_info)| &sample_info.instance_handle == handle)
-            {
                 sample_info.generation_rank = sample_info.absolute_generation_rank
-                    - most_recent_sample_absolute_generation_rank;
+                    - instance_in_coll.most_recent_sample_absolute_generation_rank;
 
-                total_instance_samples_in_collection -= 1;
-                sample_info.sample_rank = total_instance_samples_in_collection as i32;
+                sample_info.sample_rank = instance_in_coll.sample_rank_counter;
+                instance_in_coll.sample_rank_counter += 1;
             }
 
-            self.instances
-                .iter_mut()
-                .find(|x| x.handle() == handle)
-                .expect("Sample must exist")
-                .mark_viewed()
+            for inst in &instances_in_collection {
+                self.instances[inst.instance_index].mark_viewed();
+            }
         }
 
         if samples.is_empty() {

--- a/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
@@ -23,7 +23,7 @@ use crate::{
         serializer::{serialize_cdr1_be, serialize_cdr1_le, serialize_cdr2_be, serialize_cdr2_le},
     },
 };
-use alloc::{collections::VecDeque, string::String, vec::Vec};
+use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
 
 use super::rtps_traits::RtpsWriter;
 
@@ -42,7 +42,7 @@ pub struct IncompatibleSubscriptions {
 pub struct DataWriterEntity<T> {
     pub instance_handle: InstanceHandle,
     pub transport_writer: T,
-    pub topic_name: String,
+    pub topic_name: Arc<str>,
     pub enabled: bool,
     pub last_change_sequence_number: i64,
     pub qos: DataWriterQos,
@@ -53,7 +53,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
     pub fn new(
         instance_handle: InstanceHandle,
         transport_writer: T,
-        topic_name: String,
+        topic_name: Arc<str>,
         qos: DataWriterQos,
     ) -> Self {
         Self {

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -32,7 +32,7 @@ use crate::{
             data_writer_entity::IncompatibleSubscriptions,
             participant_entity::{
                 BUILT_IN_TOPIC_NAME_LIST, BuiltInKeyHolder, DcpsDomainParticipant,
-                DiscoveredParticipantInfo,
+                DiscoveredParticipantInfo, DomainParticipantEntity,
             },
             rtps_traits::RtpsReader,
             topic_entity::DiscoveredTypeRepresentationState,
@@ -54,10 +54,10 @@ use crate::{
             DATA_REPRESENTATION_QOS_POLICY_ID, DEADLINE_QOS_POLICY_ID,
             DESTINATIONORDER_QOS_POLICY_ID, DURABILITY_QOS_POLICY_ID, DurabilityQosPolicyKind,
             HistoryQosPolicy, LATENCYBUDGET_QOS_POLICY_ID, LIVELINESS_QOS_POLICY_ID,
-            LifespanQosPolicy, OWNERSHIP_QOS_POLICY_ID, PRESENTATION_QOS_POLICY_ID, QosPolicyId,
-            RELIABILITY_QOS_POLICY_ID, ReliabilityQosPolicyKind, ResourceLimitsQosPolicy,
-            TransportPriorityQosPolicy, TypeConsistencyEnforcementQosPolicy,
-            XCDR_DATA_REPRESENTATION,
+            LifespanQosPolicy, OWNERSHIP_QOS_POLICY_ID, PRESENTATION_QOS_POLICY_ID,
+            PartitionQosPolicy, QosPolicyId, RELIABILITY_QOS_POLICY_ID, ReliabilityQosPolicyKind,
+            ResourceLimitsQosPolicy, TransportPriorityQosPolicy,
+            TypeConsistencyEnforcementQosPolicy, XCDR_DATA_REPRESENTATION,
         },
         sample_info::{ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE, SampleStateKind},
         status::{
@@ -797,110 +797,69 @@ impl DcpsDomainParticipant {
 
     #[tracing::instrument(skip(self, runtime))]
     pub fn process_discovered_readers(&mut self, runtime: &impl DdsRuntime) {
-        for publisher in &mut self.domain_participant.user_defined_publisher_list {
+        if self.domain_participant.discovered_reader_list.is_empty()
+            || self
+                .domain_participant
+                .user_defined_publisher_list
+                .is_empty()
+        {
+            return;
+        }
+
+        let DomainParticipantEntity {
+            discovered_reader_list,
+            user_defined_publisher_list,
+            discovered_participant_list,
+            locally_created_topic_list,
+            builtin_publisher,
+            domain_id,
+            instance_handle: participant_instance_handle,
+            listener_mask: participant_listener_mask,
+            listener_sender: participant_listener_sender,
+            ..
+        } = &mut self.domain_participant;
+
+        let domain_id = *domain_id;
+        let participant_instance_handle = *participant_instance_handle;
+        let participant_listener_mask = *participant_listener_mask;
+        let dcps_sender = self.dcps_sender;
+        let message_writer = self.transport.message_writer.as_ref();
+
+        for publisher in user_defined_publisher_list.iter_mut() {
+            let publisher_handle = publisher.instance_handle;
+            let publisher_qos = publisher.qos.clone();
+            let publisher_listener_mask = publisher.listener_mask;
+            let publisher_listener_sender = publisher.listener_sender.clone();
+
             for data_writer in &mut publisher.data_writer_list {
                 let writer_topic_name = data_writer.topic_name.clone();
-                for discovered_reader_data in self
-                    .domain_participant
-                    .discovered_reader_list
+
+                for discovered_reader_data in discovered_reader_list
                     .iter()
                     .filter(|x| x.dds_subscription_data.topic_name.value == writer_topic_name)
                 {
-                    if data_writer
+                    if let Some(matched) = data_writer
                         .matched_subscription_list
-                        .contains(&discovered_reader_data.dds_subscription_data)
+                        .iter()
+                        .find(|x| x.key() == discovered_reader_data.dds_subscription_data.key())
                     {
-                        continue;
+                        if matched == &discovered_reader_data.dds_subscription_data {
+                            continue;
+                        }
                     }
 
-                    let default_unicast_locator_list = if let Some(p) = self
-                        .domain_participant
-                        .discovered_participant_list
-                        .iter()
-                        .find(|p| {
-                            p.guid_prefix
-                                == discovered_reader_data
-                                    .reader_proxy
-                                    .remote_reader_guid
-                                    .prefix()
-                        }) {
-                        p.default_unicast_locator_list.clone()
-                    } else {
-                        vec![]
-                    };
-
-                    let default_multicast_locator_list = if let Some(p) = self
-                        .domain_participant
-                        .discovered_participant_list
-                        .iter()
-                        .find(|p| {
-                            p.guid_prefix
-                                == discovered_reader_data
-                                    .reader_proxy
-                                    .remote_reader_guid
-                                    .prefix()
-                        }) {
-                        p.default_multicast_locator_list.clone()
-                    } else {
-                        vec![]
-                    };
-
-                    let is_any_name_matched = discovered_reader_data
-                        .dds_subscription_data
-                        .partition
-                        .name
-                        .iter()
-                        .any(|n| publisher.qos.partition.name.contains(n));
-
-                    let is_any_received_regex_matched_with_partition_qos = discovered_reader_data
-                        .dds_subscription_data
-                        .partition
-                        .name
-                        .iter()
-                        .filter_map(|n| Regex::new(&fnmatch_to_regex(n)).ok())
-                        .any(|regex| {
-                            publisher
-                                .qos
-                                .partition
-                                .name
-                                .iter()
-                                .any(|n| regex.is_match(n))
-                        });
-
-                    let is_any_local_regex_matched_with_received_partition_qos = publisher
-                        .qos
-                        .partition
-                        .name
-                        .iter()
-                        .filter_map(|n| Regex::new(&fnmatch_to_regex(n)).ok())
-                        .any(|regex| {
-                            discovered_reader_data
-                                .dds_subscription_data
-                                .partition
-                                .name
-                                .iter()
-                                .any(|n| regex.is_match(n))
-                        });
-
-                    let is_partition_matched =
-                        discovered_reader_data.dds_subscription_data.partition
-                            == publisher.qos.partition
-                            || is_any_name_matched
-                            || is_any_received_regex_matched_with_partition_qos
-                            || is_any_local_regex_matched_with_received_partition_qos;
-                    if is_partition_matched {
-                        let publisher_qos = publisher.qos.clone();
-
+                    if is_partition_matched(
+                        &discovered_reader_data.dds_subscription_data.partition,
+                        &publisher_qos.partition,
+                    ) {
                         let is_matched_topic_name = discovered_reader_data
                             .dds_subscription_data
                             .topic_name
                             .value
-                            == data_writer.topic_name;
-                        let writer_associated_topic = self
-                            .domain_participant
-                            .locally_created_topic_list
+                            == writer_topic_name;
+                        let writer_associated_topic = locally_created_topic_list
                             .iter_mut()
-                            .find(|x| x.topic_name == data_writer.topic_name)
+                            .find(|x| x.topic_name == writer_topic_name)
                             .expect("A matched topic to the writer must exist");
 
                         let is_matched_type = match &discovered_reader_data
@@ -955,9 +914,7 @@ impl DcpsDomainParticipant {
                                     }
                                 } else {
                                     let should_request = {
-                                        let type_request_writer = &mut self
-                                            .domain_participant
-                                            .builtin_publisher
+                                        let type_request_writer = &mut builtin_publisher
                                             .type_lookup_request_writer;
 
                                         let type_lookup_request = TypeLookupRequest {
@@ -973,7 +930,7 @@ impl DcpsDomainParticipant {
                                                 },
                                                 instance_name: format!(
                                                     "dds.builtin.TOS.{:x}",
-                                                    self.domain_participant.instance_handle,
+                                                    participant_instance_handle,
                                                 ),
                                             },
                                             call: TypeLookupCall::TypeLookupGetTypesHashId {
@@ -999,7 +956,7 @@ impl DcpsDomainParticipant {
                                                 serialized_data,
                                                 runtime.clock().now(),
                                                 runtime.clock().now(),
-                                                self.transport.message_writer.as_ref(),
+                                                message_writer,
                                                 runtime,
                                             )
                                             .ok();
@@ -1021,25 +978,6 @@ impl DcpsDomainParticipant {
                             }
                         };
 
-                        let the_participant = DomainParticipantAsync::new(
-                            self.dcps_sender,
-                            self.domain_participant.domain_id,
-                            self.domain_participant.instance_handle,
-                        );
-                        let the_publisher =
-                            PublisherAsync::new(publisher.instance_handle, the_participant.clone());
-                        let the_topic = TopicAsync::new(
-                            writer_associated_topic.instance_handle,
-                            writer_associated_topic.type_name.clone(),
-                            data_writer.topic_name.clone(),
-                            the_participant,
-                        );
-                        let the_writer = DataWriterAsync::new(
-                            data_writer.instance_handle,
-                            the_publisher,
-                            the_topic,
-                        );
-
                         if is_matched_topic_name {
                             if is_matched_type {
                                 let incompatible_qos_policy_list =
@@ -1049,6 +987,32 @@ impl DcpsDomainParticipant {
                                         &publisher_qos,
                                     );
                                 if incompatible_qos_policy_list.is_empty() {
+                                    let default_unicast_locator_list = if let Some(p) =
+                                        discovered_participant_list.iter().find(|p| {
+                                            p.guid_prefix
+                                                == discovered_reader_data
+                                                    .reader_proxy
+                                                    .remote_reader_guid
+                                                    .prefix()
+                                        }) {
+                                        p.default_unicast_locator_list.clone()
+                                    } else {
+                                        vec![]
+                                    };
+
+                                    let default_multicast_locator_list = if let Some(p) =
+                                        discovered_participant_list.iter().find(|p| {
+                                            p.guid_prefix
+                                                == discovered_reader_data
+                                                    .reader_proxy
+                                                    .remote_reader_guid
+                                                    .prefix()
+                                        }) {
+                                        p.default_multicast_locator_list.clone()
+                                    } else {
+                                        vec![]
+                                    };
+
                                     match data_writer.matched_subscription_list.iter_mut().find(
                                         |x| {
                                             x.key()
@@ -1144,42 +1108,67 @@ impl DcpsDomainParticipant {
                                         .transport_writer
                                         .add_matched_reader(reader_proxy);
 
-                                    if data_writer
+                                    let is_listener_enabled = data_writer
                                         .listener_mask
                                         .is_enabled(&StatusKind::PublicationMatched)
-                                    {
+                                        || publisher_listener_mask
+                                            .is_enabled(&StatusKind::PublicationMatched)
+                                        || participant_listener_mask
+                                            .is_enabled(&StatusKind::PublicationMatched);
+
+                                    if is_listener_enabled {
+                                        let the_participant = DomainParticipantAsync::new(
+                                            dcps_sender,
+                                            domain_id,
+                                            participant_instance_handle,
+                                        );
+                                        let the_publisher = PublisherAsync::new(
+                                            publisher_handle,
+                                            the_participant.clone(),
+                                        );
+                                        let the_topic = TopicAsync::new(
+                                            writer_associated_topic.instance_handle,
+                                            writer_associated_topic.type_name.clone(),
+                                            writer_topic_name.clone(),
+                                            the_participant,
+                                        );
+                                        let the_writer = DataWriterAsync::new(
+                                            data_writer.instance_handle,
+                                            the_publisher,
+                                            the_topic,
+                                        );
                                         let status = data_writer.publication_matched_status.get();
-                                        if let Some(l) = &data_writer.listener_sender {
-                                            l.send(ListenerMail::PublicationMatched {
-                                                the_writer,
-                                                status,
-                                            })
-                                            .ok();
-                                        }
-                                    } else if publisher
-                                        .listener_mask
-                                        .is_enabled(&StatusKind::PublicationMatched)
-                                    {
-                                        let status = data_writer.publication_matched_status.get();
-                                        if let Some(l) = &publisher.listener_sender {
-                                            l.send(ListenerMail::PublicationMatched {
-                                                the_writer,
-                                                status,
-                                            })
-                                            .ok();
-                                        }
-                                    } else if self
-                                        .domain_participant
-                                        .listener_mask
-                                        .is_enabled(&StatusKind::PublicationMatched)
-                                    {
-                                        let status = data_writer.publication_matched_status.get();
-                                        if let Some(l) = &self.domain_participant.listener_sender {
-                                            l.send(ListenerMail::PublicationMatched {
-                                                the_writer,
-                                                status,
-                                            })
-                                            .ok();
+                                        if data_writer
+                                            .listener_mask
+                                            .is_enabled(&StatusKind::PublicationMatched)
+                                        {
+                                            if let Some(l) = &data_writer.listener_sender {
+                                                l.send(ListenerMail::PublicationMatched {
+                                                    the_writer,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
+                                        } else if publisher_listener_mask
+                                            .is_enabled(&StatusKind::PublicationMatched)
+                                        {
+                                            if let Some(l) = &publisher_listener_sender {
+                                                l.send(ListenerMail::PublicationMatched {
+                                                    the_writer,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
+                                        } else if participant_listener_mask
+                                            .is_enabled(&StatusKind::PublicationMatched)
+                                        {
+                                            if let Some(l) = participant_listener_sender {
+                                                l.send(ListenerMail::PublicationMatched {
+                                                    the_writer,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
                                         }
                                     }
 
@@ -1199,49 +1188,70 @@ impl DcpsDomainParticipant {
                                             incompatible_qos_policy_list,
                                         );
 
-                                    if data_writer
+                                    let is_listener_enabled = data_writer
                                         .listener_mask
                                         .is_enabled(&StatusKind::OfferedIncompatibleQos)
-                                    {
+                                        || publisher_listener_mask
+                                            .is_enabled(&StatusKind::OfferedIncompatibleQos)
+                                        || participant_listener_mask
+                                            .is_enabled(&StatusKind::OfferedIncompatibleQos);
+
+                                    if is_listener_enabled {
+                                        let the_participant = DomainParticipantAsync::new(
+                                            dcps_sender,
+                                            domain_id,
+                                            participant_instance_handle,
+                                        );
+                                        let the_publisher = PublisherAsync::new(
+                                            publisher_handle,
+                                            the_participant.clone(),
+                                        );
+                                        let the_topic = TopicAsync::new(
+                                            writer_associated_topic.instance_handle,
+                                            writer_associated_topic.type_name.clone(),
+                                            writer_topic_name.clone(),
+                                            the_participant,
+                                        );
+                                        let the_writer = DataWriterAsync::new(
+                                            data_writer.instance_handle,
+                                            the_publisher,
+                                            the_topic,
+                                        );
                                         let status = data_writer
                                             .incompatible_subscriptions
                                             .get_offered_incompatible_qos_status();
 
-                                        if let Some(l) = &data_writer.listener_sender {
-                                            l.send(ListenerMail::OfferedIncompatibleQos {
-                                                the_writer,
-                                                status,
-                                            })
-                                            .ok();
-                                        }
-                                    } else if publisher
-                                        .listener_mask
-                                        .is_enabled(&StatusKind::OfferedIncompatibleQos)
-                                    {
-                                        let status = data_writer
-                                            .incompatible_subscriptions
-                                            .get_offered_incompatible_qos_status();
-                                        if let Some(l) = &publisher.listener_sender {
-                                            l.send(ListenerMail::OfferedIncompatibleQos {
-                                                the_writer,
-                                                status,
-                                            })
-                                            .ok();
-                                        }
-                                    } else if self
-                                        .domain_participant
-                                        .listener_mask
-                                        .is_enabled(&StatusKind::OfferedIncompatibleQos)
-                                    {
-                                        let status = data_writer
-                                            .incompatible_subscriptions
-                                            .get_offered_incompatible_qos_status();
-                                        if let Some(l) = &self.domain_participant.listener_sender {
-                                            l.send(ListenerMail::OfferedIncompatibleQos {
-                                                the_writer,
-                                                status,
-                                            })
-                                            .ok();
+                                        if data_writer
+                                            .listener_mask
+                                            .is_enabled(&StatusKind::OfferedIncompatibleQos)
+                                        {
+                                            if let Some(l) = &data_writer.listener_sender {
+                                                l.send(ListenerMail::OfferedIncompatibleQos {
+                                                    the_writer,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
+                                        } else if publisher_listener_mask
+                                            .is_enabled(&StatusKind::OfferedIncompatibleQos)
+                                        {
+                                            if let Some(l) = &publisher_listener_sender {
+                                                l.send(ListenerMail::OfferedIncompatibleQos {
+                                                    the_writer,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
+                                        } else if participant_listener_mask
+                                            .is_enabled(&StatusKind::OfferedIncompatibleQos)
+                                        {
+                                            if let Some(l) = participant_listener_sender {
+                                                l.send(ListenerMail::OfferedIncompatibleQos {
+                                                    the_writer,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
                                         }
                                     }
 
@@ -1256,45 +1266,52 @@ impl DcpsDomainParticipant {
                                 writer_associated_topic
                                     .inconsistent_topic_status
                                     .total_count_change += 1;
-                                let participant = DomainParticipantAsync::new(
-                                    self.dcps_sender,
-                                    self.domain_participant.domain_id,
-                                    self.domain_participant.instance_handle,
-                                );
-                                let the_topic = TopicAsync::new(
-                                    writer_associated_topic.instance_handle,
-                                    writer_associated_topic.type_name.clone(),
-                                    writer_associated_topic.topic_name.clone(),
-                                    participant,
-                                );
-                                if writer_associated_topic
+
+                                let is_listener_enabled = writer_associated_topic
                                     .listener_mask
                                     .is_enabled(&StatusKind::InconsistentTopic)
-                                {
-                                    let status = writer_associated_topic
-                                        .inconsistent_topic_status
-                                        .get_inconsistent_topic_status();
-                                    if let Some(l) = &writer_associated_topic.listener_sender {
-                                        l.send(ListenerMail::InconsistentTopic {
-                                            the_topic,
-                                            status,
-                                        })
-                                        .ok();
-                                    }
-                                } else if self
-                                    .domain_participant
-                                    .listener_mask
-                                    .is_enabled(&StatusKind::InconsistentTopic)
-                                {
-                                    let status = writer_associated_topic
-                                        .inconsistent_topic_status
-                                        .get_inconsistent_topic_status();
-                                    if let Some(l) = &self.domain_participant.listener_sender {
-                                        l.send(ListenerMail::InconsistentTopic {
-                                            the_topic,
-                                            status,
-                                        })
-                                        .ok();
+                                    || participant_listener_mask
+                                        .is_enabled(&StatusKind::InconsistentTopic);
+
+                                if is_listener_enabled {
+                                    let participant = DomainParticipantAsync::new(
+                                        dcps_sender,
+                                        domain_id,
+                                        participant_instance_handle,
+                                    );
+                                    let the_topic = TopicAsync::new(
+                                        writer_associated_topic.instance_handle,
+                                        writer_associated_topic.type_name.clone(),
+                                        writer_topic_name.clone(),
+                                        participant,
+                                    );
+                                    if writer_associated_topic
+                                        .listener_mask
+                                        .is_enabled(&StatusKind::InconsistentTopic)
+                                    {
+                                        let status = writer_associated_topic
+                                            .inconsistent_topic_status
+                                            .get_inconsistent_topic_status();
+                                        if let Some(l) = &writer_associated_topic.listener_sender {
+                                            l.send(ListenerMail::InconsistentTopic {
+                                                the_topic,
+                                                status,
+                                            })
+                                            .ok();
+                                        }
+                                    } else if participant_listener_mask
+                                        .is_enabled(&StatusKind::InconsistentTopic)
+                                    {
+                                        let status = writer_associated_topic
+                                            .inconsistent_topic_status
+                                            .get_inconsistent_topic_status();
+                                        if let Some(l) = participant_listener_sender {
+                                            l.send(ListenerMail::InconsistentTopic {
+                                                the_topic,
+                                                status,
+                                            })
+                                            .ok();
+                                        }
                                     }
                                 }
                                 writer_associated_topic
@@ -1345,15 +1362,42 @@ impl DcpsDomainParticipant {
 
     #[tracing::instrument(skip(self, runtime))]
     pub fn process_discovered_writers(&mut self, runtime: &impl DdsRuntime) {
-        for subscriber in &mut self.domain_participant.user_defined_subscriber_list {
+        if self.domain_participant.discovered_writer_list.is_empty()
+            || self
+                .domain_participant
+                .user_defined_subscriber_list
+                .is_empty()
+        {
+            return;
+        }
+
+        let DomainParticipantEntity {
+            discovered_writer_list,
+            user_defined_subscriber_list,
+            discovered_participant_list,
+            content_filtered_topic_list,
+            locally_created_topic_list,
+            builtin_publisher,
+            domain_id,
+            instance_handle: participant_instance_handle,
+            listener_mask: participant_listener_mask,
+            listener_sender: participant_listener_sender,
+            ..
+        } = &mut self.domain_participant;
+
+        let domain_id = *domain_id;
+        let participant_instance_handle = *participant_instance_handle;
+        let participant_listener_mask = *participant_listener_mask;
+        let dcps_sender = self.dcps_sender;
+        let message_writer = self.transport.message_writer.as_ref();
+
+        for subscriber in user_defined_subscriber_list.iter_mut() {
             let subscriber_handle = subscriber.instance_handle;
             let subscriber_qos = subscriber.qos.clone();
             let subscriber_listener_mask = subscriber.listener_mask;
             let subscriber_listener_sender = subscriber.listener_sender.clone();
             for data_reader in &mut subscriber.data_reader_list {
-                let reader_topic_name = if let Some(matched_topic) = self
-                    .domain_participant
-                    .content_filtered_topic_list
+                let reader_topic_name = if let Some(matched_topic) = content_filtered_topic_list
                     .iter()
                     .find(|t| t.topic_name == data_reader.topic_name)
                 {
@@ -1362,102 +1406,30 @@ impl DcpsDomainParticipant {
                     data_reader.topic_name.clone()
                 };
 
-                let discovered_writer_list = self.domain_participant.discovered_writer_list.clone();
                 for discovered_writer_data in discovered_writer_list
                     .iter()
                     .filter(|x| x.dds_publication_data.topic_name() == reader_topic_name)
                 {
-                    if data_reader
+                    if let Some(matched) = data_reader
                         .matched_publication_list
-                        .contains(&discovered_writer_data.dds_publication_data)
+                        .iter()
+                        .find(|x| x.key() == discovered_writer_data.dds_publication_data.key())
                     {
-                        continue;
+                        if matched == &discovered_writer_data.dds_publication_data {
+                            continue;
+                        }
                     }
 
-                    let default_unicast_locator_list = if let Some(p) = self
-                        .domain_participant
-                        .discovered_participant_list
-                        .iter()
-                        .find(|p| {
-                            p.guid_prefix
-                                == discovered_writer_data
-                                    .writer_proxy
-                                    .remote_writer_guid
-                                    .prefix()
-                        }) {
-                        p.default_unicast_locator_list.clone()
-                    } else {
-                        vec![]
-                    };
-
-                    let default_multicast_locator_list = if let Some(p) = self
-                        .domain_participant
-                        .discovered_participant_list
-                        .iter()
-                        .find(|p| {
-                            p.guid_prefix
-                                == discovered_writer_data
-                                    .writer_proxy
-                                    .remote_writer_guid
-                                    .prefix()
-                        }) {
-                        p.default_multicast_locator_list.clone()
-                    } else {
-                        vec![]
-                    };
-
-                    let is_any_name_matched = discovered_writer_data
-                        .dds_publication_data
-                        .partition
-                        .name
-                        .iter()
-                        .any(|n| subscriber_qos.partition.name.contains(n));
-
-                    let is_any_received_regex_matched_with_partition_qos = discovered_writer_data
-                        .dds_publication_data
-                        .partition
-                        .name
-                        .iter()
-                        .filter_map(|n| Regex::new(&fnmatch_to_regex(n)).ok())
-                        .any(|regex| {
-                            subscriber_qos
-                                .partition
-                                .name
+                    if is_partition_matched(
+                        &discovered_writer_data.dds_publication_data.partition,
+                        &subscriber_qos.partition,
+                    ) {
+                        let reader_associated_topic = if let Some(matched_topic) =
+                            content_filtered_topic_list
                                 .iter()
-                                .any(|n| regex.is_match(n))
-                        });
-
-                    let is_any_local_regex_matched_with_received_partition_qos = subscriber_qos
-                        .partition
-                        .name
-                        .iter()
-                        .filter_map(|n| Regex::new(&fnmatch_to_regex(n)).ok())
-                        .any(|regex| {
-                            discovered_writer_data
-                                .dds_publication_data
-                                .partition
-                                .name
-                                .iter()
-                                .any(|n| regex.is_match(n))
-                        });
-
-                    let is_partition_matched =
-                        discovered_writer_data.dds_publication_data.partition
-                            == subscriber_qos.partition
-                            || is_any_name_matched
-                            || is_any_received_regex_matched_with_partition_qos
-                            || is_any_local_regex_matched_with_received_partition_qos;
-
-                    if is_partition_matched {
-                        let reader_associated_topic = if let Some(matched_topic) = self
-                            .domain_participant
-                            .content_filtered_topic_list
-                            .iter()
-                            .find(|t| t.topic_name == data_reader.topic_name)
+                                .find(|t| t.topic_name == data_reader.topic_name)
                         {
-                            if let Some(t) = self
-                                .domain_participant
-                                .locally_created_topic_list
+                            if let Some(t) = locally_created_topic_list
                                 .iter_mut()
                                 .find(|x| x.topic_name == matched_topic.related_topic_name)
                             {
@@ -1465,9 +1437,7 @@ impl DcpsDomainParticipant {
                             } else {
                                 continue;
                             }
-                        } else if let Some(t) = self
-                            .domain_participant
-                            .locally_created_topic_list
+                        } else if let Some(t) = locally_created_topic_list
                             .iter_mut()
                             .find(|x| x.topic_name == data_reader.topic_name)
                         {
@@ -1531,9 +1501,7 @@ impl DcpsDomainParticipant {
                                     }
                                 } else {
                                     let should_request = {
-                                        let type_request_writer = &mut self
-                                            .domain_participant
-                                            .builtin_publisher
+                                        let type_request_writer = &mut builtin_publisher
                                             .type_lookup_request_writer;
 
                                         let type_lookup_request = TypeLookupRequest {
@@ -1549,7 +1517,7 @@ impl DcpsDomainParticipant {
                                                 },
                                                 instance_name: format!(
                                                     "dds.builtin.TOS.{:x}",
-                                                    self.domain_participant.instance_handle,
+                                                    participant_instance_handle,
                                                 ),
                                             },
                                             call: TypeLookupCall::TypeLookupGetTypesHashId {
@@ -1575,7 +1543,7 @@ impl DcpsDomainParticipant {
                                                 serialized_data,
                                                 runtime.clock().now(),
                                                 runtime.clock().now(),
-                                                self.transport.message_writer.as_ref(),
+                                                message_writer,
                                                 runtime,
                                             )
                                             .ok();
@@ -1597,20 +1565,6 @@ impl DcpsDomainParticipant {
                             }
                         };
 
-                        let the_participant = DomainParticipantAsync::new(
-                            self.dcps_sender,
-                            self.domain_participant.domain_id,
-                            self.domain_participant.instance_handle,
-                        );
-                        let the_subscriber =
-                            SubscriberAsync::new(subscriber_handle, the_participant.clone());
-                        let the_reader = DataReaderAsync::new(
-                            data_reader.instance_handle,
-                            the_subscriber,
-                            data_reader.topic_name.clone(),
-                            reader_associated_topic.type_name.clone(),
-                        );
-
                         if is_matched_topic_name {
                             if is_matched_type {
                                 let incompatible_qos_policy_list =
@@ -1620,9 +1574,36 @@ impl DcpsDomainParticipant {
                                         &subscriber_qos,
                                     );
                                 if incompatible_qos_policy_list.is_empty() {
+                                    let default_unicast_locator_list = if let Some(p) =
+                                        discovered_participant_list.iter().find(|p| {
+                                            p.guid_prefix
+                                                == discovered_writer_data
+                                                    .writer_proxy
+                                                    .remote_writer_guid
+                                                    .prefix()
+                                        }) {
+                                        p.default_unicast_locator_list.clone()
+                                    } else {
+                                        vec![]
+                                    };
+
+                                    let default_multicast_locator_list = if let Some(p) =
+                                        discovered_participant_list.iter().find(|p| {
+                                            p.guid_prefix
+                                                == discovered_writer_data
+                                                    .writer_proxy
+                                                    .remote_writer_guid
+                                                    .prefix()
+                                        }) {
+                                        p.default_multicast_locator_list.clone()
+                                    } else {
+                                        vec![]
+                                    };
+
                                     data_reader.add_matched_publication(
                                         discovered_writer_data.dds_publication_data.clone(),
                                     );
+
                                     let unicast_locator_list = if discovered_writer_data
                                         .writer_proxy
                                         .unicast_locator_list
@@ -1685,41 +1666,62 @@ impl DcpsDomainParticipant {
                                         .transport_reader
                                         .add_matched_writer(&writer_proxy);
 
-                                    if data_reader
+                                    let is_listener_enabled = data_reader
                                         .listener_mask
                                         .is_enabled(&StatusKind::SubscriptionMatched)
-                                    {
+                                        || subscriber_listener_mask
+                                            .is_enabled(&StatusKind::SubscriptionMatched)
+                                        || participant_listener_mask
+                                            .is_enabled(&StatusKind::SubscriptionMatched);
+
+                                    if is_listener_enabled {
+                                        let the_participant = DomainParticipantAsync::new(
+                                            dcps_sender,
+                                            domain_id,
+                                            participant_instance_handle,
+                                        );
+                                        let the_subscriber = SubscriberAsync::new(
+                                            subscriber_handle,
+                                            the_participant.clone(),
+                                        );
+                                        let the_reader = DataReaderAsync::new(
+                                            data_reader.instance_handle,
+                                            the_subscriber,
+                                            data_reader.topic_name.clone(),
+                                            reader_associated_topic.type_name.clone(),
+                                        );
                                         let status = data_reader.get_subscription_matched_status();
-                                        if let Some(l) = &data_reader.listener_sender {
-                                            l.send(ListenerMail::SubscriptionMatched {
-                                                the_reader,
-                                                status,
-                                            })
-                                            .ok();
-                                        }
-                                    } else if subscriber_listener_mask
-                                        .is_enabled(&StatusKind::SubscriptionMatched)
-                                    {
-                                        let status = data_reader.get_subscription_matched_status();
-                                        if let Some(l) = &subscriber_listener_sender {
-                                            l.send(ListenerMail::SubscriptionMatched {
-                                                the_reader,
-                                                status,
-                                            })
-                                            .ok();
-                                        }
-                                    } else if self
-                                        .domain_participant
-                                        .listener_mask
-                                        .is_enabled(&StatusKind::SubscriptionMatched)
-                                    {
-                                        let status = data_reader.get_subscription_matched_status();
-                                        if let Some(l) = &self.domain_participant.listener_sender {
-                                            l.send(ListenerMail::SubscriptionMatched {
-                                                the_reader,
-                                                status,
-                                            })
-                                            .ok();
+                                        if data_reader
+                                            .listener_mask
+                                            .is_enabled(&StatusKind::SubscriptionMatched)
+                                        {
+                                            if let Some(l) = &data_reader.listener_sender {
+                                                l.send(ListenerMail::SubscriptionMatched {
+                                                    the_reader,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
+                                        } else if subscriber_listener_mask
+                                            .is_enabled(&StatusKind::SubscriptionMatched)
+                                        {
+                                            if let Some(l) = &subscriber_listener_sender {
+                                                l.send(ListenerMail::SubscriptionMatched {
+                                                    the_reader,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
+                                        } else if participant_listener_mask
+                                            .is_enabled(&StatusKind::SubscriptionMatched)
+                                        {
+                                            if let Some(l) = participant_listener_sender {
+                                                l.send(ListenerMail::SubscriptionMatched {
+                                                    the_reader,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
                                         }
                                     }
 
@@ -1734,44 +1736,63 @@ impl DcpsDomainParticipant {
                                         incompatible_qos_policy_list,
                                     );
 
-                                    if data_reader
+                                    let is_listener_enabled = data_reader
                                         .listener_mask
                                         .is_enabled(&StatusKind::RequestedIncompatibleQos)
-                                    {
+                                        || subscriber_listener_mask
+                                            .is_enabled(&StatusKind::RequestedIncompatibleQos)
+                                        || participant_listener_mask
+                                            .is_enabled(&StatusKind::RequestedIncompatibleQos);
+
+                                    if is_listener_enabled {
+                                        let the_participant = DomainParticipantAsync::new(
+                                            dcps_sender,
+                                            domain_id,
+                                            participant_instance_handle,
+                                        );
+                                        let the_subscriber = SubscriberAsync::new(
+                                            subscriber_handle,
+                                            the_participant.clone(),
+                                        );
+                                        let the_reader = DataReaderAsync::new(
+                                            data_reader.instance_handle,
+                                            the_subscriber,
+                                            data_reader.topic_name.clone(),
+                                            reader_associated_topic.type_name.clone(),
+                                        );
                                         let status =
                                             data_reader.get_requested_incompatible_qos_status();
-                                        if let Some(l) = &data_reader.listener_sender {
-                                            l.send(ListenerMail::RequestedIncompatibleQos {
-                                                the_reader,
-                                                status,
-                                            })
-                                            .ok();
-                                        }
-                                    } else if subscriber_listener_mask
-                                        .is_enabled(&StatusKind::RequestedIncompatibleQos)
-                                    {
-                                        let status =
-                                            data_reader.get_requested_incompatible_qos_status();
-                                        if let Some(l) = &subscriber_listener_sender {
-                                            l.send(ListenerMail::RequestedIncompatibleQos {
-                                                the_reader,
-                                                status,
-                                            })
-                                            .ok();
-                                        }
-                                    } else if self
-                                        .domain_participant
-                                        .listener_mask
-                                        .is_enabled(&StatusKind::RequestedIncompatibleQos)
-                                    {
-                                        let status =
-                                            data_reader.get_requested_incompatible_qos_status();
-                                        if let Some(l) = &self.domain_participant.listener_sender {
-                                            l.send(ListenerMail::RequestedIncompatibleQos {
-                                                the_reader,
-                                                status,
-                                            })
-                                            .ok();
+                                        if data_reader
+                                            .listener_mask
+                                            .is_enabled(&StatusKind::RequestedIncompatibleQos)
+                                        {
+                                            if let Some(l) = &data_reader.listener_sender {
+                                                l.send(ListenerMail::RequestedIncompatibleQos {
+                                                    the_reader,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
+                                        } else if subscriber_listener_mask
+                                            .is_enabled(&StatusKind::RequestedIncompatibleQos)
+                                        {
+                                            if let Some(l) = &subscriber_listener_sender {
+                                                l.send(ListenerMail::RequestedIncompatibleQos {
+                                                    the_reader,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
+                                        } else if participant_listener_mask
+                                            .is_enabled(&StatusKind::RequestedIncompatibleQos)
+                                        {
+                                            if let Some(l) = participant_listener_sender {
+                                                l.send(ListenerMail::RequestedIncompatibleQos {
+                                                    the_reader,
+                                                    status,
+                                                })
+                                                .ok();
+                                            }
                                         }
                                     }
 
@@ -1786,45 +1807,52 @@ impl DcpsDomainParticipant {
                                 reader_associated_topic
                                     .inconsistent_topic_status
                                     .total_count_change += 1;
-                                let participant = DomainParticipantAsync::new(
-                                    self.dcps_sender,
-                                    self.domain_participant.domain_id,
-                                    self.domain_participant.instance_handle,
-                                );
-                                let the_topic = TopicAsync::new(
-                                    reader_associated_topic.instance_handle,
-                                    reader_associated_topic.type_name.clone(),
-                                    reader_associated_topic.topic_name.clone(),
-                                    participant,
-                                );
-                                if reader_associated_topic
+
+                                let is_listener_enabled = reader_associated_topic
                                     .listener_mask
                                     .is_enabled(&StatusKind::InconsistentTopic)
-                                {
-                                    let status = reader_associated_topic
-                                        .inconsistent_topic_status
-                                        .get_inconsistent_topic_status();
-                                    if let Some(l) = &reader_associated_topic.listener_sender {
-                                        l.send(ListenerMail::InconsistentTopic {
-                                            the_topic,
-                                            status,
-                                        })
-                                        .ok();
-                                    }
-                                } else if self
-                                    .domain_participant
-                                    .listener_mask
-                                    .is_enabled(&StatusKind::InconsistentTopic)
-                                {
-                                    let status = reader_associated_topic
-                                        .inconsistent_topic_status
-                                        .get_inconsistent_topic_status();
-                                    if let Some(l) = &self.domain_participant.listener_sender {
-                                        l.send(ListenerMail::InconsistentTopic {
-                                            the_topic,
-                                            status,
-                                        })
-                                        .ok();
+                                    || participant_listener_mask
+                                        .is_enabled(&StatusKind::InconsistentTopic);
+
+                                if is_listener_enabled {
+                                    let participant = DomainParticipantAsync::new(
+                                        dcps_sender,
+                                        domain_id,
+                                        participant_instance_handle,
+                                    );
+                                    let the_topic = TopicAsync::new(
+                                        reader_associated_topic.instance_handle,
+                                        reader_associated_topic.type_name.clone(),
+                                        reader_associated_topic.topic_name.clone(),
+                                        participant,
+                                    );
+                                    if reader_associated_topic
+                                        .listener_mask
+                                        .is_enabled(&StatusKind::InconsistentTopic)
+                                    {
+                                        let status = reader_associated_topic
+                                            .inconsistent_topic_status
+                                            .get_inconsistent_topic_status();
+                                        if let Some(l) = &reader_associated_topic.listener_sender {
+                                            l.send(ListenerMail::InconsistentTopic {
+                                                the_topic,
+                                                status,
+                                            })
+                                            .ok();
+                                        }
+                                    } else if participant_listener_mask
+                                        .is_enabled(&StatusKind::InconsistentTopic)
+                                    {
+                                        let status = reader_associated_topic
+                                            .inconsistent_topic_status
+                                            .get_inconsistent_topic_status();
+                                        if let Some(l) = participant_listener_sender {
+                                            l.send(ListenerMail::InconsistentTopic {
+                                                the_topic,
+                                                status,
+                                            })
+                                            .ok();
+                                        }
                                     }
                                 }
                                 reader_associated_topic
@@ -3348,6 +3376,40 @@ fn get_discovered_writer_incompatible_qos_policy_list(
     }
 
     incompatible_qos_policy_list
+}
+
+fn is_partition_matched(p1: &PartitionQosPolicy, p2: &PartitionQosPolicy) -> bool {
+    if p1 == p2 {
+        return true;
+    }
+    if p1.name.iter().any(|n| p2.name.contains(n)) {
+        return true;
+    }
+    let p1_has_wildcard = p1.name.iter().any(|n| n.contains(['*', '?', '[', '+']));
+    let p2_has_wildcard = p2.name.iter().any(|n| n.contains(['*', '?', '[', '+']));
+    if p1_has_wildcard {
+        if p1
+            .name
+            .iter()
+            .filter(|n| n.contains(['*', '?', '[', '+']))
+            .filter_map(|n| Regex::new(&fnmatch_to_regex(n)).ok())
+            .any(|regex| p2.name.iter().any(|n| regex.is_match(n)))
+        {
+            return true;
+        }
+    }
+    if p2_has_wildcard {
+        if p2
+            .name
+            .iter()
+            .filter(|n| n.contains(['*', '?', '[', '+']))
+            .filter_map(|n| Regex::new(&fnmatch_to_regex(n)).ok())
+            .any(|regex| p1.name.iter().any(|n| regex.is_match(n)))
+        {
+            return true;
+        }
+    }
+    false
 }
 
 fn fnmatch_to_regex(pattern: &str) -> String {

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -87,8 +87,7 @@ use alloc::{format, string::String, vec, vec::Vec};
 use regex::Regex;
 
 impl DcpsDomainParticipant {
-    pub fn announce_participant_if_needed(&mut self, runtime: &impl DdsRuntime) {
-        let now = runtime.clock().now();
+    pub fn announce_participant_if_needed(&mut self, runtime: &impl DdsRuntime, now: Time) {
         if let Some(time_until) = self.time_until_participant_announcement(now) {
             if time_until == Duration::new(0, 0) {
                 self.announce_participant(runtime);

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -3387,8 +3387,8 @@ fn is_partition_matched(p1: &PartitionQosPolicy, p2: &PartitionQosPolicy) -> boo
     }
     let p1_has_wildcard = p1.name.iter().any(|n| n.contains(['*', '?', '[', '+']));
     let p2_has_wildcard = p2.name.iter().any(|n| n.contains(['*', '?', '[', '+']));
-    if p1_has_wildcard {
-        if p1
+    if p1_has_wildcard
+        && p1
             .name
             .iter()
             .filter(|n| n.contains(['*', '?', '[', '+']))
@@ -3397,9 +3397,8 @@ fn is_partition_matched(p1: &PartitionQosPolicy, p2: &PartitionQosPolicy) -> boo
         {
             return true;
         }
-    }
-    if p2_has_wildcard {
-        if p2
+    if p2_has_wildcard
+        && p2
             .name
             .iter()
             .filter(|n| n.contains(['*', '?', '[', '+']))
@@ -3408,7 +3407,6 @@ fn is_partition_matched(p1: &PartitionQosPolicy, p2: &PartitionQosPolicy) -> boo
         {
             return true;
         }
-    }
     false
 }
 

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -83,7 +83,12 @@ use crate::{
         type_support::{_String, Type, TypeSupport},
     },
 };
-use alloc::{format, string::String, vec, vec::Vec};
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 use regex::Regex;
 
 impl DcpsDomainParticipant {

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -950,12 +950,13 @@ impl DcpsDomainParticipant {
                                             &type_lookup_request.create_dynamic_sample(),
                                         )
                                         .unwrap();
+                                        let now = runtime.clock().now();
                                         type_request_writer
                                             .write_w_timestamp(
                                                 sample_instance_handle,
                                                 serialized_data,
-                                                runtime.clock().now(),
-                                                runtime.clock().now(),
+                                                now,
+                                                now,
                                                 message_writer,
                                                 runtime,
                                             )
@@ -1537,12 +1538,13 @@ impl DcpsDomainParticipant {
                                             &type_lookup_request.create_dynamic_sample(),
                                         )
                                         .unwrap();
+                                        let now = runtime.clock().now();
                                         type_request_writer
                                             .write_w_timestamp(
                                                 sample_instance_handle,
                                                 serialized_data,
-                                                runtime.clock().now(),
-                                                runtime.clock().now(),
+                                                now,
+                                                now,
                                                 message_writer,
                                                 runtime,
                                             )
@@ -2237,12 +2239,13 @@ impl DcpsDomainParticipant {
                                             )
                                             .unwrap();
 
+                                            let now = runtime.clock().now();
                                             type_lookup_reply_writer
                                                 .write_w_timestamp(
                                                     InstanceHandle::default(),
                                                     serialized_data,
-                                                    runtime.clock().now(),
-                                                    runtime.clock().now(),
+                                                    now,
+                                                    now,
                                                     self.transport.message_writer.as_ref(),
                                                     runtime,
                                                 )
@@ -2551,12 +2554,13 @@ impl DcpsDomainParticipant {
                             let serialized_data =
                                 serialize_cdr2_le(&type_lookup_request.create_dynamic_sample())
                                     .unwrap();
+                            let now = runtime.clock().now();
                             type_request_writer
                                 .write_w_timestamp(
                                     sample_instance_handle,
                                     serialized_data,
-                                    runtime.clock().now(),
-                                    runtime.clock().now(),
+                                    now,
+                                    now,
                                     self.transport.message_writer.as_ref(),
                                     runtime,
                                 )

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -3394,9 +3394,9 @@ fn is_partition_matched(p1: &PartitionQosPolicy, p2: &PartitionQosPolicy) -> boo
             .filter(|n| n.contains(['*', '?', '[', '+']))
             .filter_map(|n| Regex::new(&fnmatch_to_regex(n)).ok())
             .any(|regex| p2.name.iter().any(|n| regex.is_match(n)))
-        {
-            return true;
-        }
+    {
+        return true;
+    }
     if p2_has_wildcard
         && p2
             .name
@@ -3404,9 +3404,9 @@ fn is_partition_matched(p1: &PartitionQosPolicy, p2: &PartitionQosPolicy) -> boo
             .filter(|n| n.contains(['*', '?', '[', '+']))
             .filter_map(|n| Regex::new(&fnmatch_to_regex(n)).ok())
             .any(|regex| p1.name.iter().any(|n| regex.is_match(n)))
-        {
-            return true;
-        }
+    {
+        return true;
+    }
     false
 }
 

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -209,7 +209,7 @@ impl DcpsDomainParticipant {
                         .domain_participant
                         .locally_created_topic_list
                         .iter()
-                        .any(|t| t.topic_name == x.topic_name)
+                        .any(|t| t.topic_name.as_ref() == x.topic_name.as_str())
             })
             .collect::<Vec<_>>();
         for t in found_topics {
@@ -517,8 +517,8 @@ impl DcpsDomainParticipant {
             participant_key: BuiltInTopicKey {
                 value: self.domain_participant.instance_handle.into(),
             },
-            topic_name: data_writer.topic_name.clone().into(),
-            type_name: topic.type_name.clone().into(),
+            topic_name: data_writer.topic_name.to_string().into(),
+            type_name: topic.type_name.to_string().into(),
             type_information: Some(topic.type_support.into()),
             durability: data_writer.qos.durability.clone(),
             deadline: data_writer.qos.deadline.clone(),
@@ -655,10 +655,10 @@ impl DcpsDomainParticipant {
                 value: self.domain_participant.instance_handle.into(),
             },
             topic_name: _String {
-                value: topic.topic_name.clone(),
+                value: topic.topic_name.to_string(),
             },
             type_name: _String {
-                value: topic.type_name.clone(),
+                value: topic.type_name.to_string(),
             },
             type_information: Some(topic.type_support.into()),
             durability: data_reader.qos.durability.clone(),
@@ -747,7 +747,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         else {
             return;
         };
@@ -757,9 +757,9 @@ impl DcpsDomainParticipant {
                 key: BuiltInTopicKey {
                     value: topic.instance_handle.into(),
                 },
-                name: topic.topic_name.clone().into(),
+                name: topic.topic_name.to_string().into(),
                 type_information: Some(topic.type_support.into()),
-                type_name: topic.type_name.clone().into(),
+                type_name: topic.type_name.to_string().into(),
                 durability: topic.qos.durability.clone(),
                 deadline: topic.qos.deadline.clone(),
                 latency_budget: topic.qos.latency_budget.clone(),
@@ -834,10 +834,9 @@ impl DcpsDomainParticipant {
             for data_writer in &mut publisher.data_writer_list {
                 let writer_topic_name = data_writer.topic_name.clone();
 
-                for discovered_reader_data in discovered_reader_list
-                    .iter()
-                    .filter(|x| x.dds_subscription_data.topic_name.value == writer_topic_name)
-                {
+                for discovered_reader_data in discovered_reader_list.iter().filter(|x| {
+                    x.dds_subscription_data.topic_name.value.as_str() == writer_topic_name.as_ref()
+                }) {
                     if let Some(matched) = data_writer
                         .matched_subscription_list
                         .iter()
@@ -856,7 +855,8 @@ impl DcpsDomainParticipant {
                             .dds_subscription_data
                             .topic_name
                             .value
-                            == writer_topic_name;
+                            .as_str()
+                            == writer_topic_name.as_ref();
                         let writer_associated_topic = locally_created_topic_list
                             .iter_mut()
                             .find(|x| x.topic_name == writer_topic_name)
@@ -975,7 +975,7 @@ impl DcpsDomainParticipant {
                             }
                             _ => {
                                 discovered_reader_data.dds_subscription_data.get_type_name()
-                                    == writer_associated_topic.type_name
+                                    == writer_associated_topic.type_name.as_ref()
                             }
                         };
 
@@ -1409,7 +1409,7 @@ impl DcpsDomainParticipant {
 
                 for discovered_writer_data in discovered_writer_list
                     .iter()
-                    .filter(|x| x.dds_publication_data.topic_name() == reader_topic_name)
+                    .filter(|x| x.dds_publication_data.topic_name() == reader_topic_name.as_ref())
                 {
                     if let Some(matched) = data_reader
                         .matched_publication_list
@@ -1449,7 +1449,7 @@ impl DcpsDomainParticipant {
 
                         let is_matched_topic_name =
                             discovered_writer_data.dds_publication_data.topic_name()
-                                == reader_associated_topic.topic_name;
+                                == reader_associated_topic.topic_name.as_ref();
 
                         let is_matched_type = match &discovered_writer_data
                             .dds_publication_data
@@ -1563,7 +1563,7 @@ impl DcpsDomainParticipant {
                             }
                             _ => {
                                 discovered_writer_data.dds_publication_data.get_type_name()
-                                    == reader_associated_topic.type_name
+                                    == reader_associated_topic.type_name.as_ref()
                             }
                         };
 
@@ -2323,7 +2323,7 @@ impl DcpsDomainParticipant {
                                             .iter()
                                             .any(|dr| {
                                                 dr.dds_subscription_data.topic_name()
-                                                    == topic.topic_name
+                                                    == topic.topic_name.as_ref()
                                             });
 
                                         let ignore_sequence_bounds =
@@ -2347,7 +2347,7 @@ impl DcpsDomainParticipant {
                                                         .iter()
                                                         .all(|dr| {
                                                             dr.dds_subscription_data.topic_name()
-                                                                != topic.topic_name
+                                                                != topic.topic_name.as_ref()
                                                                 || dr
                                                                     .dds_subscription_data
                                                                     .type_consistency
@@ -2375,7 +2375,7 @@ impl DcpsDomainParticipant {
                                                         .iter()
                                                         .all(|dr| {
                                                             dr.dds_subscription_data.topic_name()
-                                                                != topic.topic_name
+                                                                != topic.topic_name.as_ref()
                                                                 || dr
                                                                     .dds_subscription_data
                                                                     .type_consistency
@@ -2403,7 +2403,7 @@ impl DcpsDomainParticipant {
                                                         .iter()
                                                         .all(|dr| {
                                                             dr.dds_subscription_data.topic_name()
-                                                                != topic.topic_name
+                                                                != topic.topic_name.as_ref()
                                                                 || dr
                                                                     .dds_subscription_data
                                                                     .type_consistency
@@ -2510,7 +2510,7 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .discovered_topic_list
                 .iter()
-                .filter(|t| t.name.value == topic.topic_name)
+                .filter(|t| t.name.value.as_str() == topic.topic_name.as_ref())
             {
                 if let Some(discovered_type_information) = &discovered_topic.type_information {
                     if discovered_type_information.minimal != topic.type_information.minimal

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     xtypes::{dynamic_type::DynamicType, type_support::TypeSupport},
 };
-use alloc::{collections::BTreeSet, string::String, vec::Vec};
+use alloc::{collections::BTreeSet, string::String, sync::Arc, vec::Vec};
 
 pub struct DiscoveredParticipantInfo {
     pub dds_participant_data: ParticipantBuiltinTopicData,
@@ -382,9 +382,9 @@ impl DomainParticipantEntity {
         if let Some(topic) = self
             .locally_created_topic_list
             .iter()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name)
         {
-            Some((topic.instance_handle, topic.type_name.clone()))
+            Some((topic.instance_handle, topic.type_name.to_string()))
         } else if let Some(discovered_topic_data) = self
             .discovered_topic_list
             .iter()
@@ -428,8 +428,8 @@ impl DomainParticipantEntity {
             let status_condition = DcpsStatusCondition::default();
             let mut topic = TopicEntity::new(
                 qos,
-                type_name.clone().into(),
-                String::from(topic_name),
+                Arc::from(type_name.value.as_str()),
+                Arc::from(topic_name),
                 topic_handle,
                 status_condition,
                 None,
@@ -447,7 +447,7 @@ impl DomainParticipantEntity {
                 None => self.locally_created_topic_list.push(topic),
             }
 
-            Some((topic_handle, type_name.into()))
+            Some((topic_handle, type_name.value))
         } else {
             None
         }
@@ -498,7 +498,7 @@ impl DomainParticipantEntity {
         let no_user_defined_topics = self
             .locally_created_topic_list
             .iter()
-            .filter(|t| !BUILT_IN_TOPIC_NAME_LIST.contains(&t.topic_name.as_str()))
+            .filter(|t| !BUILT_IN_TOPIC_NAME_LIST.contains(&t.topic_name.as_ref()))
             .count()
             == 0;
 

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -35,7 +35,12 @@ use crate::{
     },
     xtypes::{dynamic_type::DynamicType, type_support::TypeSupport},
 };
-use alloc::{collections::BTreeSet, string::String, sync::Arc, vec::Vec};
+use alloc::{
+    collections::BTreeSet,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 
 pub struct DiscoveredParticipantInfo {
     pub dds_participant_data: ParticipantBuiltinTopicData,

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -119,7 +119,14 @@ impl DcpsDomainParticipant {
         self.domain_participant
             .discovered_participant_list
             .iter()
-            .map(|dp| dp.lease_duration - (now - dp.last_communication_timestamp))
+            .map(|dp| {
+                let elapsed = now - dp.last_communication_timestamp;
+                if dp.lease_duration > elapsed {
+                    dp.lease_duration - elapsed
+                } else {
+                    Duration::new(0, 0)
+                }
+            })
             .min()
     }
 
@@ -133,7 +140,14 @@ impl DcpsDomainParticipant {
                     data_reader
                         .instance_ownership
                         .iter()
-                        .map(|instance| deadline - (now - instance.last_received_time))
+                        .map(|instance| {
+                            let elapsed = now - instance.last_received_time;
+                            if deadline > elapsed {
+                                deadline - elapsed
+                            } else {
+                                Duration::new(0, 0)
+                            }
+                        })
                         .min()
                 } else {
                     None
@@ -153,7 +167,14 @@ impl DcpsDomainParticipant {
                         .registered_instance_info
                         .iter()
                         .filter_map(|instance| instance.last_write_time)
-                        .map(|last_write_time| deadline - (now - last_write_time))
+                        .map(|last_write_time| {
+                            let elapsed = now - last_write_time;
+                            if deadline > elapsed {
+                                deadline - elapsed
+                            } else {
+                                Duration::new(0, 0)
+                            }
+                        })
                         .min()
                 } else {
                     None
@@ -174,7 +195,14 @@ impl DcpsDomainParticipant {
                         .changes()
                         .iter()
                         .filter_map(|cc| cc.source_timestamp)
-                        .map(|source_timestamp| Time::from(source_timestamp) + lifespan - now)
+                        .map(|source_timestamp| {
+                            let expiry = Time::from(source_timestamp) + lifespan;
+                            if expiry > now {
+                                expiry - now
+                            } else {
+                                Duration::new(0, 0)
+                            }
+                        })
                         .min()
                 } else {
                     None

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -1,6 +1,7 @@
 use alloc::{
     format,
     string::{String, ToString},
+    sync::Arc,
     vec::Vec,
 };
 
@@ -237,7 +238,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter()
-            .any(|x| x.topic_name == topic_name)
+            .any(|x| x.topic_name.as_ref() == topic_name.as_str())
         {
             return Err(DdsError::PreconditionNotMet(format!(
                 "Topic with name {topic_name} already exists.
@@ -273,8 +274,8 @@ impl DcpsDomainParticipant {
         let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         let topic = TopicEntity::new(
             qos,
-            type_name,
-            topic_name.clone(),
+            Arc::from(type_name),
+            Arc::from(topic_name.as_str()),
             topic_handle,
             status_condition,
             listener_sender,
@@ -319,7 +320,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -346,7 +347,7 @@ impl DcpsDomainParticipant {
 
         self.domain_participant
             .locally_created_topic_list
-            .retain(|x| x.topic_name != topic_name);
+            .retain(|x| x.topic_name.as_ref() != topic_name.as_str());
 
         Ok(())
     }
@@ -364,7 +365,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter()
-            .any(|x| x.topic_name == related_topic_name)
+            .any(|x| x.topic_name.as_ref() == related_topic_name.as_str())
         {
             return Err(DdsError::PreconditionNotMet(format!(
                 "Related topic with name {related_topic_name} does not exist."
@@ -392,8 +393,8 @@ impl DcpsDomainParticipant {
         self.domain_participant.topic_counter += 1;
 
         let topic = ContentFilteredTopicEntity::new(
-            name,
-            related_topic_name,
+            Arc::from(name),
+            Arc::from(related_topic_name),
             filter_expression,
             expression_parameters,
         );
@@ -447,9 +448,9 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         {
-            Ok(Some(topic.type_name.clone()))
+            Ok(Some(topic.type_name.to_string()))
         } else if BUILT_IN_TOPIC_NAME_LIST.contains(&topic_name.as_str()) {
             let type_support = get_topic_type_support(
                 &topic_name,
@@ -533,7 +534,7 @@ impl DcpsDomainParticipant {
 
         self.domain_participant
             .locally_created_topic_list
-            .retain(|x| BUILT_IN_TOPIC_NAME_LIST.contains(&x.topic_name.as_str()));
+            .retain(|x| BUILT_IN_TOPIC_NAME_LIST.contains(&x.topic_name.as_ref()));
 
         Ok(())
     }

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -30,7 +30,7 @@ use crate::{
         qos::{DomainParticipantQos, PublisherQos, QosKind, SubscriberQos, TopicQos},
         time::{Duration, Time},
     },
-    runtime::DdsRuntime,
+    runtime::{Clock, DdsRuntime},
     transport::types::{USER_DEFINED_READER_GROUP, USER_DEFINED_TOPIC, USER_DEFINED_WRITER_GROUP},
     xtypes::dynamic_type::DynamicType,
 };
@@ -704,5 +704,9 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn is_participant_empty(&mut self) -> bool {
         self.domain_participant.is_empty()
+    }
+
+    pub fn get_current_time(&self, runtime: &impl DdsRuntime) -> Time {
+        runtime.clock().now()
     }
 }

--- a/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
@@ -39,7 +39,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -108,7 +108,7 @@ impl DcpsDomainParticipant {
         let data_writer = UserDefinedDataWriter::new(
             writer_handle,
             transport_writer,
-            topic_name,
+            topic.topic_name.clone(),
             listener_sender,
             listener_mask,
             qos,

--- a/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::{string::String, sync::Arc};
 
 use crate::{
     builtin_topics::{DCPS_PARTICIPANT, DCPS_PUBLICATION, DCPS_SUBSCRIPTION, DCPS_TOPIC},
@@ -44,7 +44,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .content_filtered_topic_list
             .iter()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         {
             let Some(topic) = self
                 .domain_participant
@@ -60,7 +60,7 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .locally_created_topic_list
                 .iter()
-                .find(|x| x.topic_name == topic_name)
+                .find(|x| x.topic_name.as_ref() == topic_name.as_str())
             else {
                 return Err(DdsError::AlreadyDeleted);
             };
@@ -133,7 +133,7 @@ impl DcpsDomainParticipant {
         let data_reader = UserDefinedDataReader::new(
             reader_handle,
             qos,
-            topic_name,
+            Arc::from(topic_name),
             listener_sender,
             listener_mask,
             transport_reader,
@@ -189,7 +189,7 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .locally_created_topic_list
                 .iter()
-                .any(|x| x.topic_name == topic_name)
+                .any(|x| x.topic_name.as_ref() == topic_name.as_str())
         {
             return Err(DdsError::BadParameter);
         }
@@ -247,7 +247,7 @@ impl DcpsDomainParticipant {
             };
             Ok(s.data_reader_list
                 .iter_mut()
-                .find(|dr| dr.topic_name == topic_name)
+                .find(|dr| dr.topic_name.as_ref() == topic_name.as_str())
                 .map(|x| x.instance_handle))
         }
     }

--- a/dds/src/dcps/dcps_domain_participant/topic_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/topic_entity.rs
@@ -19,19 +19,19 @@ use crate::{
         type_support::Type,
     },
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
 
 pub struct ContentFilteredTopicEntity {
-    pub topic_name: String,
-    pub related_topic_name: String,
+    pub topic_name: Arc<str>,
+    pub related_topic_name: Arc<str>,
     pub filter_expression: String,
     pub expression_parameters: Vec<String>,
 }
 
 impl ContentFilteredTopicEntity {
     pub fn new(
-        name: String,
-        related_topic_name: String,
+        name: Arc<str>,
+        related_topic_name: Arc<str>,
         filter_expression: String,
         expression_parameters: Vec<String>,
     ) -> Self {
@@ -52,8 +52,8 @@ pub enum DiscoveredTypeRepresentationState {
 
 pub struct TopicEntity {
     pub qos: TopicQos,
-    pub type_name: String,
-    pub topic_name: String,
+    pub type_name: Arc<str>,
+    pub topic_name: Arc<str>,
     pub instance_handle: InstanceHandle,
     pub enabled: bool,
     pub inconsistent_topic_status: InconsistentTopicStatus,
@@ -69,8 +69,8 @@ impl TopicEntity {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         qos: TopicQos,
-        type_name: String,
-        topic_name: String,
+        type_name: Arc<str>,
+        topic_name: Arc<str>,
         instance_handle: InstanceHandle,
         status_condition: DcpsStatusCondition,
         listener_sender: Option<MpscSender<ListenerMail>>,
@@ -101,9 +101,9 @@ pub fn get_topic_type_support<'a>(
 ) -> Option<&'a DynamicType<'static>> {
     let resolved_topic_name = if let Some(cf_topic) = content_filtered_topic_list
         .iter()
-        .find(|t| t.topic_name == topic_name)
+        .find(|t| t.topic_name.as_ref() == topic_name)
     {
-        cf_topic.related_topic_name.as_str()
+        cf_topic.related_topic_name.as_ref()
     } else {
         topic_name
     };
@@ -117,7 +117,7 @@ pub fn get_topic_type_support<'a>(
         TYPE_LOOKUP_REPLY_TOPIC_NAME => Some(&TypeLookupReply::TYPE),
         _ => locally_created_topic_list
             .iter()
-            .find(|t| t.topic_name == resolved_topic_name)
+            .find(|t| t.topic_name.as_ref() == resolved_topic_name)
             .map(|t| &t.type_support),
     }
 }

--- a/dds/src/dcps/dcps_domain_participant/topic_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/topic_methods.rs
@@ -21,7 +21,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter_mut()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -48,7 +48,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter_mut()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -77,7 +77,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter_mut()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -91,7 +91,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter_mut()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         else {
             return Err(DdsError::AlreadyDeleted);
         };
@@ -110,7 +110,7 @@ impl DcpsDomainParticipant {
             .domain_participant
             .locally_created_topic_list
             .iter_mut()
-            .find(|x| x.topic_name == topic_name)
+            .find(|x| x.topic_name.as_ref() == topic_name.as_str())
         else {
             return Err(DdsError::AlreadyDeleted);
         };

--- a/dds/src/dcps/dcps_domain_participant/user_defined_data_reader.rs
+++ b/dds/src/dcps/dcps_domain_participant/user_defined_data_reader.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     rtps::stateful_reader::RtpsStatefulReader,
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 use core::ops::{Deref, DerefMut};
 
 use super::data_reader_entity::{DataReaderEntity, SampleList};
@@ -54,7 +54,7 @@ impl UserDefinedDataReader {
     pub fn new(
         instance_handle: InstanceHandle,
         qos: DataReaderQos,
-        topic_name: String,
+        topic_name: Arc<str>,
         listener_sender: Option<MpscSender<ListenerMail>>,
         listener_mask: StatusMask,
         transport_reader: RtpsStatefulReader,

--- a/dds/src/dcps/dcps_domain_participant/user_defined_data_writer.rs
+++ b/dds/src/dcps/dcps_domain_participant/user_defined_data_writer.rs
@@ -19,7 +19,7 @@ use crate::{
     rtps::stateful_writer::RtpsStatefulWriter,
     xtypes::dynamic_type::DynamicData,
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 use core::ops::{Deref, DerefMut};
 
 pub struct PendingWriteSample {
@@ -65,7 +65,7 @@ impl UserDefinedDataWriter {
     pub fn new(
         instance_handle: InstanceHandle,
         transport_writer: RtpsStatefulWriter,
-        topic_name: String,
+        topic_name: Arc<str>,
         listener_sender: Option<MpscSender<ListenerMail>>,
         listener_mask: StatusMask,
         qos: DataWriterQos,

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -380,7 +380,7 @@ impl DcpsDomainParticipant {
                         return;
                     }
                     let expiration_time = match data_writer.qos.reliability.max_blocking_time {
-                        DurationKind::Finite(t) => Some(runtime.clock().now() + t),
+                        DurationKind::Finite(t) => Some(now + t),
                         DurationKind::Infinite => None,
                     };
                     data_writer.pending_write_sample = Some(PendingWriteSample {

--- a/dds/src/dcps/dcps_mail.rs
+++ b/dds/src/dcps/dcps_mail.rs
@@ -411,7 +411,7 @@ pub enum WriterServiceMail {
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData<'static>,
-        timestamp: Time,
+        timestamp: Option<Time>,
         reply_sender: OneshotSender<DdsResult<Option<InstanceHandle>>>,
     },
     UnregisterInstance {
@@ -419,7 +419,7 @@ pub enum WriterServiceMail {
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData<'static>,
-        timestamp: Time,
+        timestamp: Option<Time>,
         reply_sender: OneshotSender<DdsResult<()>>,
     },
     LookupInstance {
@@ -434,7 +434,7 @@ pub enum WriterServiceMail {
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData<'static>,
-        timestamp: Time,
+        timestamp: Option<Time>,
         reply_sender: OneshotSender<DdsResult<()>>,
     },
     DisposeWTimestamp {
@@ -442,7 +442,7 @@ pub enum WriterServiceMail {
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData<'static>,
-        timestamp: Time,
+        timestamp: Option<Time>,
         reply_sender: OneshotSender<DdsResult<()>>,
     },
     GetOfferedDeadlineMissedStatus {

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -593,12 +593,15 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.register_instance(
-                    &publisher_handle,
-                    &data_writer_handle,
-                    &dynamic_data,
-                    timestamp,
-                )),
+                Ok(p) => {
+                    let timestamp = timestamp.unwrap_or_else(|| p.get_current_time(&self.runtime));
+                    reply_sender.send(p.register_instance(
+                        &publisher_handle,
+                        &data_writer_handle,
+                        &dynamic_data,
+                        timestamp,
+                    ));
+                }
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::UnregisterInstance {
@@ -614,13 +617,16 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.unregister_instance(
-                    &publisher_handle,
-                    &data_writer_handle,
-                    &dynamic_data,
-                    timestamp,
-                    &self.runtime,
-                )),
+                Ok(p) => {
+                    let timestamp = timestamp.unwrap_or_else(|| p.get_current_time(&self.runtime));
+                    reply_sender.send(p.unregister_instance(
+                        &publisher_handle,
+                        &data_writer_handle,
+                        &dynamic_data,
+                        timestamp,
+                        &self.runtime,
+                    ));
+                }
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::LookupInstance {
@@ -645,14 +651,17 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => p.write_w_timestamp(
-                    &publisher_handle,
-                    &data_writer_handle,
-                    &dynamic_data,
-                    timestamp,
-                    &self.runtime,
-                    reply_sender,
-                ),
+                Ok(p) => {
+                    let timestamp = timestamp.unwrap_or_else(|| p.get_current_time(&self.runtime));
+                    p.write_w_timestamp(
+                        &publisher_handle,
+                        &data_writer_handle,
+                        &dynamic_data,
+                        timestamp,
+                        &self.runtime,
+                        reply_sender,
+                    );
+                }
                 Err(e) => reply_sender.send(Err(e)),
             },
 
@@ -669,13 +678,16 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.dispose_w_timestamp(
-                    &publisher_handle,
-                    &data_writer_handle,
-                    &dynamic_data,
-                    timestamp,
-                    &self.runtime,
-                )),
+                Ok(p) => {
+                    let timestamp = timestamp.unwrap_or_else(|| p.get_current_time(&self.runtime));
+                    reply_sender.send(p.dispose_w_timestamp(
+                        &publisher_handle,
+                        &data_writer_handle,
+                        &dynamic_data,
+                        timestamp,
+                        &self.runtime,
+                    ));
+                }
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::GetOfferedDeadlineMissedStatus {

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -10,9 +10,9 @@ use crate::{
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{DomainParticipantFactoryQos, DomainParticipantQos, QosKind},
-        time::Duration,
+        time::{Duration, Time},
     },
-    runtime::{Clock, DdsRuntime},
+    runtime::DdsRuntime,
     transport::{interface::RtpsTransportParticipant, types::GuidPrefix},
 };
 use alloc::{string::String, vec::Vec};
@@ -135,48 +135,42 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         self.qos.clone()
     }
 
-    pub(crate) fn time_until_stale_participant(&self) -> Option<Duration> {
-        let now = self.runtime.clock().now();
+    pub(crate) fn time_until_stale_participant(&self, now: Time) -> Option<Duration> {
         self.domain_participant_list
             .iter()
             .filter_map(|x| x.time_until_stale_participant(now))
             .min()
     }
 
-    pub(crate) fn time_until_missed_reader_deadline(&self) -> Option<Duration> {
-        let now = self.runtime.clock().now();
+    pub(crate) fn time_until_missed_reader_deadline(&self, now: Time) -> Option<Duration> {
         self.domain_participant_list
             .iter()
             .filter_map(|x| x.time_until_missed_reader_deadline(now))
             .min()
     }
 
-    pub(crate) fn time_until_missed_writer_deadline(&self) -> Option<Duration> {
-        let now = self.runtime.clock().now();
+    pub(crate) fn time_until_missed_writer_deadline(&self, now: Time) -> Option<Duration> {
         self.domain_participant_list
             .iter()
             .filter_map(|x| x.time_until_missed_writer_deadline(now))
             .min()
     }
 
-    pub(crate) fn time_until_stale_writer_sample(&self) -> Option<Duration> {
-        let now = self.runtime.clock().now();
+    pub(crate) fn time_until_stale_writer_sample(&self, now: Time) -> Option<Duration> {
         self.domain_participant_list
             .iter()
             .filter_map(|x| x.time_until_stale_writer_sample(now))
             .min()
     }
 
-    pub(crate) fn time_until_pending_writer_sample_timeout(&self) -> Option<Duration> {
-        let now = self.runtime.clock().now();
+    pub(crate) fn time_until_pending_writer_sample_timeout(&self, now: Time) -> Option<Duration> {
         self.domain_participant_list
             .iter()
             .filter_map(|x| x.time_until_pending_writer_sample_timeout(now))
             .min()
     }
 
-    pub(crate) fn time_until_participant_announcement(&self) -> Option<Duration> {
-        let now = self.runtime.clock().now();
+    pub(crate) fn time_until_participant_announcement(&self, now: Time) -> Option<Duration> {
         self.domain_participant_list
             .iter()
             .filter_map(|x| x.time_until_participant_announcement(now))

--- a/dds/src/dcps/infrastructure/time.rs
+++ b/dds/src/dcps/infrastructure/time.rs
@@ -161,7 +161,7 @@ impl From<core::time::Duration> for Duration {
 
 impl From<Duration> for core::time::Duration {
     fn from(x: Duration) -> Self {
-        core::time::Duration::new(x.sec as u64, x.nanosec)
+        core::time::Duration::new(x.sec.max(0) as u64, x.nanosec)
     }
 }
 

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -28,14 +28,14 @@ use crate::{
     },
     xtypes::type_support::TypeSupport,
 };
-use alloc::{string::String, vec, vec::Vec};
+use alloc::{string::String, sync::Arc, vec, vec::Vec};
 use core::marker::PhantomData;
 
 #[derive(Clone)]
 struct DataReaderAsyncTopic {
     participant: DomainParticipantAsync,
-    topic_name: String,
-    type_name: String,
+    topic_name: Arc<str>,
+    type_name: Arc<str>,
 }
 
 impl TopicDescriptionAsync for DataReaderAsyncTopic {
@@ -44,11 +44,11 @@ impl TopicDescriptionAsync for DataReaderAsyncTopic {
     }
 
     fn get_type_name(&self) -> String {
-        self.type_name.clone()
+        self.type_name.to_string()
     }
 
     fn get_name(&self) -> String {
-        self.topic_name.clone()
+        self.topic_name.to_string()
     }
 }
 
@@ -64,8 +64,8 @@ impl<Foo> DataReaderAsync<Foo> {
     pub(crate) fn new(
         handle: InstanceHandle,
         subscriber: SubscriberAsync,
-        topic_name: String,
-        type_name: String,
+        topic_name: Arc<str>,
+        type_name: Arc<str>,
     ) -> Self {
         let participant = subscriber.get_participant();
         Self {

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -28,7 +28,12 @@ use crate::{
     },
     xtypes::type_support::TypeSupport,
 };
-use alloc::{string::String, sync::Arc, vec, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
 use core::marker::PhantomData;
 
 #[derive(Clone)]

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -82,13 +82,19 @@ where
     /// Async version of [`register_instance`](crate::publication::data_writer::DataWriter::register_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn register_instance(&self, instance: Foo) -> DdsResult<Option<InstanceHandle>> {
-        let timestamp = self
-            .get_publisher()
-            .get_participant()
-            .get_current_time()
-            .await?;
-        self.register_instance_w_timestamp(instance, timestamp)
-            .await
+        let (reply_sender, reply_receiver) = oneshot();
+        let dynamic_data = instance.create_dynamic_sample();
+        self.dcps_sender()
+            .send(DcpsMail::Writer(WriterServiceMail::RegisterInstance {
+                participant_handle: self.publisher.get_participant().get_instance_handle(),
+                publisher_handle: self.publisher.get_instance_handle(),
+                data_writer_handle: self.handle,
+                dynamic_data,
+                timestamp: None,
+                reply_sender,
+            }))
+            .await;
+        reply_receiver.await?
     }
 
     /// Async version of [`register_instance_w_timestamp`](crate::publication::data_writer::DataWriter::register_instance_w_timestamp).
@@ -106,7 +112,7 @@ where
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
-                timestamp,
+                timestamp: Some(timestamp),
                 reply_sender,
             }))
             .await;
@@ -120,13 +126,19 @@ where
         instance: Foo,
         handle: Option<InstanceHandle>,
     ) -> DdsResult<()> {
-        let timestamp = self
-            .get_publisher()
-            .get_participant()
-            .get_current_time()
-            .await?;
-        self.unregister_instance_w_timestamp(instance, handle, timestamp)
-            .await
+        let (reply_sender, reply_receiver) = oneshot();
+        let dynamic_data = instance.create_dynamic_sample();
+        self.dcps_sender()
+            .send(DcpsMail::Writer(WriterServiceMail::UnregisterInstance {
+                participant_handle: self.publisher.get_participant().get_instance_handle(),
+                publisher_handle: self.publisher.get_instance_handle(),
+                data_writer_handle: self.handle,
+                dynamic_data,
+                timestamp: None,
+                reply_sender,
+            }))
+            .await;
+        reply_receiver.await?
     }
 
     /// Async version of [`unregister_instance_w_timestamp`](crate::publication::data_writer::DataWriter::unregister_instance_w_timestamp).
@@ -145,7 +157,7 @@ where
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
-                timestamp,
+                timestamp: Some(timestamp),
                 reply_sender,
             }))
             .await;
@@ -182,12 +194,19 @@ where
     /// Async version of [`write`](crate::publication::data_writer::DataWriter::write).
     #[tracing::instrument(skip(self, data))]
     pub async fn write(&self, data: Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
-        let timestamp = self
-            .get_publisher()
-            .get_participant()
-            .get_current_time()
-            .await?;
-        self.write_w_timestamp(data, handle, timestamp).await
+        let (reply_sender, reply_receiver) = oneshot();
+        let dynamic_data = data.create_dynamic_sample();
+        self.dcps_sender()
+            .send(DcpsMail::Writer(WriterServiceMail::WriteWTimestamp {
+                participant_handle: self.publisher.get_participant().get_instance_handle(),
+                publisher_handle: self.publisher.get_instance_handle(),
+                data_writer_handle: self.handle,
+                dynamic_data,
+                timestamp: None,
+                reply_sender,
+            }))
+            .await;
+        reply_receiver.await?
     }
 
     /// Async version of [`write_w_timestamp`](crate::publication::data_writer::DataWriter::write_w_timestamp).
@@ -206,7 +225,7 @@ where
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
-                timestamp,
+                timestamp: Some(timestamp),
                 reply_sender,
             }))
             .await;
@@ -216,12 +235,19 @@ where
     /// Async version of [`dispose`](crate::publication::data_writer::DataWriter::dispose).
     #[tracing::instrument(skip(self, data))]
     pub async fn dispose(&self, data: Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
-        let timestamp = self
-            .get_publisher()
-            .get_participant()
-            .get_current_time()
-            .await?;
-        self.dispose_w_timestamp(data, handle, timestamp).await
+        let (reply_sender, reply_receiver) = oneshot();
+        let dynamic_data = data.create_dynamic_sample();
+        self.dcps_sender()
+            .send(DcpsMail::Writer(WriterServiceMail::DisposeWTimestamp {
+                participant_handle: self.publisher.get_participant().get_instance_handle(),
+                publisher_handle: self.publisher.get_instance_handle(),
+                data_writer_handle: self.handle,
+                dynamic_data,
+                timestamp: None,
+                reply_sender,
+            }))
+            .await;
+        reply_receiver.await?
     }
 
     /// Async version of [`dispose_w_timestamp`](crate::publication::data_writer::DataWriter::dispose_w_timestamp).
@@ -240,7 +266,7 @@ where
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
-                timestamp,
+                timestamp: Some(timestamp),
                 reply_sender,
             }))
             .await;

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -28,8 +28,10 @@ use crate::{
     },
     xtypes::{dynamic_type::DynamicType, type_support::TypeSupport},
 };
+
 use alloc::{
     string::{String, ToString},
+    sync::Arc,
     vec::Vec,
 };
 
@@ -194,8 +196,8 @@ impl DomainParticipantAsync {
 
         Ok(TopicAsync::new(
             guid,
-            String::from(type_name),
-            String::from(topic_name),
+            Arc::from(type_name),
+            Arc::from(topic_name),
             self.clone(),
         ))
     }
@@ -292,8 +294,8 @@ impl DomainParticipantAsync {
         let (guid, type_name) = reply_receiver.await??;
         Ok(TopicAsync::new(
             guid,
-            type_name,
-            topic_name,
+            Arc::from(type_name),
+            Arc::from(topic_name),
             participant_async,
         ))
     }

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -320,10 +320,8 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
 
                 let now = domain_participant_factory.runtime.clock().now();
                 for dp in &mut domain_participant_factory.domain_participant_list {
-                    dp.process_builtin_cache_changes(&domain_participant_factory.runtime);
-                    dp.process_user_defined_received_cache_changes(
-                        &domain_participant_factory.runtime,
-                    );
+                    dp.process_builtin_cache_changes(now);
+                    dp.process_user_defined_received_cache_changes(now);
                     dp.process_discovered_participants_detector_cache_change(
                         &domain_participant_factory.runtime,
                     );

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -284,19 +284,20 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             let span = tracing::trace_span!("dds_actor_loop");
             let _enter = span.enter();
             while run_loop_clone.load(core::sync::atomic::Ordering::Relaxed) {
+                let now = domain_participant_factory.runtime.clock().now();
                 let poke_time = Duration::new(0, 50_000_000);
                 let time_until_missed_reader_deadline =
-                    domain_participant_factory.time_until_missed_reader_deadline();
+                    domain_participant_factory.time_until_missed_reader_deadline(now);
                 let time_until_missed_writer_deadline =
-                    domain_participant_factory.time_until_missed_writer_deadline();
+                    domain_participant_factory.time_until_missed_writer_deadline(now);
                 let time_until_stale_participant =
-                    domain_participant_factory.time_until_stale_participant();
+                    domain_participant_factory.time_until_stale_participant(now);
                 let time_until_stale_writer_sample =
-                    domain_participant_factory.time_until_stale_writer_sample();
+                    domain_participant_factory.time_until_stale_writer_sample(now);
                 let time_until_pending_writer_sample_timeout =
-                    domain_participant_factory.time_until_pending_writer_sample_timeout();
+                    domain_participant_factory.time_until_pending_writer_sample_timeout(now);
                 let time_until_participant_announcement =
-                    domain_participant_factory.time_until_participant_announcement();
+                    domain_participant_factory.time_until_participant_announcement(now);
                 let next_task_time = poke_time
                     .min(time_until_missed_reader_deadline.unwrap_or(poke_time))
                     .min(time_until_missed_writer_deadline.unwrap_or(poke_time))
@@ -317,6 +318,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     Either::B(_) => (),
                 };
 
+                let now = domain_participant_factory.runtime.clock().now();
                 for dp in &mut domain_participant_factory.domain_participant_list {
                     dp.process_builtin_cache_changes(&domain_participant_factory.runtime);
                     dp.process_user_defined_received_cache_changes(
@@ -337,22 +339,14 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     dp.request_topic_type_representation(&domain_participant_factory.runtime);
                     dp.process_discovered_readers(&domain_participant_factory.runtime);
                     dp.process_discovered_writers(&domain_participant_factory.runtime);
-                    dp.remove_stale_participants(domain_participant_factory.runtime.clock().now());
-                    dp.check_missed_reader_deadline(
-                        domain_participant_factory.runtime.clock().now(),
-                    );
-                    dp.check_missed_writer_deadline(
-                        domain_participant_factory.runtime.clock().now(),
-                    );
-                    dp.remove_stale_writer_samples(
-                        domain_participant_factory.runtime.clock().now(),
-                    );
-                    dp.check_pending_writer_sample_timeout(
-                        domain_participant_factory.runtime.clock().now(),
-                    );
+                    dp.remove_stale_participants(now);
+                    dp.check_missed_reader_deadline(now);
+                    dp.check_missed_writer_deadline(now);
+                    dp.remove_stale_writer_samples(now);
+                    dp.check_pending_writer_sample_timeout(now);
                     dp.process_pending_write_samples(&domain_participant_factory.runtime);
-                    dp.announce_participant_if_needed(&domain_participant_factory.runtime);
-                    dp.notify_find_topic_senders(domain_participant_factory.runtime.clock().now());
+                    dp.announce_participant_if_needed(&domain_participant_factory.runtime, now);
+                    dp.notify_find_topic_senders(now);
                     dp.poke(&domain_participant_factory.runtime.clock());
                 }
             }

--- a/dds/src/dds_async/subscriber.rs
+++ b/dds/src/dds_async/subscriber.rs
@@ -21,7 +21,7 @@ use crate::{
         status::{SampleLostStatus, StatusKind},
     },
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
 
 /// Async version of [`Subscriber`](crate::subscription::subscriber::Subscriber).
 #[derive(Clone)]
@@ -73,8 +73,8 @@ impl SubscriberAsync {
         Ok(DataReaderAsync::new(
             guid,
             self.clone(),
-            a_topic.get_name(),
-            a_topic.get_type_name(),
+            Arc::from(a_topic.get_name().as_str()),
+            Arc::from(a_topic.get_type_name().as_str()),
         ))
     }
 
@@ -120,8 +120,8 @@ impl SubscriberAsync {
                 Ok(Some(DataReaderAsync::new(
                     reader_handle,
                     self.clone(),
-                    topic.get_name(),
-                    topic.get_type_name(),
+                    Arc::from(topic.get_name().as_str()),
+                    Arc::from(topic.get_type_name().as_str()),
                 )))
             } else {
                 Ok(None)

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -17,22 +17,22 @@ use crate::{
     },
     xtypes::dynamic_type::DynamicType,
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
 
 /// Async version of [`Topic`](crate::topic_definition::topic::Topic).
 #[derive(Clone)]
 pub struct TopicAsync {
     handle: InstanceHandle,
-    type_name: String,
-    topic_name: String,
+    type_name: Arc<str>,
+    topic_name: Arc<str>,
     participant: DomainParticipantAsync,
 }
 
 impl TopicAsync {
     pub(crate) fn new(
         handle: InstanceHandle,
-        type_name: String,
-        topic_name: String,
+        type_name: Arc<str>,
+        topic_name: Arc<str>,
         participant: DomainParticipantAsync,
     ) -> Self {
         Self {
@@ -54,7 +54,7 @@ impl TopicAsync {
             .send(DcpsMail::Topic(
                 TopicServiceMail::GetInconsistentTopicStatus {
                     participant_handle: self.participant.get_instance_handle(),
-                    topic_name: self.topic_name.clone(),
+                    topic_name: self.topic_name.to_string(),
                     reply_sender,
                 },
             ))
@@ -69,11 +69,11 @@ impl TopicDescriptionAsync for TopicAsync {
     }
 
     fn get_type_name(&self) -> String {
-        self.type_name.clone()
+        self.type_name.to_string()
     }
 
     fn get_name(&self) -> String {
-        self.topic_name.clone()
+        self.topic_name.to_string()
     }
 }
 
@@ -86,7 +86,7 @@ impl TopicAsync {
             .dcps_sender()
             .send(DcpsMail::Topic(TopicServiceMail::SetQos {
                 participant_handle: self.participant.get_instance_handle(),
-                topic_name: self.topic_name.clone(),
+                topic_name: self.topic_name.to_string(),
                 topic_qos: qos,
                 reply_sender,
             }))
@@ -103,7 +103,7 @@ impl TopicAsync {
             .dcps_sender()
             .send(DcpsMail::Topic(TopicServiceMail::GetQos {
                 participant_handle: self.participant.get_instance_handle(),
-                topic_name: self.topic_name.clone(),
+                topic_name: self.topic_name.to_string(),
                 reply_sender,
             }))
             .await;
@@ -137,7 +137,7 @@ impl TopicAsync {
             .dcps_sender()
             .send(DcpsMail::Topic(TopicServiceMail::Enable {
                 participant_handle: self.participant.get_instance_handle(),
-                topic_name: self.topic_name.clone(),
+                topic_name: self.topic_name.to_string(),
                 reply_sender,
             }))
             .await;
@@ -170,7 +170,7 @@ impl TopicAsync {
             .dcps_sender()
             .send(DcpsMail::Topic(TopicServiceMail::GetTypeSupport {
                 participant_handle: self.participant.get_instance_handle(),
-                topic_name: self.topic_name.clone(),
+                topic_name: self.topic_name.to_string(),
                 reply_sender,
             }))
             .await;

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -17,7 +17,11 @@ use crate::{
     },
     xtypes::dynamic_type::DynamicType,
 };
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 
 /// Async version of [`Topic`](crate::topic_definition::topic::Topic).
 #[derive(Clone)]

--- a/dds/src/rtps/reader_proxy.rs
+++ b/dds/src/rtps/reader_proxy.rs
@@ -200,8 +200,8 @@ impl RtpsReaderProxy {
         self.next_unsent_change(writer_history_cache).is_some()
     }
 
-    pub fn requested_changes(&self) -> Vec<SequenceNumber> {
-        self.requested_changes.clone()
+    pub fn requested_changes(&self) -> &[SequenceNumber] {
+        &self.requested_changes
     }
 
     pub fn requested_changes_set(&mut self, req_seq_num_set: impl Iterator<Item = SequenceNumber>) {

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -578,7 +578,6 @@ impl RtpsReaderProxy {
                 // Also the post-condition:
                 // a_change BELONGS-TO the_reader_proxy.requested_changes() ) == FALSE
                 // should be full-filled by next_requested_change()
-                let now = clock.now();
                 let seq_num_min = changes.iter().map(|cc| cc.sequence_number).min();
                 let seq_num_max = changes.iter().map(|cc| cc.sequence_number).max();
                 if let Some(cache_change) = changes.iter().find(|cc| {

--- a/dds/src/rtps_messages/overall_structure.rs
+++ b/dds/src/rtps_messages/overall_structure.rs
@@ -17,7 +17,7 @@ use super::{
         INFO_TS, NACK_FRAG, PAD, ProtocolId, SubmessageFlag, SubmessageKind,
     },
 };
-use alloc::{sync::Arc, vec::Vec};
+use alloc::vec::Vec;
 
 pub enum Endianness {
     BigEndian,
@@ -112,11 +112,18 @@ impl Write for Cursor<Vec<u8>> {
     fn write_all(&mut self, buf: &[u8]) -> RtpsMessageResult<()> {
         let start_pos = self.pos as usize;
         let end_pos = start_pos + buf.len();
-        if self.inner.len() < end_pos {
-            self.inner.resize(end_pos, 0);
+        if start_pos >= self.inner.len() {
+            if start_pos > self.inner.len() {
+                self.inner.resize(start_pos, 0);
+            }
+            self.inner.extend_from_slice(buf);
+        } else if end_pos <= self.inner.len() {
+            self.inner[start_pos..end_pos].copy_from_slice(buf);
+        } else {
+            let overwrite_len = self.inner.len() - start_pos;
+            self.inner[start_pos..].copy_from_slice(&buf[..overwrite_len]);
+            self.inner.extend_from_slice(&buf[overwrite_len..]);
         }
-
-        self.inner.as_mut_slice()[start_pos..end_pos].clone_from_slice(buf);
         self.pos = end_pos as u64;
 
         Ok(())
@@ -462,19 +469,19 @@ pub fn write_submessage_into_bytes_vec(value: &(dyn Submessage + Send)) -> Vec<u
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct RtpsMessageWrite {
-    data: Arc<[u8]>,
+    data: Vec<u8>,
 }
 
 impl RtpsMessageWrite {
     pub fn new(header: &RtpsMessageHeader, submessages: &[&(dyn Submessage + Send)]) -> Self {
-        let buffer = Vec::new();
+        let buffer = Vec::with_capacity(256);
         let mut cursor = Cursor::new(buffer);
         header.write_into_bytes(&mut cursor);
         for submessage in submessages {
             submessage.write_submessage_into_bytes(&mut cursor);
         }
         Self {
-            data: Arc::from(cursor.into_inner().into_boxed_slice()),
+            data: cursor.into_inner(),
         }
     }
 

--- a/dds/src/std_runtime/timer.rs
+++ b/dds/src/std_runtime/timer.rs
@@ -156,8 +156,7 @@ impl TimerHeap {
 
     #[inline(always)]
     fn remove(&mut self, id: usize) {
-        let heap = std::mem::take(&mut self.heap);
-        self.heap = heap.into_iter().filter(|t| t.id != id).collect();
+        self.heap.retain(|t| t.id != id);
     }
 }
 


### PR DESCRIPTION
Reduce the compilation time for local development by removing the bindings from the default list and updating some crates to avoid redundant dependencies.

Improve execution performance by:
- Avoiding a Vec clone on requested_changes()
- Using a single now timestamp at the start of the loop which is passed as an argument to all the functions. This is also functionally better since it ensures all calculations are done with the same timebase instead of with a slightly different one on every function
- Use retain on the timer BinaryHeap instead of creating a new one every time
- Remove double round-trip by making the calls to the writer functions without timestamp get the time on the actor side
- Improve the process_discovered_ method to remove clones, have early returns and only fill up struct for listeners when strictly necessary
- Replace String by Arc<str> on Topic objects to avoid having to clone String and re-allocating heap objects