### PR TITLE
Refactor: Performance optimization

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/builtin_publisher.rs
+++ b/dds/src/dcps/dcps_domain_participant/builtin_publisher.rs
@@ -1,6 +1,14 @@
 use crate::{
-    builtin_topics::{DCPS_PARTICIPANT, DCPS_PUBLICATION, DCPS_SUBSCRIPTION, DCPS_TOPIC},
-    dcps::dcps_domain_participant::data_writer_entity::DataWriterEntity,
+    builtin_topics::{
+        DCPS_PARTICIPANT, DCPS_PUBLICATION, DCPS_SUBSCRIPTION, DCPS_TOPIC,
+        ParticipantBuiltinTopicData, PublicationBuiltinTopicData, SubscriptionBuiltinTopicData,
+        TopicBuiltinTopicData,
+    },
+    dcps::{
+        data_representation_builtin_endpoints::type_lookup::{TypeLookupReply, TypeLookupRequest},
+        dcps_domain_participant::data_writer_entity::DataWriterEntity,
+        xtypes_glue::key_and_instance_handle::KeyHolderType,
+    },
     infrastructure::{
         instance::InstanceHandle,
         qos::DataWriterQos,
@@ -15,6 +23,7 @@ use crate::{
         interface::RtpsTransportParticipant,
         types::{Guid, GuidPrefix},
     },
+    xtypes::type_support::Type,
 };
 use alloc::sync::Arc;
 
@@ -81,6 +90,7 @@ impl BuiltinPublisher {
             dcps_participant_transport_writer,
             Arc::from(DCPS_PARTICIPANT),
             spdp_writer_qos(),
+            KeyHolderType::new(&ParticipantBuiltinTopicData::TYPE),
         );
 
         let dcps_topics_transport_writer = RtpsStatefulWriter::new(
@@ -92,6 +102,7 @@ impl BuiltinPublisher {
             dcps_topics_transport_writer,
             Arc::from(DCPS_TOPIC),
             sedp_data_writer_qos(),
+            KeyHolderType::new(&TopicBuiltinTopicData::TYPE),
         );
 
         let dcps_publications_transport_writer = RtpsStatefulWriter::new(
@@ -103,6 +114,7 @@ impl BuiltinPublisher {
             dcps_publications_transport_writer,
             Arc::from(DCPS_PUBLICATION),
             sedp_data_writer_qos(),
+            KeyHolderType::new(&PublicationBuiltinTopicData::TYPE),
         );
 
         let dcps_subscriptions_transport_writer = RtpsStatefulWriter::new(
@@ -114,6 +126,7 @@ impl BuiltinPublisher {
             dcps_subscriptions_transport_writer,
             Arc::from(DCPS_SUBSCRIPTION),
             sedp_data_writer_qos(),
+            KeyHolderType::new(&SubscriptionBuiltinTopicData::TYPE),
         );
 
         let type_lookup_request_transport_writer = RtpsStatefulWriter::new(
@@ -125,6 +138,7 @@ impl BuiltinPublisher {
             type_lookup_request_transport_writer,
             Arc::from(TYPE_LOOKUP_REQUEST_TOPIC_NAME),
             TYPE_LOOKUP_WRITER_QOS,
+            KeyHolderType::new(&TypeLookupRequest::TYPE),
         );
 
         let type_lookup_reply_transport_writer = RtpsStatefulWriter::new(
@@ -136,6 +150,7 @@ impl BuiltinPublisher {
             type_lookup_reply_transport_writer,
             Arc::from(TYPE_LOOKUP_REPLY_TOPIC_NAME),
             TYPE_LOOKUP_WRITER_QOS,
+            KeyHolderType::new(&TypeLookupReply::TYPE),
         );
 
         Self {

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -941,7 +941,7 @@ impl DcpsDomainParticipant {
                                 .on_acknack_submessage_received(
                                     ack_nack_submessage,
                                     message_receiver.source_guid_prefix(),
-                                    self.transport.message_writer.as_ref(),
+                                    self.transport.message_writer.as_mut(),
                                     &runtime.clock(),
                                 )
                                 .is_some()
@@ -968,7 +968,7 @@ impl DcpsDomainParticipant {
                             dw.transport_writer.on_acknack_submessage_received(
                                 ack_nack_submessage,
                                 message_receiver.source_guid_prefix(),
-                                self.transport.message_writer.as_ref(),
+                                self.transport.message_writer.as_mut(),
                                 &runtime.clock(),
                             );
                         }
@@ -984,7 +984,7 @@ impl DcpsDomainParticipant {
                             dw.transport_writer.on_nack_frag_submessage_received(
                                 nack_frag_submessage,
                                 message_receiver.source_guid_prefix(),
-                                self.transport.message_writer.as_ref(),
+                                self.transport.message_writer.as_mut(),
                             );
                         }
                         for dw in self
@@ -995,7 +995,7 @@ impl DcpsDomainParticipant {
                             dw.transport_writer.on_nack_frag_submessage_received(
                                 nack_frag_submessage,
                                 message_receiver.source_guid_prefix(),
-                                self.transport.message_writer.as_ref(),
+                                self.transport.message_writer.as_mut(),
                             );
                         }
                     }
@@ -1100,7 +1100,7 @@ impl DcpsDomainParticipant {
                         writer_proxy.set_must_send_acknacks(must_send_acknacks);
 
                         writer_proxy
-                            .write_message(&reader_guid, self.transport.message_writer.as_ref());
+                            .write_message(&reader_guid, self.transport.message_writer.as_mut());
                     }
                 }
 
@@ -1133,7 +1133,7 @@ impl DcpsDomainParticipant {
                     writer_proxy.set_must_send_acknacks(must_send_acknacks);
 
                     writer_proxy
-                        .write_message(&reader_guid, self.transport.message_writer.as_ref());
+                        .write_message(&reader_guid, self.transport.message_writer.as_mut());
                 }
             }
         }
@@ -1171,7 +1171,7 @@ impl DcpsDomainParticipant {
             .flat_map(|p| p.data_writer_list.iter_mut())
         {
             dw.transport_writer
-                .write_message(self.transport.message_writer.as_ref(), clock);
+                .write_message(self.transport.message_writer.as_mut(), clock);
         }
         for dw in self
             .domain_participant
@@ -1179,12 +1179,12 @@ impl DcpsDomainParticipant {
             .stateful_data_writer_list_mut()
         {
             dw.transport_writer
-                .write_message(self.transport.message_writer.as_ref(), clock);
+                .write_message(self.transport.message_writer.as_mut(), clock);
         }
         self.domain_participant
             .builtin_publisher
             .dcps_participant_writer
             .transport_writer
-            .write_message(self.transport.message_writer.as_ref());
+            .write_message(self.transport.message_writer.as_mut());
     }
 }

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -264,17 +264,14 @@ impl DcpsDomainParticipant {
                             ChangeKind::NotAliveDisposed
                             | ChangeKind::NotAliveUnregistered
                             | ChangeKind::NotAliveDisposedUnregistered => {
-                                let mut dynamic_members = Vec::new();
-                                let Ok(key_holder) = KeyHolderType::from_dynamic_type(
-                                    &type_support,
-                                    &mut dynamic_members,
-                                ) else {
+                                let key_holder = KeyHolderType::new(&type_support);
+                                let Some(dynamic_type) = key_holder.as_dynamic_type() else {
                                     tracing::warn!("Failed to create key holder");
                                     continue 'data_readers;
                                 };
 
                                 let Ok(data_value) = deserialize_top_level_type(
-                                    *key_holder.as_dynamic_type(),
+                                    dynamic_type,
                                     cache_change.data_value.as_ref(),
                                 ) else {
                                     tracing::warn!(

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -89,8 +89,7 @@ impl DcpsDomainParticipant {
                     .iter()
                     .find(|t| t.topic_name == data_reader.topic_name);
 
-                let (topic_name, type_name) = if let Some(content_filtered_topic) =
-                    content_filtered_topic
+                let reader_type_name = if let Some(content_filtered_topic) = content_filtered_topic
                 {
                     let Some(reader_topic) = locally_created_topic_list
                         .iter()
@@ -99,10 +98,7 @@ impl DcpsDomainParticipant {
                         tracing::warn!(topic_name = ?data_reader.topic_name, "Failed to find related_topic_name for reader");
                         continue 'data_readers;
                     };
-                    (
-                        reader_topic.topic_name.clone(),
-                        reader_topic.type_name.clone(),
-                    )
+                    &reader_topic.type_name
                 } else {
                     let Some(reader_topic) = locally_created_topic_list
                         .iter()
@@ -111,10 +107,7 @@ impl DcpsDomainParticipant {
                         tracing::warn!(topic_name = ?data_reader.topic_name, "Failed to find topic for reader");
                         continue 'data_readers;
                     };
-                    (
-                        data_reader.topic_name.clone(),
-                        reader_topic.type_name.clone(),
-                    )
+                    &reader_topic.type_name
                 };
 
                 let changes = core::mem::take(data_reader.transport_reader.changes_mut());
@@ -342,8 +335,8 @@ impl DcpsDomainParticipant {
                                     let the_reader = DataReaderAsync::new(
                                         data_reader_handle,
                                         the_subscriber,
-                                        topic_name.clone(),
-                                        type_name.clone(),
+                                        data_reader.topic_name.clone(),
+                                        reader_type_name.clone(),
                                     );
                                     l.send(ListenerMail::DataAvailable { the_reader }).ok();
                                 }
@@ -384,8 +377,8 @@ impl DcpsDomainParticipant {
                                 let the_reader = DataReaderAsync::new(
                                     data_reader_handle,
                                     the_subscriber,
-                                    topic_name.clone(),
-                                    type_name.clone(),
+                                    data_reader.topic_name.clone(),
+                                    reader_type_name.clone(),
                                 );
                                 let status = data_reader.get_sample_rejected_status();
 

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -41,7 +41,6 @@ use crate::{
             heartbeat::HeartbeatSubmessage,
         },
     },
-    runtime::{Clock, DdsRuntime},
     transport::types::{ChangeKind, Guid},
     xtypes::{
         deserializer::deserialize_top_level_type,
@@ -413,11 +412,7 @@ impl DcpsDomainParticipant {
         }
     }
 
-    pub fn process_builtin_cache_changes(
-        &mut self,
-        runtime: &impl DdsRuntime,
-        reception_timestamp: Time,
-    ) {
+    pub fn process_builtin_cache_changes(&mut self, reception_timestamp: Time) {
         // 1. SPDP Participant Reader
         if !self
             .domain_participant
@@ -436,7 +431,7 @@ impl DcpsDomainParticipant {
             );
             for cache_change in changes {
                 if cache_change.kind == ChangeKind::Alive
-                    || cache_change.kind == ChangeKind::AliveFiltered
+                    && cache_change.data_value.as_ref().len() >= 4
                 {
                     if let Ok(discovered_participant_data) =
                         SpdpDiscoveredParticipantData::from_bytes(cache_change.data_value.as_ref())
@@ -444,7 +439,10 @@ impl DcpsDomainParticipant {
                         let instance_handle = InstanceHandle::new(
                             discovered_participant_data.dds_participant_data.key.value,
                         );
-                        self.add_discovered_participant(&discovered_participant_data, runtime);
+                        self.add_discovered_participant(
+                            &discovered_participant_data,
+                            reception_timestamp,
+                        );
                         self.domain_participant
                             .builtin_subscriber
                             .dcps_participant_reader
@@ -653,7 +651,7 @@ impl DcpsDomainParticipant {
                         .ok();
                 }
             }
-            self.process_discovered_writers(runtime);
+            self.process_discovered_writers(reception_timestamp);
         }
 
         // 4. SEDP Subscriptions Reader
@@ -808,7 +806,7 @@ impl DcpsDomainParticipant {
                         .ok();
                 }
             }
-            self.process_discovered_readers(runtime);
+            self.process_discovered_readers(reception_timestamp);
         }
 
         // 5. TypeLookup Request Reader
@@ -835,7 +833,7 @@ impl DcpsDomainParticipant {
                 .ok()
                 .and_then(|mut d| TypeLookupRequest::create_sample(&mut d))
                 {
-                    self.handle_type_lookup_request(type_lookup_request, runtime);
+                    self.handle_type_lookup_request(type_lookup_request, reception_timestamp);
                 }
             }
         }
@@ -865,20 +863,20 @@ impl DcpsDomainParticipant {
                 .ok()
                 .and_then(|mut d| TypeLookupReply::create_sample(&mut d))
                 {
-                    if self.handle_type_lookup_reply(type_lookup_reply, runtime) {
+                    if self.handle_type_lookup_reply(type_lookup_reply, reception_timestamp) {
                         type_lookup_reply_received = true;
                     }
                 }
             }
             if type_lookup_reply_received {
-                self.process_discovered_readers(runtime);
-                self.process_discovered_writers(runtime);
+                self.process_discovered_readers(reception_timestamp);
+                self.process_discovered_writers(reception_timestamp);
             }
         }
     }
 
-    #[tracing::instrument(skip(self, data_message, runtime))]
-    pub fn handle_data(&mut self, data_message: &[u8], runtime: &impl DdsRuntime) {
+    #[tracing::instrument(skip(self, data_message))]
+    pub fn handle_data(&mut self, data_message: &[u8], now: Time) {
         if let Ok(rtps_message) = RtpsMessageRead::try_from(data_message) {
             let mut message_receiver = MessageReceiver::new(&rtps_message);
 
@@ -939,7 +937,7 @@ impl DcpsDomainParticipant {
                                     ack_nack_submessage,
                                     message_receiver.source_guid_prefix(),
                                     self.transport.message_writer.as_mut(),
-                                    &runtime.clock(),
+                                    now,
                                 )
                                 .is_some()
                             {
@@ -966,10 +964,10 @@ impl DcpsDomainParticipant {
                                 ack_nack_submessage,
                                 message_receiver.source_guid_prefix(),
                                 self.transport.message_writer.as_mut(),
-                                &runtime.clock(),
+                                now,
                             );
                         }
-                        self.process_pending_write_samples(runtime);
+                        self.process_pending_write_samples(now);
                     }
                     RtpsSubmessageReadKind::NackFrag(nack_frag_submessage) => {
                         for dw in self
@@ -1160,7 +1158,7 @@ impl DcpsDomainParticipant {
         }
     }
 
-    pub fn poke(&mut self, clock: &impl Clock) {
+    pub fn poke(&mut self, now: Time) {
         for dw in self
             .domain_participant
             .user_defined_publisher_list
@@ -1168,7 +1166,7 @@ impl DcpsDomainParticipant {
             .flat_map(|p| p.data_writer_list.iter_mut())
         {
             dw.transport_writer
-                .write_message(self.transport.message_writer.as_mut(), clock);
+                .write_message(self.transport.message_writer.as_mut(), now);
         }
         for dw in self
             .domain_participant
@@ -1176,7 +1174,7 @@ impl DcpsDomainParticipant {
             .stateful_data_writer_list_mut()
         {
             dw.transport_writer
-                .write_message(self.transport.message_writer.as_mut(), clock);
+                .write_message(self.transport.message_writer.as_mut(), now);
         }
         self.domain_participant
             .builtin_publisher

--- a/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
@@ -1,6 +1,6 @@
 use crate::{
     dcps::xtypes_glue::key_and_instance_handle::{
-        KeyHolderData, get_instance_handle_from_key_holder_data,
+        KeyHolderData, KeyHolderType, get_instance_handle_from_key_holder_data,
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -43,6 +43,7 @@ pub struct DataWriterEntity<T> {
     pub last_change_sequence_number: i64,
     pub qos: DataWriterQos,
     pub registered_instance_info: Vec<RegisteredInstanceInfo>,
+    pub key_holder_type: KeyHolderType,
 }
 
 impl<T: RtpsWriter> DataWriterEntity<T> {
@@ -51,6 +52,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
         transport_writer: T,
         topic_name: Arc<str>,
         qos: DataWriterQos,
+        key_holder_type: KeyHolderType,
     ) -> Self {
         Self {
             instance_handle,
@@ -60,6 +62,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             last_change_sequence_number: 0,
             qos,
             registered_instance_info: Vec::new(),
+            key_holder_type,
         }
     }
 
@@ -171,8 +174,8 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             return Err(DdsError::NotEnabled);
         }
 
-        let mut member_list = Vec::new();
-        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)?;
+        let key_holder_type = KeyHolderType::new(&dynamic_data.r#type());
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &key_holder_type)?;
 
         if TopicKind::from(type_support) == TopicKind::NoKey {
             return Err(DdsError::IllegalOperation);
@@ -217,8 +220,8 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             return Err(DdsError::NotEnabled);
         }
 
-        let mut member_list = Vec::new();
-        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)?;
+        let key_holder_type = KeyHolderType::new(&dynamic_data.r#type());
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &key_holder_type)?;
 
         if TopicKind::from(type_support) == TopicKind::NoKey {
             return Err(DdsError::IllegalOperation);
@@ -255,8 +258,8 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             return Err(DdsError::NotEnabled);
         }
 
-        let mut member_list = Vec::new();
-        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)?;
+        let key_holder_type = KeyHolderType::new(&dynamic_data.r#type());
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &key_holder_type)?;
 
         if TopicKind::from(type_support) == TopicKind::NoKey {
             return Err(DdsError::IllegalOperation);

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -2424,7 +2424,10 @@ impl DcpsDomainParticipant {
 
     pub fn request_topic_type_representation(&mut self, runtime: &impl DdsRuntime) {
         if self.domain_participant.discovered_topic_list.is_empty()
-            || self.domain_participant.locally_created_topic_list.is_empty()
+            || self
+                .domain_participant
+                .locally_created_topic_list
+                .is_empty()
         {
             return;
         }

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -2423,6 +2423,11 @@ impl DcpsDomainParticipant {
     }
 
     pub fn request_topic_type_representation(&mut self, runtime: &impl DdsRuntime) {
+        if self.domain_participant.discovered_topic_list.is_empty()
+            || self.domain_participant.locally_created_topic_list.is_empty()
+        {
+            return;
+        }
         for topic in &self.domain_participant.locally_created_topic_list {
             for discovered_topic in self
                 .domain_participant

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -64,7 +64,6 @@ use crate::{
         time::{Duration, DurationKind, Time},
     },
     rtps::types::{PROTOCOLVERSION, VENDOR_ID_S2E},
-    runtime::{Clock, DdsRuntime},
     transport::{
         self,
         types::{DurabilityKind, ENTITYID_UNKNOWN, Guid, GuidPrefix, ReliabilityKind},
@@ -85,18 +84,18 @@ use alloc::{
 use regex::Regex;
 
 impl DcpsDomainParticipant {
-    pub fn announce_participant_if_needed(&mut self, runtime: &impl DdsRuntime, now: Time) {
+    pub fn announce_participant_if_needed(&mut self, now: Time) {
         if let Some(time_until) = self.time_until_participant_announcement(now) {
             if time_until == Duration::new(0, 0) {
-                self.announce_participant(runtime);
+                self.announce_participant(now);
             }
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn announce_participant(&mut self, runtime: &impl DdsRuntime) {
+    #[tracing::instrument(skip(self))]
+    pub fn announce_participant(&mut self, now: Time) {
         if self.domain_participant.enabled {
-            self.domain_participant.last_announcement_timestamp = Some(runtime.clock().now());
+            self.domain_participant.last_announcement_timestamp = Some(now);
             let builtin_topic_key = *self.domain_participant.instance_handle.as_ref();
             let guid = Guid::from(builtin_topic_key);
             let participant_builtin_topic_data = ParticipantBuiltinTopicData {
@@ -146,7 +145,7 @@ impl DcpsDomainParticipant {
                     .domain_participant
                     .builtin_publisher
                     .dcps_participant_writer;
-                let timestamp = runtime.clock().now();
+                let timestamp = now;
                 let sample_instance_handle = self.domain_participant.instance_handle;
                 let serialized_data = spdp_discovered_participant_data.into_bytes();
                 let sample_timestamp = timestamp;
@@ -162,10 +161,10 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn announce_deleted_participant(&mut self, runtime: &impl DdsRuntime) {
+    #[tracing::instrument(skip(self))]
+    pub fn announce_deleted_participant(&mut self, now: Time) {
         if self.domain_participant.enabled {
-            let timestamp = runtime.clock().now();
+            let timestamp = now;
 
             let dw = &mut self
                 .domain_participant
@@ -467,12 +466,12 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn announce_data_writer(
         &mut self,
         publisher_handle: &InstanceHandle,
         data_writer_handle: &InstanceHandle,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) {
         let Some(publisher) = self
             .domain_participant
@@ -546,7 +545,6 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .builtin_publisher
                 .dcps_publications_writer;
-            let now = runtime.clock().now();
             let sample_instance_handle = data_writer.transport_writer.guid().into();
             let serialized_data = discovered_writer_data.into_bytes();
             let sample_timestamp = now;
@@ -560,13 +558,13 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, data_writer, runtime))]
+    #[tracing::instrument(skip(self, data_writer))]
     pub(super) fn announce_deleted_data_writer(
         &mut self,
         data_writer: UserDefinedDataWriter,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) {
-        let timestamp = runtime.clock().now();
+        let timestamp = now;
         {
             let dw = &mut self
                 .domain_participant
@@ -584,12 +582,12 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn announce_data_reader(
         &mut self,
         subscriber_handle: &InstanceHandle,
         data_reader_handle: &InstanceHandle,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) {
         let Some(subscriber) = self
             .domain_participant
@@ -683,7 +681,6 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .builtin_publisher
                 .dcps_subscriptions_writer;
-            let now = runtime.clock().now();
             let sample_instance_handle = data_reader.transport_reader.guid().into();
             let serialized_data = discovered_reader_data.into_bytes();
             let sample_timestamp = now;
@@ -697,13 +694,13 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, data_reader, runtime))]
+    #[tracing::instrument(skip(self, data_reader))]
     pub(super) fn announce_deleted_data_reader(
         &mut self,
         data_reader: UserDefinedDataReader,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) {
-        let timestamp = runtime.clock().now();
+        let timestamp = now;
         {
             let dw = &mut self
                 .domain_participant
@@ -721,8 +718,8 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn announce_topic(&mut self, topic_name: String, runtime: &impl DdsRuntime) {
+    #[tracing::instrument(skip(self))]
+    pub fn announce_topic(&mut self, topic_name: String, now: Time) {
         let Some(topic) = self
             .domain_participant
             .locally_created_topic_list
@@ -764,7 +761,6 @@ impl DcpsDomainParticipant {
             let dw = &mut self.domain_participant.builtin_publisher.dcps_topics_writer;
             let sample_instance_handle = topic.instance_handle;
             let serialized_data = discovered_topic_data.into_bytes();
-            let now = runtime.clock().now();
             let sample_timestamp = now;
             dw.write_w_timestamp(
                 sample_instance_handle,
@@ -776,8 +772,8 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn process_discovered_readers(&mut self, runtime: &impl DdsRuntime) {
+    #[tracing::instrument(skip(self))]
+    pub fn process_discovered_readers(&mut self, now: Time) {
         if self.domain_participant.discovered_reader_list.is_empty()
             || self
                 .domain_participant
@@ -962,7 +958,6 @@ impl DcpsDomainParticipant {
                                                 &type_lookup_request.create_dynamic_sample(),
                                             )
                                             .unwrap();
-                                            let now = runtime.clock().now();
                                             type_request_writer
                                                 .write_w_timestamp(
                                                     sample_instance_handle,
@@ -1006,7 +1001,6 @@ impl DcpsDomainParticipant {
                                             &type_lookup_request.create_dynamic_sample(),
                                         )
                                         .unwrap();
-                                        let now = runtime.clock().now();
                                         type_request_writer
                                             .write_w_timestamp(
                                                 sample_instance_handle,
@@ -1414,8 +1408,8 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn process_discovered_writers(&mut self, runtime: &impl DdsRuntime) {
+    #[tracing::instrument(skip(self))]
+    pub fn process_discovered_writers(&mut self, now: Time) {
         if self.domain_participant.discovered_writer_list.is_empty()
             || self
                 .domain_participant
@@ -1622,7 +1616,6 @@ impl DcpsDomainParticipant {
                                                 &type_lookup_request.create_dynamic_sample(),
                                             )
                                             .unwrap();
-                                            let now = runtime.clock().now();
                                             type_request_writer
                                                 .write_w_timestamp(
                                                     sample_instance_handle,
@@ -1666,7 +1659,6 @@ impl DcpsDomainParticipant {
                                             &type_lookup_request.create_dynamic_sample(),
                                         )
                                         .unwrap();
-                                        let now = runtime.clock().now();
                                         type_request_writer
                                             .write_w_timestamp(
                                                 sample_instance_handle,
@@ -2024,7 +2016,7 @@ impl DcpsDomainParticipant {
     pub fn handle_type_lookup_request(
         &mut self,
         type_lookup_request: TypeLookupRequest,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) {
         match type_lookup_request.call {
             TypeLookupCall::TypeLookupGetTypesHashId { get_types } => {
@@ -2063,7 +2055,6 @@ impl DcpsDomainParticipant {
                     let serialized_data =
                         serialize_cdr2_le(&type_lookup_reply.create_dynamic_sample()).unwrap();
 
-                    let now = runtime.clock().now();
                     type_lookup_reply_writer
                         .write_w_timestamp(InstanceHandle::default(), serialized_data, now, now)
                         .ok();
@@ -2099,7 +2090,6 @@ impl DcpsDomainParticipant {
                         let serialized_data =
                             serialize_cdr2_le(&type_lookup_reply.create_dynamic_sample()).unwrap();
 
-                        let now = runtime.clock().now();
                         type_lookup_reply_writer
                             .write_w_timestamp(InstanceHandle::default(), serialized_data, now, now)
                             .ok();
@@ -2112,7 +2102,7 @@ impl DcpsDomainParticipant {
     pub fn handle_type_lookup_reply(
         &mut self,
         type_lookup_reply: TypeLookupReply,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) -> bool {
         let mut type_lookup_reply_received = false;
         match &type_lookup_reply.r#return {
@@ -2171,7 +2161,6 @@ impl DcpsDomainParticipant {
                         let serialized_data =
                             serialize_cdr2_le(&type_lookup_request.create_dynamic_sample())
                                 .unwrap();
-                        let now = runtime.clock().now();
                         type_request_writer
                             .write_w_timestamp(sample_instance_handle, serialized_data, now, now)
                             .ok();
@@ -2422,7 +2411,7 @@ impl DcpsDomainParticipant {
         type_lookup_reply_received
     }
 
-    pub fn request_topic_type_representation(&mut self, runtime: &impl DdsRuntime) {
+    pub fn request_topic_type_representation(&mut self, now: Time) {
         if self.domain_participant.discovered_topic_list.is_empty()
             || self
                 .domain_participant
@@ -2487,7 +2476,6 @@ impl DcpsDomainParticipant {
                                 let serialized_data =
                                     serialize_cdr2_le(&type_lookup_request.create_dynamic_sample())
                                         .unwrap();
-                                let now = runtime.clock().now();
                                 type_request_writer
                                     .write_w_timestamp(
                                         sample_instance_handle,
@@ -2534,7 +2522,6 @@ impl DcpsDomainParticipant {
                             let serialized_data =
                                 serialize_cdr2_le(&type_lookup_request.create_dynamic_sample())
                                     .unwrap();
-                            let now = runtime.clock().now();
                             type_request_writer
                                 .write_w_timestamp(
                                     sample_instance_handle,
@@ -2553,11 +2540,11 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub(crate) fn add_discovered_participant(
         &mut self,
         discovered_participant_data: &SpdpDiscoveredParticipantData,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) {
         // Check that the domainId of the discovered participant equals the local one.
         // If it is not equal then there the local endpoints are not configured to
@@ -2605,7 +2592,7 @@ impl DcpsDomainParticipant {
             self.add_matched_service_reply_data_reader(discovered_participant_data);
             self.add_matched_service_reply_data_writer(discovered_participant_data);
 
-            self.announce_participant(runtime);
+            self.announce_participant(now);
 
             let discovered_participant_info = DiscoveredParticipantInfo {
                 dds_participant_data: discovered_participant_data.dds_participant_data.clone(),
@@ -2619,7 +2606,7 @@ impl DcpsDomainParticipant {
                     .default_multicast_locator_list
                     .clone(),
                 lease_duration: discovered_participant_data.lease_duration,
-                last_communication_timestamp: runtime.clock().now(),
+                last_communication_timestamp: now,
             };
             match self
                 .domain_participant
@@ -3194,12 +3181,8 @@ impl DcpsDomainParticipant {
         dr.transport_reader.delete_matched_writer(guid);
     }
 
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn _request_type_lookup(
-        &mut self,
-        type_ids: Vec<TypeIdentifier>,
-        runtime: &impl DdsRuntime,
-    ) {
+    #[tracing::instrument(skip(self))]
+    pub fn _request_type_lookup(&mut self, type_ids: Vec<TypeIdentifier>, now: Time) {
         {
             let w = &mut self
                 .domain_participant
@@ -3219,7 +3202,7 @@ impl DcpsDomainParticipant {
             }
             .create_dynamic_sample();
 
-            let timestamp = runtime.clock().now();
+            let timestamp = now;
             let sample_instance_handle = self.domain_participant.instance_handle;
             let serialized_data = serialize_cdr2_le(&dynamic_data).unwrap();
             let sample_timestamp = timestamp;

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -28,6 +28,7 @@ use crate::{
         error::DdsResult,
         instance::InstanceHandle,
         qos::{DomainParticipantQos, PublisherQos, SubscriberQos, TopicQos},
+        qos_policy::ReliabilityQosPolicyKind,
         time::{Duration, DurationKind, Time},
     },
     transport::{
@@ -212,8 +213,12 @@ impl DcpsDomainParticipant {
                     }
                 }
 
-                if let Some(hb_time) = data_writer.transport_writer.time_until_next_heartbeat(now) {
-                    min_time = min_time.map_or(Some(hb_time), |m| Some(m.min(hb_time)));
+                if data_writer.qos.reliability.kind == ReliabilityQosPolicyKind::Reliable {
+                    if let Some(hb_time) =
+                        data_writer.transport_writer.time_until_next_heartbeat(now)
+                    {
+                        min_time = min_time.map_or(Some(hb_time), |m| Some(m.min(hb_time)));
+                    }
                 }
             }
         }

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -525,13 +525,18 @@ mod tests {
 
     #[test]
     fn test_time_until_participant_announcement() {
-        struct MockWriter;
+        struct MockWriter {
+            buffer: [u8; 512],
+        }
         impl crate::transport::interface::WriteMessage for MockWriter {
-            fn write_message(&self, _buf: &[u8], _locators: &[Locator]) {}
+            fn write_buffer_mut(&mut self) -> &mut [u8] {
+                &mut self.buffer
+            }
+            fn write_message(&mut self, _len: usize, _locators: &[Locator]) {}
         }
 
         let transport = RtpsTransportParticipant {
-            message_writer: Box::new(MockWriter),
+            message_writer: Box::new(MockWriter { buffer: [0; 512] }),
             default_unicast_locator_list: Vec::new(),
             metatraffic_unicast_locator_list: Vec::new(),
             metatraffic_multicast_locator_list: Vec::new(),

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -31,7 +31,7 @@ use crate::{
         qos::{DomainParticipantQos, PublisherQos, QosKind, SubscriberQos, TopicQos},
         time::{Duration, Time},
     },
-    runtime::{Clock, DdsRuntime},
+    runtime::DdsRuntime,
     transport::types::{USER_DEFINED_READER_GROUP, USER_DEFINED_TOPIC, USER_DEFINED_WRITER_GROUP},
     xtypes::dynamic_type::DynamicType,
 };
@@ -229,6 +229,7 @@ impl DcpsDomainParticipant {
         listener_mask: StatusMask,
         type_support: DynamicType<'static>,
         runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<InstanceHandle> {
         if BUILT_IN_TOPIC_NAME_LIST.contains(&topic_name.as_str()) {
             return Err(DdsError::BadParameter);
@@ -298,7 +299,7 @@ impl DcpsDomainParticipant {
                 .entity_factory
                 .autoenable_created_entities
         {
-            self.enable_topic(topic_name, runtime)?;
+            self.enable_topic(topic_name, now)?;
         }
 
         Ok(topic_handle)
@@ -510,11 +511,8 @@ impl DcpsDomainParticipant {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn delete_participant_contained_entities(
-        &mut self,
-        runtime: &impl DdsRuntime,
-    ) -> DdsResult<()> {
+    #[tracing::instrument(skip(self))]
+    pub fn delete_participant_contained_entities(&mut self, now: Time) -> DdsResult<()> {
         let deleted_publisher_list: Vec<PublisherEntity> = self
             .domain_participant
             .user_defined_publisher_list
@@ -522,7 +520,7 @@ impl DcpsDomainParticipant {
             .collect();
         for mut publisher in deleted_publisher_list {
             for data_writer in publisher.data_writer_list.drain(..) {
-                self.announce_deleted_data_writer(data_writer, runtime);
+                self.announce_deleted_data_writer(data_writer, now);
             }
         }
 
@@ -533,7 +531,7 @@ impl DcpsDomainParticipant {
             .collect();
         for mut subscriber in deleted_subscriber_list {
             for data_reader in subscriber.data_reader_list.drain(..) {
-                self.announce_deleted_data_reader(data_reader, runtime);
+                self.announce_deleted_data_reader(data_reader, now);
             }
         }
 
@@ -653,11 +651,11 @@ impl DcpsDomainParticipant {
         Ok(handle.clone())
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn set_domain_participant_qos(
         &mut self,
         qos: QosKind<DomainParticipantQos>,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<()> {
         let qos = match qos {
             QosKind::Default => DomainParticipantQos::default(),
@@ -666,7 +664,7 @@ impl DcpsDomainParticipant {
 
         self.domain_participant.qos = qos;
         if self.domain_participant.enabled {
-            self.announce_participant(runtime);
+            self.announce_participant(now);
         }
         Ok(())
     }
@@ -690,8 +688,8 @@ impl DcpsDomainParticipant {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn enable_domain_participant(&mut self, runtime: &impl DdsRuntime) -> DdsResult<()> {
+    #[tracing::instrument(skip(self))]
+    pub fn enable_domain_participant(&mut self, now: Time) -> DdsResult<()> {
         if !self.domain_participant.enabled {
             for t in &mut self.domain_participant.locally_created_topic_list {
                 t.enabled = true;
@@ -701,7 +699,7 @@ impl DcpsDomainParticipant {
             self.domain_participant.builtin_subscriber.enable();
             self.domain_participant.enabled = true;
 
-            self.announce_participant(runtime);
+            self.announce_participant(now);
         }
 
         Ok(())
@@ -710,9 +708,5 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self))]
     pub fn is_participant_empty(&mut self) -> bool {
         self.domain_participant.is_empty()
-    }
-
-    pub fn get_current_time(&self, runtime: &impl DdsRuntime) -> Time {
-        runtime.clock().now()
     }
 }

--- a/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
@@ -109,6 +109,16 @@ impl DcpsDomainParticipant {
             Guid::new(guid.prefix(), entity_id),
             self.transport.fragment_size,
         );
+        let key_holder_type = super::topic_entity::get_topic_type_support(
+            &topic.topic_name,
+            &self.domain_participant.content_filtered_topic_list,
+            &self.domain_participant.locally_created_topic_list,
+            &self.domain_participant.type_register,
+        )
+        .as_ref()
+        .map(crate::dcps::xtypes_glue::key_and_instance_handle::KeyHolderType::new)
+        .unwrap_or_default();
+
         let listener_sender = dcps_listener.map(|l| l.spawn(&runtime.spawner()));
         let data_writer = UserDefinedDataWriter::new(
             writer_handle,
@@ -117,6 +127,7 @@ impl DcpsDomainParticipant {
             listener_sender,
             listener_mask,
             qos,
+            key_holder_type,
         );
         let data_writer_handle = data_writer.instance_handle;
 

--- a/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/publisher_methods.rs
@@ -15,6 +15,7 @@ use crate::{
         error::{DdsError, DdsResult},
         instance::InstanceHandle,
         qos::{DataWriterQos, PublisherQos, QosKind},
+        time::Time,
     },
     rtps::stateful_writer::RtpsStatefulWriter,
     runtime::DdsRuntime,
@@ -34,6 +35,7 @@ impl DcpsDomainParticipant {
         dcps_listener: Option<DcpsDataWriterListener>,
         listener_mask: StatusMask,
         runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<InstanceHandle> {
         let Some(topic) = self
             .domain_participant
@@ -134,18 +136,18 @@ impl DcpsDomainParticipant {
         publisher.data_writer_list.push(data_writer);
 
         if publisher.enabled && publisher.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_writer(publisher_handle, &writer_handle, runtime)?;
+            self.enable_data_writer(publisher_handle, &writer_handle, now)?;
         }
 
         Ok(data_writer_handle)
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn delete_data_writer(
         &mut self,
         publisher_handle: &InstanceHandle,
         datawriter_handle: &InstanceHandle,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -162,7 +164,7 @@ impl DcpsDomainParticipant {
             .position(|x| &x.instance_handle == datawriter_handle)
         {
             let data_writer = publisher.data_writer_list.remove(index);
-            self.announce_deleted_data_writer(data_writer, runtime);
+            self.announce_deleted_data_writer(data_writer, now);
             Ok(())
         } else {
             Err(DdsError::AlreadyDeleted)

--- a/dds/src/dcps/dcps_domain_participant/reader_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/reader_methods.rs
@@ -35,12 +35,12 @@ use crate::{
     },
 };
 
-pub fn deserialize_topic_type<'a>(
+pub fn deserialize_topic_type(
     topic_name: &str,
-    type_support: DynamicType<'a>,
+    type_support: DynamicType<'static>,
     data: &[u8],
-) -> Option<DynamicData<'a>> {
-    let mut dynamic_data = match topic_name {
+) -> Option<DynamicData<'static>> {
+    match topic_name {
         DCPS_PARTICIPANT => SpdpDiscoveredParticipantData::from_bytes(data)
             .map(|x| x.dds_participant_data.create_dynamic_sample())
             .ok(),
@@ -54,13 +54,7 @@ pub fn deserialize_topic_type<'a>(
             .map(|x| x.topic_builtin_topic_data.create_dynamic_sample())
             .ok(),
         _ => deserialize_top_level_type(type_support, data).ok(),
-    };
-    if let Some(dynamic_data) = dynamic_data.as_mut() {
-        if !dynamic_data.validate_dynamic_data() {
-            return None;
-        }
     }
-    dynamic_data
 }
 
 impl DcpsDomainParticipant {
@@ -87,7 +81,7 @@ impl DcpsDomainParticipant {
                         instance_states,
                         specific_instance_handle,
                     )?;
-                    (sample_list, bs.dcps_participant_reader.topic_name.clone())
+                    (sample_list, bs.dcps_participant_reader.topic_name.as_ref())
                 } else if let Some(dr) = bs.find_stateful_data_reader_mut(data_reader_handle) {
                     let sample_list = dr.read(
                         max_samples,
@@ -96,7 +90,7 @@ impl DcpsDomainParticipant {
                         instance_states,
                         specific_instance_handle,
                     )?;
-                    (sample_list, dr.topic_name.clone())
+                    (sample_list, dr.topic_name.as_ref())
                 } else {
                     return Err(DdsError::AlreadyDeleted);
                 }
@@ -123,11 +117,11 @@ impl DcpsDomainParticipant {
                     instance_states,
                     specific_instance_handle,
                 )?;
-                (sample_list, data_reader.topic_name.clone())
+                (sample_list, data_reader.topic_name.as_ref())
             };
 
         let Some(type_support) = get_topic_type_support(
-            &topic_name,
+            topic_name,
             &self.domain_participant.content_filtered_topic_list,
             &self.domain_participant.locally_created_topic_list,
             &self.domain_participant.type_register,
@@ -140,7 +134,7 @@ impl DcpsDomainParticipant {
             .map(|(data, info)| {
                 (
                     if info.valid_data {
-                        deserialize_topic_type(&topic_name, type_support, data.as_ref())
+                        deserialize_topic_type(topic_name, type_support, data.as_ref())
                     } else {
                         None
                     },

--- a/dds/src/dcps/dcps_domain_participant/reader_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/reader_methods.rs
@@ -26,6 +26,7 @@ use crate::{
         qos_policy::DurabilityQosPolicyKind,
         sample_info::{InstanceStateKind, SampleInfo, SampleStateKind, ViewStateKind},
         status::{StatusKind, SubscriptionMatchedStatus},
+        time::Time,
     },
     runtime::DdsRuntime,
     xtypes::{
@@ -408,13 +409,13 @@ impl DcpsDomainParticipant {
         Ok(data_reader.get_matched_publications())
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn set_data_reader_qos(
         &mut self,
         subscriber_handle: &InstanceHandle,
         data_reader_handle: &InstanceHandle,
         qos: QosKind<DataReaderQos>,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -444,7 +445,7 @@ impl DcpsDomainParticipant {
         data_reader.qos = qos;
 
         if data_reader.enabled {
-            self.announce_data_reader(subscriber_handle, data_reader_handle, runtime);
+            self.announce_data_reader(subscriber_handle, data_reader_handle, now);
         }
         Ok(())
     }
@@ -549,12 +550,12 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn enable_data_reader(
         &mut self,
         subscriber_handle: &InstanceHandle,
         data_reader_handle: &InstanceHandle,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -574,8 +575,8 @@ impl DcpsDomainParticipant {
         if !data_reader.enabled {
             data_reader.enabled = true;
 
-            self.announce_data_reader(subscriber_handle, data_reader_handle, runtime);
-            self.process_discovered_writers(runtime);
+            self.announce_data_reader(subscriber_handle, data_reader_handle, now);
+            self.process_discovered_writers(now);
         }
         Ok(())
     }

--- a/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/subscriber_methods.rs
@@ -19,6 +19,7 @@ use crate::{
         instance::InstanceHandle,
         qos::{DataReaderQos, QosKind, SubscriberQos},
         qos_policy::ReliabilityQosPolicyKind,
+        time::Time,
     },
     rtps::stateful_reader::RtpsStatefulReader,
     runtime::DdsRuntime,
@@ -39,6 +40,7 @@ impl DcpsDomainParticipant {
         dcps_listener: Option<DcpsDataReaderListener>,
         listener_mask: StatusMask,
         runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<InstanceHandle> {
         let topic = if let Some(content_filtered_topic) = self
             .domain_participant
@@ -149,17 +151,17 @@ impl DcpsDomainParticipant {
         subscriber.data_reader_list.push(data_reader);
 
         if subscriber.enabled && subscriber.qos.entity_factory.autoenable_created_entities {
-            self.enable_data_reader(subscriber_handle, &data_reader_handle, runtime)?;
+            self.enable_data_reader(subscriber_handle, &data_reader_handle, now)?;
         }
         Ok(data_reader_handle)
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn delete_data_reader(
         &mut self,
         subscriber_handle: &InstanceHandle,
         datareader_handle: &InstanceHandle,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<()> {
         let Some(subscriber) = self
             .domain_participant
@@ -176,7 +178,7 @@ impl DcpsDomainParticipant {
             .position(|x| &x.instance_handle == datareader_handle)
         {
             let data_reader = subscriber.data_reader_list.remove(index);
-            self.announce_deleted_data_reader(data_reader, runtime);
+            self.announce_deleted_data_reader(data_reader, now);
         } else {
             return Err(DdsError::AlreadyDeleted);
         };

--- a/dds/src/dcps/dcps_domain_participant/topic_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/topic_methods.rs
@@ -6,8 +6,8 @@ use crate::{
         error::{DdsError, DdsResult},
         qos::{QosKind, TopicQos},
         status::{InconsistentTopicStatus, StatusKind},
+        time::Time,
     },
-    runtime::DdsRuntime,
     xtypes::dynamic_type::DynamicType,
 };
 
@@ -85,8 +85,8 @@ impl DcpsDomainParticipant {
         Ok(topic.qos.clone())
     }
 
-    #[tracing::instrument(skip(self, runtime))]
-    pub fn enable_topic(&mut self, topic_name: String, runtime: &impl DdsRuntime) -> DdsResult<()> {
+    #[tracing::instrument(skip(self))]
+    pub fn enable_topic(&mut self, topic_name: String, now: Time) -> DdsResult<()> {
         let Some(topic) = self
             .domain_participant
             .locally_created_topic_list
@@ -98,7 +98,7 @@ impl DcpsDomainParticipant {
 
         if !topic.enabled {
             topic.enabled = true;
-            self.announce_topic(topic_name, runtime);
+            self.announce_topic(topic_name, now);
         }
 
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/user_defined_data_writer.rs
+++ b/dds/src/dcps/dcps_domain_participant/user_defined_data_writer.rs
@@ -8,6 +8,7 @@ use crate::{
         listeners::domain_participant_listener::ListenerMail,
         status_condition::DcpsStatusCondition,
         status_mask::StatusMask,
+        xtypes_glue::key_and_instance_handle::KeyHolderType,
     },
     infrastructure::{
         error::DdsResult,
@@ -69,9 +70,16 @@ impl UserDefinedDataWriter {
         listener_sender: Option<MpscSender<ListenerMail>>,
         listener_mask: StatusMask,
         qos: DataWriterQos,
+        key_holder_type: KeyHolderType,
     ) -> Self {
         Self {
-            writer: DataWriterEntity::new(instance_handle, transport_writer, topic_name, qos),
+            writer: DataWriterEntity::new(
+                instance_handle,
+                transport_writer,
+                topic_name,
+                qos,
+                key_holder_type,
+            ),
             listener_sender,
             listener_mask,
             status_condition: DcpsStatusCondition::default(),

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -20,7 +20,7 @@ use crate::{
         status::{OfferedDeadlineMissedStatus, PublicationMatchedStatus, StatusKind},
         time::{DurationKind, Time},
     },
-    runtime::{Clock, DdsRuntime},
+    runtime::DdsRuntime,
     xtypes::dynamic_type::DynamicData,
 };
 
@@ -291,17 +291,16 @@ impl DcpsDomainParticipant {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip(self, reply_sender, runtime))]
+    #[tracing::instrument(skip(self, reply_sender))]
     pub fn write_w_timestamp(
         &mut self,
         publisher_handle: &InstanceHandle,
         data_writer_handle: &InstanceHandle,
         dynamic_data: &DynamicData<'static>,
         timestamp: Time,
-        runtime: &impl DdsRuntime,
+        now: Time,
         reply_sender: OneshotSender<DdsResult<()>>,
     ) {
-        let now = runtime.clock().now();
         let Some(publisher) = self
             .domain_participant
             .user_defined_publisher_list
@@ -469,12 +468,12 @@ impl DcpsDomainParticipant {
         Ok(data_writer.get_offered_deadline_missed_status())
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn enable_data_writer(
         &mut self,
         publisher_handle: &InstanceHandle,
         data_writer_handle: &InstanceHandle,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -494,19 +493,19 @@ impl DcpsDomainParticipant {
         if !data_writer.enabled {
             data_writer.enabled = true;
 
-            self.announce_data_writer(publisher_handle, data_writer_handle, runtime);
-            self.process_discovered_readers(runtime);
+            self.announce_data_writer(publisher_handle, data_writer_handle, now);
+            self.process_discovered_readers(now);
         }
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, runtime))]
+    #[tracing::instrument(skip(self))]
     pub fn set_data_writer_qos(
         &mut self,
         publisher_handle: &InstanceHandle,
         data_writer_handle: &InstanceHandle,
         qos: QosKind<DataWriterQos>,
-        runtime: &impl DdsRuntime,
+        now: Time,
     ) -> DdsResult<()> {
         let Some(publisher) = self
             .domain_participant
@@ -535,7 +534,7 @@ impl DcpsDomainParticipant {
         data_writer.qos = qos;
 
         if data_writer.enabled {
-            self.announce_data_writer(publisher_handle, data_writer_handle, runtime);
+            self.announce_data_writer(publisher_handle, data_writer_handle, now);
         }
         Ok(())
     }
@@ -579,8 +578,7 @@ impl DcpsDomainParticipant {
         }
     }
 
-    pub fn process_pending_write_samples(&mut self, runtime: &impl DdsRuntime) {
-        let now = runtime.clock().now();
+    pub fn process_pending_write_samples(&mut self, now: Time) {
         for publisher in &mut self.domain_participant.user_defined_publisher_list {
             for data_writer in &mut publisher.data_writer_list {
                 if let Some(pending) = &data_writer.pending_write_sample {

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -10,9 +10,7 @@ use crate::{
         },
         listeners::data_writer_listener::DcpsDataWriterListener,
         status_mask::StatusMask,
-        xtypes_glue::key_and_instance_handle::{
-            KeyHolderData, get_instance_handle_from_key_holder_data,
-        },
+        xtypes_glue::key_and_instance_handle::get_instance_handle_from_dynamic_data_and_key_holder,
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -275,15 +273,10 @@ impl DcpsDomainParticipant {
             return Err(DdsError::NotEnabled);
         }
 
-        let mut member_list = Vec::new();
-        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)
-        {
-            Ok(k) => k,
-            Err(e) => {
-                return Err(e.into());
-            }
-        };
-        let instance_handle = match get_instance_handle_from_key_holder_data(&key_holder_data) {
+        let instance_handle = match get_instance_handle_from_dynamic_data_and_key_holder(
+            dynamic_data,
+            &data_writer.key_holder_type,
+        ) {
             Ok(k) => k,
             Err(e) => {
                 return Err(e.into());
@@ -340,16 +333,10 @@ impl DcpsDomainParticipant {
             }
         };
 
-        let mut member_list = Vec::new();
-        let key_holder_data = match KeyHolderData::from_dynamic_data(dynamic_data, &mut member_list)
-        {
-            Ok(h) => h,
-            Err(e) => {
-                reply_sender.send(Err(e.into()));
-                return;
-            }
-        };
-        let instance_handle = match get_instance_handle_from_key_holder_data(&key_holder_data) {
+        let instance_handle = match get_instance_handle_from_dynamic_data_and_key_holder(
+            dynamic_data,
+            &data_writer.key_holder_type,
+        ) {
             Ok(h) => h,
             Err(e) => {
                 reply_sender.send(Err(e.into()));
@@ -600,15 +587,10 @@ impl DcpsDomainParticipant {
                     if !data_writer.enabled {
                         continue;
                     }
-                    let mut member_list = Vec::new();
-                    let Ok(key_holder_data) =
-                        KeyHolderData::from_dynamic_data(&pending.dynamic_data, &mut member_list)
-                    else {
-                        continue;
-                    };
-                    let Ok(instance_handle) =
-                        get_instance_handle_from_key_holder_data(&key_holder_data)
-                    else {
+                    let Ok(instance_handle) = get_instance_handle_from_dynamic_data_and_key_holder(
+                        &pending.dynamic_data,
+                        &data_writer.key_holder_type,
+                    ) else {
                         continue;
                     };
 

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -7,12 +7,12 @@ use crate::{
         },
         dcps_participant_factory::DcpsParticipantFactory,
     },
-    infrastructure::error::DdsError,
-    runtime::{Clock, DdsRuntime},
+    infrastructure::{error::DdsError, time::Time},
+    runtime::DdsRuntime,
 };
 
 impl<R: DdsRuntime> DcpsParticipantFactory<R> {
-    pub fn handle(&mut self, message: DcpsMail) {
+    pub fn handle(&mut self, message: DcpsMail, now: Time) {
         match message {
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::CreateParticipant {
                 guid_prefix,
@@ -35,11 +35,12 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 domain_tag,
                 participant_announcement_interval,
                 enable_type_information,
+                now,
             )),
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::DeleteParticipant {
                 participant_handle,
                 reply_sender,
-            }) => reply_sender.send(self.delete_participant(&participant_handle)),
+            }) => reply_sender.send(self.delete_participant(&participant_handle, now)),
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::SetDefaultParticipantQos {
                 qos,
                 reply_sender,
@@ -141,6 +142,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     listener_mask,
                     type_support,
                     &self.runtime,
+                    now,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -185,13 +187,10 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 type_support,
                 timeout,
                 reply_sender,
-            }) => {
-                let now = self.runtime.clock().now();
-                match self.find_participant(&participant_handle) {
-                    Ok(p) => p.find_topic(topic_name, type_support, timeout, now, reply_sender),
-                    Err(e) => reply_sender.send(Err(e)),
-                }
-            }
+            }) => match self.find_participant(&participant_handle) {
+                Ok(p) => p.find_topic(topic_name, type_support, timeout, now, reply_sender),
+                Err(e) => reply_sender.send(Err(e)),
+            },
 
             DcpsMail::Participant(ParticipantServiceMail::LookupTopicdescription {
                 participant_handle,
@@ -234,7 +233,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.delete_participant_contained_entities(&self.runtime)),
+                Ok(p) => reply_sender.send(p.delete_participant_contained_entities(now)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::SetDefaultPublisherQos {
@@ -290,7 +289,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
                     .ok_or(DdsError::AlreadyDeleted)
-                    .map(|_| self.runtime.clock().now()),
+                    .map(|_| now),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredParticipants {
                 participant_handle,
@@ -334,7 +333,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.set_domain_participant_qos(qos, &self.runtime)),
+                Ok(p) => reply_sender.send(p.set_domain_participant_qos(qos, now)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::GetQos {
@@ -372,7 +371,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.enable_domain_participant(&self.runtime)),
+                Ok(p) => reply_sender.send(p.enable_domain_participant(now)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::GetInconsistentTopicStatus {
@@ -411,7 +410,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.enable_topic(topic_name, &self.runtime)),
+                Ok(p) => reply_sender.send(p.enable_topic(topic_name, now)),
                 Err(e) => reply_sender.send(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::GetTypeSupport {
@@ -443,6 +442,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     dcps_listener,
                     listener_mask,
                     &self.runtime,
+                    now,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -460,7 +460,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.delete_data_writer(
                     &publisher_handle,
                     &datawriter_handle,
-                    &self.runtime,
+                    now,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -596,7 +596,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => {
-                    let timestamp = timestamp.unwrap_or_else(|| p.get_current_time(&self.runtime));
+                    let timestamp = timestamp.unwrap_or(now);
                     reply_sender.send(p.register_instance(
                         &publisher_handle,
                         &data_writer_handle,
@@ -620,7 +620,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => {
-                    let timestamp = timestamp.unwrap_or_else(|| p.get_current_time(&self.runtime));
+                    let timestamp = timestamp.unwrap_or(now);
                     reply_sender.send(p.unregister_instance(
                         &publisher_handle,
                         &data_writer_handle,
@@ -653,13 +653,13 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => {
-                    let timestamp = timestamp.unwrap_or_else(|| p.get_current_time(&self.runtime));
+                    let timestamp = timestamp.unwrap_or(now);
                     p.write_w_timestamp(
                         &publisher_handle,
                         &data_writer_handle,
                         &dynamic_data,
                         timestamp,
-                        &self.runtime,
+                        now,
                         reply_sender,
                     );
                 }
@@ -680,7 +680,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 .ok_or(DdsError::AlreadyDeleted)
             {
                 Ok(p) => {
-                    let timestamp = timestamp.unwrap_or_else(|| p.get_current_time(&self.runtime));
+                    let timestamp = timestamp.unwrap_or(now);
                     reply_sender.send(p.dispose_w_timestamp(
                         &publisher_handle,
                         &data_writer_handle,
@@ -715,7 +715,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.enable_data_writer(
                     &publisher_handle,
                     &data_writer_handle,
-                    &self.runtime,
+                    now,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -735,7 +735,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     &publisher_handle,
                     &data_writer_handle,
                     qos,
-                    &self.runtime,
+                    now,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -760,6 +760,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     dcps_listener,
                     listener_mask,
                     &self.runtime,
+                    now,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -777,7 +778,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.delete_data_reader(
                     &subscriber_handle,
                     &datareader_handle,
-                    &self.runtime,
+                    now,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -946,7 +947,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 Ok(p) => reply_sender.send(p.enable_data_reader(
                     &subscriber_handle,
                     &data_reader_handle,
-                    &self.runtime,
+                    now,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -1009,7 +1010,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                     &subscriber_handle,
                     &data_reader_handle,
                     qos,
-                    &self.runtime,
+                    now,
                 )),
                 Err(e) => reply_sender.send(Err(e)),
             },
@@ -1088,14 +1089,14 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         }
     }
 
-    pub fn handle_wire_mail(&mut self, wire_mail: crate::dcps::dcps_mail::WireMail) {
+    pub fn handle_wire_mail(&mut self, wire_mail: crate::dcps::dcps_mail::WireMail, now: Time) {
         if let Ok(p) = self
             .domain_participant_list
             .iter_mut()
             .find(|x| x.get_instance_handle() == &wire_mail.participant_handle)
             .ok_or(DdsError::AlreadyDeleted)
         {
-            p.handle_data(wire_mail.data_message.as_slice(), &self.runtime);
+            p.handle_data(wire_mail.data_message.as_slice(), now);
         }
     }
 }

--- a/dds/src/dcps/dcps_participant_factory.rs
+++ b/dds/src/dcps/dcps_participant_factory.rs
@@ -48,6 +48,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         domain_tag: String,
         participant_announcement_interval: core::time::Duration,
         enable_type_information: bool,
+        now: Time,
     ) -> DdsResult<InstanceHandle> {
         let domain_participant_qos = match qos {
             QosKind::Default => self.default_participant_qos.clone(),
@@ -71,7 +72,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         let participant_handle = *dcps_participant.get_instance_handle();
 
         if self.qos.entity_factory.autoenable_created_entities {
-            dcps_participant.enable_domain_participant(&self.runtime)?;
+            dcps_participant.enable_domain_participant(now)?;
         }
 
         self.domain_participant_list.push(dcps_participant);
@@ -79,7 +80,11 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
         Ok(participant_handle)
     }
 
-    pub fn delete_participant(&mut self, participant_handle: &InstanceHandle) -> DdsResult<()> {
+    pub fn delete_participant(
+        &mut self,
+        participant_handle: &InstanceHandle,
+        now: Time,
+    ) -> DdsResult<()> {
         let index = self
             .domain_participant_list
             .iter()
@@ -91,8 +96,8 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             )));
         }
         let mut participant = self.domain_participant_list.remove(index);
-        participant.announce_deleted_participant(&self.runtime);
-        participant.poke(&self.runtime.clock());
+        participant.announce_deleted_participant(now);
+        participant.poke(now);
         Ok(())
     }
 

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -2,24 +2,38 @@ use crate::{
     infrastructure::instance::InstanceHandle,
     transport::types::TopicKind,
     xtypes::{
-        dynamic_type::{DynamicData, DynamicDataFactory, DynamicType, DynamicTypeMember, TypeKind},
+        dynamic_type::{
+            DynamicData, DynamicDataFactory, DynamicType, DynamicTypeMember, TypeDescriptor,
+            TypeKind,
+        },
         error::{XTypesError, XTypesResult},
         serializer::serialize_final_without_header,
     },
 };
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 
-pub struct KeyHolderType<'a>(DynamicType<'a>);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KeyHolderType {
+    descriptor: Option<TypeDescriptor>,
+    key_members: Box<[DynamicTypeMember]>,
+}
 
-impl<'a> KeyHolderType<'a> {
-    pub fn from_dynamic_type(
-        value: &DynamicType<'a>,
-        member_list: &'a mut Vec<DynamicTypeMember>,
-    ) -> XTypesResult<Self> {
-        fn fill_struct_key_holder_type<'a>(
-            value: &DynamicType<'a>,
-            member_list: &'a mut Vec<DynamicTypeMember>,
-        ) -> XTypesResult<()> {
+impl Default for KeyHolderType {
+    fn default() -> Self {
+        Self {
+            descriptor: None,
+            key_members: Box::new([]),
+        }
+    }
+}
+
+impl KeyHolderType {
+    pub fn new(value: &DynamicType<'_>) -> Self {
+        let mut member_list = Vec::new();
+        fn fill_struct_key_holder_type(
+            value: &DynamicType<'_>,
+            member_list: &mut Vec<DynamicTypeMember>,
+        ) {
             if value.get_kind() == TypeKind::STRUCTURE {
                 for member in value.member_list {
                     if member.descriptor.is_key {
@@ -27,22 +41,28 @@ impl<'a> KeyHolderType<'a> {
                     } else if member.descriptor.r#type.descriptor.kind == TypeKind::STRUCTURE
                         && !member.descriptor.is_optional
                     {
-                        fill_struct_key_holder_type(&member.descriptor.r#type, member_list)?;
+                        fill_struct_key_holder_type(&member.descriptor.r#type, member_list);
                     }
                 }
             }
-            Ok(())
         }
 
-        fill_struct_key_holder_type(value, member_list)?;
-        Ok(Self(DynamicType {
-            descriptor: value.descriptor,
-            member_list: member_list.as_slice(),
-        }))
+        fill_struct_key_holder_type(value, &mut member_list);
+        Self {
+            descriptor: Some(value.descriptor.clone()),
+            key_members: member_list.into_boxed_slice(),
+        }
     }
 
-    pub fn as_dynamic_type(&self) -> &DynamicType<'a> {
-        &self.0
+    pub fn as_dynamic_type(&self) -> Option<DynamicType<'_>> {
+        self.descriptor.as_ref().map(|descriptor| DynamicType {
+            descriptor,
+            member_list: &self.key_members,
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.key_members.is_empty()
     }
 }
 
@@ -71,7 +91,7 @@ pub struct KeyHolderData<'a>(DynamicData<'a>);
 impl<'a> KeyHolderData<'a> {
     pub fn from_dynamic_data(
         value: &DynamicData<'a>,
-        member_list: &'a mut Vec<DynamicTypeMember>,
+        key_holder_type: &'a KeyHolderType,
     ) -> XTypesResult<KeyHolderData<'a>> {
         fn fill_struct_key_holder_data<'a>(
             value: &DynamicData<'a>,
@@ -98,8 +118,10 @@ impl<'a> KeyHolderData<'a> {
             }
             Ok(())
         }
-        let key_holder_type = KeyHolderType::from_dynamic_type(&value.r#type(), member_list)?.0;
-        let mut key_holder_data = DynamicDataFactory::create_data(key_holder_type);
+        let dynamic_type = key_holder_type
+            .as_dynamic_type()
+            .ok_or(XTypesError::InvalidType)?;
+        let mut key_holder_data = DynamicDataFactory::create_data(dynamic_type);
         fill_struct_key_holder_data(value, &mut key_holder_data)?;
         Ok(Self(key_holder_data))
     }
@@ -124,12 +146,22 @@ pub fn get_instance_handle_from_key_holder_data<'a>(
     Ok(InstanceHandle::new(key))
 }
 
+pub fn get_instance_handle_from_dynamic_data_and_key_holder<'a>(
+    value: &DynamicData<'a>,
+    key_holder_type: &KeyHolderType,
+) -> Result<InstanceHandle, XTypesError> {
+    if key_holder_type.is_empty() {
+        return Ok(InstanceHandle::new([0; 16]));
+    }
+    let key_holder_data = KeyHolderData::from_dynamic_data(value, key_holder_type)?;
+    get_instance_handle_from_key_holder_data(&key_holder_data)
+}
+
 pub fn get_instance_handle_from_dynamic_data<'a>(
     value: &DynamicData<'a>,
 ) -> Result<InstanceHandle, XTypesError> {
-    let mut member_list = Vec::with_capacity(4);
-    let key_holder_data = KeyHolderData::from_dynamic_data(value, &mut member_list)?;
-    get_instance_handle_from_key_holder_data(&key_holder_data)
+    let key_holder_type = KeyHolderType::new(&value.r#type());
+    get_instance_handle_from_dynamic_data_and_key_holder(value, &key_holder_type)
 }
 
 #[cfg(test)]

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -112,7 +112,7 @@ impl<'a> KeyHolderData<'a> {
 pub fn get_instance_handle_from_key_holder_data<'a>(
     key_holder_data: &KeyHolderData<'a>,
 ) -> Result<InstanceHandle, XTypesError> {
-    let data = serialize_final_without_header(Vec::new(), &key_holder_data.0)?;
+    let data = serialize_final_without_header(Vec::with_capacity(16), &key_holder_data.0)?;
     let key = if data.len() <= 16 {
         let mut key = [0; 16];
         key[0..data.len()].copy_from_slice(&data);
@@ -127,7 +127,7 @@ pub fn get_instance_handle_from_key_holder_data<'a>(
 pub fn get_instance_handle_from_dynamic_data<'a>(
     value: &DynamicData<'a>,
 ) -> Result<InstanceHandle, XTypesError> {
-    let mut member_list = Vec::new();
+    let mut member_list = Vec::with_capacity(4);
     let key_holder_data = KeyHolderData::from_dynamic_data(value, &mut member_list)?;
     get_instance_handle_from_key_holder_data(&key_holder_data)
 }

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -351,24 +351,20 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     .await
                     {
                         Either3::A(user_mail) => {
-                            domain_participant_factory.handle(user_mail);
+                            let now = domain_participant_factory.runtime.clock().now();
+                            domain_participant_factory.handle(user_mail, now);
                             for dp in &mut domain_participant_factory.domain_participant_list {
-                                dp.poke(&domain_participant_factory.runtime.clock());
+                                dp.poke(now);
                             }
                         }
                         Either3::B(wire_mail) => {
-                            domain_participant_factory.handle_wire_mail(wire_mail);
                             let now = domain_participant_factory.runtime.clock().now();
+                            domain_participant_factory.handle_wire_mail(wire_mail, now);
                             for dp in &mut domain_participant_factory.domain_participant_list {
-                                dp.process_builtin_cache_changes(
-                                    &domain_participant_factory.runtime,
-                                    now,
-                                );
+                                dp.process_builtin_cache_changes(now);
                                 dp.process_user_defined_received_cache_changes(now);
-                                dp.request_topic_type_representation(
-                                    &domain_participant_factory.runtime,
-                                );
-                                dp.poke(&domain_participant_factory.runtime.clock());
+                                dp.request_topic_type_representation(now);
+                                dp.poke(now);
                             }
                         }
                         Either3::C(_) => {
@@ -379,39 +375,30 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                                 dp.check_missed_writer_deadline(now);
                                 dp.remove_stale_writer_samples(now);
                                 dp.check_pending_writer_sample_timeout(now);
-                                dp.process_pending_write_samples(
-                                    &domain_participant_factory.runtime,
-                                );
-                                dp.announce_participant_if_needed(
-                                    &domain_participant_factory.runtime,
-                                    now,
-                                );
+                                dp.process_pending_write_samples(now);
+                                dp.announce_participant_if_needed(now);
                                 dp.notify_find_topic_senders(now);
-                                dp.poke(&domain_participant_factory.runtime.clock());
+                                dp.poke(now);
                             }
                         }
                     };
                 } else {
                     match select_future(dcps_receiver.receive(), wire_receiver.receive()).await {
                         Either::A(user_mail) => {
-                            domain_participant_factory.handle(user_mail);
+                            let now = domain_participant_factory.runtime.clock().now();
+                            domain_participant_factory.handle(user_mail, now);
                             for dp in &mut domain_participant_factory.domain_participant_list {
-                                dp.poke(&domain_participant_factory.runtime.clock());
+                                dp.poke(now);
                             }
                         }
                         Either::B(wire_mail) => {
-                            domain_participant_factory.handle_wire_mail(wire_mail);
                             let now = domain_participant_factory.runtime.clock().now();
+                            domain_participant_factory.handle_wire_mail(wire_mail, now);
                             for dp in &mut domain_participant_factory.domain_participant_list {
-                                dp.process_builtin_cache_changes(
-                                    &domain_participant_factory.runtime,
-                                    now,
-                                );
+                                dp.process_builtin_cache_changes(now);
                                 dp.process_user_defined_received_cache_changes(now);
-                                dp.request_topic_type_representation(
-                                    &domain_participant_factory.runtime,
-                                );
-                                dp.poke(&domain_participant_factory.runtime.clock());
+                                dp.request_topic_type_representation(now);
+                                dp.poke(now);
                             }
                         }
                     };

--- a/dds/src/rtps/cache_change.rs
+++ b/dds/src/rtps/cache_change.rs
@@ -128,7 +128,7 @@ impl CacheChange {
         data_max_size_serialized: usize,
         fragment_number: usize,
     ) -> DataFragSubmessage {
-        let inline_qos_flag = true;
+        let inline_qos_flag = false;
         let key_flag = false;
         let non_standard_payload_flag = false;
         let writer_sn = self.sequence_number;
@@ -157,7 +157,7 @@ impl CacheChange {
             fragments_in_submessage,
             fragment_size,
             data_size,
-            ParameterList::new(Vec::new()),
+            ParameterList::empty(),
             serialized_payload,
         )
     }

--- a/dds/src/rtps/cache_change.rs
+++ b/dds/src/rtps/cache_change.rs
@@ -49,10 +49,15 @@ impl CacheChange {
         if let Some(i) = self.instance_handle {
             parameters.push(Parameter::new(PID_KEY_HASH, Arc::from(i)));
         }
-        let parameter_list = ParameterList::new(parameters);
+        let inline_qos_flag = !parameters.is_empty();
+        let parameter_list = if inline_qos_flag {
+            ParameterList::new(parameters)
+        } else {
+            ParameterList::empty()
+        };
 
         DataSubmessage::new(
-            true,
+            inline_qos_flag,
             data_flag,
             key_flag,
             false,

--- a/dds/src/rtps/message_creator.rs
+++ b/dds/src/rtps/message_creator.rs
@@ -5,12 +5,13 @@ use crate::{
 
 use super::types::{PROTOCOLVERSION_2_4, VENDOR_ID_S2E};
 
-impl RtpsMessageWrite {
+impl<'a> RtpsMessageWrite<'a> {
     pub fn from_submessages(
+        buffer: &'a mut [u8],
         submessages: &[&(dyn Submessage + Send)],
         guid_prefix: GuidPrefix,
     ) -> Self {
         let header = RtpsMessageHeader::new(PROTOCOLVERSION_2_4, VENDOR_ID_S2E, guid_prefix);
-        RtpsMessageWrite::new(&header, submessages)
+        RtpsMessageWrite::new(buffer, &header, submessages)
     }
 }

--- a/dds/src/rtps/reader_proxy.rs
+++ b/dds/src/rtps/reader_proxy.rs
@@ -245,7 +245,9 @@ impl RtpsReaderProxy {
         heartbeat_period: Duration,
         highest_available_seq_num: Option<SequenceNumber>,
     ) -> Option<Duration> {
-        if self.unacked_changes(highest_available_seq_num) {
+        if self.reliability == ReliabilityKind::Reliable
+            && self.unacked_changes(highest_available_seq_num)
+        {
             Some(
                 self.heartbeat_machine
                     .time_until_heartbeat(now, heartbeat_period),

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -123,7 +123,7 @@ impl RtpsStatefulWriter {
 
     pub fn write_message(
         &mut self,
-        message_writer: &(impl WriteMessage + ?Sized),
+        message_writer: &mut (impl WriteMessage + ?Sized),
         clock: &impl Clock,
     ) {
         for reader_proxy in &mut self.matched_readers {
@@ -145,7 +145,7 @@ impl RtpsStatefulWriter {
         &mut self,
         acknack_submessage: &AckNackSubmessage,
         source_guid_prefix: GuidPrefix,
-        message_writer: &(impl WriteMessage + ?Sized),
+        message_writer: &mut (impl WriteMessage + ?Sized),
         clock: &impl Clock,
     ) -> Option<SequenceNumber> {
         if &self.guid.entity_id() == acknack_submessage.writer_id() {
@@ -185,7 +185,7 @@ impl RtpsStatefulWriter {
         &mut self,
         nackfrag_submessage: &NackFragSubmessage,
         source_guid_prefix: GuidPrefix,
-        message_writer: &(impl WriteMessage + ?Sized),
+        message_writer: &mut (impl WriteMessage + ?Sized),
     ) {
         let reader_guid = Guid::new(source_guid_prefix, nackfrag_submessage.reader_id());
 
@@ -237,14 +237,14 @@ impl RtpsStatefulWriter {
                                     InfoTimestampSubmessage::new(true, TIME_INVALID)
                                 };
 
-                            let rtps_message = RtpsMessageWrite::from_submessages(
+                            let len = RtpsMessageWrite::from_submessages(
+                                message_writer.write_buffer_mut(),
                                 &[&info_dst, &info_timestamp, &data_frag],
                                 self.guid.prefix(),
-                            );
-                            message_writer.write_message(
-                                rtps_message.buffer(),
-                                reader_proxy.unicast_locator_list(),
                             )
+                            .buffer()
+                            .len();
+                            message_writer.write_message(len, reader_proxy.unicast_locator_list())
                         }
                     }
                 } else {
@@ -258,12 +258,14 @@ impl RtpsStatefulWriter {
                         SequenceNumberSet::new(change_seq_num + 1, []),
                     );
 
-                    let rtps_message = RtpsMessageWrite::from_submessages(
+                    let len = RtpsMessageWrite::from_submessages(
+                        message_writer.write_buffer_mut(),
                         &[&info_dst, &gap_submessage],
                         self.guid.prefix(),
-                    );
-                    message_writer
-                        .write_message(rtps_message.buffer(), reader_proxy.unicast_locator_list())
+                    )
+                    .buffer()
+                    .len();
+                    message_writer.write_message(len, reader_proxy.unicast_locator_list())
                 }
             }
         }
@@ -286,7 +288,7 @@ impl RtpsReaderProxy {
         changes: &[CacheChange],
         data_max_size_serialized: usize,
         heartbeat_period: Duration,
-        message_writer: &(impl WriteMessage + ?Sized),
+        message_writer: &mut (impl WriteMessage + ?Sized),
         clock: &impl Clock,
         guid_prefix: GuidPrefix,
     ) {
@@ -315,7 +317,7 @@ impl RtpsReaderProxy {
         writer_id: EntityId,
         changes: &[CacheChange],
         data_max_size_serialized: usize,
-        message_writer: &(impl WriteMessage + ?Sized),
+        message_writer: &mut (impl WriteMessage + ?Sized),
         guid_prefix: GuidPrefix,
     ) {
         // a_change_seq_num := the_reader_proxy.next_unsent_change();
@@ -352,9 +354,14 @@ impl RtpsReaderProxy {
                     gap_start_sequence_number,
                     SequenceNumberSet::new(gap_end_sequence_number + 1, []),
                 );
-                let rtps_message =
-                    RtpsMessageWrite::from_submessages(&[&gap_submessage], guid_prefix);
-                message_writer.write_message(rtps_message.buffer(), self.unicast_locator_list());
+                let len = RtpsMessageWrite::from_submessages(
+                    message_writer.write_buffer_mut(),
+                    &[&gap_submessage],
+                    guid_prefix,
+                )
+                .buffer()
+                .len();
+                message_writer.write_message(len, self.unicast_locator_list());
 
                 self.set_highest_sent_seq_num(next_unsent_change_seq_num);
             } else if let Some(cache_change) = changes
@@ -384,22 +391,27 @@ impl RtpsReaderProxy {
                             data_max_size_serialized,
                             fragment_number,
                         );
-                        let rtps_message = RtpsMessageWrite::from_submessages(
+                        let len = RtpsMessageWrite::from_submessages(
+                            message_writer.write_buffer_mut(),
                             &[&info_dst, &info_timestamp, &data_frag],
                             guid_prefix,
-                        );
-                        message_writer
-                            .write_message(rtps_message.buffer(), self.unicast_locator_list())
+                        )
+                        .buffer()
+                        .len();
+                        message_writer.write_message(len, self.unicast_locator_list())
                     }
                 } else {
                     let data_submessage = cache_change
                         .as_data_submessage(self.remote_reader_guid().entity_id(), writer_id);
 
-                    let rtps_message = RtpsMessageWrite::from_submessages(
+                    let len = RtpsMessageWrite::from_submessages(
+                        message_writer.write_buffer_mut(),
                         &[&info_dst, &info_timestamp, &data_submessage],
                         guid_prefix,
-                    );
-                    message_writer.write_message(rtps_message.buffer(), self.unicast_locator_list())
+                    )
+                    .buffer()
+                    .len();
+                    message_writer.write_message(len, self.unicast_locator_list())
                 }
             } else {
                 let gap_submessage = GapSubmessage::new(
@@ -408,9 +420,14 @@ impl RtpsReaderProxy {
                     next_unsent_change_seq_num,
                     SequenceNumberSet::new(next_unsent_change_seq_num + 1, []),
                 );
-                let rtps_message =
-                    RtpsMessageWrite::from_submessages(&[&gap_submessage], guid_prefix);
-                message_writer.write_message(rtps_message.buffer(), self.unicast_locator_list())
+                let len = RtpsMessageWrite::from_submessages(
+                    message_writer.write_buffer_mut(),
+                    &[&gap_submessage],
+                    guid_prefix,
+                )
+                .buffer()
+                .len();
+                message_writer.write_message(len, self.unicast_locator_list())
             }
 
             self.set_highest_sent_seq_num(next_unsent_change_seq_num);
@@ -424,7 +441,7 @@ impl RtpsReaderProxy {
         changes: &[CacheChange],
         data_max_size_serialized: usize,
         heartbeat_period: Duration,
-        message_writer: &(impl WriteMessage + ?Sized),
+        message_writer: &mut (impl WriteMessage + ?Sized),
         clock: &impl Clock,
         guid_prefix: GuidPrefix,
     ) {
@@ -450,11 +467,14 @@ impl RtpsReaderProxy {
                         .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
                     let info_dst =
                         InfoDestinationSubmessage::new(self.remote_reader_guid().prefix());
-                    let rtps_message = RtpsMessageWrite::from_submessages(
+                    let len = RtpsMessageWrite::from_submessages(
+                        message_writer.write_buffer_mut(),
                         &[&info_dst, &gap_submessage, &heartbeat_submessage],
                         guid_prefix,
-                    );
-                    message_writer.write_message(rtps_message.buffer(), self.unicast_locator_list())
+                    )
+                    .buffer()
+                    .len();
+                    message_writer.write_message(len, self.unicast_locator_list())
                 } else {
                     let seq_num_min = changes.iter().map(|cc| cc.sequence_number).min();
                     let seq_num_max = changes.iter().map(|cc| cc.sequence_number).max();
@@ -488,7 +508,7 @@ impl RtpsReaderProxy {
                                         InfoTimestampSubmessage::new(true, TIME_INVALID)
                                     };
 
-                                let rtps_message = if fragment_number == number_of_fragments - 1 {
+                                let len = if fragment_number == number_of_fragments - 1 {
                                     let first_sn = seq_num_min.unwrap_or(1);
                                     let last_sn = seq_num_max.unwrap_or(0);
                                     let heartbeat =
@@ -496,19 +516,20 @@ impl RtpsReaderProxy {
                                             writer_id, first_sn, last_sn, now, false,
                                         );
                                     RtpsMessageWrite::from_submessages(
+                                        message_writer.write_buffer_mut(),
                                         &[&info_dst, &info_timestamp, &data_frag, &heartbeat],
                                         guid_prefix,
                                     )
                                 } else {
                                     RtpsMessageWrite::from_submessages(
+                                        message_writer.write_buffer_mut(),
                                         &[&info_dst, &info_timestamp, &data_frag],
                                         guid_prefix,
                                     )
-                                };
-                                message_writer.write_message(
-                                    rtps_message.buffer(),
-                                    self.unicast_locator_list(),
-                                )
+                                }
+                                .buffer()
+                                .len();
+                                message_writer.write_message(len, self.unicast_locator_list())
                             }
                         } else {
                             let info_dst =
@@ -532,12 +553,14 @@ impl RtpsReaderProxy {
                                 .heartbeat_machine()
                                 .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
 
-                            let rtps_message = RtpsMessageWrite::from_submessages(
+                            let len = RtpsMessageWrite::from_submessages(
+                                message_writer.write_buffer_mut(),
                                 &[&info_dst, &info_timestamp, &data_submessage, &heartbeat],
                                 guid_prefix,
-                            );
-                            message_writer
-                                .write_message(rtps_message.buffer(), self.unicast_locator_list())
+                            )
+                            .buffer()
+                            .len();
+                            message_writer.write_message(len, self.unicast_locator_list())
                         }
                     } else {
                         let info_dst =
@@ -550,12 +573,14 @@ impl RtpsReaderProxy {
                             SequenceNumberSet::new(next_unsent_change_seq_num + 1, []),
                         );
 
-                        let rtps_message = RtpsMessageWrite::from_submessages(
+                        let len = RtpsMessageWrite::from_submessages(
+                            message_writer.write_buffer_mut(),
                             &[&info_dst, &gap_submessage],
                             guid_prefix,
-                        );
-                        message_writer
-                            .write_message(rtps_message.buffer(), self.unicast_locator_list())
+                        )
+                        .buffer()
+                        .len();
+                        message_writer.write_message(len, self.unicast_locator_list())
                     }
                 }
                 self.set_highest_sent_seq_num(next_unsent_change_seq_num);
@@ -574,11 +599,14 @@ impl RtpsReaderProxy {
 
             let info_dst = InfoDestinationSubmessage::new(self.remote_reader_guid().prefix());
 
-            let rtps_message = RtpsMessageWrite::from_submessages(
+            let len = RtpsMessageWrite::from_submessages(
+                message_writer.write_buffer_mut(),
                 &[&info_dst, &heartbeat_submessage],
                 guid_prefix,
-            );
-            message_writer.write_message(rtps_message.buffer(), self.unicast_locator_list())
+            )
+            .buffer()
+            .len();
+            message_writer.write_message(len, self.unicast_locator_list())
         }
 
         // Middle-part of the state-machine - Figure 8.19 RTPS standard
@@ -625,12 +653,14 @@ impl RtpsReaderProxy {
                             .heartbeat_machine()
                             .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
 
-                        let rtps_message = RtpsMessageWrite::from_submessages(
+                        let len = RtpsMessageWrite::from_submessages(
+                            message_writer.write_buffer_mut(),
                             &[&info_dst, &info_timestamp, &data_frag, &heartbeat],
                             guid_prefix,
-                        );
-                        message_writer
-                            .write_message(rtps_message.buffer(), self.unicast_locator_list());
+                        )
+                        .buffer()
+                        .len();
+                        message_writer.write_message(len, self.unicast_locator_list());
                     } else {
                         let info_dst =
                             InfoDestinationSubmessage::new(self.remote_reader_guid().prefix());
@@ -651,12 +681,14 @@ impl RtpsReaderProxy {
                             .heartbeat_machine()
                             .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
 
-                        let rtps_message = RtpsMessageWrite::from_submessages(
+                        let len = RtpsMessageWrite::from_submessages(
+                            message_writer.write_buffer_mut(),
                             &[&info_dst, &info_timestamp, &data_submessage, &heartbeat],
                             guid_prefix,
-                        );
-                        message_writer
-                            .write_message(rtps_message.buffer(), self.unicast_locator_list());
+                        )
+                        .buffer()
+                        .len();
+                        message_writer.write_message(len, self.unicast_locator_list());
                     }
                 } else {
                     let info_dst =
@@ -669,12 +701,14 @@ impl RtpsReaderProxy {
                         SequenceNumberSet::new(next_requested_change_seq_num + 1, []),
                     );
 
-                    let rtps_message = RtpsMessageWrite::from_submessages(
+                    let len = RtpsMessageWrite::from_submessages(
+                        message_writer.write_buffer_mut(),
                         &[&info_dst, &gap_submessage],
                         guid_prefix,
-                    );
-                    message_writer
-                        .write_message(rtps_message.buffer(), self.unicast_locator_list());
+                    )
+                    .buffer()
+                    .len();
+                    message_writer.write_message(len, self.unicast_locator_list());
                 }
             }
         }
@@ -705,14 +739,18 @@ mod tests {
         }
         struct MockWriter {
             total_fragments_sent: Mutex<usize>,
+            buffer: [u8; 65535],
         }
         impl WriteMessage for MockWriter {
+            fn write_buffer_mut(&mut self) -> &mut [u8] {
+                &mut self.buffer
+            }
             fn write_message(
-                &self,
-                datagram: &[u8],
+                &mut self,
+                len: usize,
                 _locator_list: &[crate::transport::types::Locator],
             ) {
-                let message = RtpsMessageRead::try_from(datagram).unwrap();
+                let message = RtpsMessageRead::try_from(&self.buffer[..len]).unwrap();
                 assert!(matches!(
                     message.submessages()[2],
                     RtpsSubmessageReadKind::DataFrag(_)
@@ -736,8 +774,9 @@ mod tests {
             expects_inline_qos: false,
         });
 
-        let message_writer = MockWriter {
+        let mut message_writer = MockWriter {
             total_fragments_sent: Mutex::new(0),
+            buffer: [0; 65535],
         };
         writer.add_change(CacheChange {
             kind: ChangeKind::Alive,
@@ -747,7 +786,7 @@ mod tests {
             instance_handle: Some([10; 16]),
             data_value: vec![8; 1300].into(),
         });
-        writer.write_message(&message_writer, &MockClock {});
+        writer.write_message(&mut message_writer, &MockClock {});
         assert_eq!(*message_writer.total_fragments_sent.lock().unwrap(), 3);
     }
 
@@ -761,14 +800,18 @@ mod tests {
         }
         struct MockWriter {
             total_fragments_sent: Mutex<usize>,
+            buffer: [u8; 65535],
         }
         impl WriteMessage for MockWriter {
+            fn write_buffer_mut(&mut self) -> &mut [u8] {
+                &mut self.buffer
+            }
             fn write_message(
-                &self,
-                datagram: &[u8],
+                &mut self,
+                len: usize,
                 _locator_list: &[crate::transport::types::Locator],
             ) {
-                let message = RtpsMessageRead::try_from(datagram).unwrap();
+                let message = RtpsMessageRead::try_from(&self.buffer[..len]).unwrap();
                 assert!(matches!(
                     message.submessages()[2],
                     RtpsSubmessageReadKind::DataFrag(_)
@@ -794,8 +837,9 @@ mod tests {
             multicast_locator_list: vec![],
             expects_inline_qos: false,
         });
-        let message_writer = MockWriter {
+        let mut message_writer = MockWriter {
             total_fragments_sent: Mutex::new(0),
+            buffer: [0; 65535],
         };
         writer.add_change(CacheChange {
             kind: ChangeKind::Alive,
@@ -805,7 +849,7 @@ mod tests {
             instance_handle: Some([10; 16]),
             data_value: vec![8; 1300].into(),
         });
-        writer.write_message(&message_writer, &MockClock {});
+        writer.write_message(&mut message_writer, &MockClock {});
 
         let nackfrag_submessage = NackFragSubmessage::new(
             remote_reader_id,
@@ -814,13 +858,14 @@ mod tests {
             FragmentNumberSet::new(1, []),
             1,
         );
-        let message_writer = MockWriter {
+        let mut message_writer = MockWriter {
             total_fragments_sent: Mutex::new(0),
+            buffer: [0; 65535],
         };
         writer.on_nack_frag_submessage_received(
             &nackfrag_submessage,
             remote_reader_guid_prefix,
-            &message_writer,
+            &mut message_writer,
         );
 
         assert_eq!(*message_writer.total_fragments_sent.lock().unwrap(), 1);

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -69,9 +69,13 @@ impl RtpsStatefulWriter {
         &self,
         now: crate::infrastructure::time::Time,
     ) -> Option<crate::infrastructure::time::Duration> {
+        if self.changes.is_empty() || self.matched_readers.is_empty() {
+            return None;
+        }
         let seq_num_max = self.changes.iter().map(|cc| cc.sequence_number).max();
         self.matched_readers
             .iter()
+            .filter(|rp| rp.reliability() == ReliabilityKind::Reliable)
             .filter_map(|rp| {
                 rp.time_until_heartbeat(now, self.heartbeat_period.into(), seq_num_max)
             })

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -1,5 +1,6 @@
 use super::{behavior_types::Duration, reader_proxy::RtpsReaderProxy};
 use crate::{
+    infrastructure::time::Time,
     rtps_messages::{
         overall_structure::RtpsMessageWrite,
         submessage_elements::SequenceNumberSet,
@@ -10,7 +11,6 @@ use crate::{
         },
         types::TIME_INVALID,
     },
-    runtime::Clock,
     transport::{
         interface::WriteMessage,
         types::{
@@ -121,11 +121,7 @@ impl RtpsStatefulWriter {
             .retain(|reader_proxy| reader_proxy.remote_reader_guid() != reader_guid);
     }
 
-    pub fn write_message(
-        &mut self,
-        message_writer: &mut (impl WriteMessage + ?Sized),
-        clock: &impl Clock,
-    ) {
+    pub fn write_message(&mut self, message_writer: &mut (impl WriteMessage + ?Sized), now: Time) {
         for reader_proxy in &mut self.matched_readers {
             reader_proxy.write_message(
                 self.guid.entity_id(),
@@ -133,7 +129,7 @@ impl RtpsStatefulWriter {
                 self.data_max_size_serialized,
                 self.heartbeat_period,
                 message_writer,
-                clock,
+                now,
                 self.guid.prefix(),
             )
         }
@@ -146,7 +142,7 @@ impl RtpsStatefulWriter {
         acknack_submessage: &AckNackSubmessage,
         source_guid_prefix: GuidPrefix,
         message_writer: &mut (impl WriteMessage + ?Sized),
-        clock: &impl Clock,
+        now: Time,
     ) -> Option<SequenceNumber> {
         if &self.guid.entity_id() == acknack_submessage.writer_id() {
             let reader_guid = Guid::new(source_guid_prefix, *acknack_submessage.reader_id());
@@ -171,7 +167,7 @@ impl RtpsStatefulWriter {
                         self.data_max_size_serialized,
                         self.heartbeat_period,
                         message_writer,
-                        clock,
+                        now,
                         self.guid.prefix(),
                     );
                     return Some(acked_changes);
@@ -289,7 +285,7 @@ impl RtpsReaderProxy {
         data_max_size_serialized: usize,
         heartbeat_period: Duration,
         message_writer: &mut (impl WriteMessage + ?Sized),
-        clock: &impl Clock,
+        now: Time,
         guid_prefix: GuidPrefix,
     ) {
         match self.reliability() {
@@ -306,7 +302,7 @@ impl RtpsReaderProxy {
                 data_max_size_serialized,
                 heartbeat_period,
                 message_writer,
-                clock,
+                now,
                 guid_prefix,
             ),
         }
@@ -442,10 +438,9 @@ impl RtpsReaderProxy {
         data_max_size_serialized: usize,
         heartbeat_period: Duration,
         message_writer: &mut (impl WriteMessage + ?Sized),
-        clock: &impl Clock,
+        now: Time,
         guid_prefix: GuidPrefix,
     ) {
-        let now = clock.now();
         let seq_num_min = changes.iter().map(|cc| cc.sequence_number).min();
         let seq_num_max = changes.iter().map(|cc| cc.sequence_number).max();
         // Top part of the state machine - Figure 8.19 RTPS standard
@@ -731,12 +726,6 @@ mod tests {
 
     #[test]
     fn test_all_fragments_sent() {
-        struct MockClock {}
-        impl Clock for MockClock {
-            fn now(&self) -> crate::infrastructure::time::Time {
-                Time::new(1, 0)
-            }
-        }
         struct MockWriter {
             total_fragments_sent: Mutex<usize>,
             buffer: [u8; 65535],
@@ -786,18 +775,12 @@ mod tests {
             instance_handle: Some([10; 16]),
             data_value: vec![8; 1300].into(),
         });
-        writer.write_message(&mut message_writer, &MockClock {});
+        writer.write_message(&mut message_writer, Time::new(1, 0));
         assert_eq!(*message_writer.total_fragments_sent.lock().unwrap(), 3);
     }
 
     #[test]
     fn test_single_fragment_sent_after_acknack_frag() {
-        struct MockClock {}
-        impl Clock for MockClock {
-            fn now(&self) -> crate::infrastructure::time::Time {
-                Time::new(1, 0)
-            }
-        }
         struct MockWriter {
             total_fragments_sent: Mutex<usize>,
             buffer: [u8; 65535],
@@ -849,7 +832,7 @@ mod tests {
             instance_handle: Some([10; 16]),
             data_value: vec![8; 1300].into(),
         });
-        writer.write_message(&mut message_writer, &MockClock {});
+        writer.write_message(&mut message_writer, Time::new(1, 0));
 
         let nackfrag_submessage = NackFragSubmessage::new(
             remote_reader_id,

--- a/dds/src/rtps/stateless_writer.rs
+++ b/dds/src/rtps/stateless_writer.rs
@@ -36,7 +36,7 @@ impl RtpsStatelessWriter {
         self.changes.push(cache_change);
     }
 
-    pub fn write_message(&mut self, message_writer: &(impl WriteMessage + ?Sized)) {
+    pub fn write_message(&mut self, message_writer: &mut (impl WriteMessage + ?Sized)) {
         for reader_locator in &mut self.reader_locators {
             while let Some(unsent_change_seq_num) =
                 reader_locator.next_unsent_change(self.changes.iter())
@@ -59,12 +59,14 @@ impl RtpsStatelessWriter {
                     let data_submessage =
                         cache_change.as_data_submessage(ENTITYID_UNKNOWN, self.guid.entity_id());
 
-                    let rtps_message = RtpsMessageWrite::from_submessages(
+                    let len = RtpsMessageWrite::from_submessages(
+                        message_writer.write_buffer_mut(),
                         &[&info_ts_submessage, &data_submessage],
                         self.guid.prefix(),
-                    );
-                    message_writer
-                        .write_message(rtps_message.buffer(), &[reader_locator.locator()]);
+                    )
+                    .buffer()
+                    .len();
+                    message_writer.write_message(len, &[reader_locator.locator()]);
                 } else {
                     let gap_submessage = GapSubmessage::new(
                         ENTITYID_UNKNOWN,
@@ -72,10 +74,14 @@ impl RtpsStatelessWriter {
                         unsent_change_seq_num,
                         SequenceNumberSet::new(unsent_change_seq_num + 1, []),
                     );
-                    let rtps_message =
-                        RtpsMessageWrite::from_submessages(&[&gap_submessage], self.guid.prefix());
-                    message_writer
-                        .write_message(rtps_message.buffer(), &[reader_locator.locator()]);
+                    let len = RtpsMessageWrite::from_submessages(
+                        message_writer.write_buffer_mut(),
+                        &[&gap_submessage],
+                        self.guid.prefix(),
+                    )
+                    .buffer()
+                    .len();
+                    message_writer.write_message(len, &[reader_locator.locator()]);
                 }
                 reader_locator.set_highest_sent_change_sn(unsent_change_seq_num);
             }

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -256,7 +256,7 @@ impl RtpsWriterProxy {
     pub fn write_message(
         &mut self,
         reader_guid: &Guid,
-        message_writer: &(impl WriteMessage + ?Sized),
+        message_writer: &mut (impl WriteMessage + ?Sized),
     ) {
         if self.must_send_acknacks() || !self.missing_changes().count() == 0 {
             self.set_must_send_acknacks(false);
@@ -282,7 +282,7 @@ impl RtpsWriterProxy {
                 self.acknack_count(),
             );
 
-            let rtps_message = if let Some(missing_change_fragments_seq_num) = self
+            let len = if let Some(missing_change_fragments_seq_num) = self
                 .missing_changes()
                 .take(256)
                 .find(|s| self.frag_buffer.iter().any(|x| &x.writer_sn() == s))
@@ -316,6 +316,7 @@ impl RtpsWriterProxy {
                 );
 
                 RtpsMessageWrite::from_submessages(
+                    message_writer.write_buffer_mut(),
                     &[
                         &info_dst_submessage,
                         &acknack_submessage,
@@ -323,14 +324,19 @@ impl RtpsWriterProxy {
                     ],
                     reader_guid.prefix(),
                 )
+                .buffer()
+                .len()
             } else {
                 RtpsMessageWrite::from_submessages(
+                    message_writer.write_buffer_mut(),
                     &[&info_dst_submessage, &acknack_submessage],
                     reader_guid.prefix(),
                 )
+                .buffer()
+                .len()
             };
 
-            message_writer.write_message(rtps_message.buffer(), self.unicast_locator_list());
+            message_writer.write_message(len, self.unicast_locator_list());
         }
     }
 

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -73,7 +73,10 @@ impl RtpsWriterProxy {
     }
 
     pub fn push_data_frag(&mut self, submessage: DataFragSubmessage) {
-        if !self.frag_buffer.contains(&submessage) {
+        if !self.frag_buffer.iter().any(|f| {
+            f.writer_sn() == submessage.writer_sn()
+                && f.fragment_starting_num() == submessage.fragment_starting_num()
+        }) {
             self.frag_buffer.push(submessage);
         }
     }
@@ -89,42 +92,36 @@ impl RtpsWriterProxy {
         let frag_submessage = self.frag_buffer.iter().find(|f| f.writer_sn() == seq_num)?;
         let total_fragments_expected = total_fragments_expected(frag_submessage);
 
-        let total_fragments = self
+        let total_fragments: u32 = self
             .frag_buffer
             .iter()
             .filter(|f| f.writer_sn() == seq_num)
-            .fold(0, |mut acc, f| {
-                acc += f.fragments_in_submessage() as u32;
-                acc
-            });
+            .map(|f| f.fragments_in_submessage() as u32)
+            .sum();
 
         if total_fragments == total_fragments_expected {
-            let mut data = Vec::new();
-            for frag_number in 0..=total_fragments {
-                let Some(frag) = self
-                    .frag_buffer
-                    .iter()
-                    .find(|f| f.writer_sn() == seq_num && f.fragment_starting_num() == frag_number)
-                else {
-                    continue;
-                };
+            let mut matching_frags: Vec<&DataFragSubmessage> = self
+                .frag_buffer
+                .iter()
+                .filter(|f| f.writer_sn() == seq_num)
+                .collect();
+            matching_frags.sort_unstable_by_key(|f| f.fragment_starting_num());
 
+            let mut data = Vec::with_capacity(frag_submessage.data_size() as usize);
+            for frag in &matching_frags {
                 data.extend_from_slice(frag.serialized_payload().as_ref());
             }
 
-            let frag = self
-                .frag_buffer
-                .iter()
-                .find(|f| f.writer_sn() == seq_num && f.fragment_starting_num() == 1)?;
+            let first_frag = matching_frags.first().copied()?;
 
-            let inline_qos_flag = frag.inline_qos_flag();
-            let data_flag = !frag.key_flag();
-            let key_flag = frag.key_flag();
+            let inline_qos_flag = first_frag.inline_qos_flag();
+            let data_flag = !first_frag.key_flag();
+            let key_flag = first_frag.key_flag();
             let non_standard_payload_flag = false;
             let writer_id = self.remote_writer_guid.entity_id();
-            let reader_id = frag.reader_id();
+            let reader_id = first_frag.reader_id();
             let writer_sn = seq_num;
-            let inline_qos = frag.inline_qos().clone();
+            let inline_qos = first_frag.inline_qos().clone();
 
             self.frag_buffer.retain(|f| f.writer_sn() != seq_num);
 

--- a/dds/src/rtps_messages/overall_structure.rs
+++ b/dds/src/rtps_messages/overall_structure.rs
@@ -109,13 +109,14 @@ impl Write for Vec<u8> {
 }
 
 impl Write for Cursor<Vec<u8>> {
+    #[inline]
     fn write_all(&mut self, buf: &[u8]) -> RtpsMessageResult<()> {
         let start_pos = self.pos as usize;
         let end_pos = start_pos + buf.len();
-        if start_pos >= self.inner.len() {
-            if start_pos > self.inner.len() {
-                self.inner.resize(start_pos, 0);
-            }
+        if start_pos == self.inner.len() {
+            self.inner.extend_from_slice(buf);
+        } else if start_pos > self.inner.len() {
+            self.inner.resize(start_pos, 0);
             self.inner.extend_from_slice(buf);
         } else if end_pos <= self.inner.len() {
             self.inner[start_pos..end_pos].copy_from_slice(buf);
@@ -133,13 +134,16 @@ impl Write for Cursor<Vec<u8>> {
 pub trait WriteIntoBytes {
     fn write_into_bytes(&self, buf: &mut dyn Write);
 }
+
 impl WriteIntoBytes for Octet {
+    #[inline]
     fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(&[*self]).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for Long {
+    #[inline]
     fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self.to_le_bytes().as_slice())
             .expect("buffer big enough");
@@ -147,6 +151,7 @@ impl WriteIntoBytes for Long {
 }
 
 impl WriteIntoBytes for UnsignedLong {
+    #[inline]
     fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self.to_le_bytes().as_slice())
             .expect("buffer big enough");
@@ -154,6 +159,7 @@ impl WriteIntoBytes for UnsignedLong {
 }
 
 impl WriteIntoBytes for u16 {
+    #[inline]
     fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self.to_le_bytes().as_slice())
             .expect("buffer big enough");
@@ -161,6 +167,7 @@ impl WriteIntoBytes for u16 {
 }
 
 impl WriteIntoBytes for i16 {
+    #[inline]
     fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self.to_le_bytes().as_slice())
             .expect("buffer big enough");
@@ -168,12 +175,14 @@ impl WriteIntoBytes for i16 {
 }
 
 impl<const N: usize> WriteIntoBytes for [Octet; N] {
+    #[inline]
     fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self).expect("buffer big enough");
     }
 }
 
 impl WriteIntoBytes for &[u8] {
+    #[inline]
     fn write_into_bytes(&self, buf: &mut dyn Write) {
         buf.write_all(self).expect("buffer big enough");
     }

--- a/dds/src/rtps_messages/overall_structure.rs
+++ b/dds/src/rtps_messages/overall_structure.rs
@@ -479,114 +479,44 @@ pub fn write_submessage_into_bytes_vec(value: &(dyn Submessage + Send)) -> Vec<u
     cursor.into_inner()
 }
 
-const STACK_BUFFER_SIZE: usize = 512;
-
-#[derive(Debug, PartialEq, Eq)]
-enum WriteBuffer {
-    Stack {
-        buf: [u8; STACK_BUFFER_SIZE],
-        len: usize,
-    },
-    Heap(Vec<u8>),
-}
-
-impl WriteBuffer {
-    pub const fn new() -> Self {
-        Self::Stack {
-            buf: [0; STACK_BUFFER_SIZE],
-            len: 0,
-        }
-    }
-
-    pub fn as_slice(&self) -> &[u8] {
-        match self {
-            Self::Stack { buf, len } => &buf[..*len],
-            Self::Heap(vec) => vec.as_slice(),
-        }
-    }
-}
-
-impl Write for Cursor<WriteBuffer> {
+impl Write for Cursor<&mut [u8]> {
     #[inline]
     fn write_all(&mut self, buf: &[u8]) -> RtpsMessageResult<()> {
         let start_pos = self.pos as usize;
         let end_pos = start_pos + buf.len();
-
-        match &mut self.inner {
-            WriteBuffer::Stack {
-                buf: stack_buf,
-                len,
-            } => {
-                if end_pos <= STACK_BUFFER_SIZE {
-                    if start_pos > *len {
-                        stack_buf[*len..start_pos].fill(0);
-                    }
-                    stack_buf[start_pos..end_pos].copy_from_slice(buf);
-                    if end_pos > *len {
-                        *len = end_pos;
-                    }
-                    self.pos = end_pos as u64;
-                    return Ok(());
-                }
-
-                // Spill over to heap
-                let mut heap_vec = Vec::with_capacity(end_pos.max(STACK_BUFFER_SIZE * 2));
-                heap_vec.extend_from_slice(&stack_buf[..*len]);
-                if start_pos > heap_vec.len() {
-                    heap_vec.resize(start_pos, 0);
-                }
-                if start_pos == heap_vec.len() {
-                    heap_vec.extend_from_slice(buf);
-                } else if end_pos <= heap_vec.len() {
-                    heap_vec[start_pos..end_pos].copy_from_slice(buf);
-                } else {
-                    let overwrite_len = heap_vec.len() - start_pos;
-                    heap_vec[start_pos..].copy_from_slice(&buf[..overwrite_len]);
-                    heap_vec.extend_from_slice(&buf[overwrite_len..]);
-                }
-                self.inner = WriteBuffer::Heap(heap_vec);
-                self.pos = end_pos as u64;
-                Ok(())
-            }
-            WriteBuffer::Heap(heap_vec) => {
-                if start_pos == heap_vec.len() {
-                    heap_vec.extend_from_slice(buf);
-                } else if start_pos > heap_vec.len() {
-                    heap_vec.resize(start_pos, 0);
-                    heap_vec.extend_from_slice(buf);
-                } else if end_pos <= heap_vec.len() {
-                    heap_vec[start_pos..end_pos].copy_from_slice(buf);
-                } else {
-                    let overwrite_len = heap_vec.len() - start_pos;
-                    heap_vec[start_pos..].copy_from_slice(&buf[..overwrite_len]);
-                    heap_vec.extend_from_slice(&buf[overwrite_len..]);
-                }
-                self.pos = end_pos as u64;
-                Ok(())
-            }
+        if end_pos > self.inner.len() {
+            return Err(RtpsMessageError::NotEnoughData);
         }
+        self.inner[start_pos..end_pos].copy_from_slice(buf);
+        self.pos = end_pos as u64;
+        Ok(())
     }
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct RtpsMessageWrite {
-    buffer: WriteBuffer,
+pub struct RtpsMessageWrite<'a> {
+    buffer: &'a [u8],
 }
 
-impl RtpsMessageWrite {
-    pub fn new(header: &RtpsMessageHeader, submessages: &[&(dyn Submessage + Send)]) -> Self {
-        let mut cursor = Cursor::new(WriteBuffer::new());
+impl<'a> RtpsMessageWrite<'a> {
+    pub fn new(
+        buffer: &'a mut [u8],
+        header: &RtpsMessageHeader,
+        submessages: &[&(dyn Submessage + Send)],
+    ) -> Self {
+        let mut cursor = Cursor::new(buffer);
         header.write_into_bytes(&mut cursor);
         for submessage in submessages {
             submessage.write_submessage_into_bytes(&mut cursor);
         }
+        let len = cursor.position() as usize;
         Self {
-            buffer: cursor.into_inner(),
+            buffer: &cursor.into_inner()[..len],
         }
     }
 
     pub fn buffer(&self) -> &[u8] {
-        self.buffer.as_slice()
+        self.buffer
     }
 }
 
@@ -731,7 +661,8 @@ mod tests {
             vendor_id: [9, 8],
             guid_prefix: [3; 12],
         };
-        let message = RtpsMessageWrite::new(&header, &[]);
+        let mut buffer = [0u8; 512];
+        let message = RtpsMessageWrite::new(&mut buffer, &header, &[]);
         #[rustfmt::skip]
         assert_eq!(message.buffer(), vec![
             b'R', b'T', b'P', b'S', // Protocol
@@ -772,7 +703,8 @@ mod tests {
             inline_qos,
             serialized_payload,
         );
-        let value = RtpsMessageWrite::new(&header, &[&submessage]);
+        let mut buffer = [0u8; 512];
+        let value = RtpsMessageWrite::new(&mut buffer, &header, &[&submessage]);
         #[rustfmt::skip]
         assert_eq!(value.buffer(), vec![
             b'R', b'T', b'P', b'S', // Protocol
@@ -826,7 +758,12 @@ mod tests {
             inline_qos,
             serialized_payload,
         );
-        let value = RtpsMessageWrite::new(&header, &[&info_timestamp_submessage, &data_submessage]);
+        let mut buffer = [0u8; 512];
+        let value = RtpsMessageWrite::new(
+            &mut buffer,
+            &header,
+            &[&info_timestamp_submessage, &data_submessage],
+        );
         #[rustfmt::skip]
         assert_eq!(value.buffer(), vec![
             b'R', b'T', b'P', b'S', // Protocol

--- a/dds/src/rtps_messages/overall_structure.rs
+++ b/dds/src/rtps_messages/overall_structure.rs
@@ -278,7 +278,10 @@ pub trait Submessage {
 }
 
 impl dyn Submessage + Send + '_ {
-    fn write_submessage_into_bytes(&self, buf: &mut Cursor<Vec<u8>>) {
+    fn write_submessage_into_bytes<T>(&self, buf: &mut Cursor<T>)
+    where
+        Cursor<T>: Write,
+    {
         let header_position: u64 = buf.position();
         let elements_position = header_position + 4;
         buf.set_position(elements_position);
@@ -476,26 +479,114 @@ pub fn write_submessage_into_bytes_vec(value: &(dyn Submessage + Send)) -> Vec<u
     cursor.into_inner()
 }
 
+const STACK_BUFFER_SIZE: usize = 512;
+
+#[derive(Debug, PartialEq, Eq)]
+enum WriteBuffer {
+    Stack {
+        buf: [u8; STACK_BUFFER_SIZE],
+        len: usize,
+    },
+    Heap(Vec<u8>),
+}
+
+impl WriteBuffer {
+    pub const fn new() -> Self {
+        Self::Stack {
+            buf: [0; STACK_BUFFER_SIZE],
+            len: 0,
+        }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Stack { buf, len } => &buf[..*len],
+            Self::Heap(vec) => vec.as_slice(),
+        }
+    }
+}
+
+impl Write for Cursor<WriteBuffer> {
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> RtpsMessageResult<()> {
+        let start_pos = self.pos as usize;
+        let end_pos = start_pos + buf.len();
+
+        match &mut self.inner {
+            WriteBuffer::Stack {
+                buf: stack_buf,
+                len,
+            } => {
+                if end_pos <= STACK_BUFFER_SIZE {
+                    if start_pos > *len {
+                        stack_buf[*len..start_pos].fill(0);
+                    }
+                    stack_buf[start_pos..end_pos].copy_from_slice(buf);
+                    if end_pos > *len {
+                        *len = end_pos;
+                    }
+                    self.pos = end_pos as u64;
+                    return Ok(());
+                }
+
+                // Spill over to heap
+                let mut heap_vec = Vec::with_capacity(end_pos.max(STACK_BUFFER_SIZE * 2));
+                heap_vec.extend_from_slice(&stack_buf[..*len]);
+                if start_pos > heap_vec.len() {
+                    heap_vec.resize(start_pos, 0);
+                }
+                if start_pos == heap_vec.len() {
+                    heap_vec.extend_from_slice(buf);
+                } else if end_pos <= heap_vec.len() {
+                    heap_vec[start_pos..end_pos].copy_from_slice(buf);
+                } else {
+                    let overwrite_len = heap_vec.len() - start_pos;
+                    heap_vec[start_pos..].copy_from_slice(&buf[..overwrite_len]);
+                    heap_vec.extend_from_slice(&buf[overwrite_len..]);
+                }
+                self.inner = WriteBuffer::Heap(heap_vec);
+                self.pos = end_pos as u64;
+                Ok(())
+            }
+            WriteBuffer::Heap(heap_vec) => {
+                if start_pos == heap_vec.len() {
+                    heap_vec.extend_from_slice(buf);
+                } else if start_pos > heap_vec.len() {
+                    heap_vec.resize(start_pos, 0);
+                    heap_vec.extend_from_slice(buf);
+                } else if end_pos <= heap_vec.len() {
+                    heap_vec[start_pos..end_pos].copy_from_slice(buf);
+                } else {
+                    let overwrite_len = heap_vec.len() - start_pos;
+                    heap_vec[start_pos..].copy_from_slice(&buf[..overwrite_len]);
+                    heap_vec.extend_from_slice(&buf[overwrite_len..]);
+                }
+                self.pos = end_pos as u64;
+                Ok(())
+            }
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct RtpsMessageWrite {
-    data: Vec<u8>,
+    buffer: WriteBuffer,
 }
 
 impl RtpsMessageWrite {
     pub fn new(header: &RtpsMessageHeader, submessages: &[&(dyn Submessage + Send)]) -> Self {
-        let buffer = Vec::with_capacity(256);
-        let mut cursor = Cursor::new(buffer);
+        let mut cursor = Cursor::new(WriteBuffer::new());
         header.write_into_bytes(&mut cursor);
         for submessage in submessages {
             submessage.write_submessage_into_bytes(&mut cursor);
         }
         Self {
-            data: cursor.into_inner(),
+            buffer: cursor.into_inner(),
         }
     }
 
     pub fn buffer(&self) -> &[u8] {
-        &self.data
+        self.buffer.as_slice()
     }
 }
 

--- a/dds/src/rtps_udp_transport/udp_transport.rs
+++ b/dds/src/rtps_udp_transport/udp_transport.rs
@@ -354,23 +354,40 @@ impl UdpLocator {
 
 struct MessageWriter {
     socket: UdpSocket,
+    buffer: Box<[u8; MAX_DATAGRAM_SIZE]>,
 }
 
 impl Clone for MessageWriter {
     fn clone(&self) -> Self {
         Self {
             socket: self.socket.try_clone().expect("Socket cloning"),
+            buffer: vec![0u8; MAX_DATAGRAM_SIZE]
+                .into_boxed_slice()
+                .try_into()
+                .unwrap(),
         }
     }
 }
 
 impl MessageWriter {
     fn new(socket: UdpSocket) -> Self {
-        Self { socket }
+        Self {
+            socket,
+            buffer: vec![0u8; MAX_DATAGRAM_SIZE]
+                .into_boxed_slice()
+                .try_into()
+                .unwrap(),
+        }
     }
 }
+
 impl WriteMessage for MessageWriter {
-    fn write_message(&self, datagram: &[u8], locator_list: &[Locator]) {
+    fn write_buffer_mut(&mut self) -> &mut [u8] {
+        self.buffer.as_mut_slice()
+    }
+
+    fn write_message(&mut self, len: usize, locator_list: &[Locator]) {
+        let datagram = &self.buffer[..len];
         for &destination_locator in locator_list {
             if UdpLocator(destination_locator).is_multicast() {
                 let socket2: socket2::Socket = self.socket.try_clone().unwrap().into();

--- a/dds/src/transport/interface.rs
+++ b/dds/src/transport/interface.rs
@@ -5,7 +5,8 @@ use crate::{
 use alloc::{boxed::Box, vec::Vec};
 
 pub trait WriteMessage {
-    fn write_message(&self, buf: &[u8], locators: &[Locator]);
+    fn write_buffer_mut(&mut self) -> &mut [u8];
+    fn write_message(&mut self, len: usize, locators: &[Locator]);
 }
 
 #[derive(Clone)]

--- a/dds/src/xtypes/serializer.rs
+++ b/dds/src/xtypes/serializer.rs
@@ -80,7 +80,7 @@ fn serialize_cdr1(
     dynamic_data: &DynamicData,
     endianness: impl EndiannessWrite,
 ) -> XTypesResult<Vec<u8>> {
-    let mut buffer = Vec::new();
+    let mut buffer = Vec::with_capacity(64);
     XTypesSerializer {
         writer: CdrWriter::new(&mut buffer),
         _endianness: endianness,
@@ -95,7 +95,7 @@ fn serialize_cdr2(
     dynamic_data: &DynamicData,
     endianness: impl EndiannessWrite,
 ) -> XTypesResult<Vec<u8>> {
-    let mut buffer = Vec::new();
+    let mut buffer = Vec::with_capacity(64);
     XTypesSerializer {
         writer: CdrWriter::new(&mut buffer),
         _endianness: endianness,

--- a/dds/tests/wire_tests.rs
+++ b/dds/tests/wire_tests.rs
@@ -20,9 +20,14 @@ use dust_dds::{
 
 use crate::utils::domain_id_generator::TEST_DOMAIN_ID_GENERATOR;
 
-struct MockWriter;
+struct MockWriter {
+    buffer: [u8; 512],
+}
 impl WriteMessage for MockWriter {
-    fn write_message(&self, _buf: &[u8], _locators: &[Locator]) {}
+    fn write_buffer_mut(&mut self) -> &mut [u8] {
+        &mut self.buffer
+    }
+    fn write_message(&mut self, _len: usize, _locators: &[Locator]) {}
 }
 
 struct MockTransport(std::sync::mpsc::SyncSender<TransportDataReceiver>);
@@ -34,7 +39,7 @@ impl TransportParticipantFactory for MockTransport {
     ) -> RtpsTransportParticipant {
         self.0.send(data_receiver).unwrap();
         RtpsTransportParticipant {
-            message_writer: Box::new(MockWriter),
+            message_writer: Box::new(MockWriter { buffer: [0; 512] }),
             default_unicast_locator_list: Vec::new(),
             metatraffic_unicast_locator_list: Vec::new(),
             metatraffic_multicast_locator_list: Vec::new(),
@@ -74,7 +79,7 @@ fn detect_stale_participant() {
         .unwrap(),
     );
 
-    let guid_prefix = <[u8; 16]>::from(participant.get_instance_handle())[0..12]
+    let guid_prefix: [u8; 12] = <[u8; 16]>::from(participant.get_instance_handle())[0..12]
         .try_into()
         .unwrap();
 
@@ -122,8 +127,9 @@ fn detect_stale_participant() {
         inline_qos,
         serialized_payload,
     );
+    let mut buf = [0u8; 1024];
     let spdp_rtps_message =
-        RtpsMessageWrite::from_submessages(&[&spdp_data_submessage], guid_prefix);
+        RtpsMessageWrite::from_submessages(&mut buf, &[&spdp_data_submessage], guid_prefix);
 
     dust_dds::std_runtime::executor::block_on(
         data_receiver.receive_message(spdp_rtps_message.buffer().to_vec()),
@@ -238,7 +244,9 @@ fn xtypes_mismatch_does_not_abort_discovery() {
         ParameterList::empty(),
         spdp_payload,
     );
-    let spdp_msg = RtpsMessageWrite::from_submessages(&[&spdp_submsg], remote_guid_prefix);
+    let mut buf = [0u8; 1024];
+    let spdp_msg =
+        RtpsMessageWrite::from_submessages(&mut buf, &[&spdp_submsg], remote_guid_prefix);
     dust_dds::std_runtime::executor::block_on(
         data_receiver.receive_message(spdp_msg.buffer().to_vec()),
     );
@@ -322,8 +330,12 @@ fn xtypes_mismatch_does_not_abort_discovery() {
         reader2_sedp_payload,
     );
 
-    let sedp_msg =
-        RtpsMessageWrite::from_submessages(&[&sedp_submsg1, &sedp_submsg2], remote_guid_prefix);
+    let mut buf = [0u8; 2048];
+    let sedp_msg = RtpsMessageWrite::from_submessages(
+        &mut buf,
+        &[&sedp_submsg1, &sedp_submsg2],
+        remote_guid_prefix,
+    );
     dust_dds::std_runtime::executor::block_on(
         data_receiver.receive_message(sedp_msg.buffer().to_vec()),
     );


### PR DESCRIPTION
This is a set of performance optimization to improve the executions speed of the benchmarks and reduce the number of allocations to minimize the time variability during execution. The main changes are: 
- the message buffer is now allocated once in the transport and written by getting a &mut [u8] from the message writer (this avoid allocating a new Vec for every message that will be written)
- The keyholder type is kept in the writer to avoid having to allocate a new one every time it is needed which requires iterating through the DynamicType
- The rest are small optimizations like pre-allocating Vec to avoid consecutive re-allocations, disabling inline qos when not needed and so on