### PR TITLE
645 discovery issue different type

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -33,7 +33,7 @@ use crate::{
 impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn process_user_defined_received_cache_changes(&mut self, reception_timestamp: Time) {
-        let dcps_sender = self.dcps_sender;
+        let dcps_sender = self.dcps_sender.clone();
         let domain_id = self.domain_participant.domain_id;
         let dp_instance_handle = self.domain_participant.instance_handle;
         let dp_listener_mask = self.domain_participant.listener_mask;
@@ -300,7 +300,7 @@ impl DcpsDomainParticipant {
                             if subscriber_listener_mask.is_enabled(&StatusKind::DataOnReaders) {
                                 if let Some(l) = &subscriber_listener_sender {
                                     let the_participant = DomainParticipantAsync::new(
-                                        dcps_sender,
+                                        dcps_sender.clone(),
                                         domain_id,
                                         dp_instance_handle,
                                     );
@@ -312,7 +312,7 @@ impl DcpsDomainParticipant {
                                 if let Some(l) = &data_reader.listener_sender {
                                     info!("Triggering data reader DataAvailable listener");
                                     let the_participant = DomainParticipantAsync::new(
-                                        dcps_sender,
+                                        dcps_sender.clone(),
                                         domain_id,
                                         dp_instance_handle,
                                     );
@@ -354,7 +354,7 @@ impl DcpsDomainParticipant {
 
                             if is_listener_enabled {
                                 let the_participant = DomainParticipantAsync::new(
-                                    dcps_sender,
+                                    dcps_sender.clone(),
                                     domain_id,
                                     dp_instance_handle,
                                 );

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -278,7 +278,7 @@ impl DcpsDomainParticipant {
                             .last_instance_handle = change_instance_handle;
 
                         let the_participant = DomainParticipantAsync::new(
-                            self.dcps_sender,
+                            self.dcps_sender.clone(),
                             self.domain_participant.domain_id,
                             self.domain_participant.instance_handle,
                         );
@@ -389,7 +389,7 @@ impl DcpsDomainParticipant {
 
                     for instance_handle in missed_handles {
                         let the_participant = DomainParticipantAsync::new(
-                            self.dcps_sender,
+                            self.dcps_sender.clone(),
                             self.domain_participant.domain_id,
                             self.domain_participant.instance_handle,
                         );
@@ -827,7 +827,7 @@ impl DcpsDomainParticipant {
         let domain_id = *domain_id;
         let participant_instance_handle = *participant_instance_handle;
         let participant_listener_mask = *participant_listener_mask;
-        let dcps_sender = self.dcps_sender;
+        let dcps_sender = self.dcps_sender.clone();
         let message_writer = self.transport.message_writer.as_ref();
 
         for publisher in user_defined_publisher_list.iter_mut() {
@@ -1124,7 +1124,7 @@ impl DcpsDomainParticipant {
 
                                     if is_listener_enabled {
                                         let the_participant = DomainParticipantAsync::new(
-                                            dcps_sender,
+                                            dcps_sender.clone(),
                                             domain_id,
                                             participant_instance_handle,
                                         );
@@ -1204,7 +1204,7 @@ impl DcpsDomainParticipant {
 
                                     if is_listener_enabled {
                                         let the_participant = DomainParticipantAsync::new(
-                                            dcps_sender,
+                                            dcps_sender.clone(),
                                             domain_id,
                                             participant_instance_handle,
                                         );
@@ -1281,7 +1281,7 @@ impl DcpsDomainParticipant {
 
                                 if is_listener_enabled {
                                     let participant = DomainParticipantAsync::new(
-                                        dcps_sender,
+                                        dcps_sender.clone(),
                                         domain_id,
                                         participant_instance_handle,
                                     );
@@ -1394,7 +1394,7 @@ impl DcpsDomainParticipant {
         let domain_id = *domain_id;
         let participant_instance_handle = *participant_instance_handle;
         let participant_listener_mask = *participant_listener_mask;
-        let dcps_sender = self.dcps_sender;
+        let dcps_sender = self.dcps_sender.clone();
         let message_writer = self.transport.message_writer.as_ref();
 
         for subscriber in user_defined_subscriber_list.iter_mut() {
@@ -1683,7 +1683,7 @@ impl DcpsDomainParticipant {
 
                                     if is_listener_enabled {
                                         let the_participant = DomainParticipantAsync::new(
-                                            dcps_sender,
+                                            dcps_sender.clone(),
                                             domain_id,
                                             participant_instance_handle,
                                         );
@@ -1753,7 +1753,7 @@ impl DcpsDomainParticipant {
 
                                     if is_listener_enabled {
                                         let the_participant = DomainParticipantAsync::new(
-                                            dcps_sender,
+                                            dcps_sender.clone(),
                                             domain_id,
                                             participant_instance_handle,
                                         );
@@ -1823,7 +1823,7 @@ impl DcpsDomainParticipant {
 
                                 if is_listener_enabled {
                                     let participant = DomainParticipantAsync::new(
-                                        dcps_sender,
+                                        dcps_sender.clone(),
                                         domain_id,
                                         participant_instance_handle,
                                     );
@@ -2448,7 +2448,7 @@ impl DcpsDomainParticipant {
                                             topic.inconsistent_topic_status.total_count += 1;
                                             topic.inconsistent_topic_status.total_count_change += 1;
                                             let participant = DomainParticipantAsync::new(
-                                                self.dcps_sender,
+                                                self.dcps_sender.clone(),
                                                 self.domain_participant.domain_id,
                                                 self.domain_participant.instance_handle,
                                             );

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -896,7 +896,7 @@ impl DcpsDomainParticipant {
                                         .find(|(x, _)| x == discovered_type_information)
                                 {
                                     match &discovered_type_information.1 {
-                                        DiscoveredTypeRepresentationState::Requested => return,
+                                        DiscoveredTypeRepresentationState::Requested => continue,
                                         DiscoveredTypeRepresentationState::Discovered(
                                             type_object,
                                         ) => match &type_object {
@@ -975,7 +975,7 @@ impl DcpsDomainParticipant {
                                             DiscoveredTypeRepresentationState::Requested,
                                         ));
                                     }
-                                    return;
+                                    continue;
                                 }
                             }
                             _ => {
@@ -1485,7 +1485,7 @@ impl DcpsDomainParticipant {
                                         .find(|(x, _)| x == discovered_type_information)
                                 {
                                     match &discovered_type_information.1 {
-                                        DiscoveredTypeRepresentationState::Requested => return,
+                                        DiscoveredTypeRepresentationState::Requested => continue,
                                         DiscoveredTypeRepresentationState::Discovered(
                                             type_object,
                                         ) => match &type_object {
@@ -1563,7 +1563,7 @@ impl DcpsDomainParticipant {
                                             DiscoveredTypeRepresentationState::Requested,
                                         ));
                                     }
-                                    return;
+                                    continue;
                                 }
                             }
                             _ => {

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -63,7 +63,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             listener_sender,
             listener_mask,
             transport_participant,
-            self.dcps_sender,
+            self.dcps_sender.clone(),
             participant_announcement_interval,
         );
         let participant_handle = *dcps_participant.get_instance_handle();

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -517,7 +517,7 @@ impl<Foo> DataReaderAsync<Foo> {
     #[tracing::instrument(skip(self))]
     pub fn get_statuscondition(&self) -> StatusConditionAsync {
         StatusConditionAsync::new(
-            *self.dcps_sender(),
+            self.dcps_sender().clone(),
             StatusConditionEntity::DataReader {
                 participant_handle: self
                     .get_subscriber()

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -280,7 +280,7 @@ impl<Foo> DataWriterAsync<Foo> {
     /// to be handle on the user side if needed.
     #[tracing::instrument(skip(self))]
     pub async fn wait_for_acknowledgments(&self) -> DdsResult<()> {
-        let participant_address = *self.dcps_sender();
+        let participant_address = self.dcps_sender().clone();
         let publisher_handle = self.get_publisher().get_instance_handle();
         let data_writer_handle = self.handle;
         let (reply_sender, reply_receiver) = oneshot();
@@ -440,7 +440,7 @@ impl<Foo> DataWriterAsync<Foo> {
     #[tracing::instrument(skip(self))]
     pub fn get_statuscondition(&self) -> StatusConditionAsync {
         StatusConditionAsync::new(
-            *self.dcps_sender(),
+            self.dcps_sender().clone(),
             StatusConditionEntity::DataWriter {
                 participant_handle: self.get_publisher().get_participant().get_instance_handle(),
                 publisher_handle: self.get_publisher().get_instance_handle(),

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -278,7 +278,7 @@ impl DomainParticipantAsync {
         Foo: TypeSupport,
     {
         let topic_name = String::from(topic_name);
-        let participant_address = self.dcps_sender;
+        let participant_address = self.dcps_sender.clone();
         let participant_async = self.clone();
         let (reply_sender, reply_receiver) = oneshot();
 

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::ToOwned, boxed::Box};
+use alloc::{borrow::ToOwned, boxed::Box, sync::Arc};
 use core::ops::DerefMut;
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
@@ -38,20 +38,27 @@ pub type DcpsChannel = embassy_sync::channel::Channel<
 >;
 
 #[doc(hidden)]
-pub type DcpsSender = embassy_sync::channel::Sender<
-    'static,
-    embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
-    DcpsMail,
-    DCPS_CHANNEL_SIZE,
->;
+#[derive(Clone)]
+pub struct DcpsSender {
+    channel: Arc<DcpsChannel>,
+}
+
+impl DcpsSender {
+    pub async fn send(&self, message: DcpsMail) {
+        self.channel.send(message).await;
+    }
+}
 
 #[doc(hidden)]
-pub type DcpsReceiver = embassy_sync::channel::Receiver<
-    'static,
-    embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
-    DcpsMail,
-    DCPS_CHANNEL_SIZE,
->;
+pub struct DcpsReceiver {
+    channel: Arc<DcpsChannel>,
+}
+
+impl DcpsReceiver {
+    pub async fn receive(&self) -> DcpsMail {
+        self.channel.receive().await
+    }
+}
 
 /// Async version of [`DomainParticipantFactory`](crate::domain::domain_participant_factory::DomainParticipantFactory).
 /// Unlike the sync version, the [`DomainParticipantFactoryAsync`] is not a singleton and can be created by means of
@@ -65,7 +72,7 @@ pub struct DomainParticipantFactoryAsync<T: TransportParticipantFactory> {
     transport: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, T>,
     configuration: embassy_sync::mutex::Mutex<CriticalSectionRawMutex, DustDdsConfiguration>,
     worker_task: alloc::boxed::Box<dyn TaskHandle>,
-    run_loop: alloc::sync::Arc<core::sync::atomic::AtomicBool>,
+    run_loop: Arc<core::sync::atomic::AtomicBool>,
 }
 
 impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
@@ -82,7 +89,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         let participant_handle = InstanceHandle::from(Guid::new(guid_prefix, ENTITYID_PARTICIPANT));
         let transport_participant = self.transport.lock().await.create_participant(
             domain_id,
-            TransportDataReceiver::new(participant_handle, self.dcps_sender),
+            TransportDataReceiver::new(participant_handle, self.dcps_sender.clone()),
         );
 
         let domain_tag = configuration.domain_tag().to_owned();
@@ -109,7 +116,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         let participant_handle = reply_receiver.await??;
 
         let domain_participant =
-            DomainParticipantAsync::new(self.dcps_sender, domain_id, participant_handle);
+            DomainParticipantAsync::new(self.dcps_sender.clone(), domain_id, participant_handle);
 
         Ok(domain_participant)
     }
@@ -146,7 +153,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             .await;
         Ok(reply_receiver
             .await?
-            .map(|handle| DomainParticipantAsync::new(self.dcps_sender, domain_id, handle)))
+            .map(|handle| DomainParticipantAsync::new(self.dcps_sender.clone(), domain_id, handle)))
     }
 
     /// Async version of [`set_default_participant_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::set_default_participant_qos).
@@ -268,17 +275,22 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         transport: T,
         configuration: DustDdsConfiguration,
     ) -> Self {
-        static DCPS_CHANNEL: DcpsChannel = DcpsChannel::new();
+        let dcps_channel = Arc::new(DcpsChannel::new());
+        let dcps_sender = DcpsSender {
+            channel: dcps_channel.clone(),
+        };
+        let dcps_receiver = DcpsReceiver {
+            channel: dcps_channel,
+        };
         let spawner_handle = runtime.spawner();
         let mut timer_handle = runtime.timer();
 
         let mut domain_participant_factory =
             crate::dcps::dcps_participant_factory::DcpsParticipantFactory::new(
                 runtime,
-                DCPS_CHANNEL.sender(),
+                dcps_sender.clone(),
             );
-        let dcps_receiver = DCPS_CHANNEL.receiver();
-        let run_loop = alloc::sync::Arc::new(core::sync::atomic::AtomicBool::new(true));
+        let run_loop = Arc::new(core::sync::atomic::AtomicBool::new(true));
         let run_loop_clone = run_loop.clone();
         let worker_task = spawner_handle.spawn(async move {
             let span = tracing::trace_span!("dds_actor_loop");
@@ -350,7 +362,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
             }
         });
         Self {
-            dcps_sender: DCPS_CHANNEL.sender(),
+            dcps_sender,
             app_id,
             host_id,
             entity_counter: core::sync::atomic::AtomicU32::new(0),

--- a/dds/src/dds_async/subscriber.rs
+++ b/dds/src/dds_async/subscriber.rs
@@ -254,7 +254,7 @@ impl SubscriberAsync {
     #[tracing::instrument(skip(self))]
     pub fn get_statuscondition(&self) -> StatusConditionAsync {
         StatusConditionAsync::new(
-            *self.dcps_sender(),
+            self.dcps_sender().clone(),
             StatusConditionEntity::Subscriber {
                 participant_handle: self.get_participant().get_instance_handle(),
                 subscriber_handle: self.handle,

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -119,7 +119,7 @@ impl TopicAsync {
     #[tracing::instrument(skip(self))]
     pub fn get_statuscondition(&self) -> StatusConditionAsync {
         StatusConditionAsync::new(
-            *self.participant.dcps_sender(),
+            self.participant.dcps_sender().clone(),
             StatusConditionEntity::Topic {
                 participant_handle: self.get_participant().get_instance_handle(),
                 topic_handle: self.handle,

--- a/dds/tests/wire_tests.rs
+++ b/dds/tests/wire_tests.rs
@@ -1,10 +1,8 @@
 mod utils;
 
-use std::sync::{Mutex, OnceLock};
-
 use dust_dds::{
     dds_async::domain_participant_factory::DomainParticipantFactoryAsync,
-    domain::domain_participant_factory::DomainParticipantFactory,
+    domain::domain_participant::DomainParticipant,
     infrastructure::{listener::NO_LISTENER, qos::QosKind, status::NO_STATUS},
     rtps_messages::{
         overall_structure::RtpsMessageWrite,
@@ -27,20 +25,14 @@ impl WriteMessage for MockWriter {
     fn write_message(&self, _buf: &[u8], _locators: &[Locator]) {}
 }
 
-static DATA_RECEIVER_SEND: Mutex<Option<std::sync::mpsc::SyncSender<TransportDataReceiver>>> =
-    Mutex::new(None);
-static TEST_MUTEX: Mutex<()> = Mutex::new(());
-
-struct MockTransport;
+struct MockTransport(std::sync::mpsc::SyncSender<TransportDataReceiver>);
 impl TransportParticipantFactory for MockTransport {
     fn create_participant(
         &self,
         _domain_id: i32,
         data_receiver: TransportDataReceiver,
     ) -> RtpsTransportParticipant {
-        if let Some(sender) = DATA_RECEIVER_SEND.lock().unwrap().take() {
-            sender.send(data_receiver).unwrap();
-        }
+        self.0.send(data_receiver).unwrap();
         RtpsTransportParticipant {
             message_writer: Box::new(MockWriter),
             default_unicast_locator_list: Vec::new(),
@@ -52,34 +44,35 @@ impl TransportParticipantFactory for MockTransport {
     }
 }
 
-static PARTICIPANT_FACTORY_ASYNC: OnceLock<DomainParticipantFactoryAsync<MockTransport>> =
-    OnceLock::new();
-
-fn get_participant_factory() -> DomainParticipantFactory<MockTransport> {
-    DomainParticipantFactory::new(PARTICIPANT_FACTORY_ASYNC.get_or_init(|| {
-        let executor = dust_dds::std_runtime::executor::Executor::new();
-        let timer_driver = dust_dds::std_runtime::timer::TimerDriver::new();
-        let runtime = dust_dds::std_runtime::StdRuntime::new(executor, timer_driver);
-        let app_id = [1, 2, 3, 4];
-        let host_id = [5, 6, 7, 8];
-        let configuration = Default::default();
-
-        DomainParticipantFactoryAsync::new(runtime, app_id, host_id, MockTransport, configuration)
-    }))
-}
-
 #[test]
 fn detect_stale_participant() {
-    let _guard = TEST_MUTEX.lock().unwrap();
     let (data_receiver_send, data_receiver_recv) = std::sync::mpsc::sync_channel(1);
-    *DATA_RECEIVER_SEND.lock().unwrap() = Some(data_receiver_send);
-
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
-    let domain_participant_factory = get_participant_factory();
 
-    let participant = domain_participant_factory
-        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
-        .unwrap();
+    let executor = dust_dds::std_runtime::executor::Executor::new();
+    let timer_driver = dust_dds::std_runtime::timer::TimerDriver::new();
+    let runtime = dust_dds::std_runtime::StdRuntime::new(executor, timer_driver);
+    let app_id = [1, 2, 3, 4];
+    let host_id = [5, 6, 7, 8];
+    let configuration = Default::default();
+
+    let domain_participant_factory = DomainParticipantFactoryAsync::new(
+        runtime,
+        app_id,
+        host_id,
+        MockTransport(data_receiver_send),
+        configuration,
+    );
+
+    let participant = DomainParticipant::from(
+        dust_dds::std_runtime::executor::block_on(domain_participant_factory.create_participant(
+            domain_id,
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        ))
+        .unwrap(),
+    );
 
     let guid_prefix = <[u8; 16]>::from(participant.get_instance_handle())[0..12]
         .try_into()
@@ -148,16 +141,33 @@ fn detect_stale_participant() {
 
 #[test]
 fn xtypes_mismatch_does_not_abort_discovery() {
-    let _guard = TEST_MUTEX.lock().unwrap();
     let (data_receiver_send, data_receiver_recv) = std::sync::mpsc::sync_channel(1);
-    *DATA_RECEIVER_SEND.lock().unwrap() = Some(data_receiver_send);
-
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
-    let domain_participant_factory = get_participant_factory();
 
-    let participant = domain_participant_factory
-        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
-        .unwrap();
+    let executor = dust_dds::std_runtime::executor::Executor::new();
+    let timer_driver = dust_dds::std_runtime::timer::TimerDriver::new();
+    let runtime = dust_dds::std_runtime::StdRuntime::new(executor, timer_driver);
+    let app_id = [1, 2, 3, 4];
+    let host_id = [5, 6, 7, 8];
+    let configuration = Default::default();
+
+    let domain_participant_factory = DomainParticipantFactoryAsync::new(
+        runtime,
+        app_id,
+        host_id,
+        MockTransport(data_receiver_send),
+        configuration,
+    );
+
+    let participant = DomainParticipant::from(
+        dust_dds::std_runtime::executor::block_on(domain_participant_factory.create_participant(
+            domain_id,
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        ))
+        .unwrap(),
+    );
 
     let data_receiver = data_receiver_recv.recv().unwrap();
 

--- a/dds/tests/wire_tests.rs
+++ b/dds/tests/wire_tests.rs
@@ -207,16 +207,13 @@ fn xtypes_mismatch_does_not_abort_discovery() {
         vec![
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
             0x50, 0x00, 16, 0x00, // PID_PARTICIPANT_GUID
-            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0xc1,
-            0x15, 0x00, 4, 0x00, // PID_PROTOCOL_VERSION
-            0x02, 0x04, 0x00, 0x00,
-            0x16, 0x00, 4, 0x00, // PID_VENDORID
-            73, 74, 0x00, 0x00,
-            0x58, 0x00, 4, 0x00, // PID_BUILTIN_ENDPOINT_SET
-            0x3f, 0x00, 0x00, 0x00,
-            0x02, 0x00, 8, 0x00, // PID_PARTICIPANT_LEASE_DURATION
-            100, 0x00, 0x00, 0x00, 0, 0x00, 0x00, 0x00,
-            0x01, 0x00, 0x00, 0x00, // PID_SENTINEL
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0xc1, 0x15, 0x00, 4,
+            0x00, // PID_PROTOCOL_VERSION
+            0x02, 0x04, 0x00, 0x00, 0x16, 0x00, 4, 0x00, // PID_VENDORID
+            73, 74, 0x00, 0x00, 0x58, 0x00, 4, 0x00, // PID_BUILTIN_ENDPOINT_SET
+            0x3f, 0x00, 0x00, 0x00, 0x02, 0x00, 8, 0x00, // PID_PARTICIPANT_LEASE_DURATION
+            100, 0x00, 0x00, 0x00, 0, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, // PID_SENTINEL
         ]
         .into(),
     );
@@ -246,28 +243,29 @@ fn xtypes_mismatch_does_not_abort_discovery() {
         vec![
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
             0x5a, 0x00, 16, 0x00, // PID_ENDPOINT_GUID
-            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0x04,
-            0x50, 0x00, 16, 0x00, // PID_PARTICIPANT_GUID
-            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0xc1,
-            0x05, 0x00, 12, 0x00, // PID_TOPIC_NAME (Topic1)
-            7, 0x00, 0x00, 0x00, b'T', b'o', b'p', b'i', b'c', b'1', 0, 0,
-            0x07, 0x00, 16, 0x00, // PID_TYPE_NAME (LocalType1)
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0x04, 0x50, 0x00, 16,
+            0x00, // PID_PARTICIPANT_GUID
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0xc1, 0x05, 0x00, 12,
+            0x00, // PID_TOPIC_NAME (Topic1)
+            7, 0x00, 0x00, 0x00, b'T', b'o', b'p', b'i', b'c', b'1', 0, 0, 0x07, 0x00, 16,
+            0x00, // PID_TYPE_NAME (LocalType1)
             11, 0x00, 0x00, 0x00, b'L', b'o', b'c', b'a', b'l', b'T', b'y', b'p', b'e', b'1', 0, 0,
             // PID_TYPE_INFORMATION: XCDR2 mutable struct TypeInformation with serialized_size > 0
-            0x75, 0x00, 76, 0x00,
-            72, 0x00, 0x00, 0x00, // DHEADER (72 bytes)
+            0x75, 0x00, 76, 0x00, 72, 0x00, 0x00, 0x00, // DHEADER (72 bytes)
             // minimal (id 0x1001, lc 4)
             0x01, 0x10, 0x00, 0x40, // emheader
             28, 0x00, 0x00, 0x00, // length
             100, 0x00, 0x00, 0x00, // typeobject_serialized_size = 100 > 0
-            0xf1, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 0, // type_id (EK_MINIMAL + 14-byte hash + pad)
+            0xf1, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+            0, // type_id (EK_MINIMAL + 14-byte hash + pad)
             0, 0, 0, 0, // dependent_typeid_count
             0, 0, 0, 0, // dependent_typeids len
             // complete (id 0x1002, lc 4)
             0x02, 0x10, 0x00, 0x40, // emheader
             28, 0x00, 0x00, 0x00, // length
             100, 0x00, 0x00, 0x00, // typeobject_serialized_size = 100 > 0
-            0xf2, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 0, // type_id (EK_COMPLETE + 14-byte hash + pad)
+            0xf2, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,
+            0, // type_id (EK_COMPLETE + 14-byte hash + pad)
             0, 0, 0, 0, // dependent_typeid_count
             0, 0, 0, 0, // dependent_typeids len
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL
@@ -291,12 +289,12 @@ fn xtypes_mismatch_does_not_abort_discovery() {
         vec![
             0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
             0x5a, 0x00, 16, 0x00, // PID_ENDPOINT_GUID
-            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 2, 0x04,
-            0x50, 0x00, 16, 0x00, // PID_PARTICIPANT_GUID
-            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0xc1,
-            0x05, 0x00, 12, 0x00, // PID_TOPIC_NAME (Topic2)
-            7, 0x00, 0x00, 0x00, b'T', b'o', b'p', b'i', b'c', b'2', 0, 0,
-            0x07, 0x00, 16, 0x00, // PID_TYPE_NAME (LocalType2)
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 2, 0x04, 0x50, 0x00, 16,
+            0x00, // PID_PARTICIPANT_GUID
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0xc1, 0x05, 0x00, 12,
+            0x00, // PID_TOPIC_NAME (Topic2)
+            7, 0x00, 0x00, 0x00, b'T', b'o', b'p', b'i', b'c', b'2', 0, 0, 0x07, 0x00, 16,
+            0x00, // PID_TYPE_NAME (LocalType2)
             11, 0x00, 0x00, 0x00, b'L', b'o', b'c', b'a', b'l', b'T', b'y', b'p', b'e', b'2', 0, 0,
             0x01, 0x00, 0x00, 0x00, // PID_SENTINEL
         ]

--- a/dds/tests/wire_tests.rs
+++ b/dds/tests/wire_tests.rs
@@ -1,5 +1,6 @@
 mod utils;
-use std::sync::OnceLock;
+
+use std::sync::{Mutex, OnceLock};
 
 use dust_dds::{
     dds_async::domain_participant_factory::DomainParticipantFactoryAsync,
@@ -21,48 +22,60 @@ use dust_dds::{
 
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
-#[test]
-fn detect_stale_participant() {
-    struct MockWriter;
-    impl WriteMessage for MockWriter {
-        fn write_message(&self, _buf: &[u8], _locators: &[Locator]) {}
-    }
+struct MockWriter;
+impl WriteMessage for MockWriter {
+    fn write_message(&self, _buf: &[u8], _locators: &[Locator]) {}
+}
 
-    struct MockTransport(std::sync::mpsc::SyncSender<TransportDataReceiver>);
-    impl TransportParticipantFactory for MockTransport {
-        fn create_participant(
-            &self,
-            _domain_id: i32,
-            data_receiver: TransportDataReceiver,
-        ) -> RtpsTransportParticipant {
-            self.0.send(data_receiver).unwrap();
-            RtpsTransportParticipant {
-                message_writer: Box::new(MockWriter),
-                default_unicast_locator_list: Vec::new(),
-                metatraffic_unicast_locator_list: Vec::new(),
-                metatraffic_multicast_locator_list: Vec::new(),
-                default_multicast_locator_list: Vec::new(),
-                fragment_size: 1000,
-            }
+static DATA_RECEIVER_SEND: Mutex<Option<std::sync::mpsc::SyncSender<TransportDataReceiver>>> =
+    Mutex::new(None);
+static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+struct MockTransport;
+impl TransportParticipantFactory for MockTransport {
+    fn create_participant(
+        &self,
+        _domain_id: i32,
+        data_receiver: TransportDataReceiver,
+    ) -> RtpsTransportParticipant {
+        if let Some(sender) = DATA_RECEIVER_SEND.lock().unwrap().take() {
+            sender.send(data_receiver).unwrap();
+        }
+        RtpsTransportParticipant {
+            message_writer: Box::new(MockWriter),
+            default_unicast_locator_list: Vec::new(),
+            metatraffic_unicast_locator_list: Vec::new(),
+            metatraffic_multicast_locator_list: Vec::new(),
+            default_multicast_locator_list: Vec::new(),
+            fragment_size: 1000,
         }
     }
-    static PARTICIPANT_FACTORY_ASYNC: OnceLock<DomainParticipantFactoryAsync<MockTransport>> =
-        OnceLock::new();
+}
 
+static PARTICIPANT_FACTORY_ASYNC: OnceLock<DomainParticipantFactoryAsync<MockTransport>> =
+    OnceLock::new();
+
+fn get_participant_factory() -> DomainParticipantFactory<MockTransport> {
+    DomainParticipantFactory::new(PARTICIPANT_FACTORY_ASYNC.get_or_init(|| {
+        let executor = dust_dds::std_runtime::executor::Executor::new();
+        let timer_driver = dust_dds::std_runtime::timer::TimerDriver::new();
+        let runtime = dust_dds::std_runtime::StdRuntime::new(executor, timer_driver);
+        let app_id = [1, 2, 3, 4];
+        let host_id = [5, 6, 7, 8];
+        let configuration = Default::default();
+
+        DomainParticipantFactoryAsync::new(runtime, app_id, host_id, MockTransport, configuration)
+    }))
+}
+
+#[test]
+fn detect_stale_participant() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     let (data_receiver_send, data_receiver_recv) = std::sync::mpsc::sync_channel(1);
-    let transport = MockTransport(data_receiver_send);
-    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
-    let domain_participant_factory =
-        DomainParticipantFactory::new(PARTICIPANT_FACTORY_ASYNC.get_or_init(|| {
-            let executor = dust_dds::std_runtime::executor::Executor::new();
-            let timer_driver = dust_dds::std_runtime::timer::TimerDriver::new();
-            let runtime = dust_dds::std_runtime::StdRuntime::new(executor, timer_driver);
-            let app_id = [1, 2, 3, 4];
-            let host_id = [5, 6, 7, 8];
-            let configuration = Default::default();
+    *DATA_RECEIVER_SEND.lock().unwrap() = Some(data_receiver_send);
 
-            DomainParticipantFactoryAsync::new(runtime, app_id, host_id, transport, configuration)
-        }));
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let domain_participant_factory = get_participant_factory();
 
     let participant = domain_participant_factory
         .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
@@ -131,4 +144,188 @@ fn detect_stale_participant() {
     std::thread::sleep(std::time::Duration::from_secs(2));
 
     assert_eq!(participant.get_discovered_participants().unwrap().len(), 0);
+}
+
+#[test]
+fn xtypes_mismatch_does_not_abort_discovery() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let (data_receiver_send, data_receiver_recv) = std::sync::mpsc::sync_channel(1);
+    *DATA_RECEIVER_SEND.lock().unwrap() = Some(data_receiver_send);
+
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let domain_participant_factory = get_participant_factory();
+
+    let participant = domain_participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let data_receiver = data_receiver_recv.recv().unwrap();
+
+    #[derive(dust_dds::infrastructure::type_support::DdsType)]
+    struct LocalType1 {
+        id: i32,
+    }
+    #[derive(dust_dds::infrastructure::type_support::DdsType)]
+    struct LocalType2 {
+        id: i32,
+    }
+
+    let topic1 = participant
+        .create_topic::<LocalType1>(
+            "Topic1",
+            "LocalType1",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+    let topic2 = participant
+        .create_topic::<LocalType2>(
+            "Topic2",
+            "LocalType2",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let _writer1 = publisher
+        .create_datawriter::<LocalType1>(&topic1, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer2 = publisher
+        .create_datawriter::<LocalType2>(&topic2, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    // 1. Announce remote participant via SPDP
+    let remote_guid_prefix = [8; 12];
+    const ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER: EntityId =
+        EntityId::new([0x00, 0x01, 0x00], BUILT_IN_WRITER_WITH_KEY);
+    let spdp_payload = Data::new(
+        vec![
+            0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
+            0x50, 0x00, 16, 0x00, // PID_PARTICIPANT_GUID
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0xc1,
+            0x15, 0x00, 4, 0x00, // PID_PROTOCOL_VERSION
+            0x02, 0x04, 0x00, 0x00,
+            0x16, 0x00, 4, 0x00, // PID_VENDORID
+            73, 74, 0x00, 0x00,
+            0x58, 0x00, 4, 0x00, // PID_BUILTIN_ENDPOINT_SET
+            0x3f, 0x00, 0x00, 0x00,
+            0x02, 0x00, 8, 0x00, // PID_PARTICIPANT_LEASE_DURATION
+            100, 0x00, 0x00, 0x00, 0, 0x00, 0x00, 0x00,
+            0x01, 0x00, 0x00, 0x00, // PID_SENTINEL
+        ]
+        .into(),
+    );
+    let spdp_submsg = DataSubmessage::new(
+        false,
+        true,
+        false,
+        false,
+        ENTITYID_UNKNOWN,
+        ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER,
+        1,
+        ParameterList::empty(),
+        spdp_payload,
+    );
+    let spdp_msg = RtpsMessageWrite::from_submessages(&[&spdp_submsg], remote_guid_prefix);
+    dust_dds::std_runtime::executor::block_on(
+        data_receiver.receive_message(spdp_msg.buffer().to_vec()),
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // 2. Announce Reader 1 on Topic1 with mismatched TypeInformation (serialized_size > 0)
+    const ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER: EntityId =
+        EntityId::new([0x00, 0x00, 0x04], BUILT_IN_WRITER_WITH_KEY);
+
+    let reader1_sedp_payload = Data::new(
+        vec![
+            0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
+            0x5a, 0x00, 16, 0x00, // PID_ENDPOINT_GUID
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0x04,
+            0x50, 0x00, 16, 0x00, // PID_PARTICIPANT_GUID
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0xc1,
+            0x05, 0x00, 12, 0x00, // PID_TOPIC_NAME (Topic1)
+            7, 0x00, 0x00, 0x00, b'T', b'o', b'p', b'i', b'c', b'1', 0, 0,
+            0x07, 0x00, 16, 0x00, // PID_TYPE_NAME (LocalType1)
+            11, 0x00, 0x00, 0x00, b'L', b'o', b'c', b'a', b'l', b'T', b'y', b'p', b'e', b'1', 0, 0,
+            // PID_TYPE_INFORMATION: XCDR2 mutable struct TypeInformation with serialized_size > 0
+            0x75, 0x00, 76, 0x00,
+            72, 0x00, 0x00, 0x00, // DHEADER (72 bytes)
+            // minimal (id 0x1001, lc 4)
+            0x01, 0x10, 0x00, 0x40, // emheader
+            28, 0x00, 0x00, 0x00, // length
+            100, 0x00, 0x00, 0x00, // typeobject_serialized_size = 100 > 0
+            0xf1, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 0, // type_id (EK_MINIMAL + 14-byte hash + pad)
+            0, 0, 0, 0, // dependent_typeid_count
+            0, 0, 0, 0, // dependent_typeids len
+            // complete (id 0x1002, lc 4)
+            0x02, 0x10, 0x00, 0x40, // emheader
+            28, 0x00, 0x00, 0x00, // length
+            100, 0x00, 0x00, 0x00, // typeobject_serialized_size = 100 > 0
+            0xf2, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 0, // type_id (EK_COMPLETE + 14-byte hash + pad)
+            0, 0, 0, 0, // dependent_typeid_count
+            0, 0, 0, 0, // dependent_typeids len
+            0x01, 0x00, 0x00, 0x00, // PID_SENTINEL
+        ]
+        .into(),
+    );
+    let sedp_submsg1 = DataSubmessage::new(
+        false,
+        true,
+        false,
+        false,
+        ENTITYID_UNKNOWN,
+        ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER,
+        1,
+        ParameterList::empty(),
+        reader1_sedp_payload,
+    );
+
+    // 3. Announce Reader 2 on Topic2 (matching LocalType2)
+    let reader2_sedp_payload = Data::new(
+        vec![
+            0x00, 0x03, 0x00, 0x00, // PL_CDR_LE
+            0x5a, 0x00, 16, 0x00, // PID_ENDPOINT_GUID
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 2, 0x04,
+            0x50, 0x00, 16, 0x00, // PID_PARTICIPANT_GUID
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 0, 0, 1, 0xc1,
+            0x05, 0x00, 12, 0x00, // PID_TOPIC_NAME (Topic2)
+            7, 0x00, 0x00, 0x00, b'T', b'o', b'p', b'i', b'c', b'2', 0, 0,
+            0x07, 0x00, 16, 0x00, // PID_TYPE_NAME (LocalType2)
+            11, 0x00, 0x00, 0x00, b'L', b'o', b'c', b'a', b'l', b'T', b'y', b'p', b'e', b'2', 0, 0,
+            0x01, 0x00, 0x00, 0x00, // PID_SENTINEL
+        ]
+        .into(),
+    );
+    let sedp_submsg2 = DataSubmessage::new(
+        false,
+        true,
+        false,
+        false,
+        ENTITYID_UNKNOWN,
+        ENTITYID_SEDP_BUILTIN_SUBSCRIPTIONS_WRITER,
+        2,
+        ParameterList::empty(),
+        reader2_sedp_payload,
+    );
+
+    let sedp_msg =
+        RtpsMessageWrite::from_submessages(&[&sedp_submsg1, &sedp_submsg2], remote_guid_prefix);
+    dust_dds::std_runtime::executor::block_on(
+        data_receiver.receive_message(sedp_msg.buffer().to_vec()),
+    );
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    // writer2 on Topic2 should have matched Reader 2, even though Reader 1 had a type mismatch
+    assert_eq!(
+        writer2.get_matched_subscriptions().unwrap().len(),
+        1,
+        "Writer 2 should have discovered Reader 2 despite Reader 1 type mismatch"
+    );
 }


### PR DESCRIPTION
Fixes #645 

Because the wire tests couldn't run in parallel due to use a single static channel for all factories there is also an architecture change to use instead a channel on an Arc such that each ParticipantFactory is independent from each other