### PR TITLE
Refactor: Use an RPC style communication for sending mail with a response

### DIFF
--- a/dds/src/dcps/channels/mod.rs
+++ b/dds/src/dcps/channels/mod.rs
@@ -1,3 +1,4 @@
 pub mod mpsc;
 pub mod notification;
 pub mod oneshot;
+pub mod rpc;

--- a/dds/src/dcps/channels/rpc.rs
+++ b/dds/src/dcps/channels/rpc.rs
@@ -1,0 +1,63 @@
+use alloc::sync::Arc;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel, mutex::Mutex};
+
+use crate::{
+    dcps::dcps_mail::{DcpsMail, DcpsReply},
+    infrastructure::error::DdsResult,
+};
+
+/// Mailbox owned by the participant factory actor loop to receive requests and send responses.
+pub struct RpcMailbox {
+    rpc_lock: Mutex<CriticalSectionRawMutex, ()>,
+    request_channel: Channel<CriticalSectionRawMutex, DcpsMail, 1>,
+    response_channel: Channel<CriticalSectionRawMutex, DcpsReply, 1>,
+}
+
+impl RpcMailbox {
+    /// Creates a new RPC mailbox.
+    pub fn new() -> Self {
+        Self {
+            rpc_lock: Mutex::new(()),
+            request_channel: Channel::new(),
+            response_channel: Channel::new(),
+        }
+    }
+
+    /// Receives a request from a caller.
+    pub async fn receive_request(&self) -> DcpsMail {
+        self.request_channel.receive().await
+    }
+
+    /// Sends a response back to the waiting caller.
+    pub async fn send_reply(&self, reply: DcpsReply) {
+        self.response_channel.send(reply).await;
+    }
+}
+
+impl Default for RpcMailbox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Client handle held by async entities to perform request-response RPC calls with the backend.
+#[derive(Clone)]
+pub struct RpcClient {
+    mailbox: Arc<RpcMailbox>,
+}
+
+impl RpcClient {
+    /// Creates a new RPC client wrapping a shared mailbox.
+    pub fn new(mailbox: Arc<RpcMailbox>) -> Self {
+        Self { mailbox }
+    }
+
+    /// Sends an RPC request to the backend actor and awaits its response.
+    pub async fn call(&self, mail: DcpsMail) -> DdsResult<DcpsReply> {
+        let _guard = self.mailbox.rpc_lock.lock().await;
+        // Drain any unconsumed response left over from a previous cancelled caller
+        let _ = self.mailbox.response_channel.try_receive();
+        self.mailbox.request_channel.send(mail).await;
+        Ok(self.mailbox.response_channel.receive().await)
+    }
+}

--- a/dds/src/dcps/dcps_mail.rs
+++ b/dds/src/dcps/dcps_mail.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 use crate::{
     builtin_topics::{
@@ -35,7 +35,6 @@ use crate::{
     transport::{interface::RtpsTransportParticipant, types::GuidPrefix},
     xtypes::dynamic_type::{DynamicData, DynamicType},
 };
-use alloc::vec::Vec;
 
 pub enum DcpsMail {
     ParticipantFactory(ParticipantFactoryMail),
@@ -49,42 +48,52 @@ pub enum DcpsMail {
     Message(MessageServiceMail),
 }
 
-#[allow(clippy::large_enum_variant)]
+pub struct CreateParticipantMail {
+    pub guid_prefix: GuidPrefix,
+    pub domain_id: DomainId,
+    pub qos: QosKind<DomainParticipantQos>,
+    pub dcps_listener: Option<DcpsDomainParticipantListener>,
+    pub listener_mask: StatusMask,
+    pub transport_participant: RtpsTransportParticipant,
+    pub domain_tag: String,
+    pub participant_announcement_interval: core::time::Duration,
+    pub enable_type_information: bool,
+}
+
 pub enum ParticipantFactoryMail {
-    CreateParticipant {
-        guid_prefix: GuidPrefix,
-        domain_id: DomainId,
-        qos: QosKind<DomainParticipantQos>,
-        dcps_listener: Option<DcpsDomainParticipantListener>,
-        listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<InstanceHandle>>,
-        transport_participant: RtpsTransportParticipant,
-        domain_tag: String,
-        participant_announcement_interval: core::time::Duration,
-        enable_type_information: bool,
-    },
+    CreateParticipant(Box<CreateParticipantMail>),
     DeleteParticipant {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     SetDefaultParticipantQos {
-        qos: QosKind<DomainParticipantQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<DomainParticipantQos>>,
     },
-    GetDefaultParticipantQos {
-        reply_sender: OneshotSender<DomainParticipantQos>,
-    },
+    GetDefaultParticipantQos,
     SetQos {
-        qos: QosKind<DomainParticipantFactoryQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<DomainParticipantFactoryQos>>,
     },
-    GetQos {
-        reply_sender: OneshotSender<DomainParticipantFactoryQos>,
-    },
+    GetQos,
     LookupParticipant {
         domain_id: DomainId,
-        reply_sender: OneshotSender<Option<InstanceHandle>>,
     },
+}
+
+pub struct CreateTopicMail {
+    pub participant_handle: InstanceHandle,
+    pub topic_name: String,
+    pub type_name: String,
+    pub qos: QosKind<TopicQos>,
+    pub dcps_listener: Option<DcpsTopicListener>,
+    pub listener_mask: StatusMask,
+    pub type_support: DynamicType<'static>,
+}
+
+pub struct CreateContentFilteredTopicMail {
+    pub participant_handle: InstanceHandle,
+    pub name: String,
+    pub related_topic_name: String,
+    pub filter_expression: String,
+    pub expression_parameters: Vec<String>,
 }
 
 pub enum ParticipantServiceMail {
@@ -93,55 +102,33 @@ pub enum ParticipantServiceMail {
         qos: QosKind<PublisherQos>,
         dcps_listener: Option<DcpsPublisherListener>,
         listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<InstanceHandle>>,
     },
     DeleteUserDefinedPublisher {
         participant_handle: InstanceHandle,
         parent_participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     CreateUserDefinedSubscriber {
         participant_handle: InstanceHandle,
         qos: QosKind<SubscriberQos>,
         dcps_listener: Option<DcpsSubscriberListener>,
         listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<InstanceHandle>>,
     },
     DeleteUserDefinedSubscriber {
         participant_handle: InstanceHandle,
         parent_participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
-    CreateTopic {
-        participant_handle: InstanceHandle,
-        topic_name: String,
-        type_name: String,
-        qos: QosKind<TopicQos>,
-        dcps_listener: Option<DcpsTopicListener>,
-        listener_mask: StatusMask,
-        type_support: DynamicType<'static>,
-        reply_sender: OneshotSender<DdsResult<InstanceHandle>>,
-    },
+    CreateTopic(Box<CreateTopicMail>),
     DeleteUserDefinedTopic {
         participant_handle: InstanceHandle,
         parent_participant_handle: InstanceHandle,
         topic_name: String,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
-    CreateContentFilteredTopic {
-        participant_handle: InstanceHandle,
-        name: String,
-        related_topic_name: String,
-        filter_expression: String,
-        expression_parameters: Vec<String>,
-        reply_sender: OneshotSender<DdsResult<InstanceHandle>>,
-    },
+    CreateContentFilteredTopic(Box<CreateContentFilteredTopicMail>),
     DeleteContentFilteredTopic {
         participant_handle: InstanceHandle,
         name: String,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     FindTopic {
         participant_handle: InstanceHandle,
@@ -153,94 +140,74 @@ pub enum ParticipantServiceMail {
     LookupTopicdescription {
         participant_handle: InstanceHandle,
         topic_name: String,
-        reply_sender: OneshotSender<DdsResult<Option<String>>>,
     },
     IgnoreParticipant {
         participant_handle: InstanceHandle,
         handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     IgnoreSubscription {
         participant_handle: InstanceHandle,
         handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     IgnorePublication {
         participant_handle: InstanceHandle,
         handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     DeleteContainedEntities {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     SetDefaultPublisherQos {
         participant_handle: InstanceHandle,
-        qos: QosKind<PublisherQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<PublisherQos>>,
     },
     GetDefaultPublisherQos {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<PublisherQos>>,
     },
     SetDefaultSubscriberQos {
         participant_handle: InstanceHandle,
-        qos: QosKind<SubscriberQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<SubscriberQos>>,
     },
     GetDefaultSubscriberQos {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<SubscriberQos>>,
     },
     SetDefaultTopicQos {
         participant_handle: InstanceHandle,
-        qos: QosKind<TopicQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<TopicQos>>,
     },
     GetDefaultTopicQos {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<TopicQos>>,
     },
     GetDiscoveredParticipants {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<Vec<InstanceHandle>>>,
     },
     GetDiscoveredParticipantData {
         participant_handle: InstanceHandle,
         discovered_participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<ParticipantBuiltinTopicData>>,
     },
     GetDiscoveredTopics {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<Vec<InstanceHandle>>>,
     },
     GetDiscoveredTopicData {
         participant_handle: InstanceHandle,
         topic_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<TopicBuiltinTopicData>>,
     },
     GetCurrentTime {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<Time>>,
     },
     SetQos {
         participant_handle: InstanceHandle,
-        qos: QosKind<DomainParticipantQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<DomainParticipantQos>>,
     },
     GetQos {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<DomainParticipantQos>>,
     },
     SetListener {
         participant_handle: InstanceHandle,
         dcps_listener: Option<DcpsDomainParticipantListener>,
         listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     Enable {
         participant_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
 }
 
@@ -248,128 +215,112 @@ pub enum TopicServiceMail {
     GetInconsistentTopicStatus {
         participant_handle: InstanceHandle,
         topic_name: String,
-        reply_sender: OneshotSender<DdsResult<InconsistentTopicStatus>>,
     },
     SetQos {
         participant_handle: InstanceHandle,
         topic_name: String,
-        topic_qos: QosKind<TopicQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        topic_qos: Box<QosKind<TopicQos>>,
     },
     GetQos {
         participant_handle: InstanceHandle,
         topic_name: String,
-        reply_sender: OneshotSender<DdsResult<TopicQos>>,
     },
     Enable {
         participant_handle: InstanceHandle,
         topic_name: String,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     GetTypeSupport {
         participant_handle: InstanceHandle,
         topic_name: String,
-        reply_sender: OneshotSender<DdsResult<DynamicType<'static>>>,
     },
 }
 
+pub struct CreateDataWriterMail {
+    pub participant_handle: InstanceHandle,
+    pub publisher_handle: InstanceHandle,
+    pub topic_name: String,
+    pub qos: QosKind<DataWriterQos>,
+    pub dcps_listener: Option<DcpsDataWriterListener>,
+    pub listener_mask: StatusMask,
+}
+
 pub enum PublisherServiceMail {
-    CreateDataWriter {
-        participant_handle: InstanceHandle,
-        publisher_handle: InstanceHandle,
-        topic_name: String,
-        qos: QosKind<DataWriterQos>,
-        dcps_listener: Option<DcpsDataWriterListener>,
-        listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<InstanceHandle>>,
-    },
+    CreateDataWriter(Box<CreateDataWriterMail>),
     DeleteDataWriter {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         datawriter_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     GetDefaultDataWriterQos {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<DataWriterQos>>,
     },
     SetDefaultDataWriterQos {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
-        qos: QosKind<DataWriterQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<DataWriterQos>>,
     },
     GetPublisherQos {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<PublisherQos>>,
     },
     SetPublisherQos {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
-        qos: QosKind<PublisherQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<PublisherQos>>,
     },
     SetPublisherListener {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         dcps_listener: Option<DcpsPublisherListener>,
         listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
 }
 
+pub struct CreateDataReaderMail {
+    pub participant_handle: InstanceHandle,
+    pub subscriber_handle: InstanceHandle,
+    pub topic_name: String,
+    pub qos: QosKind<DataReaderQos>,
+    pub dcps_listener: Option<DcpsDataReaderListener>,
+    pub listener_mask: StatusMask,
+}
+
 pub enum SubscriberServiceMail {
-    CreateDataReader {
-        participant_handle: InstanceHandle,
-        subscriber_handle: InstanceHandle,
-        topic_name: String,
-        qos: QosKind<DataReaderQos>,
-        dcps_listener: Option<DcpsDataReaderListener>,
-        listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<InstanceHandle>>,
-    },
+    CreateDataReader(Box<CreateDataReaderMail>),
     DeleteDataReader {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
         datareader_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     LookupDataReader {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
         topic_name: String,
-        reply_sender: OneshotSender<DdsResult<Option<InstanceHandle>>>,
     },
     SetDefaultDataReaderQos {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
-        qos: QosKind<DataReaderQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<DataReaderQos>>,
     },
     GetDefaultDataReaderQos {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<DataReaderQos>>,
     },
     SetQos {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
-        qos: QosKind<SubscriberQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<SubscriberQos>>,
     },
     GetSubscriberQos {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<SubscriberQos>>,
     },
     SetListener {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
         dcps_listener: Option<DcpsSubscriberListener>,
         listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
 }
 
@@ -380,32 +331,27 @@ pub enum WriterServiceMail {
         data_writer_handle: InstanceHandle,
         dcps_listener: Option<DcpsDataWriterListener>,
         listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     GetDataWriterQos {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<DataWriterQos>>,
     },
     GetMatchedSubscriptions {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<Vec<InstanceHandle>>>,
     },
     GetMatchedSubscriptionData {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         subscription_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<SubscriptionBuiltinTopicData>>,
     },
     GetPublicationMatchedStatus {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<PublicationMatchedStatus>>,
     },
     RegisterInstance {
         participant_handle: InstanceHandle,
@@ -413,7 +359,6 @@ pub enum WriterServiceMail {
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData<'static>,
         timestamp: Option<Time>,
-        reply_sender: OneshotSender<DdsResult<Option<InstanceHandle>>>,
     },
     UnregisterInstance {
         participant_handle: InstanceHandle,
@@ -421,14 +366,12 @@ pub enum WriterServiceMail {
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData<'static>,
         timestamp: Option<Time>,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     LookupInstance {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData<'static>,
-        reply_sender: OneshotSender<DdsResult<Option<InstanceHandle>>>,
     },
     WriteWTimestamp {
         participant_handle: InstanceHandle,
@@ -444,27 +387,45 @@ pub enum WriterServiceMail {
         data_writer_handle: InstanceHandle,
         dynamic_data: DynamicData<'static>,
         timestamp: Option<Time>,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     GetOfferedDeadlineMissedStatus {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<OfferedDeadlineMissedStatus>>,
     },
     EnableDataWriter {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     SetDataWriterQos {
         participant_handle: InstanceHandle,
         publisher_handle: InstanceHandle,
         data_writer_handle: InstanceHandle,
-        qos: QosKind<DataWriterQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<DataWriterQos>>,
     },
+}
+
+pub struct ReadMail {
+    pub participant_handle: InstanceHandle,
+    pub subscriber_handle: InstanceHandle,
+    pub data_reader_handle: InstanceHandle,
+    pub max_samples: i32,
+    pub sample_states: Vec<SampleStateKind>,
+    pub view_states: Vec<ViewStateKind>,
+    pub instance_states: Vec<InstanceStateKind>,
+    pub specific_instance_handle: Option<InstanceHandle>,
+}
+
+pub struct ReadNextInstanceMail {
+    pub participant_handle: InstanceHandle,
+    pub subscriber_handle: InstanceHandle,
+    pub data_reader_handle: InstanceHandle,
+    pub max_samples: i32,
+    pub previous_handle: Option<InstanceHandle>,
+    pub sample_states: Vec<SampleStateKind>,
+    pub view_states: Vec<ViewStateKind>,
+    pub instance_states: Vec<InstanceStateKind>,
 }
 
 pub enum ReaderServiceMail {
@@ -472,87 +433,37 @@ pub enum ReaderServiceMail {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
-    Read {
-        participant_handle: InstanceHandle,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
-        max_samples: i32,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
-        specific_instance_handle: Option<InstanceHandle>,
-        #[allow(clippy::type_complexity)]
-        reply_sender: OneshotSender<DdsResult<Vec<(Option<DynamicData<'static>>, SampleInfo)>>>,
-    },
-    Take {
-        participant_handle: InstanceHandle,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
-        max_samples: i32,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
-        specific_instance_handle: Option<InstanceHandle>,
-        #[allow(clippy::type_complexity)]
-        reply_sender: OneshotSender<DdsResult<Vec<(Option<DynamicData<'static>>, SampleInfo)>>>,
-    },
-    ReadNextInstance {
-        participant_handle: InstanceHandle,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
-        max_samples: i32,
-        previous_handle: Option<InstanceHandle>,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
-        #[allow(clippy::type_complexity)]
-        reply_sender: OneshotSender<DdsResult<Vec<(Option<DynamicData<'static>>, SampleInfo)>>>,
-    },
-    TakeNextInstance {
-        participant_handle: InstanceHandle,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
-        max_samples: i32,
-        previous_handle: Option<InstanceHandle>,
-        sample_states: Vec<SampleStateKind>,
-        view_states: Vec<ViewStateKind>,
-        instance_states: Vec<InstanceStateKind>,
-        #[allow(clippy::type_complexity)]
-        reply_sender: OneshotSender<DdsResult<Vec<(Option<DynamicData<'static>>, SampleInfo)>>>,
-    },
+    Read(Box<ReadMail>),
+    Take(Box<ReadMail>),
+    ReadNextInstance(Box<ReadNextInstanceMail>),
+    TakeNextInstance(Box<ReadNextInstanceMail>),
     GetSubscriptionMatchedStatus {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<SubscriptionMatchedStatus>>,
     },
     GetMatchedPublicationData {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
         publication_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<PublicationBuiltinTopicData>>,
     },
     GetMatchedPublications {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<Vec<InstanceHandle>>>,
     },
     SetQos {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
-        qos: QosKind<DataReaderQos>,
-        reply_sender: OneshotSender<DdsResult<()>>,
+        qos: Box<QosKind<DataReaderQos>>,
     },
     GetQos {
         participant_handle: InstanceHandle,
         subscriber_handle: InstanceHandle,
         data_reader_handle: InstanceHandle,
-        reply_sender: OneshotSender<DdsResult<DataReaderQos>>,
     },
     SetListener {
         participant_handle: InstanceHandle,
@@ -560,28 +471,23 @@ pub enum ReaderServiceMail {
         data_reader_handle: InstanceHandle,
         dcps_listener: Option<DcpsDataReaderListener>,
         listener_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
 }
 
 pub enum StatusConditionMail {
     GetStatusConditionEnabledStatuses {
         entity: StatusConditionEntity,
-        reply_sender: OneshotSender<DdsResult<StatusMask>>,
     },
     SetStatusConditionEnabledStatuses {
         entity: StatusConditionEntity,
         status_mask: StatusMask,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
     GetStatusConditionTriggerValue {
         entity: StatusConditionEntity,
-        reply_sender: OneshotSender<DdsResult<bool>>,
     },
     RegisterNotification {
         entity: StatusConditionEntity,
         notification_sender: NotificationSender,
-        reply_sender: OneshotSender<DdsResult<()>>,
     },
 }
 
@@ -603,4 +509,222 @@ pub enum MessageServiceMail {
 pub struct WireMail {
     pub participant_handle: InstanceHandle,
     pub data_message: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub enum DcpsReply {
+    Ok(DdsResult<()>),
+    InstanceHandle(DdsResult<InstanceHandle>),
+    OptionInstanceHandle(DdsResult<Option<InstanceHandle>>),
+    ParticipantQos(DdsResult<DomainParticipantQos>),
+    PublisherQos(DdsResult<PublisherQos>),
+    SubscriberQos(DdsResult<SubscriberQos>),
+    TopicQos(DdsResult<Box<TopicQos>>),
+    DataWriterQos(DdsResult<Box<DataWriterQos>>),
+    DataReaderQos(DdsResult<Box<DataReaderQos>>),
+    FactoryQos(DdsResult<DomainParticipantFactoryQos>),
+    InstanceHandleList(DdsResult<Vec<InstanceHandle>>),
+    ParticipantBuiltinTopicData(DdsResult<Box<ParticipantBuiltinTopicData>>),
+    TopicBuiltinTopicData(DdsResult<Box<TopicBuiltinTopicData>>),
+    PublicationBuiltinTopicData(DdsResult<Box<PublicationBuiltinTopicData>>),
+    SubscriptionBuiltinTopicData(DdsResult<Box<SubscriptionBuiltinTopicData>>),
+    InconsistentTopicStatus(DdsResult<InconsistentTopicStatus>),
+    PublicationMatchedStatus(DdsResult<PublicationMatchedStatus>),
+    SubscriptionMatchedStatus(DdsResult<SubscriptionMatchedStatus>),
+    OfferedDeadlineMissedStatus(DdsResult<OfferedDeadlineMissedStatus>),
+    Time(DdsResult<Time>),
+    DynamicType(DdsResult<DynamicType<'static>>),
+    TopicDescription(DdsResult<Option<String>>),
+    StatusMask(DdsResult<StatusMask>),
+    TriggerValue(DdsResult<bool>),
+    Samples(DdsResult<Vec<(Option<DynamicData<'static>>, SampleInfo)>>),
+}
+
+impl DcpsReply {
+    pub fn expect_ok(self) -> DdsResult<()> {
+        match self {
+            DcpsReply::Ok(res) => res,
+            other => panic!("expected Ok reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_instance_handle(self) -> DdsResult<InstanceHandle> {
+        match self {
+            DcpsReply::InstanceHandle(res) => res,
+            other => panic!("expected InstanceHandle reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_option_instance_handle(self) -> DdsResult<Option<InstanceHandle>> {
+        match self {
+            DcpsReply::OptionInstanceHandle(res) => res,
+            other => panic!("expected Option<InstanceHandle> reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_participant_qos(self) -> DdsResult<DomainParticipantQos> {
+        match self {
+            DcpsReply::ParticipantQos(res) => res,
+            other => panic!("expected ParticipantQos reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_publisher_qos(self) -> DdsResult<PublisherQos> {
+        match self {
+            DcpsReply::PublisherQos(res) => res,
+            other => panic!("expected PublisherQos reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_subscriber_qos(self) -> DdsResult<SubscriberQos> {
+        match self {
+            DcpsReply::SubscriberQos(res) => res,
+            other => panic!("expected SubscriberQos reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_topic_qos(self) -> DdsResult<TopicQos> {
+        match self {
+            DcpsReply::TopicQos(res) => res.map(|b| *b),
+            other => panic!("expected TopicQos reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_data_writer_qos(self) -> DdsResult<DataWriterQos> {
+        match self {
+            DcpsReply::DataWriterQos(res) => res.map(|b| *b),
+            other => panic!("expected DataWriterQos reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_data_reader_qos(self) -> DdsResult<DataReaderQos> {
+        match self {
+            DcpsReply::DataReaderQos(res) => res.map(|b| *b),
+            other => panic!("expected DataReaderQos reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_factory_qos(self) -> DdsResult<DomainParticipantFactoryQos> {
+        match self {
+            DcpsReply::FactoryQos(res) => res,
+            other => panic!("expected FactoryQos reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_instance_handle_list(self) -> DdsResult<Vec<InstanceHandle>> {
+        match self {
+            DcpsReply::InstanceHandleList(res) => res,
+            other => panic!("expected InstanceHandleList reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_participant_builtin_topic_data(self) -> DdsResult<ParticipantBuiltinTopicData> {
+        match self {
+            DcpsReply::ParticipantBuiltinTopicData(res) => res.map(|b| *b),
+            other => panic!(
+                "expected ParticipantBuiltinTopicData reply, got {:?}",
+                other
+            ),
+        }
+    }
+
+    pub fn expect_topic_builtin_topic_data(self) -> DdsResult<TopicBuiltinTopicData> {
+        match self {
+            DcpsReply::TopicBuiltinTopicData(res) => res.map(|b| *b),
+            other => panic!("expected TopicBuiltinTopicData reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_publication_builtin_topic_data(self) -> DdsResult<PublicationBuiltinTopicData> {
+        match self {
+            DcpsReply::PublicationBuiltinTopicData(res) => res.map(|b| *b),
+            other => panic!(
+                "expected PublicationBuiltinTopicData reply, got {:?}",
+                other
+            ),
+        }
+    }
+
+    pub fn expect_subscription_builtin_topic_data(self) -> DdsResult<SubscriptionBuiltinTopicData> {
+        match self {
+            DcpsReply::SubscriptionBuiltinTopicData(res) => res.map(|b| *b),
+            other => panic!(
+                "expected SubscriptionBuiltinTopicData reply, got {:?}",
+                other
+            ),
+        }
+    }
+
+    pub fn expect_inconsistent_topic_status(self) -> DdsResult<InconsistentTopicStatus> {
+        match self {
+            DcpsReply::InconsistentTopicStatus(res) => res,
+            other => panic!("expected InconsistentTopicStatus reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_publication_matched_status(self) -> DdsResult<PublicationMatchedStatus> {
+        match self {
+            DcpsReply::PublicationMatchedStatus(res) => res,
+            other => panic!("expected PublicationMatchedStatus reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_subscription_matched_status(self) -> DdsResult<SubscriptionMatchedStatus> {
+        match self {
+            DcpsReply::SubscriptionMatchedStatus(res) => res,
+            other => panic!("expected SubscriptionMatchedStatus reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_offered_deadline_missed_status(self) -> DdsResult<OfferedDeadlineMissedStatus> {
+        match self {
+            DcpsReply::OfferedDeadlineMissedStatus(res) => res,
+            other => panic!(
+                "expected OfferedDeadlineMissedStatus reply, got {:?}",
+                other
+            ),
+        }
+    }
+
+    pub fn expect_time(self) -> DdsResult<Time> {
+        match self {
+            DcpsReply::Time(res) => res,
+            other => panic!("expected Time reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_dynamic_type(self) -> DdsResult<DynamicType<'static>> {
+        match self {
+            DcpsReply::DynamicType(res) => res,
+            other => panic!("expected DynamicType reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_topic_description(self) -> DdsResult<Option<String>> {
+        match self {
+            DcpsReply::TopicDescription(res) => res,
+            other => panic!("expected TopicDescription reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_status_mask(self) -> DdsResult<StatusMask> {
+        match self {
+            DcpsReply::StatusMask(res) => res,
+            other => panic!("expected StatusMask reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_trigger_value(self) -> DdsResult<bool> {
+        match self {
+            DcpsReply::TriggerValue(res) => res,
+            other => panic!("expected TriggerValue reply, got {:?}", other),
+        }
+    }
+
+    pub fn expect_samples(self) -> DdsResult<Vec<(Option<DynamicData<'static>>, SampleInfo)>> {
+        match self {
+            DcpsReply::Samples(res) => res,
+            other => panic!("expected Samples reply, got {:?}", other),
+        }
+    }
 }

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -1,9 +1,11 @@
+use alloc::boxed::Box;
+
 use crate::{
     dcps::{
         dcps_mail::{
-            DcpsMail, MessageServiceMail, ParticipantFactoryMail, ParticipantServiceMail,
-            PublisherServiceMail, ReaderServiceMail, StatusConditionMail, SubscriberServiceMail,
-            TopicServiceMail, WriterServiceMail,
+            DcpsMail, DcpsReply, MessageServiceMail, ParticipantFactoryMail,
+            ParticipantServiceMail, PublisherServiceMail, ReaderServiceMail, StatusConditionMail,
+            SubscriberServiceMail, TopicServiceMail, WriterServiceMail,
         },
         dcps_participant_factory::DcpsParticipantFactory,
     },
@@ -12,64 +14,50 @@ use crate::{
 };
 
 impl<R: DdsRuntime> DcpsParticipantFactory<R> {
-    pub fn handle(&mut self, message: DcpsMail, now: Time) {
+    pub fn handle(&mut self, message: DcpsMail, now: Time) -> DcpsReply {
         match message {
-            DcpsMail::ParticipantFactory(ParticipantFactoryMail::CreateParticipant {
-                guid_prefix,
-                domain_id,
-                qos,
-                dcps_listener,
-                listener_mask,
-                reply_sender,
-                transport_participant,
-                domain_tag,
-                participant_announcement_interval,
-                enable_type_information,
-            }) => reply_sender.send(self.create_participant(
-                guid_prefix,
-                domain_id,
-                qos,
-                dcps_listener,
-                listener_mask,
-                transport_participant,
-                domain_tag,
-                participant_announcement_interval,
-                enable_type_information,
-                now,
-            )),
+            DcpsMail::ParticipantFactory(ParticipantFactoryMail::CreateParticipant(p)) => {
+                DcpsReply::InstanceHandle(self.create_participant(
+                    p.guid_prefix,
+                    p.domain_id,
+                    p.qos,
+                    p.dcps_listener,
+                    p.listener_mask,
+                    p.transport_participant,
+                    p.domain_tag,
+                    p.participant_announcement_interval,
+                    p.enable_type_information,
+                    now,
+                ))
+            }
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::DeleteParticipant {
                 participant_handle,
-                reply_sender,
-            }) => reply_sender.send(self.delete_participant(&participant_handle, now)),
+            }) => DcpsReply::Ok(self.delete_participant(&participant_handle, now)),
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::SetDefaultParticipantQos {
                 qos,
-                reply_sender,
-            }) => reply_sender.send(self.set_default_participant_qos(qos)),
-            DcpsMail::ParticipantFactory(ParticipantFactoryMail::GetDefaultParticipantQos {
-                reply_sender,
-            }) => reply_sender.send(self.get_default_participant_qos()),
-            DcpsMail::ParticipantFactory(ParticipantFactoryMail::SetQos { qos, reply_sender }) => {
-                reply_sender.send(self.set_qos(qos))
+            }) => DcpsReply::Ok(self.set_default_participant_qos(*qos)),
+            DcpsMail::ParticipantFactory(ParticipantFactoryMail::GetDefaultParticipantQos) => {
+                DcpsReply::ParticipantQos(Ok(self.get_default_participant_qos()))
             }
-            DcpsMail::ParticipantFactory(ParticipantFactoryMail::GetQos { reply_sender }) => {
-                reply_sender.send(self.get_qos())
+            DcpsMail::ParticipantFactory(ParticipantFactoryMail::SetQos { qos }) => {
+                DcpsReply::Ok(self.set_qos(*qos))
+            }
+            DcpsMail::ParticipantFactory(ParticipantFactoryMail::GetQos) => {
+                DcpsReply::FactoryQos(Ok(self.get_qos()))
             }
             DcpsMail::ParticipantFactory(ParticipantFactoryMail::LookupParticipant {
                 domain_id,
-                reply_sender,
-            }) => reply_sender.send(
-                self.domain_participant_list
-                    .iter()
-                    .find(|x| x.domain_id() == domain_id)
-                    .map(|x| *x.get_instance_handle()),
-            ),
+            }) => DcpsReply::OptionInstanceHandle(Ok(self
+                .domain_participant_list
+                .iter()
+                .find(|x| x.domain_id() == domain_id)
+                .map(|x| *x.get_instance_handle()))),
             DcpsMail::Participant(ParticipantServiceMail::CreateUserDefinedPublisher {
                 qos,
                 participant_handle,
                 dcps_listener,
                 listener_mask,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::InstanceHandle(
                 self.domain_participant_list
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
@@ -87,8 +75,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 parent_participant_handle,
                 publisher_handle,
-                reply_sender,
-            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
+            }) => DcpsReply::Ok(self.find_participant(&participant_handle).and_then(|p| {
                 p.delete_user_defined_publisher(&parent_participant_handle, &publisher_handle)
             })),
             DcpsMail::Participant(ParticipantServiceMail::CreateUserDefinedSubscriber {
@@ -96,8 +83,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 qos,
                 dcps_listener,
                 listener_mask,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::InstanceHandle(
                 self.domain_participant_list
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
@@ -115,69 +101,56 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 parent_participant_handle,
                 subscriber_handle,
-                reply_sender,
-            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
+            }) => DcpsReply::Ok(self.find_participant(&participant_handle).and_then(|p| {
                 p.delete_user_defined_subscriber(&parent_participant_handle, &subscriber_handle)
             })),
-            DcpsMail::Participant(ParticipantServiceMail::CreateTopic {
-                participant_handle,
-                topic_name,
-                type_name,
-                qos,
-                dcps_listener,
-                listener_mask,
-                type_support,
-                reply_sender,
-            }) => match self
-                .domain_participant_list
-                .iter_mut()
-                .find(|x| x.get_instance_handle() == &participant_handle)
-                .ok_or(DdsError::AlreadyDeleted)
-            {
-                Ok(p) => reply_sender.send(p.create_topic(
-                    topic_name,
-                    type_name,
-                    qos,
-                    dcps_listener,
-                    listener_mask,
-                    type_support,
-                    &self.runtime,
-                    now,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
-            },
+            DcpsMail::Participant(ParticipantServiceMail::CreateTopic(p)) => {
+                match self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == &p.participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    Ok(participant) => DcpsReply::InstanceHandle(participant.create_topic(
+                        p.topic_name,
+                        p.type_name,
+                        p.qos,
+                        p.dcps_listener,
+                        p.listener_mask,
+                        p.type_support,
+                        &self.runtime,
+                        now,
+                    )),
+                    Err(e) => DcpsReply::InstanceHandle(Err(e)),
+                }
+            }
             DcpsMail::Participant(ParticipantServiceMail::DeleteUserDefinedTopic {
                 participant_handle,
                 parent_participant_handle,
                 topic_name,
-                reply_sender,
             }) => {
-                reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
+                DcpsReply::Ok(self.find_participant(&participant_handle).and_then(|p| {
                     p.delete_user_defined_topic(&parent_participant_handle, topic_name)
                 }))
             }
-            DcpsMail::Participant(ParticipantServiceMail::CreateContentFilteredTopic {
-                participant_handle,
-                name,
-                related_topic_name,
-                filter_expression,
-                expression_parameters,
-                reply_sender,
-            }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender.send(p.create_content_filtered_topic(
-                    &participant_handle,
-                    name,
-                    related_topic_name,
-                    filter_expression,
-                    expression_parameters,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
-            },
+            DcpsMail::Participant(ParticipantServiceMail::CreateContentFilteredTopic(p)) => {
+                match self.find_participant(&p.participant_handle) {
+                    Ok(participant) => {
+                        DcpsReply::InstanceHandle(participant.create_content_filtered_topic(
+                            &p.participant_handle,
+                            p.name,
+                            p.related_topic_name,
+                            p.filter_expression,
+                            p.expression_parameters,
+                        ))
+                    }
+                    Err(e) => DcpsReply::InstanceHandle(Err(e)),
+                }
+            }
             DcpsMail::Participant(ParticipantServiceMail::DeleteContentFilteredTopic {
                 participant_handle,
                 name,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.delete_content_filtered_topic(&participant_handle, name)),
             ),
@@ -187,104 +160,94 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 type_support,
                 timeout,
                 reply_sender,
-            }) => match self.find_participant(&participant_handle) {
-                Ok(p) => p.find_topic(topic_name, type_support, timeout, now, reply_sender),
-                Err(e) => reply_sender.send(Err(e)),
-            },
-
+            }) => {
+                match self.find_participant(&participant_handle) {
+                    Ok(p) => p.find_topic(topic_name, type_support, timeout, now, reply_sender),
+                    Err(e) => reply_sender.send(Err(e)),
+                }
+                DcpsReply::Ok(Ok(()))
+            }
             DcpsMail::Participant(ParticipantServiceMail::LookupTopicdescription {
                 participant_handle,
                 topic_name,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::TopicDescription(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.lookup_topicdescription(topic_name)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::IgnoreParticipant {
                 participant_handle,
                 handle,
-                reply_sender,
             }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender.send(p.ignore_participant(&handle)),
-                Err(e) => reply_sender.send(Err(e)),
+                Ok(p) => DcpsReply::Ok(p.ignore_participant(&handle)),
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::IgnoreSubscription {
                 participant_handle,
                 handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.ignore_subscription(&handle)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::IgnorePublication {
                 participant_handle,
                 handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.ignore_publication(&handle)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::DeleteContainedEntities {
                 participant_handle,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.delete_participant_contained_entities(now)),
-                Err(e) => reply_sender.send(Err(e)),
+                Ok(p) => DcpsReply::Ok(p.delete_participant_contained_entities(now)),
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::SetDefaultPublisherQos {
                 participant_handle,
                 qos,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_default_publisher_qos(qos)),
+                    .and_then(|p| p.set_default_publisher_qos(*qos)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDefaultPublisherQos {
                 participant_handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::PublisherQos(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.get_default_publisher_qos()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::SetDefaultSubscriberQos {
                 participant_handle,
                 qos,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_default_subscriber_qos(qos)),
+                    .and_then(|p| p.set_default_subscriber_qos(*qos)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDefaultSubscriberQos {
                 participant_handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::SubscriberQos(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.get_default_subscriber_qos()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::SetDefaultTopicQos {
                 participant_handle,
                 qos,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_default_topic_qos(qos)),
+                    .and_then(|p| p.set_default_topic_qos(*qos)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDefaultTopicQos {
                 participant_handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::TopicQos(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_default_topic_qos()),
+                    .and_then(|p| p.get_default_topic_qos().map(Box::new)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetCurrentTime {
                 participant_handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Time(
                 self.domain_participant_list
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
@@ -293,62 +256,55 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredParticipants {
                 participant_handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::InstanceHandleList(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.get_discovered_participants()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredParticipantData {
                 participant_handle,
                 discovered_participant_handle,
-                reply_sender,
-            }) => {
-                reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
+            }) => DcpsReply::ParticipantBuiltinTopicData(
+                self.find_participant(&participant_handle).and_then(|p| {
                     p.get_discovered_participant_data(&discovered_participant_handle)
-                }))
-            }
+                        .map(Box::new)
+                }),
+            ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredTopics {
                 participant_handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::InstanceHandleList(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.get_discovered_topics()),
             ),
             DcpsMail::Participant(ParticipantServiceMail::GetDiscoveredTopicData {
                 participant_handle,
                 topic_handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::TopicBuiltinTopicData(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_discovered_topic_data(&topic_handle)),
+                    .and_then(|p| p.get_discovered_topic_data(&topic_handle).map(Box::new)),
             ),
             DcpsMail::Participant(ParticipantServiceMail::SetQos {
                 participant_handle,
                 qos,
-
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.set_domain_participant_qos(qos, now)),
-                Err(e) => reply_sender.send(Err(e)),
+                Ok(p) => DcpsReply::Ok(p.set_domain_participant_qos(*qos, now)),
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
-            DcpsMail::Participant(ParticipantServiceMail::GetQos {
-                participant_handle,
-                reply_sender,
-            }) => reply_sender.send(
-                self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_domain_participant_qos()),
-            ),
+            DcpsMail::Participant(ParticipantServiceMail::GetQos { participant_handle }) => {
+                DcpsReply::ParticipantQos(
+                    self.find_participant(&participant_handle)
+                        .and_then(|p| p.get_domain_participant_qos()),
+                )
+            }
             DcpsMail::Participant(ParticipantServiceMail::SetListener {
                 participant_handle,
                 dcps_listener,
                 listener_mask,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.domain_participant_list
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
@@ -361,131 +317,115 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                         )
                     }),
             ),
-            DcpsMail::Participant(ParticipantServiceMail::Enable {
-                participant_handle,
-
-                reply_sender,
-            }) => match self
-                .domain_participant_list
-                .iter_mut()
-                .find(|x| x.get_instance_handle() == &participant_handle)
-                .ok_or(DdsError::AlreadyDeleted)
-            {
-                Ok(p) => reply_sender.send(p.enable_domain_participant(now)),
-                Err(e) => reply_sender.send(Err(e)),
-            },
+            DcpsMail::Participant(ParticipantServiceMail::Enable { participant_handle }) => {
+                match self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == &participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    Ok(p) => DcpsReply::Ok(p.enable_domain_participant(now)),
+                    Err(e) => DcpsReply::Ok(Err(e)),
+                }
+            }
             DcpsMail::Topic(TopicServiceMail::GetInconsistentTopicStatus {
                 participant_handle,
                 topic_name,
-                reply_sender,
             }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender.send(p.get_inconsistent_topic_status(topic_name)),
-                Err(e) => reply_sender.send(Err(e)),
+                Ok(p) => {
+                    DcpsReply::InconsistentTopicStatus(p.get_inconsistent_topic_status(topic_name))
+                }
+                Err(e) => DcpsReply::InconsistentTopicStatus(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::SetQos {
                 participant_handle,
                 topic_name,
                 topic_qos,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_topic_qos(topic_name, topic_qos)),
+                    .and_then(|p| p.set_topic_qos(topic_name, *topic_qos)),
             ),
             DcpsMail::Topic(TopicServiceMail::GetQos {
                 participant_handle,
                 topic_name,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::TopicQos(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_topic_qos(topic_name)),
+                    .and_then(|p| p.get_topic_qos(topic_name).map(Box::new)),
             ),
             DcpsMail::Topic(TopicServiceMail::Enable {
                 participant_handle,
                 topic_name,
-
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.enable_topic(topic_name, now)),
-                Err(e) => reply_sender.send(Err(e)),
+                Ok(p) => DcpsReply::Ok(p.enable_topic(topic_name, now)),
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
             DcpsMail::Topic(TopicServiceMail::GetTypeSupport {
                 participant_handle,
                 topic_name,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::DynamicType(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.get_type_support(topic_name)),
             ),
-            DcpsMail::Publisher(PublisherServiceMail::CreateDataWriter {
-                participant_handle,
-                publisher_handle,
-                topic_name,
-                qos,
-                dcps_listener,
-                listener_mask,
-                reply_sender,
-            }) => match self
-                .domain_participant_list
-                .iter_mut()
-                .find(|x| x.get_instance_handle() == &participant_handle)
-                .ok_or(DdsError::AlreadyDeleted)
-            {
-                Ok(p) => reply_sender.send(p.create_data_writer(
-                    &publisher_handle,
-                    topic_name,
-                    qos,
-                    dcps_listener,
-                    listener_mask,
-                    &self.runtime,
-                    now,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
-            },
+            DcpsMail::Publisher(PublisherServiceMail::CreateDataWriter(p)) => {
+                match self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == &p.participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    Ok(participant) => DcpsReply::InstanceHandle(participant.create_data_writer(
+                        &p.publisher_handle,
+                        p.topic_name,
+                        p.qos,
+                        p.dcps_listener,
+                        p.listener_mask,
+                        &self.runtime,
+                        now,
+                    )),
+                    Err(e) => DcpsReply::InstanceHandle(Err(e)),
+                }
+            }
             DcpsMail::Publisher(PublisherServiceMail::DeleteDataWriter {
                 participant_handle,
                 publisher_handle,
                 datawriter_handle,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.delete_data_writer(
-                    &publisher_handle,
-                    &datawriter_handle,
-                    now,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
+                Ok(p) => {
+                    DcpsReply::Ok(p.delete_data_writer(&publisher_handle, &datawriter_handle, now))
+                }
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
             DcpsMail::Publisher(PublisherServiceMail::GetDefaultDataWriterQos {
                 participant_handle,
                 publisher_handle,
-                reply_sender,
-            }) => reply_sender.send(
-                self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_default_datawriter_qos(&publisher_handle)),
-            ),
+            }) => {
+                DcpsReply::DataWriterQos(self.find_participant(&participant_handle).and_then(|p| {
+                    p.get_default_datawriter_qos(&publisher_handle)
+                        .map(Box::new)
+                }))
+            }
             DcpsMail::Publisher(PublisherServiceMail::SetDefaultDataWriterQos {
                 participant_handle,
                 publisher_handle,
                 qos,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_default_datawriter_qos(&publisher_handle, qos)),
+                    .and_then(|p| p.set_default_datawriter_qos(&publisher_handle, *qos)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::GetPublisherQos {
                 participant_handle,
                 publisher_handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::PublisherQos(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.get_publisher_qos(&publisher_handle)),
             ),
@@ -493,18 +433,16 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 publisher_handle,
                 qos,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_publisher_qos(&publisher_handle, qos)),
+                    .and_then(|p| p.set_publisher_qos(&publisher_handle, *qos)),
             ),
             DcpsMail::Publisher(PublisherServiceMail::SetPublisherListener {
                 participant_handle,
                 publisher_handle,
                 dcps_listener,
                 listener_mask,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.domain_participant_list
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
@@ -524,8 +462,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_writer_handle,
                 dcps_listener,
                 listener_mask,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.domain_participant_list
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
@@ -544,43 +481,45 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
-                reply_sender,
-            }) => reply_sender.send(
-                self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_data_writer_qos(&publisher_handle, &data_writer_handle)),
-            ),
+            }) => {
+                DcpsReply::DataWriterQos(self.find_participant(&participant_handle).and_then(|p| {
+                    p.get_data_writer_qos(&publisher_handle, &data_writer_handle)
+                        .map(Box::new)
+                }))
+            }
             DcpsMail::Writer(WriterServiceMail::GetMatchedSubscriptions {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
-                reply_sender,
             }) => {
-                reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
-                    p.get_matched_subscriptions(&publisher_handle, &data_writer_handle)
-                }))
+                DcpsReply::InstanceHandleList(self.find_participant(&participant_handle).and_then(
+                    |p| p.get_matched_subscriptions(&publisher_handle, &data_writer_handle),
+                ))
             }
             DcpsMail::Writer(WriterServiceMail::GetMatchedSubscriptionData {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
                 subscription_handle,
-                reply_sender,
-            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
-                p.get_matched_subscription_data(
-                    &publisher_handle,
-                    &data_writer_handle,
-                    &subscription_handle,
-                )
-            })),
+            }) => DcpsReply::SubscriptionBuiltinTopicData(
+                self.find_participant(&participant_handle).and_then(|p| {
+                    p.get_matched_subscription_data(
+                        &publisher_handle,
+                        &data_writer_handle,
+                        &subscription_handle,
+                    )
+                    .map(Box::new)
+                }),
+            ),
             DcpsMail::Writer(WriterServiceMail::GetPublicationMatchedStatus {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
-                reply_sender,
             }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender
-                    .send(p.get_publication_matched_status(&publisher_handle, &data_writer_handle)),
-                Err(e) => reply_sender.send(Err(e)),
+                Ok(p) => DcpsReply::PublicationMatchedStatus(
+                    p.get_publication_matched_status(&publisher_handle, &data_writer_handle),
+                ),
+                Err(e) => DcpsReply::PublicationMatchedStatus(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::RegisterInstance {
                 participant_handle,
@@ -588,7 +527,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_writer_handle,
                 dynamic_data,
                 timestamp,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
@@ -597,14 +535,14 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             {
                 Ok(p) => {
                     let timestamp = timestamp.unwrap_or(now);
-                    reply_sender.send(p.register_instance(
+                    DcpsReply::OptionInstanceHandle(p.register_instance(
                         &publisher_handle,
                         &data_writer_handle,
                         &dynamic_data,
                         timestamp,
-                    ));
+                    ))
                 }
-                Err(e) => reply_sender.send(Err(e)),
+                Err(e) => DcpsReply::OptionInstanceHandle(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::UnregisterInstance {
                 participant_handle,
@@ -612,7 +550,6 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 data_writer_handle,
                 dynamic_data,
                 timestamp,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
@@ -621,24 +558,25 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             {
                 Ok(p) => {
                     let timestamp = timestamp.unwrap_or(now);
-                    reply_sender.send(p.unregister_instance(
+                    DcpsReply::Ok(p.unregister_instance(
                         &publisher_handle,
                         &data_writer_handle,
                         &dynamic_data,
                         timestamp,
-                    ));
+                    ))
                 }
-                Err(e) => reply_sender.send(Err(e)),
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::LookupInstance {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
                 dynamic_data,
-                reply_sender,
-            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
-                p.lookup_instance(&publisher_handle, &data_writer_handle, &dynamic_data)
-            })),
+            }) => DcpsReply::OptionInstanceHandle(
+                self.find_participant(&participant_handle).and_then(|p| {
+                    p.lookup_instance(&publisher_handle, &data_writer_handle, &dynamic_data)
+                }),
+            ),
             DcpsMail::Writer(WriterServiceMail::WriteWTimestamp {
                 participant_handle,
                 publisher_handle,
@@ -646,33 +584,34 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 dynamic_data,
                 timestamp,
                 reply_sender,
-            }) => match self
-                .domain_participant_list
-                .iter_mut()
-                .find(|x| x.get_instance_handle() == &participant_handle)
-                .ok_or(DdsError::AlreadyDeleted)
-            {
-                Ok(p) => {
-                    let timestamp = timestamp.unwrap_or(now);
-                    p.write_w_timestamp(
-                        &publisher_handle,
-                        &data_writer_handle,
-                        &dynamic_data,
-                        timestamp,
-                        now,
-                        reply_sender,
-                    );
+            }) => {
+                match self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == &participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    Ok(p) => {
+                        let timestamp = timestamp.unwrap_or(now);
+                        p.write_w_timestamp(
+                            &publisher_handle,
+                            &data_writer_handle,
+                            &dynamic_data,
+                            timestamp,
+                            now,
+                            reply_sender,
+                        );
+                    }
+                    Err(e) => reply_sender.send(Err(e)),
                 }
-                Err(e) => reply_sender.send(Err(e)),
-            },
-
+                DcpsReply::Ok(Ok(()))
+            }
             DcpsMail::Writer(WriterServiceMail::DisposeWTimestamp {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
                 dynamic_data,
                 timestamp,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
@@ -681,113 +620,98 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             {
                 Ok(p) => {
                     let timestamp = timestamp.unwrap_or(now);
-                    reply_sender.send(p.dispose_w_timestamp(
+                    DcpsReply::Ok(p.dispose_w_timestamp(
                         &publisher_handle,
                         &data_writer_handle,
                         &dynamic_data,
                         timestamp,
-                    ));
+                    ))
                 }
-                Err(e) => reply_sender.send(Err(e)),
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::GetOfferedDeadlineMissedStatus {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
-                reply_sender,
             }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender.send(
+                Ok(p) => DcpsReply::OfferedDeadlineMissedStatus(
                     p.get_offered_deadline_missed_status(&publisher_handle, &data_writer_handle),
                 ),
-                Err(e) => reply_sender.send(Err(e)),
+                Err(e) => DcpsReply::OfferedDeadlineMissedStatus(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::EnableDataWriter {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.enable_data_writer(
-                    &publisher_handle,
-                    &data_writer_handle,
-                    now,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
+                Ok(p) => {
+                    DcpsReply::Ok(p.enable_data_writer(&publisher_handle, &data_writer_handle, now))
+                }
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
             DcpsMail::Writer(WriterServiceMail::SetDataWriterQos {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
                 qos,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.set_data_writer_qos(
+                Ok(p) => DcpsReply::Ok(p.set_data_writer_qos(
                     &publisher_handle,
                     &data_writer_handle,
-                    qos,
+                    *qos,
                     now,
                 )),
-                Err(e) => reply_sender.send(Err(e)),
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
-            DcpsMail::Subscriber(SubscriberServiceMail::CreateDataReader {
-                participant_handle,
-                subscriber_handle,
-                topic_name,
-                qos,
-                dcps_listener,
-                listener_mask,
-                reply_sender,
-            }) => match self
-                .domain_participant_list
-                .iter_mut()
-                .find(|x| x.get_instance_handle() == &participant_handle)
-                .ok_or(DdsError::AlreadyDeleted)
-            {
-                Ok(p) => reply_sender.send(p.create_data_reader(
-                    &subscriber_handle,
-                    topic_name,
-                    qos,
-                    dcps_listener,
-                    listener_mask,
-                    &self.runtime,
-                    now,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
-            },
+            DcpsMail::Subscriber(SubscriberServiceMail::CreateDataReader(p)) => {
+                match self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == &p.participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    Ok(participant) => DcpsReply::InstanceHandle(participant.create_data_reader(
+                        &p.subscriber_handle,
+                        p.topic_name,
+                        p.qos,
+                        p.dcps_listener,
+                        p.listener_mask,
+                        &self.runtime,
+                        now,
+                    )),
+                    Err(e) => DcpsReply::InstanceHandle(Err(e)),
+                }
+            }
             DcpsMail::Subscriber(SubscriberServiceMail::DeleteDataReader {
                 participant_handle,
                 subscriber_handle,
                 datareader_handle,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.delete_data_reader(
-                    &subscriber_handle,
-                    &datareader_handle,
-                    now,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
+                Ok(p) => {
+                    DcpsReply::Ok(p.delete_data_reader(&subscriber_handle, &datareader_handle, now))
+                }
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
             DcpsMail::Subscriber(SubscriberServiceMail::LookupDataReader {
                 participant_handle,
                 subscriber_handle,
                 topic_name,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::OptionInstanceHandle(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.lookup_data_reader(&subscriber_handle, topic_name)),
             ),
@@ -795,33 +719,31 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 subscriber_handle,
                 qos,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_default_data_reader_qos(&subscriber_handle, qos)),
+                    .and_then(|p| p.set_default_data_reader_qos(&subscriber_handle, *qos)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::GetDefaultDataReaderQos {
                 participant_handle,
                 subscriber_handle,
-                reply_sender,
-            }) => reply_sender.send(
-                self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_default_data_reader_qos(&subscriber_handle)),
-            ),
+            }) => {
+                DcpsReply::DataReaderQos(self.find_participant(&participant_handle).and_then(|p| {
+                    p.get_default_data_reader_qos(&subscriber_handle)
+                        .map(Box::new)
+                }))
+            }
             DcpsMail::Subscriber(SubscriberServiceMail::SetQos {
                 participant_handle,
                 subscriber_handle,
                 qos,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.find_participant(&participant_handle)
-                    .and_then(|p| p.set_subscriber_qos(&subscriber_handle, qos)),
+                    .and_then(|p| p.set_subscriber_qos(&subscriber_handle, *qos)),
             ),
             DcpsMail::Subscriber(SubscriberServiceMail::GetSubscriberQos {
                 participant_handle,
                 subscriber_handle,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::SubscriberQos(
                 self.find_participant(&participant_handle)
                     .and_then(|p| p.get_subscriber_qos(&subscriber_handle)),
             ),
@@ -830,8 +752,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 subscriber_handle,
                 dcps_listener,
                 listener_mask,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.domain_participant_list
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
@@ -845,183 +766,169 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                         )
                     }),
             ),
-            DcpsMail::Reader(ReaderServiceMail::Read {
-                participant_handle,
-                subscriber_handle,
-                data_reader_handle,
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                specific_instance_handle,
-                reply_sender,
-            }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender.send(p.read(
-                    &subscriber_handle,
-                    &data_reader_handle,
-                    max_samples,
-                    &sample_states,
-                    &view_states,
-                    &instance_states,
-                    &specific_instance_handle,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
-            },
-            DcpsMail::Reader(ReaderServiceMail::Take {
-                participant_handle,
-                subscriber_handle,
-                data_reader_handle,
-                max_samples,
-                sample_states,
-                view_states,
-                instance_states,
-                specific_instance_handle,
-                reply_sender,
-            }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender.send(p.take(
-                    &subscriber_handle,
-                    &data_reader_handle,
-                    max_samples,
-                    &sample_states,
-                    &view_states,
-                    &instance_states,
-                    &specific_instance_handle,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
-            },
-            DcpsMail::Reader(ReaderServiceMail::ReadNextInstance {
-                participant_handle,
-                subscriber_handle,
-                data_reader_handle,
-                max_samples,
-                previous_handle,
-                sample_states,
-                view_states,
-                instance_states,
-                reply_sender,
-            }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender.send(p.read_next_instance(
-                    &subscriber_handle,
-                    &data_reader_handle,
-                    max_samples,
-                    &previous_handle,
-                    &sample_states,
-                    &view_states,
-                    &instance_states,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
-            },
-            DcpsMail::Reader(ReaderServiceMail::TakeNextInstance {
-                participant_handle,
-                subscriber_handle,
-                data_reader_handle,
-                max_samples,
-                previous_handle,
-                sample_states,
-                view_states,
-                instance_states,
-                reply_sender,
-            }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender.send(p.take_next_instance(
-                    &subscriber_handle,
-                    &data_reader_handle,
-                    max_samples,
-                    &previous_handle,
-                    &sample_states,
-                    &view_states,
-                    &instance_states,
-                )),
-                Err(e) => reply_sender.send(Err(e)),
-            },
             DcpsMail::Reader(ReaderServiceMail::Enable {
                 participant_handle,
                 subscriber_handle,
                 data_reader_handle,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.enable_data_reader(
+                Ok(p) => DcpsReply::Ok(p.enable_data_reader(
                     &subscriber_handle,
                     &data_reader_handle,
                     now,
                 )),
-                Err(e) => reply_sender.send(Err(e)),
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
+            DcpsMail::Reader(ReaderServiceMail::Read(p)) => {
+                match self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == &p.participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    Ok(participant) => DcpsReply::Samples(participant.read(
+                        &p.subscriber_handle,
+                        &p.data_reader_handle,
+                        p.max_samples,
+                        &p.sample_states,
+                        &p.view_states,
+                        &p.instance_states,
+                        &p.specific_instance_handle,
+                    )),
+                    Err(e) => DcpsReply::Samples(Err(e)),
+                }
+            }
+            DcpsMail::Reader(ReaderServiceMail::Take(p)) => {
+                match self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == &p.participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    Ok(participant) => DcpsReply::Samples(participant.take(
+                        &p.subscriber_handle,
+                        &p.data_reader_handle,
+                        p.max_samples,
+                        &p.sample_states,
+                        &p.view_states,
+                        &p.instance_states,
+                        &p.specific_instance_handle,
+                    )),
+                    Err(e) => DcpsReply::Samples(Err(e)),
+                }
+            }
+            DcpsMail::Reader(ReaderServiceMail::ReadNextInstance(p)) => {
+                match self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == &p.participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    Ok(participant) => DcpsReply::Samples(participant.read_next_instance(
+                        &p.subscriber_handle,
+                        &p.data_reader_handle,
+                        p.max_samples,
+                        &p.previous_handle,
+                        &p.sample_states,
+                        &p.view_states,
+                        &p.instance_states,
+                    )),
+                    Err(e) => DcpsReply::Samples(Err(e)),
+                }
+            }
+            DcpsMail::Reader(ReaderServiceMail::TakeNextInstance(p)) => {
+                match self
+                    .domain_participant_list
+                    .iter_mut()
+                    .find(|x| x.get_instance_handle() == &p.participant_handle)
+                    .ok_or(DdsError::AlreadyDeleted)
+                {
+                    Ok(participant) => DcpsReply::Samples(participant.take_next_instance(
+                        &p.subscriber_handle,
+                        &p.data_reader_handle,
+                        p.max_samples,
+                        &p.previous_handle,
+                        &p.sample_states,
+                        &p.view_states,
+                        &p.instance_states,
+                    )),
+                    Err(e) => DcpsReply::Samples(Err(e)),
+                }
+            }
             DcpsMail::Reader(ReaderServiceMail::GetSubscriptionMatchedStatus {
                 participant_handle,
                 subscriber_handle,
                 data_reader_handle,
-                reply_sender,
             }) => match self.find_participant(&participant_handle) {
-                Ok(p) => reply_sender.send(
+                Ok(p) => DcpsReply::SubscriptionMatchedStatus(
                     p.get_subscription_matched_status(&subscriber_handle, &data_reader_handle),
                 ),
-                Err(e) => reply_sender.send(Err(e)),
+                Err(e) => DcpsReply::SubscriptionMatchedStatus(Err(e)),
             },
             DcpsMail::Reader(ReaderServiceMail::GetMatchedPublicationData {
                 participant_handle,
                 subscriber_handle,
                 data_reader_handle,
                 publication_handle,
-                reply_sender,
-            }) => reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
-                p.get_matched_publication_data(
-                    &subscriber_handle,
-                    &data_reader_handle,
-                    &publication_handle,
-                )
-            })),
+            }) => DcpsReply::PublicationBuiltinTopicData(
+                self.find_participant(&participant_handle).and_then(|p| {
+                    p.get_matched_publication_data(
+                        &subscriber_handle,
+                        &data_reader_handle,
+                        &publication_handle,
+                    )
+                    .map(Box::new)
+                }),
+            ),
             DcpsMail::Reader(ReaderServiceMail::GetMatchedPublications {
                 participant_handle,
                 subscriber_handle,
                 data_reader_handle,
-                reply_sender,
             }) => {
-                reply_sender.send(self.find_participant(&participant_handle).and_then(|p| {
-                    p.get_matched_publications(&subscriber_handle, &data_reader_handle)
-                }))
+                DcpsReply::InstanceHandleList(self.find_participant(&participant_handle).and_then(
+                    |p| p.get_matched_publications(&subscriber_handle, &data_reader_handle),
+                ))
             }
-            DcpsMail::Reader(ReaderServiceMail::GetQos {
-                participant_handle,
-                subscriber_handle,
-                data_reader_handle,
-                reply_sender,
-            }) => reply_sender.send(
-                self.find_participant(&participant_handle)
-                    .and_then(|p| p.get_data_reader_qos(&subscriber_handle, &data_reader_handle)),
-            ),
             DcpsMail::Reader(ReaderServiceMail::SetQos {
                 participant_handle,
                 subscriber_handle,
                 data_reader_handle,
                 qos,
-                reply_sender,
             }) => match self
                 .domain_participant_list
                 .iter_mut()
                 .find(|x| x.get_instance_handle() == &participant_handle)
                 .ok_or(DdsError::AlreadyDeleted)
             {
-                Ok(p) => reply_sender.send(p.set_data_reader_qos(
+                Ok(p) => DcpsReply::Ok(p.set_data_reader_qos(
                     &subscriber_handle,
                     &data_reader_handle,
-                    qos,
+                    *qos,
                     now,
                 )),
-                Err(e) => reply_sender.send(Err(e)),
+                Err(e) => DcpsReply::Ok(Err(e)),
             },
+            DcpsMail::Reader(ReaderServiceMail::GetQos {
+                participant_handle,
+                subscriber_handle,
+                data_reader_handle,
+            }) => {
+                DcpsReply::DataReaderQos(self.find_participant(&participant_handle).and_then(|p| {
+                    p.get_data_reader_qos(&subscriber_handle, &data_reader_handle)
+                        .map(Box::new)
+                }))
+            }
             DcpsMail::Reader(ReaderServiceMail::SetListener {
                 participant_handle,
                 subscriber_handle,
                 data_reader_handle,
                 dcps_listener,
                 listener_mask,
-                reply_sender,
-            }) => reply_sender.send(
+            }) => DcpsReply::Ok(
                 self.domain_participant_list
                     .iter_mut()
                     .find(|x| x.get_instance_handle() == &participant_handle)
@@ -1038,65 +945,50 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
             ),
             DcpsMail::StatusCondition(StatusConditionMail::GetStatusConditionEnabledStatuses {
                 entity,
-                reply_sender,
-            }) => {
-                reply_sender.send(self.get_status_condition_enabled_statuses(entity));
-            }
+            }) => DcpsReply::StatusMask(self.get_status_condition_enabled_statuses(entity)),
             DcpsMail::StatusCondition(StatusConditionMail::GetStatusConditionTriggerValue {
                 entity,
-                reply_sender,
-            }) => {
-                reply_sender.send(self.get_status_condition_trigger_value(entity));
-            }
+            }) => DcpsReply::TriggerValue(self.get_status_condition_trigger_value(entity)),
             DcpsMail::StatusCondition(StatusConditionMail::RegisterNotification {
                 entity,
                 notification_sender,
-                reply_sender,
-            }) => {
-                reply_sender.send(self.register_notification(entity, notification_sender));
-            }
+            }) => DcpsReply::Ok(self.register_notification(entity, notification_sender)),
             DcpsMail::StatusCondition(StatusConditionMail::SetStatusConditionEnabledStatuses {
                 entity,
                 status_mask,
-                reply_sender,
-            }) => {
-                reply_sender.send(self.set_status_condition_enabled_statuses(entity, status_mask));
-            }
+            }) => DcpsReply::Ok(self.set_status_condition_enabled_statuses(entity, status_mask)),
             DcpsMail::Message(MessageServiceMail::NotifyAcknowledgments {
                 participant_handle,
                 publisher_handle,
                 data_writer_handle,
                 reply_sender,
-            }) => match self.find_participant(&participant_handle) {
-                Ok(p) => {
-                    p.notify_acknowledgments(&publisher_handle, &data_writer_handle, reply_sender)
+            }) => {
+                match self.find_participant(&participant_handle) {
+                    Ok(p) => p.notify_acknowledgments(
+                        &publisher_handle,
+                        &data_writer_handle,
+                        reply_sender,
+                    ),
+                    Err(e) => reply_sender.send(Err(e)),
                 }
-
-                Err(e) => reply_sender.send(Err(e)),
-            },
+                DcpsReply::Ok(Ok(()))
+            }
             DcpsMail::Message(MessageServiceMail::NotifyHistoricalData {
                 participant_handle,
                 subscriber_handle,
                 data_reader_handle,
                 reply_sender,
-            }) => match self.find_participant(&participant_handle) {
-                Ok(p) => {
-                    p.notify_historical_data(&subscriber_handle, &data_reader_handle, reply_sender)
+            }) => {
+                match self.find_participant(&participant_handle) {
+                    Ok(p) => p.notify_historical_data(
+                        &subscriber_handle,
+                        &data_reader_handle,
+                        reply_sender,
+                    ),
+                    Err(e) => reply_sender.send(Err(e)),
                 }
-
-                Err(e) => reply_sender.send(Err(e)),
-            },
-        }
-    }
-
-    pub fn handle_wire_mail(&mut self, wire_mail: crate::dcps::dcps_mail::WireMail, now: Time) {
-        if let Ok(p) = self
-            .domain_participant_list
-            .iter_mut()
-            .find(|x| x.get_instance_handle() == &wire_mail.participant_handle)
-            .ok_or(DdsError::AlreadyDeleted)
-        {
-            p.handle_data(wire_mail.data_message.as_slice(), now);
+                DcpsReply::Ok(Ok(()))
+            }
         }
     }
 }

--- a/dds/src/dds_async/condition.rs
+++ b/dds/src/dds_async/condition.rs
@@ -1,6 +1,6 @@
 use crate::{
     dcps::{
-        channels::{notification::NotificationSender, oneshot::oneshot},
+        channels::notification::NotificationSender,
         dcps_mail::{DcpsMail, StatusConditionMail},
         status_condition::StatusConditionEntity,
     },
@@ -27,17 +27,15 @@ impl StatusConditionAsync {
         &self,
         notification_sender: NotificationSender,
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::StatusCondition(
+            .call(DcpsMail::StatusCondition(
                 StatusConditionMail::RegisterNotification {
                     entity: self.entity.clone(),
                     notification_sender,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 }
 
@@ -45,32 +43,28 @@ impl StatusConditionAsync {
     /// Async version of [`get_enabled_statuses`](crate::infrastructure::condition::StatusCondition::get_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn get_enabled_statuses(&self) -> DdsResult<impl IntoIterator<Item = StatusKind>> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::StatusCondition(
+            .call(DcpsMail::StatusCondition(
                 StatusConditionMail::GetStatusConditionEnabledStatuses {
                     entity: self.entity.clone(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_status_mask()
     }
 
     /// Async version of [`set_enabled_statuses`](crate::infrastructure::condition::StatusCondition::set_enabled_statuses).
     #[tracing::instrument(skip(self))]
     pub async fn set_enabled_statuses(&self, mask: &[StatusKind]) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::StatusCondition(
+            .call(DcpsMail::StatusCondition(
                 StatusConditionMail::SetStatusConditionEnabledStatuses {
                     entity: self.entity.clone(),
                     status_mask: mask.iter().collect(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_entity`](crate::infrastructure::condition::StatusCondition::get_entity).
@@ -84,15 +78,13 @@ impl StatusConditionAsync {
     /// Async version of [`get_trigger_value`](crate::infrastructure::condition::StatusCondition::get_trigger_value).
     #[tracing::instrument(skip(self))]
     pub async fn get_trigger_value(&self) -> DdsResult<bool> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::StatusCondition(
+            .call(DcpsMail::StatusCondition(
                 StatusConditionMail::GetStatusConditionTriggerValue {
                     entity: self.entity.clone(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_trigger_value()
     }
 }

--- a/dds/src/dds_async/data_reader.rs
+++ b/dds/src/dds_async/data_reader.rs
@@ -5,7 +5,9 @@ use crate::{
     builtin_topics::PublicationBuiltinTopicData,
     dcps::{
         channels::oneshot::oneshot,
-        dcps_mail::{DcpsMail, MessageServiceMail, ReaderServiceMail},
+        dcps_mail::{
+            DcpsMail, MessageServiceMail, ReadMail, ReadNextInstanceMail, ReaderServiceMail,
+        },
         listeners::data_reader_listener::DcpsDataReaderListener,
         status_condition::StatusConditionEntity,
     },
@@ -29,6 +31,7 @@ use crate::{
     xtypes::type_support::TypeSupport,
 };
 use alloc::{
+    boxed::Box,
     string::{String, ToString},
     sync::Arc,
     vec,
@@ -120,21 +123,22 @@ impl<Foo: TypeSupport> DataReaderAsync<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::Read {
-                participant_handle: self.subscriber.get_participant().get_instance_handle(),
-                subscriber_handle: self.subscriber.get_instance_handle(),
-                data_reader_handle: self.handle,
-                max_samples,
-                sample_states: sample_states.to_vec(),
-                view_states: view_states.to_vec(),
-                instance_states: instance_states.to_vec(),
-                specific_instance_handle: None,
-                reply_sender,
-            }))
-            .await;
-        let samples = reply_receiver.await??;
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Reader(ReaderServiceMail::Read(Box::new(
+                ReadMail {
+                    participant_handle: self.subscriber.get_participant().get_instance_handle(),
+                    subscriber_handle: self.subscriber.get_instance_handle(),
+                    data_reader_handle: self.handle,
+                    max_samples,
+                    sample_states: sample_states.to_vec(),
+                    view_states: view_states.to_vec(),
+                    instance_states: instance_states.to_vec(),
+                    specific_instance_handle: None,
+                },
+            ))))
+            .await?;
+        let samples = reply.expect_samples()?;
 
         Ok(samples
             .into_iter()
@@ -151,21 +155,22 @@ impl<Foo: TypeSupport> DataReaderAsync<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::Take {
-                participant_handle: self.subscriber.get_participant().get_instance_handle(),
-                subscriber_handle: self.subscriber.get_instance_handle(),
-                data_reader_handle: self.handle,
-                max_samples,
-                sample_states: sample_states.to_vec(),
-                view_states: view_states.to_vec(),
-                instance_states: instance_states.to_vec(),
-                specific_instance_handle: None,
-                reply_sender,
-            }))
-            .await;
-        let samples = reply_receiver.await??;
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Reader(ReaderServiceMail::Take(Box::new(
+                ReadMail {
+                    participant_handle: self.subscriber.get_participant().get_instance_handle(),
+                    subscriber_handle: self.subscriber.get_instance_handle(),
+                    data_reader_handle: self.handle,
+                    max_samples,
+                    sample_states: sample_states.to_vec(),
+                    view_states: view_states.to_vec(),
+                    instance_states: instance_states.to_vec(),
+                    specific_instance_handle: None,
+                },
+            ))))
+            .await?;
+        let samples = reply.expect_samples()?;
 
         Ok(samples
             .into_iter()
@@ -176,21 +181,22 @@ impl<Foo: TypeSupport> DataReaderAsync<Foo> {
     /// Async version of [`read_next_sample`](crate::subscription::data_reader::DataReader::read_next_sample).
     #[tracing::instrument(skip(self))]
     pub async fn read_next_sample(&self) -> DdsResult<Sample<Foo>> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::Read {
-                participant_handle: self.subscriber.get_participant().get_instance_handle(),
-                subscriber_handle: self.subscriber.get_instance_handle(),
-                data_reader_handle: self.handle,
-                max_samples: 1,
-                sample_states: vec![SampleStateKind::NotRead],
-                view_states: ANY_VIEW_STATE.to_vec(),
-                instance_states: ANY_INSTANCE_STATE.to_vec(),
-                specific_instance_handle: None,
-                reply_sender,
-            }))
-            .await;
-        let mut samples = reply_receiver.await??;
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Reader(ReaderServiceMail::Read(Box::new(
+                ReadMail {
+                    participant_handle: self.subscriber.get_participant().get_instance_handle(),
+                    subscriber_handle: self.subscriber.get_instance_handle(),
+                    data_reader_handle: self.handle,
+                    max_samples: 1,
+                    sample_states: vec![SampleStateKind::NotRead],
+                    view_states: ANY_VIEW_STATE.to_vec(),
+                    instance_states: ANY_INSTANCE_STATE.to_vec(),
+                    specific_instance_handle: None,
+                },
+            ))))
+            .await?;
+        let mut samples = reply.expect_samples()?;
         let (data, sample_info) = samples.pop().expect("Would return NoData if empty");
         Ok(Sample::new(data, sample_info))
     }
@@ -198,21 +204,22 @@ impl<Foo: TypeSupport> DataReaderAsync<Foo> {
     /// Async version of [`take_next_sample`](crate::subscription::data_reader::DataReader::take_next_sample).
     #[tracing::instrument(skip(self))]
     pub async fn take_next_sample(&self) -> DdsResult<Sample<Foo>> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::Take {
-                participant_handle: self.subscriber.get_participant().get_instance_handle(),
-                subscriber_handle: self.subscriber.get_instance_handle(),
-                data_reader_handle: self.handle,
-                max_samples: 1,
-                sample_states: vec![SampleStateKind::NotRead],
-                view_states: ANY_VIEW_STATE.to_vec(),
-                instance_states: ANY_INSTANCE_STATE.to_vec(),
-                specific_instance_handle: None,
-                reply_sender,
-            }))
-            .await;
-        let mut samples = reply_receiver.await??;
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Reader(ReaderServiceMail::Take(Box::new(
+                ReadMail {
+                    participant_handle: self.subscriber.get_participant().get_instance_handle(),
+                    subscriber_handle: self.subscriber.get_instance_handle(),
+                    data_reader_handle: self.handle,
+                    max_samples: 1,
+                    sample_states: vec![SampleStateKind::NotRead],
+                    view_states: ANY_VIEW_STATE.to_vec(),
+                    instance_states: ANY_INSTANCE_STATE.to_vec(),
+                    specific_instance_handle: None,
+                },
+            ))))
+            .await?;
+        let mut samples = reply.expect_samples()?;
         let (data, sample_info) = samples.pop().expect("Would return NoData if empty");
         Ok(Sample::new(data, sample_info))
     }
@@ -227,21 +234,22 @@ impl<Foo: TypeSupport> DataReaderAsync<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::Read {
-                participant_handle: self.subscriber.get_participant().get_instance_handle(),
-                subscriber_handle: self.subscriber.get_instance_handle(),
-                data_reader_handle: self.handle,
-                max_samples,
-                sample_states: sample_states.to_vec(),
-                view_states: view_states.to_vec(),
-                instance_states: instance_states.to_vec(),
-                specific_instance_handle: Some(a_handle),
-                reply_sender,
-            }))
-            .await;
-        let samples = reply_receiver.await??;
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Reader(ReaderServiceMail::Read(Box::new(
+                ReadMail {
+                    participant_handle: self.subscriber.get_participant().get_instance_handle(),
+                    subscriber_handle: self.subscriber.get_instance_handle(),
+                    data_reader_handle: self.handle,
+                    max_samples,
+                    sample_states: sample_states.to_vec(),
+                    view_states: view_states.to_vec(),
+                    instance_states: instance_states.to_vec(),
+                    specific_instance_handle: Some(a_handle),
+                },
+            ))))
+            .await?;
+        let samples = reply.expect_samples()?;
         Ok(samples
             .into_iter()
             .map(|(data, sample_info)| Sample::new(data, sample_info))
@@ -258,21 +266,22 @@ impl<Foo: TypeSupport> DataReaderAsync<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::Take {
-                participant_handle: self.subscriber.get_participant().get_instance_handle(),
-                subscriber_handle: self.subscriber.get_instance_handle(),
-                data_reader_handle: self.handle,
-                max_samples,
-                sample_states: sample_states.to_vec(),
-                view_states: view_states.to_vec(),
-                instance_states: instance_states.to_vec(),
-                specific_instance_handle: Some(a_handle),
-                reply_sender,
-            }))
-            .await;
-        let samples = reply_receiver.await??;
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Reader(ReaderServiceMail::Take(Box::new(
+                ReadMail {
+                    participant_handle: self.subscriber.get_participant().get_instance_handle(),
+                    subscriber_handle: self.subscriber.get_instance_handle(),
+                    data_reader_handle: self.handle,
+                    max_samples,
+                    sample_states: sample_states.to_vec(),
+                    view_states: view_states.to_vec(),
+                    instance_states: instance_states.to_vec(),
+                    specific_instance_handle: Some(a_handle),
+                },
+            ))))
+            .await?;
+        let samples = reply.expect_samples()?;
 
         Ok(samples
             .into_iter()
@@ -290,21 +299,22 @@ impl<Foo: TypeSupport> DataReaderAsync<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::ReadNextInstance {
-                participant_handle: self.subscriber.get_participant().get_instance_handle(),
-                subscriber_handle: self.subscriber.get_instance_handle(),
-                data_reader_handle: self.handle,
-                max_samples,
-                previous_handle,
-                sample_states: sample_states.to_vec(),
-                view_states: view_states.to_vec(),
-                instance_states: instance_states.to_vec(),
-                reply_sender,
-            }))
-            .await;
-        let samples = reply_receiver.await??;
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Reader(ReaderServiceMail::ReadNextInstance(
+                Box::new(ReadNextInstanceMail {
+                    participant_handle: self.subscriber.get_participant().get_instance_handle(),
+                    subscriber_handle: self.subscriber.get_instance_handle(),
+                    data_reader_handle: self.handle,
+                    max_samples,
+                    previous_handle,
+                    sample_states: sample_states.to_vec(),
+                    view_states: view_states.to_vec(),
+                    instance_states: instance_states.to_vec(),
+                }),
+            )))
+            .await?;
+        let samples = reply.expect_samples()?;
         Ok(samples
             .into_iter()
             .map(|(data, sample_info)| Sample::new(data, sample_info))
@@ -321,21 +331,22 @@ impl<Foo: TypeSupport> DataReaderAsync<Foo> {
         view_states: &[ViewStateKind],
         instance_states: &[InstanceStateKind],
     ) -> DdsResult<Vec<Sample<Foo>>> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::TakeNextInstance {
-                participant_handle: self.subscriber.get_participant().get_instance_handle(),
-                subscriber_handle: self.subscriber.get_instance_handle(),
-                data_reader_handle: self.handle,
-                max_samples,
-                previous_handle,
-                sample_states: sample_states.to_vec(),
-                view_states: view_states.to_vec(),
-                instance_states: instance_states.to_vec(),
-                reply_sender,
-            }))
-            .await;
-        let samples = reply_receiver.await??;
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Reader(ReaderServiceMail::TakeNextInstance(
+                Box::new(ReadNextInstanceMail {
+                    participant_handle: self.subscriber.get_participant().get_instance_handle(),
+                    subscriber_handle: self.subscriber.get_instance_handle(),
+                    data_reader_handle: self.handle,
+                    max_samples,
+                    previous_handle,
+                    sample_states: sample_states.to_vec(),
+                    view_states: view_states.to_vec(),
+                    instance_states: instance_states.to_vec(),
+                }),
+            )))
+            .await?;
+        let samples = reply.expect_samples()?;
         Ok(samples
             .into_iter()
             .map(|(data, sample_info)| Sample::new(data, sample_info))
@@ -397,18 +408,16 @@ impl<Foo> DataReaderAsync<Foo> {
     /// Async version of [`get_subscription_matched_status`](crate::subscription::data_reader::DataReader::get_subscription_matched_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_subscription_matched_status(&self) -> DdsResult<SubscriptionMatchedStatus> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Reader(
+            .call(DcpsMail::Reader(
                 ReaderServiceMail::GetSubscriptionMatchedStatus {
                     participant_handle: self.subscriber.get_participant().get_instance_handle(),
                     subscriber_handle: self.subscriber.get_instance_handle(),
                     data_reader_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_subscription_matched_status()
     }
 
     /// Async version of [`get_topicdescription`](crate::subscription::data_reader::DataReader::get_topicdescription).
@@ -430,7 +439,7 @@ impl<Foo> DataReaderAsync<Foo> {
     pub async fn wait_for_historical_data(&self) -> DdsResult<()> {
         let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Message(
+            .call(DcpsMail::Message(
                 MessageServiceMail::NotifyHistoricalData {
                     participant_handle: self.subscriber.get_participant().get_instance_handle(),
                     subscriber_handle: self.subscriber.get_instance_handle(),
@@ -438,7 +447,7 @@ impl<Foo> DataReaderAsync<Foo> {
                     reply_sender,
                 },
             ))
-            .await;
+            .await?;
         reply_receiver.await?
     }
 
@@ -448,69 +457,60 @@ impl<Foo> DataReaderAsync<Foo> {
         &self,
         publication_handle: InstanceHandle,
     ) -> DdsResult<PublicationBuiltinTopicData> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Reader(
+            .call(DcpsMail::Reader(
                 ReaderServiceMail::GetMatchedPublicationData {
                     participant_handle: self.subscriber.get_participant().get_instance_handle(),
                     subscriber_handle: self.subscriber.get_instance_handle(),
                     data_reader_handle: self.handle,
                     publication_handle,
-                    reply_sender,
                 },
             ))
-            .await;
-
-        reply_receiver.await?
+            .await?
+            .expect_publication_builtin_topic_data()
     }
 
     /// Async version of [`get_matched_publications`](crate::subscription::data_reader::DataReader::get_matched_publications).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_publications(&self) -> DdsResult<Vec<InstanceHandle>> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Reader(
+            .call(DcpsMail::Reader(
                 ReaderServiceMail::GetMatchedPublications {
                     participant_handle: self.subscriber.get_participant().get_instance_handle(),
                     subscriber_handle: self.subscriber.get_instance_handle(),
                     data_reader_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_instance_handle_list()
     }
 }
 
 impl<Foo> DataReaderAsync<Foo> {
     /// Async version of [`set_qos`](crate::subscription::data_reader::DataReader::set_qos).
     pub async fn set_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::SetQos {
+            .call(DcpsMail::Reader(ReaderServiceMail::SetQos {
                 participant_handle: self.subscriber.get_participant().get_instance_handle(),
                 subscriber_handle: self.subscriber.get_instance_handle(),
                 data_reader_handle: self.handle,
-                qos,
-                reply_sender,
+                qos: Box::new(qos),
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_qos`](crate::subscription::data_reader::DataReader::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DataReaderQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::GetQos {
+            .call(DcpsMail::Reader(ReaderServiceMail::GetQos {
                 participant_handle: self.subscriber.get_participant().get_instance_handle(),
                 subscriber_handle: self.subscriber.get_instance_handle(),
                 data_reader_handle: self.handle,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_data_reader_qos()
     }
 
     /// Async version of [`get_statuscondition`](crate::subscription::data_reader::DataReader::get_statuscondition).
@@ -538,16 +538,14 @@ impl<Foo> DataReaderAsync<Foo> {
     /// Async version of [`enable`](crate::subscription::data_reader::DataReader::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::Enable {
+            .call(DcpsMail::Reader(ReaderServiceMail::Enable {
                 participant_handle: self.subscriber.get_participant().get_instance_handle(),
                 subscriber_handle: self.subscriber.get_instance_handle(),
                 data_reader_handle: self.handle,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_instance_handle`](crate::subscription::data_reader::DataReader::get_instance_handle).
@@ -565,18 +563,16 @@ impl<Foo> DataReaderAsync<Foo> {
         a_listener: Option<impl DataReaderListener<Foo> + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dcps_listener = a_listener.map(DcpsDataReaderListener::new);
         self.dcps_sender()
-            .send(DcpsMail::Reader(ReaderServiceMail::SetListener {
+            .call(DcpsMail::Reader(ReaderServiceMail::SetListener {
                 participant_handle: self.subscriber.get_participant().get_instance_handle(),
                 subscriber_handle: self.subscriber.get_instance_handle(),
                 data_reader_handle: self.handle,
                 dcps_listener,
                 listener_mask: mask.iter().collect(),
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 }

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -82,19 +82,17 @@ where
     /// Async version of [`register_instance`](crate::publication::data_writer::DataWriter::register_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn register_instance(&self, instance: Foo) -> DdsResult<Option<InstanceHandle>> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dynamic_data = instance.create_dynamic_sample();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::RegisterInstance {
+            .call(DcpsMail::Writer(WriterServiceMail::RegisterInstance {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
                 timestamp: None,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_option_instance_handle()
     }
 
     /// Async version of [`register_instance_w_timestamp`](crate::publication::data_writer::DataWriter::register_instance_w_timestamp).
@@ -104,19 +102,17 @@ where
         instance: Foo,
         timestamp: Time,
     ) -> DdsResult<Option<InstanceHandle>> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dynamic_data = instance.create_dynamic_sample();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::RegisterInstance {
+            .call(DcpsMail::Writer(WriterServiceMail::RegisterInstance {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
                 timestamp: Some(timestamp),
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_option_instance_handle()
     }
 
     /// Async version of [`unregister_instance`](crate::publication::data_writer::DataWriter::unregister_instance).
@@ -126,19 +122,17 @@ where
         instance: Foo,
         handle: Option<InstanceHandle>,
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dynamic_data = instance.create_dynamic_sample();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::UnregisterInstance {
+            .call(DcpsMail::Writer(WriterServiceMail::UnregisterInstance {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
                 timestamp: None,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`unregister_instance_w_timestamp`](crate::publication::data_writer::DataWriter::unregister_instance_w_timestamp).
@@ -149,19 +143,17 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dynamic_data = instance.create_dynamic_sample();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::UnregisterInstance {
+            .call(DcpsMail::Writer(WriterServiceMail::UnregisterInstance {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
                 timestamp: Some(timestamp),
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_key_value`](crate::publication::data_writer::DataWriter::get_key_value).
@@ -177,18 +169,16 @@ where
     /// Async version of [`lookup_instance`](crate::publication::data_writer::DataWriter::lookup_instance).
     #[tracing::instrument(skip(self, instance))]
     pub async fn lookup_instance(&self, instance: Foo) -> DdsResult<Option<InstanceHandle>> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dynamic_data = instance.create_dynamic_sample();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::LookupInstance {
+            .call(DcpsMail::Writer(WriterServiceMail::LookupInstance {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_option_instance_handle()
     }
 
     /// Async version of [`write`](crate::publication::data_writer::DataWriter::write).
@@ -197,7 +187,7 @@ where
         let (reply_sender, reply_receiver) = oneshot();
         let dynamic_data = data.create_dynamic_sample();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::WriteWTimestamp {
+            .call(DcpsMail::Writer(WriterServiceMail::WriteWTimestamp {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
@@ -205,7 +195,7 @@ where
                 timestamp: None,
                 reply_sender,
             }))
-            .await;
+            .await?;
         reply_receiver.await?
     }
 
@@ -220,7 +210,7 @@ where
         let (reply_sender, reply_receiver) = oneshot();
         let dynamic_data = data.create_dynamic_sample();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::WriteWTimestamp {
+            .call(DcpsMail::Writer(WriterServiceMail::WriteWTimestamp {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
@@ -228,26 +218,24 @@ where
                 timestamp: Some(timestamp),
                 reply_sender,
             }))
-            .await;
+            .await?;
         reply_receiver.await?
     }
 
     /// Async version of [`dispose`](crate::publication::data_writer::DataWriter::dispose).
     #[tracing::instrument(skip(self, data))]
     pub async fn dispose(&self, data: Foo, handle: Option<InstanceHandle>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dynamic_data = data.create_dynamic_sample();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::DisposeWTimestamp {
+            .call(DcpsMail::Writer(WriterServiceMail::DisposeWTimestamp {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
                 timestamp: None,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`dispose_w_timestamp`](crate::publication::data_writer::DataWriter::dispose_w_timestamp).
@@ -258,19 +246,17 @@ where
         handle: Option<InstanceHandle>,
         timestamp: Time,
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dynamic_data = data.create_dynamic_sample();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::DisposeWTimestamp {
+            .call(DcpsMail::Writer(WriterServiceMail::DisposeWTimestamp {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dynamic_data,
                 timestamp: Some(timestamp),
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 }
 
@@ -285,7 +271,7 @@ impl<Foo> DataWriterAsync<Foo> {
         let data_writer_handle = self.handle;
         let (reply_sender, reply_receiver) = oneshot();
         participant_address
-            .send(DcpsMail::Message(
+            .call(DcpsMail::Message(
                 MessageServiceMail::NotifyAcknowledgments {
                     participant_handle: self.publisher.get_participant().get_instance_handle(),
                     publisher_handle,
@@ -293,7 +279,7 @@ impl<Foo> DataWriterAsync<Foo> {
                     reply_sender,
                 },
             ))
-            .await;
+            .await?;
         reply_receiver.await?
     }
 
@@ -308,18 +294,16 @@ impl<Foo> DataWriterAsync<Foo> {
     pub async fn get_offered_deadline_missed_status(
         &self,
     ) -> DdsResult<OfferedDeadlineMissedStatus> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Writer(
+            .call(DcpsMail::Writer(
                 WriterServiceMail::GetOfferedDeadlineMissedStatus {
                     participant_handle: self.publisher.get_participant().get_instance_handle(),
                     publisher_handle: self.publisher.get_instance_handle(),
                     data_writer_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_offered_deadline_missed_status()
     }
 
     /// Async version of [`get_offered_incompatible_qos_status`](crate::publication::data_writer::DataWriter::get_offered_incompatible_qos_status).
@@ -333,18 +317,16 @@ impl<Foo> DataWriterAsync<Foo> {
     /// Async version of [`get_publication_matched_status`](crate::publication::data_writer::DataWriter::get_publication_matched_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_publication_matched_status(&self) -> DdsResult<PublicationMatchedStatus> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Writer(
+            .call(DcpsMail::Writer(
                 WriterServiceMail::GetPublicationMatchedStatus {
                     participant_handle: self.publisher.get_participant().get_instance_handle(),
                     publisher_handle: self.publisher.get_instance_handle(),
                     data_writer_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_publication_matched_status()
     }
 
     /// Async version of [`get_topic`](crate::publication::data_writer::DataWriter::get_topic).
@@ -371,36 +353,32 @@ impl<Foo> DataWriterAsync<Foo> {
         &self,
         subscription_handle: InstanceHandle,
     ) -> DdsResult<SubscriptionBuiltinTopicData> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Writer(
+            .call(DcpsMail::Writer(
                 WriterServiceMail::GetMatchedSubscriptionData {
                     participant_handle: self.publisher.get_participant().get_instance_handle(),
                     publisher_handle: self.publisher.get_instance_handle(),
                     data_writer_handle: self.handle,
                     subscription_handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_subscription_builtin_topic_data()
     }
 
     /// Async version of [`get_matched_subscriptions`](crate::publication::data_writer::DataWriter::get_matched_subscriptions).
     #[tracing::instrument(skip(self))]
     pub async fn get_matched_subscriptions(&self) -> DdsResult<Vec<InstanceHandle>> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Writer(
+            .call(DcpsMail::Writer(
                 WriterServiceMail::GetMatchedSubscriptions {
                     participant_handle: self.publisher.get_participant().get_instance_handle(),
                     publisher_handle: self.publisher.get_instance_handle(),
                     data_writer_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_instance_handle_list()
     }
 }
 
@@ -408,32 +386,28 @@ impl<Foo> DataWriterAsync<Foo> {
     /// Async version of [`set_qos`](crate::publication::data_writer::DataWriter::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::SetDataWriterQos {
+            .call(DcpsMail::Writer(WriterServiceMail::SetDataWriterQos {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
-                qos,
-                reply_sender,
+                qos: Box::new(qos),
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_qos`](crate::publication::data_writer::DataWriter::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DataWriterQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::GetDataWriterQos {
+            .call(DcpsMail::Writer(WriterServiceMail::GetDataWriterQos {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_data_writer_qos()
     }
 
     /// Async version of [`get_statuscondition`](crate::publication::data_writer::DataWriter::get_statuscondition).
@@ -458,16 +432,14 @@ impl<Foo> DataWriterAsync<Foo> {
     /// Async version of [`enable`](crate::publication::data_writer::DataWriter::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::EnableDataWriter {
+            .call(DcpsMail::Writer(WriterServiceMail::EnableDataWriter {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_instance_handle`](crate::publication::data_writer::DataWriter::get_instance_handle).
@@ -484,18 +456,16 @@ impl<Foo> DataWriterAsync<Foo> {
         a_listener: Option<impl DataWriterListener<Foo> + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dcps_listener = a_listener.map(DcpsDataWriterListener::new);
         self.dcps_sender()
-            .send(DcpsMail::Writer(WriterServiceMail::SetListener {
+            .call(DcpsMail::Writer(WriterServiceMail::SetListener {
                 participant_handle: self.publisher.get_participant().get_instance_handle(),
                 publisher_handle: self.publisher.get_instance_handle(),
                 data_writer_handle: self.handle,
                 dcps_listener,
                 listener_mask: mask.iter().collect(),
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 }

--- a/dds/src/dds_async/data_writer.rs
+++ b/dds/src/dds_async/data_writer.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     xtypes::type_support::TypeSupport,
 };
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::marker::PhantomData;
 
 /// Async version of [`DataWriter`](crate::publication::data_writer::DataWriter).

--- a/dds/src/dds_async/domain_participant.rs
+++ b/dds/src/dds_async/domain_participant.rs
@@ -6,7 +6,9 @@ use crate::{
     builtin_topics::{ParticipantBuiltinTopicData, TopicBuiltinTopicData},
     dcps::{
         channels::oneshot::oneshot,
-        dcps_mail::{DcpsMail, ParticipantServiceMail},
+        dcps_mail::{
+            CreateContentFilteredTopicMail, CreateTopicMail, DcpsMail, ParticipantServiceMail,
+        },
         listeners::{
             domain_participant_listener::DcpsDomainParticipantListener,
             publisher_listener::DcpsPublisherListener, subscriber_listener::DcpsSubscriberListener,
@@ -30,6 +32,7 @@ use crate::{
 };
 
 use alloc::{
+    boxed::Box,
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
@@ -70,20 +73,19 @@ impl DomainParticipantAsync {
         a_listener: Option<impl PublisherListener + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<PublisherAsync> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dcps_listener = a_listener.map(DcpsPublisherListener::new);
-        self.dcps_sender
-            .send(DcpsMail::Participant(
+        let reply = self
+            .dcps_sender
+            .call(DcpsMail::Participant(
                 crate::dcps::dcps_mail::ParticipantServiceMail::CreateUserDefinedPublisher {
                     participant_handle: self.handle,
                     qos,
                     dcps_listener,
                     listener_mask: mask.iter().collect(),
-                    reply_sender,
                 },
             ))
-            .await;
-        let guid = reply_receiver.await??;
+            .await?;
+        let guid = reply.expect_instance_handle()?;
         let publisher = PublisherAsync::new(guid, self.clone());
 
         Ok(publisher)
@@ -92,18 +94,16 @@ impl DomainParticipantAsync {
     /// Async version of [`delete_publisher`](crate::domain::domain_participant::DomainParticipant::delete_publisher).
     #[tracing::instrument(skip(self, a_publisher))]
     pub async fn delete_publisher(&self, a_publisher: &PublisherAsync) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::DeleteUserDefinedPublisher {
                     participant_handle: self.handle,
                     parent_participant_handle: a_publisher.get_participant().handle,
                     publisher_handle: a_publisher.get_instance_handle(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`create_subscriber`](crate::domain::domain_participant::DomainParticipant::create_subscriber).
@@ -114,20 +114,19 @@ impl DomainParticipantAsync {
         a_listener: Option<impl SubscriberListener + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<SubscriberAsync> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dcps_listener = a_listener.map(DcpsSubscriberListener::new);
-        self.dcps_sender
-            .send(DcpsMail::Participant(
+        let reply = self
+            .dcps_sender
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::CreateUserDefinedSubscriber {
                     participant_handle: self.handle,
                     qos,
                     dcps_listener,
                     listener_mask: mask.iter().collect(),
-                    reply_sender,
                 },
             ))
-            .await;
-        let guid = reply_receiver.await??;
+            .await?;
+        let guid = reply.expect_instance_handle()?;
         let subscriber = SubscriberAsync::new(guid, self.clone());
 
         Ok(subscriber)
@@ -136,18 +135,16 @@ impl DomainParticipantAsync {
     /// Async version of [`delete_subscriber`](crate::domain::domain_participant::DomainParticipant::delete_subscriber).
     #[tracing::instrument(skip(self, a_subscriber))]
     pub async fn delete_subscriber(&self, a_subscriber: &SubscriberAsync) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::DeleteUserDefinedSubscriber {
                     participant_handle: self.handle,
                     parent_participant_handle: a_subscriber.get_participant().handle,
                     subscriber_handle: a_subscriber.get_instance_handle(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`create_topic`](crate::domain::domain_participant::DomainParticipant::create_topic).
@@ -178,21 +175,22 @@ impl DomainParticipantAsync {
         mask: &[StatusKind],
         dynamic_type_representation: DynamicType<'static>,
     ) -> DdsResult<TopicAsync> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dcps_listener = a_listener.map(DcpsTopicListener::new);
-        self.dcps_sender
-            .send(DcpsMail::Participant(ParticipantServiceMail::CreateTopic {
-                participant_handle: self.handle,
-                topic_name: String::from(topic_name),
-                type_name: String::from(type_name),
-                qos,
-                dcps_listener,
-                listener_mask: mask.iter().collect(),
-                type_support: dynamic_type_representation,
-                reply_sender,
-            }))
-            .await;
-        let guid = reply_receiver.await??;
+        let reply = self
+            .dcps_sender
+            .call(DcpsMail::Participant(ParticipantServiceMail::CreateTopic(
+                Box::new(CreateTopicMail {
+                    participant_handle: self.handle,
+                    topic_name: String::from(topic_name),
+                    type_name: String::from(type_name),
+                    qos,
+                    dcps_listener,
+                    listener_mask: mask.iter().collect(),
+                    type_support: dynamic_type_representation,
+                }),
+            )))
+            .await?;
+        let guid = reply.expect_instance_handle()?;
 
         Ok(TopicAsync::new(
             guid,
@@ -205,18 +203,16 @@ impl DomainParticipantAsync {
     /// Async version of [`delete_topic`](crate::domain::domain_participant::DomainParticipant::delete_topic).
     #[tracing::instrument(skip(self, a_topic))]
     pub async fn delete_topic(&self, a_topic: &TopicAsync) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::DeleteUserDefinedTopic {
                     participant_handle: a_topic.get_participant().handle,
                     parent_participant_handle: self.handle,
                     topic_name: a_topic.get_name(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`create_contentfilteredtopic`](crate::domain::domain_participant::DomainParticipant::create_contentfilteredtopic).
@@ -231,20 +227,20 @@ impl DomainParticipantAsync {
         let topic = related_topic.clone();
         let name = name.to_string();
         let related_topic_name = related_topic.get_name();
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
-                ParticipantServiceMail::CreateContentFilteredTopic {
-                    participant_handle: topic.get_participant().handle,
-                    name: name.clone(),
-                    related_topic_name,
-                    filter_expression,
-                    expression_parameters,
-                    reply_sender,
-                },
+            .call(DcpsMail::Participant(
+                ParticipantServiceMail::CreateContentFilteredTopic(Box::new(
+                    CreateContentFilteredTopicMail {
+                        participant_handle: topic.get_participant().handle,
+                        name: name.clone(),
+                        related_topic_name,
+                        filter_expression,
+                        expression_parameters,
+                    },
+                )),
             ))
-            .await;
-        reply_receiver.await??;
+            .await?
+            .expect_instance_handle()?;
         Ok(ContentFilteredTopicAsync::new(name.clone(), topic))
     }
 
@@ -254,17 +250,15 @@ impl DomainParticipantAsync {
         &self,
         a_contentfilteredtopic: &ContentFilteredTopicAsync,
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::DeleteContentFilteredTopic {
                     participant_handle: a_contentfilteredtopic.get_participant().handle,
                     name: a_contentfilteredtopic.get_name(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`find_topic`](crate::domain::domain_participant::DomainParticipant::find_topic).
@@ -283,14 +277,14 @@ impl DomainParticipantAsync {
         let (reply_sender, reply_receiver) = oneshot();
 
         participant_address
-            .send(DcpsMail::Participant(ParticipantServiceMail::FindTopic {
+            .call(DcpsMail::Participant(ParticipantServiceMail::FindTopic {
                 participant_handle: self.handle,
                 topic_name: topic_name.clone(),
                 type_support: Foo::TYPE,
                 timeout,
                 reply_sender,
             }))
-            .await;
+            .await?;
         let (guid, type_name) = reply_receiver.await??;
         Ok(TopicAsync::new(
             guid,
@@ -325,17 +319,16 @@ impl DomainParticipantAsync {
             }
         }
 
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender
-            .send(DcpsMail::Participant(
+        let reply = self
+            .dcps_sender
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::LookupTopicdescription {
                     participant_handle: self.handle,
                     topic_name: String::from(topic_name),
-                    reply_sender,
                 },
             ))
-            .await;
-        if let Some(type_name) = reply_receiver.await?? {
+            .await?;
+        if let Some(type_name) = reply.expect_topic_description()? {
             Ok(Some(LocalTopicDescription {
                 participant: self.clone(),
                 type_name,
@@ -355,17 +348,15 @@ impl DomainParticipantAsync {
     /// Async version of [`ignore_participant`](crate::domain::domain_participant::DomainParticipant::ignore_participant).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_participant(&self, handle: InstanceHandle) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::IgnoreParticipant {
                     participant_handle: self.handle,
                     handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`ignore_topic`](crate::domain::domain_participant::DomainParticipant::ignore_topic).
@@ -377,33 +368,29 @@ impl DomainParticipantAsync {
     /// Async version of [`ignore_publication`](crate::domain::domain_participant::DomainParticipant::ignore_publication).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_publication(&self, handle: InstanceHandle) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::IgnorePublication {
                     participant_handle: self.handle,
                     handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`ignore_subscription`](crate::domain::domain_participant::DomainParticipant::ignore_subscription).
     #[tracing::instrument(skip(self))]
     pub async fn ignore_subscription(&self, handle: InstanceHandle) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::IgnoreSubscription {
                     participant_handle: self.handle,
                     handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_domain_id`](crate::domain::domain_participant::DomainParticipant::get_domain_id).
@@ -415,16 +402,14 @@ impl DomainParticipantAsync {
     /// Async version of [`delete_contained_entities`](crate::domain::domain_participant::DomainParticipant::delete_contained_entities).
     #[tracing::instrument(skip(self))]
     pub async fn delete_contained_entities(&self) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::DeleteContainedEntities {
                     participant_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`assert_liveliness`](crate::domain::domain_participant::DomainParticipant::assert_liveliness).
@@ -436,109 +421,95 @@ impl DomainParticipantAsync {
     /// Async version of [`set_default_publisher_qos`](crate::domain::domain_participant::DomainParticipant::set_default_publisher_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_publisher_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::SetDefaultPublisherQos {
                     participant_handle: self.handle,
-                    qos,
-                    reply_sender,
+                    qos: Box::new(qos),
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_default_publisher_qos`](crate::domain::domain_participant::DomainParticipant::get_default_publisher_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_publisher_qos(&self) -> DdsResult<PublisherQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::GetDefaultPublisherQos {
                     participant_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_publisher_qos()
     }
 
     /// Async version of [`set_default_subscriber_qos`](crate::domain::domain_participant::DomainParticipant::set_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_subscriber_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::SetDefaultSubscriberQos {
                     participant_handle: self.handle,
-                    qos,
-                    reply_sender,
+                    qos: Box::new(qos),
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_default_subscriber_qos`](crate::domain::domain_participant::DomainParticipant::get_default_subscriber_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_subscriber_qos(&self) -> DdsResult<SubscriberQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::GetDefaultSubscriberQos {
                     participant_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_subscriber_qos()
     }
 
     /// Async version of [`set_default_topic_qos`](crate::domain::domain_participant::DomainParticipant::set_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_topic_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::SetDefaultTopicQos {
                     participant_handle: self.handle,
-                    qos,
-                    reply_sender,
+                    qos: Box::new(qos),
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_default_topic_qos`](crate::domain::domain_participant::DomainParticipant::get_default_topic_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_topic_qos(&self) -> DdsResult<TopicQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::GetDefaultTopicQos {
                     participant_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_topic_qos()
     }
 
     /// Async version of [`get_discovered_participants`](crate::domain::domain_participant::DomainParticipant::get_discovered_participants).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_participants(&self) -> DdsResult<Vec<InstanceHandle>> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::GetDiscoveredParticipants {
                     participant_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_instance_handle_list()
     }
 
     /// Async version of [`get_discovered_participant_data`](crate::domain::domain_participant::DomainParticipant::get_discovered_participant_data).
@@ -547,32 +518,28 @@ impl DomainParticipantAsync {
         &self,
         participant_handle: InstanceHandle,
     ) -> DdsResult<ParticipantBuiltinTopicData> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::GetDiscoveredParticipantData {
                     participant_handle: self.handle,
                     discovered_participant_handle: participant_handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_participant_builtin_topic_data()
     }
 
     /// Async version of [`get_discovered_topics`](crate::domain::domain_participant::DomainParticipant::get_discovered_topics).
     #[tracing::instrument(skip(self))]
     pub async fn get_discovered_topics(&self) -> DdsResult<Vec<InstanceHandle>> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::GetDiscoveredTopics {
                     participant_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_instance_handle_list()
     }
 
     /// Async version of [`get_discovered_topic_data`](crate::domain::domain_participant::DomainParticipant::get_discovered_topic_data).
@@ -581,17 +548,15 @@ impl DomainParticipantAsync {
         &self,
         topic_handle: InstanceHandle,
     ) -> DdsResult<TopicBuiltinTopicData> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::GetDiscoveredTopicData {
                     participant_handle: self.handle,
                     topic_handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_topic_builtin_topic_data()
     }
 
     /// Async version of [`contains_entity`](crate::domain::domain_participant::DomainParticipant::contains_entity).
@@ -603,16 +568,14 @@ impl DomainParticipantAsync {
     /// Async version of [`get_current_time`](crate::domain::domain_participant::DomainParticipant::get_current_time).
     #[tracing::instrument(skip(self))]
     pub async fn get_current_time(&self) -> DdsResult<Time> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(
+            .call(DcpsMail::Participant(
                 ParticipantServiceMail::GetCurrentTime {
                     participant_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_time()
     }
 }
 
@@ -620,28 +583,24 @@ impl DomainParticipantAsync {
     /// Async version of [`set_qos`](crate::domain::domain_participant::DomainParticipant::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<DomainParticipantQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(ParticipantServiceMail::SetQos {
+            .call(DcpsMail::Participant(ParticipantServiceMail::SetQos {
                 participant_handle: self.handle,
-                qos,
-                reply_sender,
+                qos: Box::new(qos),
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_qos`](crate::domain::domain_participant::DomainParticipant::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(ParticipantServiceMail::GetQos {
+            .call(DcpsMail::Participant(ParticipantServiceMail::GetQos {
                 participant_handle: self.handle,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_participant_qos()
     }
 
     /// Async version of [`set_listener`](crate::domain::domain_participant::DomainParticipant::set_listener).
@@ -651,17 +610,15 @@ impl DomainParticipantAsync {
         a_listener: Option<impl DomainParticipantListener + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dcps_listener = a_listener.map(DcpsDomainParticipantListener::new);
         self.dcps_sender
-            .send(DcpsMail::Participant(ParticipantServiceMail::SetListener {
+            .call(DcpsMail::Participant(ParticipantServiceMail::SetListener {
                 participant_handle: self.handle,
                 dcps_listener,
                 listener_mask: mask.iter().collect(),
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_status_changes`](crate::domain::domain_participant::DomainParticipant::get_status_changes).
@@ -673,14 +630,12 @@ impl DomainParticipantAsync {
     /// Async version of [`enable`](crate::domain::domain_participant::DomainParticipant::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::Participant(ParticipantServiceMail::Enable {
+            .call(DcpsMail::Participant(ParticipantServiceMail::Enable {
                 participant_handle: self.handle,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_instance_handle`](crate::domain::domain_participant::DomainParticipant::get_instance_handle).

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -6,8 +6,8 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
 use super::domain_participant::DomainParticipantAsync;
 use crate::{
     dcps::{
-        channels::oneshot::oneshot,
-        dcps_mail::{DcpsMail, ParticipantFactoryMail, WireMail},
+        channels::rpc::{RpcClient, RpcMailbox},
+        dcps_mail::{CreateParticipantMail, DcpsMail, ParticipantFactoryMail, WireMail},
         listeners::domain_participant_listener::DcpsDomainParticipantListener,
     },
     dds_async::{
@@ -30,38 +30,10 @@ use crate::{
     },
 };
 
-const DCPS_CHANNEL_SIZE: usize = 128;
 const WIRE_CHANNEL_SIZE: usize = 256;
 
 #[doc(hidden)]
-pub type DcpsChannel = embassy_sync::channel::Channel<
-    embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex,
-    DcpsMail,
-    DCPS_CHANNEL_SIZE,
->;
-
-#[doc(hidden)]
-#[derive(Clone)]
-pub struct DcpsSender {
-    channel: Arc<DcpsChannel>,
-}
-
-impl DcpsSender {
-    pub async fn send(&self, message: DcpsMail) {
-        self.channel.send(message).await;
-    }
-}
-
-#[doc(hidden)]
-pub struct DcpsReceiver {
-    channel: Arc<DcpsChannel>,
-}
-
-impl DcpsReceiver {
-    pub async fn receive(&self) -> DcpsMail {
-        self.channel.receive().await
-    }
-}
+pub type DcpsSender = RpcClient;
 
 #[doc(hidden)]
 pub type WireChannel = embassy_sync::channel::Channel<
@@ -131,25 +103,25 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         let enable_type_information = configuration.enable_type_information();
         let listener_mask = mask.iter().collect();
         let dcps_listener = a_listener.map(DcpsDomainParticipantListener::new);
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender
-            .send(DcpsMail::ParticipantFactory(
-                ParticipantFactoryMail::CreateParticipant {
+
+        let reply = self
+            .dcps_sender
+            .call(DcpsMail::ParticipantFactory(
+                ParticipantFactoryMail::CreateParticipant(Box::new(CreateParticipantMail {
                     guid_prefix,
                     domain_id,
                     qos,
                     dcps_listener,
                     listener_mask,
-                    reply_sender,
                     transport_participant,
                     domain_tag,
                     participant_announcement_interval,
                     enable_type_information,
-                },
+                })),
             ))
-            .await;
+            .await?;
 
-        let participant_handle = reply_receiver.await??;
+        let participant_handle = reply.expect_instance_handle()?;
 
         let domain_participant =
             DomainParticipantAsync::new(self.dcps_sender.clone(), domain_id, participant_handle);
@@ -159,18 +131,14 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
 
     /// Async version of [`delete_participant`](crate::domain::domain_participant_factory::DomainParticipantFactory::delete_participant).
     pub async fn delete_participant(&self, participant: &DomainParticipantAsync) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         let participant_handle = participant.get_instance_handle();
 
         self.dcps_sender
-            .send(DcpsMail::ParticipantFactory(
-                ParticipantFactoryMail::DeleteParticipant {
-                    participant_handle,
-                    reply_sender,
-                },
+            .call(DcpsMail::ParticipantFactory(
+                ParticipantFactoryMail::DeleteParticipant { participant_handle },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`lookup_participant`](crate::domain::domain_participant_factory::DomainParticipantFactory::lookup_participant).
@@ -178,17 +146,14 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         &self,
         domain_id: DomainId,
     ) -> DdsResult<Option<DomainParticipantAsync>> {
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender
-            .send(DcpsMail::ParticipantFactory(
-                ParticipantFactoryMail::LookupParticipant {
-                    domain_id,
-                    reply_sender,
-                },
+        let reply = self
+            .dcps_sender
+            .call(DcpsMail::ParticipantFactory(
+                ParticipantFactoryMail::LookupParticipant { domain_id },
             ))
-            .await;
-        Ok(reply_receiver
-            .await?
+            .await?;
+        Ok(reply
+            .expect_option_instance_handle()?
             .map(|handle| DomainParticipantAsync::new(self.dcps_sender.clone(), domain_id, handle)))
     }
 
@@ -197,46 +162,40 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         &self,
         qos: QosKind<DomainParticipantQos>,
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::ParticipantFactory(
-                ParticipantFactoryMail::SetDefaultParticipantQos { qos, reply_sender },
+            .call(DcpsMail::ParticipantFactory(
+                ParticipantFactoryMail::SetDefaultParticipantQos { qos: Box::new(qos) },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_default_participant_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::get_default_participant_qos).
     pub async fn get_default_participant_qos(&self) -> DdsResult<DomainParticipantQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::ParticipantFactory(
-                ParticipantFactoryMail::GetDefaultParticipantQos { reply_sender },
+            .call(DcpsMail::ParticipantFactory(
+                ParticipantFactoryMail::GetDefaultParticipantQos,
             ))
-            .await;
-        reply_receiver.await
+            .await?
+            .expect_participant_qos()
     }
 
     /// Async version of [`set_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::set_qos).
     pub async fn set_qos(&self, qos: QosKind<DomainParticipantFactoryQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::ParticipantFactory(
-                ParticipantFactoryMail::SetQos { qos, reply_sender },
+            .call(DcpsMail::ParticipantFactory(
+                ParticipantFactoryMail::SetQos { qos: Box::new(qos) },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_qos`](crate::domain::domain_participant_factory::DomainParticipantFactory::get_qos).
     pub async fn get_qos(&self) -> DdsResult<DomainParticipantFactoryQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender
-            .send(DcpsMail::ParticipantFactory(
-                ParticipantFactoryMail::GetQos { reply_sender },
-            ))
-            .await;
-        reply_receiver.await
+            .call(DcpsMail::ParticipantFactory(ParticipantFactoryMail::GetQos))
+            .await?
+            .expect_factory_qos()
     }
 
     /// Get a mutable reference to the transport object
@@ -271,7 +230,6 @@ impl
             >,
         > = OnceLock::new();
         PARTICIPANT_FACTORY_ASYNC.get_or_init(|| {
-
             let executor = crate::std_runtime::executor::Executor::new();
             let timer_driver = crate::std_runtime::timer::TimerDriver::new();
             let runtime = crate::std_runtime::StdRuntime::new(executor, timer_driver);
@@ -311,13 +269,8 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
         transport: T,
         configuration: DustDdsConfiguration,
     ) -> Self {
-        let dcps_channel = Arc::new(DcpsChannel::new());
-        let dcps_sender = DcpsSender {
-            channel: dcps_channel.clone(),
-        };
-        let dcps_receiver = DcpsReceiver {
-            channel: dcps_channel,
-        };
+        let rpc_mailbox = Arc::new(RpcMailbox::new());
+        let dcps_sender = RpcClient::new(rpc_mailbox.clone());
         let wire_channel = Arc::new(WireChannel::new());
         let wire_sender = WireSender {
             channel: wire_channel.clone(),
@@ -344,7 +297,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
 
                 if let Some(next_task_time) = next_task_time {
                     match select3_future(
-                        dcps_receiver.receive(),
+                        rpc_mailbox.receive_request(),
                         wire_receiver.receive(),
                         timer_handle.delay(next_task_time.into()),
                     )
@@ -352,15 +305,20 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                     {
                         Either3::A(user_mail) => {
                             let now = domain_participant_factory.runtime.clock().now();
-                            domain_participant_factory.handle(user_mail, now);
+                            let reply = domain_participant_factory.handle(user_mail, now);
+                            rpc_mailbox.send_reply(reply).await;
                             for dp in &mut domain_participant_factory.domain_participant_list {
                                 dp.poke(now);
                             }
                         }
                         Either3::B(wire_mail) => {
                             let now = domain_participant_factory.runtime.clock().now();
-                            domain_participant_factory.handle_wire_mail(wire_mail, now);
-                            for dp in &mut domain_participant_factory.domain_participant_list {
+                            if let Some(dp) = domain_participant_factory
+                                .domain_participant_list
+                                .iter_mut()
+                                .find(|x| x.get_instance_handle() == &wire_mail.participant_handle)
+                            {
+                                dp.handle_data(&wire_mail.data_message, now);
                                 dp.process_builtin_cache_changes(now);
                                 dp.process_user_defined_received_cache_changes(now);
                                 dp.request_topic_type_representation(now);
@@ -383,18 +341,25 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                         }
                     };
                 } else {
-                    match select_future(dcps_receiver.receive(), wire_receiver.receive()).await {
+                    match select_future(rpc_mailbox.receive_request(), wire_receiver.receive())
+                        .await
+                    {
                         Either::A(user_mail) => {
                             let now = domain_participant_factory.runtime.clock().now();
-                            domain_participant_factory.handle(user_mail, now);
+                            let reply = domain_participant_factory.handle(user_mail, now);
+                            rpc_mailbox.send_reply(reply).await;
                             for dp in &mut domain_participant_factory.domain_participant_list {
                                 dp.poke(now);
                             }
                         }
                         Either::B(wire_mail) => {
                             let now = domain_participant_factory.runtime.clock().now();
-                            domain_participant_factory.handle_wire_mail(wire_mail, now);
-                            for dp in &mut domain_participant_factory.domain_participant_list {
+                            if let Some(dp) = domain_participant_factory
+                                .domain_participant_list
+                                .iter_mut()
+                                .find(|x| x.get_instance_handle() == &wire_mail.participant_handle)
+                            {
+                                dp.handle_data(&wire_mail.data_message, now);
                                 dp.process_builtin_cache_changes(now);
                                 dp.process_user_defined_received_cache_changes(now);
                                 dp.request_topic_type_representation(now);

--- a/dds/src/dds_async/publisher.rs
+++ b/dds/src/dds_async/publisher.rs
@@ -4,8 +4,7 @@ use super::{
 };
 use crate::{
     dcps::{
-        channels::oneshot::oneshot,
-        dcps_mail::{DcpsMail, PublisherServiceMail},
+        dcps_mail::{CreateDataWriterMail, DcpsMail, PublisherServiceMail},
         listeners::{
             data_writer_listener::DcpsDataWriterListener, publisher_listener::DcpsPublisherListener,
         },
@@ -22,7 +21,7 @@ use crate::{
         time::Duration,
     },
 };
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 
 /// Async version of [`Publisher`](crate::publication::publisher::Publisher).
 #[derive(Clone)]
@@ -56,21 +55,20 @@ impl PublisherAsync {
     ) -> DdsResult<DataWriterAsync<Foo>> {
         let topic_name = a_topic.get_name();
         let dcps_listener = a_listener.map(DcpsDataWriterListener::new);
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Publisher(
-                PublisherServiceMail::CreateDataWriter {
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Publisher(PublisherServiceMail::CreateDataWriter(
+                Box::new(CreateDataWriterMail {
                     participant_handle: self.participant.get_instance_handle(),
                     publisher_handle: self.handle,
                     topic_name,
                     qos,
                     dcps_listener,
                     listener_mask: mask.iter().collect(),
-                    reply_sender,
-                },
-            ))
-            .await;
-        let guid = reply_receiver.await??;
+                }),
+            )))
+            .await?;
+        let guid = reply.expect_instance_handle()?;
 
         Ok(DataWriterAsync::new(guid, self.clone(), a_topic.clone()))
     }
@@ -81,18 +79,16 @@ impl PublisherAsync {
         &self,
         a_datawriter: &DataWriterAsync<Foo>,
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Publisher(
+            .call(DcpsMail::Publisher(
                 PublisherServiceMail::DeleteDataWriter {
                     participant_handle: self.participant.get_instance_handle(),
                     publisher_handle: self.handle,
                     datawriter_handle: a_datawriter.get_instance_handle(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`delete_datawriter`](crate::publication::publisher::Publisher::lookup_datawriter).
@@ -149,34 +145,30 @@ impl PublisherAsync {
     /// Async version of [`set_default_datawriter_qos`](crate::publication::publisher::Publisher::set_default_datawriter_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_datawriter_qos(&self, qos: QosKind<DataWriterQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Publisher(
+            .call(DcpsMail::Publisher(
                 PublisherServiceMail::SetDefaultDataWriterQos {
                     participant_handle: self.participant.get_instance_handle(),
                     publisher_handle: self.handle,
-                    qos,
-                    reply_sender,
+                    qos: Box::new(qos),
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_default_datawriter_qos`](crate::publication::publisher::Publisher::get_default_datawriter_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_datawriter_qos(&self) -> DdsResult<DataWriterQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Publisher(
+            .call(DcpsMail::Publisher(
                 PublisherServiceMail::GetDefaultDataWriterQos {
                     participant_handle: self.participant.get_instance_handle(),
                     publisher_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_data_writer_qos()
     }
 
     /// Async version of [`copy_from_topic_qos`](crate::publication::publisher::Publisher::copy_from_topic_qos).
@@ -194,30 +186,26 @@ impl PublisherAsync {
     /// Async version of [`set_qos`](crate::publication::publisher::Publisher::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<PublisherQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Publisher(PublisherServiceMail::SetPublisherQos {
+            .call(DcpsMail::Publisher(PublisherServiceMail::SetPublisherQos {
                 participant_handle: self.participant.get_instance_handle(),
                 publisher_handle: self.handle,
-                qos,
-                reply_sender,
+                qos: Box::new(qos),
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_qos`](crate::publication::publisher::Publisher::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<PublisherQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Publisher(PublisherServiceMail::GetPublisherQos {
+            .call(DcpsMail::Publisher(PublisherServiceMail::GetPublisherQos {
                 participant_handle: self.participant.get_instance_handle(),
                 publisher_handle: self.handle,
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_publisher_qos()
     }
 
     /// Async version of [`set_listener`](crate::publication::publisher::Publisher::set_listener).
@@ -227,20 +215,18 @@ impl PublisherAsync {
         a_listener: Option<impl PublisherListener + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         let dcps_listener = a_listener.map(DcpsPublisherListener::new);
         self.dcps_sender()
-            .send(DcpsMail::Publisher(
+            .call(DcpsMail::Publisher(
                 PublisherServiceMail::SetPublisherListener {
                     participant_handle: self.participant.get_instance_handle(),
                     publisher_handle: self.handle,
                     dcps_listener,
                     listener_mask: mask.iter().collect(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_status_changes`](crate::publication::publisher::Publisher::get_status_changes).

--- a/dds/src/dds_async/subscriber.rs
+++ b/dds/src/dds_async/subscriber.rs
@@ -5,8 +5,7 @@ use super::{
 };
 use crate::{
     dcps::{
-        channels::oneshot::oneshot,
-        dcps_mail::{DcpsMail, SubscriberServiceMail},
+        dcps_mail::{CreateDataReaderMail, DcpsMail, SubscriberServiceMail},
         listeners::{
             data_reader_listener::DcpsDataReaderListener,
             subscriber_listener::DcpsSubscriberListener,
@@ -21,7 +20,7 @@ use crate::{
         status::{SampleLostStatus, StatusKind},
     },
 };
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 
 /// Async version of [`Subscriber`](crate::subscription::subscriber::Subscriber).
 #[derive(Clone)]
@@ -54,21 +53,20 @@ impl SubscriberAsync {
         mask: &[StatusKind],
     ) -> DdsResult<DataReaderAsync<Foo>> {
         let dcps_listener = a_listener.map(DcpsDataReaderListener::new);
-        let (reply_sender, reply_receiver) = oneshot();
-        self.dcps_sender()
-            .send(DcpsMail::Subscriber(
-                SubscriberServiceMail::CreateDataReader {
+        let reply = self
+            .dcps_sender()
+            .call(DcpsMail::Subscriber(
+                SubscriberServiceMail::CreateDataReader(Box::new(CreateDataReaderMail {
                     participant_handle: self.participant.get_instance_handle(),
                     subscriber_handle: self.handle,
                     topic_name: a_topic.get_name(),
                     qos,
                     dcps_listener,
                     listener_mask: mask.iter().collect(),
-                    reply_sender,
-                },
+                })),
             ))
-            .await;
-        let guid = reply_receiver.await??;
+            .await?;
+        let guid = reply.expect_instance_handle()?;
 
         Ok(DataReaderAsync::new(
             guid,
@@ -84,18 +82,16 @@ impl SubscriberAsync {
         &self,
         a_datareader: &DataReaderAsync<Foo>,
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Subscriber(
+            .call(DcpsMail::Subscriber(
                 SubscriberServiceMail::DeleteDataReader {
                     participant_handle: self.participant.get_instance_handle(),
                     subscriber_handle: self.handle,
                     datareader_handle: a_datareader.get_instance_handle(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`lookup_datareader`](crate::subscription::subscriber::Subscriber::lookup_datareader).
@@ -105,18 +101,17 @@ impl SubscriberAsync {
         topic_name: &str,
     ) -> DdsResult<Option<DataReaderAsync<Foo>>> {
         if let Some(topic) = self.participant.lookup_topicdescription(topic_name).await? {
-            let (reply_sender, reply_receiver) = oneshot();
-            self.dcps_sender()
-                .send(DcpsMail::Subscriber(
+            let reply = self
+                .dcps_sender()
+                .call(DcpsMail::Subscriber(
                     SubscriberServiceMail::LookupDataReader {
                         participant_handle: self.participant.get_instance_handle(),
                         subscriber_handle: self.handle,
                         topic_name: String::from(topic_name),
-                        reply_sender,
                     },
                 ))
-                .await;
-            if let Some(reader_handle) = reply_receiver.await?? {
+                .await?;
+            if let Some(reader_handle) = reply.expect_option_instance_handle()? {
                 Ok(Some(DataReaderAsync::new(
                     reader_handle,
                     self.clone(),
@@ -158,35 +153,30 @@ impl SubscriberAsync {
     /// Async version of [`set_default_datareader_qos`](crate::subscription::subscriber::Subscriber::set_default_datareader_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_default_datareader_qos(&self, qos: QosKind<DataReaderQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Subscriber(
+            .call(DcpsMail::Subscriber(
                 SubscriberServiceMail::SetDefaultDataReaderQos {
                     participant_handle: self.participant.get_instance_handle(),
                     subscriber_handle: self.handle,
-                    qos,
-                    reply_sender,
+                    qos: Box::new(qos),
                 },
             ))
-            .await;
-
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_default_datareader_qos`](crate::subscription::subscriber::Subscriber::get_default_datareader_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_default_datareader_qos(&self) -> DdsResult<DataReaderQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Subscriber(
+            .call(DcpsMail::Subscriber(
                 SubscriberServiceMail::GetDefaultDataReaderQos {
                     participant_handle: self.participant.get_instance_handle(),
                     subscriber_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_data_reader_qos()
     }
 
     /// Async version of [`copy_from_topic_qos`](crate::subscription::subscriber::Subscriber::copy_from_topic_qos).
@@ -201,32 +191,28 @@ impl SubscriberAsync {
     /// Async version of [`set_qos`](crate::subscription::subscriber::Subscriber::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<SubscriberQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Subscriber(SubscriberServiceMail::SetQos {
+            .call(DcpsMail::Subscriber(SubscriberServiceMail::SetQos {
                 participant_handle: self.participant.get_instance_handle(),
                 subscriber_handle: self.handle,
-                qos,
-                reply_sender,
+                qos: Box::new(qos),
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_qos`](crate::subscription::subscriber::Subscriber::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<SubscriberQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.dcps_sender()
-            .send(DcpsMail::Subscriber(
+            .call(DcpsMail::Subscriber(
                 SubscriberServiceMail::GetSubscriberQos {
                     participant_handle: self.participant.get_instance_handle(),
                     subscriber_handle: self.handle,
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_subscriber_qos()
     }
 
     /// Async version of [`set_listener`](crate::subscription::subscriber::Subscriber::set_listener).
@@ -236,18 +222,16 @@ impl SubscriberAsync {
         a_listener: Option<impl SubscriberListener + Send + 'static>,
         mask: &[StatusKind],
     ) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
-        let dcps_listener = a_listener.map(|l| DcpsSubscriberListener::new(l));
+        let dcps_listener = a_listener.map(DcpsSubscriberListener::new);
         self.dcps_sender()
-            .send(DcpsMail::Subscriber(SubscriberServiceMail::SetListener {
+            .call(DcpsMail::Subscriber(SubscriberServiceMail::SetListener {
                 participant_handle: self.participant.get_instance_handle(),
                 subscriber_handle: self.handle,
                 dcps_listener,
                 listener_mask: mask.iter().collect(),
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_statuscondition`](crate::subscription::subscriber::Subscriber::get_statuscondition).

--- a/dds/src/dds_async/topic.rs
+++ b/dds/src/dds_async/topic.rs
@@ -4,7 +4,6 @@ use super::{
 };
 use crate::{
     dcps::{
-        channels::oneshot::oneshot,
         dcps_mail::{DcpsMail, TopicServiceMail},
         status_condition::StatusConditionEntity,
     },
@@ -18,6 +17,7 @@ use crate::{
     xtypes::dynamic_type::DynamicType,
 };
 use alloc::{
+    boxed::Box,
     string::{String, ToString},
     sync::Arc,
     vec::Vec,
@@ -52,18 +52,16 @@ impl TopicAsync {
     /// Async version of [`get_inconsistent_topic_status`](crate::topic_definition::topic::Topic::get_inconsistent_topic_status).
     #[tracing::instrument(skip(self))]
     pub async fn get_inconsistent_topic_status(&self) -> DdsResult<InconsistentTopicStatus> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.participant
             .dcps_sender()
-            .send(DcpsMail::Topic(
+            .call(DcpsMail::Topic(
                 TopicServiceMail::GetInconsistentTopicStatus {
                     participant_handle: self.participant.get_instance_handle(),
                     topic_name: self.topic_name.to_string(),
-                    reply_sender,
                 },
             ))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_inconsistent_topic_status()
     }
 }
 
@@ -85,34 +83,28 @@ impl TopicAsync {
     /// Async version of [`set_qos`](crate::topic_definition::topic::Topic::set_qos).
     #[tracing::instrument(skip(self))]
     pub async fn set_qos(&self, qos: QosKind<TopicQos>) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.participant
             .dcps_sender()
-            .send(DcpsMail::Topic(TopicServiceMail::SetQos {
+            .call(DcpsMail::Topic(TopicServiceMail::SetQos {
                 participant_handle: self.participant.get_instance_handle(),
                 topic_name: self.topic_name.to_string(),
-                topic_qos: qos,
-                reply_sender,
+                topic_qos: Box::new(qos),
             }))
-            .await;
-
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_qos`](crate::topic_definition::topic::Topic::get_qos).
     #[tracing::instrument(skip(self))]
     pub async fn get_qos(&self) -> DdsResult<TopicQos> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.participant
             .dcps_sender()
-            .send(DcpsMail::Topic(TopicServiceMail::GetQos {
+            .call(DcpsMail::Topic(TopicServiceMail::GetQos {
                 participant_handle: self.participant.get_instance_handle(),
                 topic_name: self.topic_name.to_string(),
-                reply_sender,
             }))
-            .await;
-
-        reply_receiver.await?
+            .await?
+            .expect_topic_qos()
     }
 
     /// Async version of [`get_statuscondition`](crate::topic_definition::topic::Topic::get_statuscondition).
@@ -136,16 +128,14 @@ impl TopicAsync {
     /// Async version of [`enable`](crate::topic_definition::topic::Topic::enable).
     #[tracing::instrument(skip(self))]
     pub async fn enable(&self) -> DdsResult<()> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.participant
             .dcps_sender()
-            .send(DcpsMail::Topic(TopicServiceMail::Enable {
+            .call(DcpsMail::Topic(TopicServiceMail::Enable {
                 participant_handle: self.participant.get_instance_handle(),
                 topic_name: self.topic_name.to_string(),
-                reply_sender,
             }))
-            .await;
-        reply_receiver.await?
+            .await?
+            .expect_ok()
     }
 
     /// Async version of [`get_instance_handle`](crate::topic_definition::topic::Topic::get_instance_handle).
@@ -169,16 +159,13 @@ impl TopicAsync {
     #[doc(hidden)]
     #[tracing::instrument(skip(self))]
     pub async fn get_type_support(&self) -> DdsResult<DynamicType<'static>> {
-        let (reply_sender, reply_receiver) = oneshot();
         self.participant
             .dcps_sender()
-            .send(DcpsMail::Topic(TopicServiceMail::GetTypeSupport {
+            .call(DcpsMail::Topic(TopicServiceMail::GetTypeSupport {
                 participant_handle: self.participant.get_instance_handle(),
                 topic_name: self.topic_name.to_string(),
-                reply_sender,
             }))
-            .await;
-
-        reply_receiver.await?
+            .await?
+            .expect_dynamic_type()
     }
 }


### PR DESCRIPTION
This refactor modifies the communication to use an RPC style of communication in which instead of having a single channel and allocating a new Oneshot for getting the reply every time, the object in which the reply to the request is written is allocated one single time and re-used for writing the replies after each request from the API functions. This avoids a large number of allocations and reduces the code size by having only a single place where to put the DCPS mail instead of having a large channel with entries for it.