### PR TITLE
Refactor: Split message sending from cache change writing

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -739,5 +739,10 @@ impl DcpsDomainParticipant {
             dw.transport_writer
                 .write_message(self.transport.message_writer.as_ref(), clock);
         }
+        self.domain_participant
+            .builtin_publisher
+            .dcps_participant_writer
+            .transport_writer
+            .write_message(self.transport.message_writer.as_ref());
     }
 }

--- a/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
@@ -13,11 +13,7 @@ use crate::{
         status::OfferedIncompatibleQosStatus,
         time::{Duration, DurationKind, Time},
     },
-    runtime::DdsRuntime,
-    transport::{
-        interface::WriteMessage,
-        types::{CacheChange, ChangeKind, TopicKind},
-    },
+    transport::types::{CacheChange, ChangeKind, TopicKind},
     xtypes::{
         dynamic_type::{DynamicData, DynamicType},
         serializer::{serialize_cdr1_be, serialize_cdr1_le, serialize_cdr2_be, serialize_cdr2_le},
@@ -73,8 +69,6 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
         serialized_data: Vec<u8>,
         sample_timestamp: Time,
         now: Time,
-        message_writer: &(impl WriteMessage + ?Sized),
-        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         if !self
             .registered_instance_info
@@ -162,8 +156,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             }
         }
 
-        self.transport_writer
-            .add_change(change, message_writer, runtime);
+        self.transport_writer.add_change(change);
 
         Ok(())
     }
@@ -173,8 +166,6 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
         dynamic_data: &DynamicData<'static>,
         type_support: &DynamicType<'static>,
         timestamp: Time,
-        message_writer: &(impl WriteMessage + ?Sized),
-        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         if !self.enabled {
             return Err(DdsError::NotEnabled);
@@ -211,8 +202,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             instance_handle: Some(instance_handle.into()),
             data_value: serialized_key.into(),
         };
-        self.transport_writer
-            .add_change(cache_change, message_writer, runtime);
+        self.transport_writer.add_change(cache_change);
 
         Ok(())
     }
@@ -260,8 +250,6 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
         dynamic_data: &DynamicData<'static>,
         type_support: &DynamicType<'static>,
         timestamp: Time,
-        message_writer: &(impl WriteMessage + ?Sized),
-        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         if !self.enabled {
             return Err(DdsError::NotEnabled);
@@ -306,8 +294,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             instance_handle: Some(instance_handle.into()),
             data_value: serialized_key.into(),
         };
-        self.transport_writer
-            .add_change(cache_change, message_writer, runtime);
+        self.transport_writer.add_change(cache_change);
         Ok(())
     }
 }

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -160,8 +160,6 @@ impl DcpsDomainParticipant {
                     serialized_data,
                     sample_timestamp,
                     now,
-                    self.transport.message_writer.as_ref(),
-                    runtime,
                 )
                 .ok();
             }
@@ -185,14 +183,8 @@ impl DcpsDomainParticipant {
             .create_dynamic_sample();
             dynamic_data.set_complex_value(0, topic_key_data).unwrap();
 
-            dw.unregister_w_timestamp(
-                &dynamic_data,
-                &BuiltInKeyHolder::TYPE,
-                timestamp,
-                self.transport.message_writer.as_ref(),
-                runtime,
-            )
-            .ok();
+            dw.unregister_w_timestamp(&dynamic_data, &BuiltInKeyHolder::TYPE, timestamp)
+                .ok();
         }
     }
 
@@ -562,14 +554,11 @@ impl DcpsDomainParticipant {
             let sample_instance_handle = data_writer.transport_writer.guid().into();
             let serialized_data = discovered_writer_data.into_bytes();
             let sample_timestamp = now;
-            let message_writer = self.transport.message_writer.as_ref();
             dw.write_w_timestamp(
                 sample_instance_handle,
                 serialized_data,
                 sample_timestamp,
                 now,
-                message_writer,
-                runtime,
             )
             .ok();
         }
@@ -594,14 +583,8 @@ impl DcpsDomainParticipant {
             .create_dynamic_sample();
             dynamic_data.set_complex_value(0, topic_key_data).unwrap();
 
-            dw.unregister_w_timestamp(
-                &dynamic_data,
-                &BuiltInKeyHolder::TYPE,
-                timestamp,
-                self.transport.message_writer.as_ref(),
-                runtime,
-            )
-            .ok();
+            dw.unregister_w_timestamp(&dynamic_data, &BuiltInKeyHolder::TYPE, timestamp)
+                .ok();
         }
     }
 
@@ -708,14 +691,11 @@ impl DcpsDomainParticipant {
             let sample_instance_handle = data_reader.transport_reader.guid().into();
             let serialized_data = discovered_reader_data.into_bytes();
             let sample_timestamp = now;
-            let message_writer = self.transport.message_writer.as_ref();
             dw.write_w_timestamp(
                 sample_instance_handle,
                 serialized_data,
                 sample_timestamp,
                 now,
-                message_writer,
-                runtime,
             )
             .ok();
         }
@@ -740,14 +720,8 @@ impl DcpsDomainParticipant {
             .create_dynamic_sample();
             dynamic_data.set_complex_value(0, topic_key_data).unwrap();
 
-            dw.unregister_w_timestamp(
-                &dynamic_data,
-                &BuiltInKeyHolder::TYPE,
-                timestamp,
-                self.transport.message_writer.as_ref(),
-                runtime,
-            )
-            .ok();
+            dw.unregister_w_timestamp(&dynamic_data, &BuiltInKeyHolder::TYPE, timestamp)
+                .ok();
         }
     }
 
@@ -796,14 +770,11 @@ impl DcpsDomainParticipant {
             let serialized_data = discovered_topic_data.into_bytes();
             let now = runtime.clock().now();
             let sample_timestamp = now;
-            let message_writer = self.transport.message_writer.as_ref();
             dw.write_w_timestamp(
                 sample_instance_handle,
                 serialized_data,
                 sample_timestamp,
                 now,
-                message_writer,
-                runtime,
             )
             .ok();
         }
@@ -838,7 +809,6 @@ impl DcpsDomainParticipant {
         let participant_instance_handle = *participant_instance_handle;
         let participant_listener_mask = *participant_listener_mask;
         let dcps_sender = self.dcps_sender.clone();
-        let message_writer = self.transport.message_writer.as_ref();
 
         for publisher in user_defined_publisher_list.iter_mut() {
             let publisher_handle = publisher.instance_handle;
@@ -1003,8 +973,6 @@ impl DcpsDomainParticipant {
                                                     serialized_data,
                                                     now,
                                                     now,
-                                                    message_writer,
-                                                    runtime,
                                                 )
                                                 .ok();
                                             type_register.add_pending_dependencies_lookup(
@@ -1019,7 +987,7 @@ impl DcpsDomainParticipant {
                                             header: RequestHeader {
                                                 request_id: SampleIdentity {
                                                     writer_guid: type_request_writer
-                                                        .transport_writer
+                                                         .transport_writer
                                                         .guid(),
                                                     sequence_number: (type_request_writer
                                                         .last_change_sequence_number
@@ -1049,8 +1017,6 @@ impl DcpsDomainParticipant {
                                                 serialized_data,
                                                 now,
                                                 now,
-                                                message_writer,
-                                                runtime,
                                             )
                                             .ok();
                                         type_register.add_pending_types_lookup(vec![
@@ -1482,7 +1448,6 @@ impl DcpsDomainParticipant {
         let participant_instance_handle = *participant_instance_handle;
         let participant_listener_mask = *participant_listener_mask;
         let dcps_sender = self.dcps_sender.clone();
-        let message_writer = self.transport.message_writer.as_ref();
 
         for subscriber in user_defined_subscriber_list.iter_mut() {
             let subscriber_handle = subscriber.instance_handle;
@@ -1668,8 +1633,6 @@ impl DcpsDomainParticipant {
                                                     serialized_data,
                                                     now,
                                                     now,
-                                                    message_writer,
-                                                    runtime,
                                                 )
                                                 .ok();
                                             type_register.add_pending_dependencies_lookup(
@@ -1714,8 +1677,6 @@ impl DcpsDomainParticipant {
                                                 serialized_data,
                                                 now,
                                                 now,
-                                                message_writer,
-                                                runtime,
                                             )
                                             .ok();
                                         type_register.add_pending_types_lookup(vec![
@@ -2403,8 +2364,6 @@ impl DcpsDomainParticipant {
                                             serialized_data,
                                             now,
                                             now,
-                                            self.transport.message_writer.as_ref(),
-                                            runtime,
                                         )
                                         .ok();
                                 }
@@ -2454,8 +2413,6 @@ impl DcpsDomainParticipant {
                                                 serialized_data,
                                                 now,
                                                 now,
-                                                self.transport.message_writer.as_ref(),
-                                                runtime,
                                             )
                                             .ok();
                                     }
@@ -2558,8 +2515,6 @@ impl DcpsDomainParticipant {
                                                 serialized_data,
                                                 now,
                                                 now,
-                                                self.transport.message_writer.as_ref(),
-                                                runtime,
                                             )
                                             .ok();
                                         self.domain_participant
@@ -2939,8 +2894,6 @@ impl DcpsDomainParticipant {
                                         serialized_data,
                                         now,
                                         now,
-                                        self.transport.message_writer.as_ref(),
-                                        runtime,
                                     )
                                     .ok();
                                 self.domain_participant
@@ -2988,8 +2941,6 @@ impl DcpsDomainParticipant {
                                     serialized_data,
                                     now,
                                     now,
-                                    self.transport.message_writer.as_ref(),
-                                    runtime,
                                 )
                                 .ok();
                             self.domain_participant
@@ -3678,8 +3629,6 @@ impl DcpsDomainParticipant {
                 serialized_data,
                 sample_timestamp,
                 now,
-                self.transport.message_writer.as_ref(),
-                runtime,
             )
             .ok();
         }

--- a/dds/src/dcps/dcps_domain_participant/rtps_traits.rs
+++ b/dds/src/dcps/dcps_domain_participant/rtps_traits.rs
@@ -3,22 +3,13 @@ use crate::{
         stateful_reader::RtpsStatefulReader, stateful_writer::RtpsStatefulWriter,
         stateless_reader::RtpsStatelessReader, stateless_writer::RtpsStatelessWriter,
     },
-    runtime::DdsRuntime,
-    transport::{
-        interface::WriteMessage,
-        types::{CacheChange, Guid},
-    },
+    transport::types::{CacheChange, Guid},
 };
 use alloc::vec::Vec;
 
 pub trait RtpsWriter {
     fn guid(&self) -> Guid;
-    fn add_change(
-        &mut self,
-        cache_change: CacheChange,
-        message_writer: &(impl WriteMessage + ?Sized),
-        runtime: &impl DdsRuntime,
-    );
+    fn add_change(&mut self, cache_change: CacheChange);
 }
 
 impl RtpsWriter for RtpsStatefulWriter {
@@ -26,13 +17,8 @@ impl RtpsWriter for RtpsStatefulWriter {
         self.guid()
     }
 
-    fn add_change(
-        &mut self,
-        cache_change: CacheChange,
-        message_writer: &(impl WriteMessage + ?Sized),
-        runtime: &impl DdsRuntime,
-    ) {
-        self.add_change(cache_change, message_writer, &runtime.clock())
+    fn add_change(&mut self, cache_change: CacheChange) {
+        self.add_change(cache_change)
     }
 }
 
@@ -41,13 +27,8 @@ impl RtpsWriter for RtpsStatelessWriter {
         self.guid()
     }
 
-    fn add_change(
-        &mut self,
-        cache_change: CacheChange,
-        message_writer: &(impl WriteMessage + ?Sized),
-        _runtime: &impl DdsRuntime,
-    ) {
-        self.add_change(cache_change, message_writer)
+    fn add_change(&mut self, cache_change: CacheChange) {
+        self.add_change(cache_change)
     }
 }
 

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -210,14 +210,13 @@ impl DcpsDomainParticipant {
         data_writer.register_w_timestamp(dynamic_data, &type_support, timestamp)
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn unregister_instance(
         &mut self,
         publisher_handle: &InstanceHandle,
         data_writer_handle: &InstanceHandle,
         dynamic_data: &DynamicData<'static>,
         timestamp: Time,
-        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -246,13 +245,7 @@ impl DcpsDomainParticipant {
             .get_dynamic_type(&topic.type_information.complete.typeid_with_size.type_id)
             .expect("Type must exist in type_register");
 
-        data_writer.unregister_w_timestamp(
-            dynamic_data,
-            &type_support,
-            timestamp,
-            self.transport.message_writer.as_ref(),
-            runtime,
-        )
+        data_writer.unregister_w_timestamp(dynamic_data, &type_support, timestamp)
     }
 
     #[tracing::instrument(skip(self))]
@@ -416,14 +409,8 @@ impl DcpsDomainParticipant {
             }
         }
 
-        let write_result = data_writer.write_w_timestamp(
-            instance_handle,
-            serialized_data,
-            timestamp,
-            now,
-            self.transport.message_writer.as_ref(),
-            runtime,
-        );
+        let write_result =
+            data_writer.write_w_timestamp(instance_handle, serialized_data, timestamp, now);
         if write_result.is_err() {
             reply_sender.send(write_result);
             return;
@@ -432,14 +419,13 @@ impl DcpsDomainParticipant {
         reply_sender.send(Ok(()));
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn dispose_w_timestamp(
         &mut self,
         publisher_handle: &InstanceHandle,
         data_writer_handle: &InstanceHandle,
         dynamic_data: &DynamicData<'static>,
         timestamp: Time,
-        runtime: &impl DdsRuntime,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -468,13 +454,7 @@ impl DcpsDomainParticipant {
             .get_dynamic_type(&topic.type_information.complete.typeid_with_size.type_id)
             .expect("Type must exist in type_register");
 
-        data_writer.dispose_w_timestamp(
-            dynamic_data,
-            &type_support,
-            timestamp,
-            self.transport.message_writer.as_ref(),
-            runtime,
-        )
+        data_writer.dispose_w_timestamp(dynamic_data, &type_support, timestamp)
     }
 
     #[tracing::instrument(skip(self))]
@@ -693,8 +673,6 @@ impl DcpsDomainParticipant {
                             serialized_data,
                             pending.timestamp,
                             now,
-                            self.transport.message_writer.as_ref(),
-                            runtime,
                         );
                         if write_result.is_err() {
                             pending.reply_sender.send(write_result);

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -626,7 +626,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                         &data_writer_handle,
                         &dynamic_data,
                         timestamp,
-                        &self.runtime,
                     ));
                 }
                 Err(e) => reply_sender.send(Err(e)),
@@ -687,7 +686,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                         &data_writer_handle,
                         &dynamic_data,
                         timestamp,
-                        &self.runtime,
                     ));
                 }
                 Err(e) => reply_sender.send(Err(e)),

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -92,6 +92,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         }
         let mut participant = self.domain_participant_list.remove(index);
         participant.announce_deleted_participant(&self.runtime);
+        participant.poke(&self.runtime.clock());
         Ok(())
     }
 

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -48,14 +48,8 @@ impl RtpsStatefulWriter {
         self.data_max_size_serialized
     }
 
-    pub fn add_change(
-        &mut self,
-        cache_change: CacheChange,
-        message_writer: &(impl WriteMessage + ?Sized),
-        clock: &impl Clock,
-    ) {
+    pub fn add_change(&mut self, cache_change: CacheChange) {
         self.changes.push(cache_change);
-        self.write_message(message_writer, clock);
     }
 
     pub fn remove_change(&mut self, sequence_number: SequenceNumber) {
@@ -728,18 +722,15 @@ mod tests {
         let message_writer = MockWriter {
             total_fragments_sent: Mutex::new(0),
         };
-        writer.add_change(
-            CacheChange {
-                kind: ChangeKind::Alive,
-                writer_guid: guid,
-                sequence_number: 1,
-                source_timestamp: None,
-                instance_handle: Some([10; 16]),
-                data_value: vec![8; 1300].into(),
-            },
-            &message_writer,
-            &MockClock {},
-        );
+        writer.add_change(CacheChange {
+            kind: ChangeKind::Alive,
+            writer_guid: guid,
+            sequence_number: 1,
+            source_timestamp: None,
+            instance_handle: Some([10; 16]),
+            data_value: vec![8; 1300].into(),
+        });
+        writer.write_message(&message_writer, &MockClock {});
         assert_eq!(*message_writer.total_fragments_sent.lock().unwrap(), 3);
     }
 
@@ -789,18 +780,15 @@ mod tests {
         let message_writer = MockWriter {
             total_fragments_sent: Mutex::new(0),
         };
-        writer.add_change(
-            CacheChange {
-                kind: ChangeKind::Alive,
-                writer_guid: guid,
-                sequence_number: 1,
-                source_timestamp: None,
-                instance_handle: Some([10; 16]),
-                data_value: vec![8; 1300].into(),
-            },
-            &message_writer,
-            &MockClock {},
-        );
+        writer.add_change(CacheChange {
+            kind: ChangeKind::Alive,
+            writer_guid: guid,
+            sequence_number: 1,
+            source_timestamp: None,
+            instance_handle: Some([10; 16]),
+            data_value: vec![8; 1300].into(),
+        });
+        writer.write_message(&message_writer, &MockClock {});
 
         let nackfrag_submessage = NackFragSubmessage::new(
             remote_reader_id,

--- a/dds/src/rtps/stateless_writer.rs
+++ b/dds/src/rtps/stateless_writer.rs
@@ -32,13 +32,11 @@ impl RtpsStatelessWriter {
         self.guid
     }
 
-    pub fn add_change(
-        &mut self,
-        cache_change: CacheChange,
-        message_writer: &(impl WriteMessage + ?Sized),
-    ) {
+    pub fn add_change(&mut self, cache_change: CacheChange) {
         self.changes.push(cache_change);
+    }
 
+    pub fn write_message(&mut self, message_writer: &(impl WriteMessage + ?Sized)) {
         for reader_locator in &mut self.reader_locators {
             while let Some(unsent_change_seq_num) =
                 reader_locator.next_unsent_change(self.changes.iter())


### PR DESCRIPTION
At the moment cache change writing is tightly coupled together with message sending. This makes the interface for writing quite complex and prevents implementing the QoS to allow delaying the writing of message. This PR is a refactor which splits these two operations. It has little functional impact since messages are anyway writing at the end of each loop by calling the poke() function