### PR TITLE
Fix Dust DDS to comply with latest version of RTPS interoperability tests

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -8,20 +8,20 @@ FROM cimg/base:2023.09 AS FastDdsBuilder
 USER root
 RUN apt-get update && apt-get install -y libasio-dev libtinyxml2-dev
 
-RUN git clone --depth 1 --branch v1.3.1 --single-branch https://github.com/eProsima/foonathan_memory_vendor.git
+RUN git clone --depth 1 --branch v1.4.1 --single-branch https://github.com/eProsima/foonathan_memory_vendor.git
 RUN cmake -B foonathan_memory_vendor-build -S foonathan_memory_vendor -DCMAKE_INSTALL_PREFIX=Fast-DDS-install -DBUILD_SHARED_LIBS=ON \
     && cmake --build foonathan_memory_vendor-build --parallel 5 --target install
 
-RUN git clone --depth 1 --branch v1.1.1 --single-branch https://github.com/eProsima/Fast-CDR.git
+RUN git clone --depth 1 --branch v2.4.0 --single-branch https://github.com/eProsima/Fast-CDR.git
 RUN cmake -B Fast-CDR-build -S Fast-CDR -DCMAKE_INSTALL_PREFIX=Fast-DDS-install \
     && cmake --build Fast-CDR-build --parallel 5 --target install
 
-RUN git clone --depth 1 --branch v2.10.2 --single-branch https://github.com/eProsima/Fast-DDS.git
+RUN git clone --depth 1 --branch v3.6.2 --single-branch https://github.com/eProsima/Fast-DDS.git
 RUN cmake -B Fast-DDS-build -S Fast-DDS -DCMAKE_INSTALL_PREFIX=Fast-DDS-install \
     && cmake --build Fast-DDS-build --parallel 5 --target install
 
-FROM cimg/openjdk:11.0 AS FastDdsGenBuilder
-RUN git clone --depth 1 --branch v2.5.1 --single-branch https://github.com/eProsima/Fast-DDS-Gen.git
+FROM cimg/openjdk:17.0 AS FastDdsGenBuilder
+RUN git clone --depth 1 --branch v4.3.0 --single-branch https://github.com/eProsima/Fast-DDS-Gen.git
 RUN cd Fast-DDS-Gen && ./gradlew assemble
 
 
@@ -31,7 +31,7 @@ COPY --from=FastDdsBuilder /home/circleci/project/Fast-DDS-install /usr/local/
 COPY --from=FastDdsGenBuilder /home/circleci/project/Fast-DDS-Gen/share /usr/local/share
 USER root
 RUN apt-get update \
-    && apt-get install -y libtinyxml2-9 openjdk-11-jre-headless \
+    && apt-get install -y libtinyxml2-9 openjdk-17-jre-headless \
     && rm -rf /var/lib/apt/lists/* \
     && ln -s /usr/lib/x86_64-linux-gnu/libtinyxml2.so.9 /usr/lib/x86_64-linux-gnu/libtinyxml2.so \
     && ldconfig

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -22,7 +22,7 @@ jobs:
         ref: ${{ env.dds_rtps_rep_ref }}
         path: dds-rtps
     - name: Build executable
-      run: cargo build --package dust_dds_shape_main_linux --release --manifest-path dds-rtps/srcRs/DustDDS/Cargo.toml --config patch.crates-io.dust_dds.path="'dust-dds/dds'"
+      run: cargo build --package dust_dds_shape_main_linux --release --manifest-path dds-rtps/srcRs/DustDDS/Cargo.toml --config patch.crates-io.dust_dds.path="'dust-dds/dds'" --config patch.crates-io.dust_dds_gen.path="'dust-dds/dds_gen'"
     - name: Zip executable  # Zipping done here to preserve executable bit
       run: |
         version=$( cargo tree --package dust_dds --depth 0 --prefix none | sed -n 's/.*v\([0-9.]*\).*/\1/p' )
@@ -139,5 +139,4 @@ jobs:
       with:
         name: interoperability_report_complete
         path: |
-          ./index.html
           ./interoperability_report.xlsx

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -77,11 +77,10 @@ jobs:
       with:
         python-version: '3.11.4'
     - name: Downloads shape_main executables from OMG
-      uses: robinraju/release-downloader@v1.10
+      uses: robinraju/release-downloader@v1.13
       with:
         repository: omg-dds/dds-rtps
         latest: true
-        preRelease: false
         fileName: "*"
         out-file-path: zipped_executables
     - name: Remove DustDDS
@@ -135,16 +134,10 @@ jobs:
       run: ls -l
     - name: Generate xlsx report
       run: python3 ./omg-dds-rtps/generate_xlsx_report.py --input junit_interoperability_report.xml --output interoperability_report.xlsx
-    - name: XUnit
-      uses: AutoModality/action-xunit-viewer@v1
-      with:
-        results: ./junit_interoperability_report.xml
-        fail: false
     - name: Upload report
       uses: actions/upload-artifact@v7
       with:
         name: interoperability_report_complete
         path: |
           ./index.html
-          ./junit_interoperability_report.xml
           ./interoperability_report.xlsx

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -1,7 +1,10 @@
-name: OMG interoperability
+name: OMG RTPS interoperability
 
 on:
   workflow_dispatch:
+
+env:
+  dds_rtps_rep_ref: update-dust-dds
 
 jobs:
   create_bin_release:
@@ -9,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         path: dust-dds
     - name: Checkout omg dds-rtps from s2e-systems fork
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: s2e-systems/dds-rtps
-        ref: update-dust-dds-src
+        ref: ${{ env.dds_rtps_rep_ref }}
         path: dds-rtps
     - name: Build executable
       run: cargo build --package dust_dds_shape_main_linux --release --manifest-path dds-rtps/srcRs/DustDDS/Cargo.toml --config patch.crates-io.dust_dds.path="'dust-dds/dds'"
@@ -30,7 +33,7 @@ jobs:
       working-directory:
         dust-dds
     - name: Upload executable artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: interoperability_executable
         path: artifacts
@@ -63,14 +66,14 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Checkout omg dds-rtps
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: s2e-systems/dds-rtps
-        ref: update-dust-dds-src
+        ref: ${{ env.dds_rtps_rep_ref }}
         path: omg-dds-rtps
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v7
       with:
         python-version: '3.11.4'
     - name: Downloads shape_main executables from OMG
@@ -85,7 +88,7 @@ jobs:
       run: rm zipped_executables/dust_dds*
       continue-on-error: true
     - name: Download dust_dds_shape_main executable artifact from create_bin_release
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: interoperability_executable
         path: zipped_executables
@@ -101,7 +104,7 @@ jobs:
       run: python3 ./omg-dds-rtps/interoperability_report.py --verbose --publisher ./executables/${{ matrix.publisher }}*shape_main_linux --subscriber ./executables/${{ matrix.subscriber }}*shape_main_linux --output-name junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
 
     - name: Upload report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}
         path: ./junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
@@ -111,17 +114,17 @@ jobs:
     needs: run_tests
     steps:
     - name: Download junit reports
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         pattern: junit_report-*
         merge-multiple: true
     - name: Checkout omg-dds dds-rtps
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: s2e-systems/dds-rtps
-        ref: update-dust-dds-src
+        ref: ${{ env.dds_rtps_rep_ref }}
         path: omg-dds-rtps
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v7
       with:
         python-version: '3.11.4'
     - name: Install omg-dds dds-rtps Python requirements
@@ -138,7 +141,7 @@ jobs:
         results: ./junit_interoperability_report.xml
         fail: false
     - name: Upload report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: interoperability_report_complete
         path: |

--- a/.github/workflows/interoperability.yml
+++ b/.github/workflows/interoperability.yml
@@ -99,7 +99,7 @@ jobs:
       run: pip install --requirement omg-dds-rtps/requirements.txt
 
     - name: Run Interoperability script
-      timeout-minutes: 30
+      timeout-minutes: 45
       run: python3 ./omg-dds-rtps/interoperability_report.py --verbose --publisher ./executables/${{ matrix.publisher }}*shape_main_linux --subscriber ./executables/${{ matrix.subscriber }}*shape_main_linux --output-name junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml
 
     - name: Upload report

--- a/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation.rs
@@ -314,10 +314,10 @@ impl CdrDeserialize for BuiltinEndpointSet {
 }
 impl CdrDeserialize for Duration {
     fn cdr_deserialize<'a>(de: &mut CdrDeserializer<'a>) -> CdrResult<Self> {
-        Ok(Duration {
-            sec: CdrDeserialize::cdr_deserialize(de)?,
-            nanosec: CdrDeserialize::cdr_deserialize(de)?,
-        })
+        Ok(Duration::new(
+            CdrDeserialize::cdr_deserialize(de)?,
+            CdrDeserialize::cdr_deserialize(de)?,
+        ))
     }
 }
 impl CdrDeserialize for EntityId {

--- a/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation_serialization.rs
+++ b/dds/src/dcps/data_representation_builtin_endpoints/rtps_data_representation_serialization.rs
@@ -159,8 +159,8 @@ impl CdrSerialize for BuiltinEndpointSet {
 }
 impl CdrSerialize for Duration {
     fn cdr_serialize(&self, ser: &mut CdrSerializer) {
-        self.sec.cdr_serialize(ser);
-        self.nanosec.cdr_serialize(ser);
+        self.sec().cdr_serialize(ser);
+        self.nanosec().cdr_serialize(ser);
     }
 }
 impl CdrSerialize for EntityId {

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -166,19 +166,20 @@ impl DcpsDomainParticipant {
                                             .split_once(operator.to_str())
                                     {
                                         let trimmed_val = value_expr.trim();
-                                        let value_str = if trimmed_val.starts_with('%') {
-                                            if let Ok(index) = trimmed_val[1..].parse::<usize>() {
-                                                content_filtered_topic
-                                                    .expression_parameters
-                                                    .get(index)
-                                                    .map(|s| s.as_str())
-                                                    .unwrap_or(trimmed_val)
+                                        let value_str =
+                                            if let Some(stripped) = trimmed_val.strip_prefix('%') {
+                                                if let Ok(index) = stripped.parse::<usize>() {
+                                                    content_filtered_topic
+                                                        .expression_parameters
+                                                        .get(index)
+                                                        .map(|s| s.as_str())
+                                                        .unwrap_or(trimmed_val)
+                                                } else {
+                                                    trimmed_val
+                                                }
                                             } else {
-                                                trimmed_val
-                                            }
-                                        } else {
-                                            trimmed_val.trim_matches('\'').trim_matches('"')
-                                        };
+                                                trimmed_val.trim_matches('\'').trim_matches('"')
+                                            };
                                         break Some((variable_name, operator, value_str));
                                     }
                                 } else {

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -160,9 +160,10 @@ impl DcpsDomainParticipant {
                             let mut operators = [Operator::LessThan, Operator::Equal].iter();
                             let filter = loop {
                                 if let Some(operator) = operators.next() {
-                                    if let Some((variable_name, value_expr)) = content_filtered_topic
-                                        .filter_expression
-                                        .split_once(operator.to_str())
+                                    if let Some((variable_name, value_expr)) =
+                                        content_filtered_topic
+                                            .filter_expression
+                                            .split_once(operator.to_str())
                                     {
                                         let trimmed_val = value_expr.trim();
                                         let value_str = if trimmed_val.starts_with('%') {
@@ -204,10 +205,7 @@ impl DcpsDomainParticipant {
                                         let Ok(rhs) = value_str.parse::<i32>() else {
                                             continue 'data_readers;
                                         };
-                                        if !comparison_function.compare_int32(
-                                            member_value,
-                                            &rhs,
-                                        ) {
+                                        if !comparison_function.compare_int32(member_value, &rhs) {
                                             continue 'data_readers;
                                         }
                                     }
@@ -226,10 +224,9 @@ impl DcpsDomainParticipant {
                                     | crate::xtypes::dynamic_type::TypeKind::STRING16 => {
                                         let member_value =
                                             data.get_string_value(member_id).unwrap();
-                                        if !comparison_function.compare_string(
-                                            member_value.as_str(),
-                                            value_str,
-                                        ) {
+                                        if !comparison_function
+                                            .compare_string(member_value.as_str(), value_str)
+                                        {
                                             continue 'data_readers;
                                         }
                                     }

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -891,6 +891,15 @@ impl DcpsDomainParticipant {
     #[tracing::instrument(skip(self, data_message))]
     pub fn handle_data(&mut self, data_message: &[u8], now: Time) {
         if let Ok(rtps_message) = RtpsMessageRead::try_from(data_message) {
+            if let Some(matched_participant) = self
+                .domain_participant
+                .discovered_participant_list
+                .iter_mut()
+                .find(|x| x.guid_prefix == rtps_message.header().guid_prefix())
+            {
+                matched_participant.last_communication_timestamp = now;
+            }
+
             let mut message_receiver = MessageReceiver::new(&rtps_message);
 
             while let Some(submessage) = message_receiver.next() {

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 use tracing::info;
 
 use crate::{
@@ -143,7 +143,7 @@ impl DcpsDomainParticipant {
                                     }
                                 }
 
-                                fn compare_string(&self, lhs: &String, rhs: &String) -> bool {
+                                fn compare_string(&self, lhs: &str, rhs: &str) -> bool {
                                     match self {
                                         Self::Equal => lhs == rhs,
                                         Self::LessThan => lhs <= rhs,
@@ -160,18 +160,32 @@ impl DcpsDomainParticipant {
                             let mut operators = [Operator::LessThan, Operator::Equal].iter();
                             let filter = loop {
                                 if let Some(operator) = operators.next() {
-                                    if let Some((variable_name, _)) = content_filtered_topic
+                                    if let Some((variable_name, value_expr)) = content_filtered_topic
                                         .filter_expression
                                         .split_once(operator.to_str())
                                     {
-                                        break Some((variable_name, operator));
+                                        let trimmed_val = value_expr.trim();
+                                        let value_str = if trimmed_val.starts_with('%') {
+                                            if let Ok(index) = trimmed_val[1..].parse::<usize>() {
+                                                content_filtered_topic
+                                                    .expression_parameters
+                                                    .get(index)
+                                                    .map(|s| s.as_str())
+                                                    .unwrap_or(trimmed_val)
+                                            } else {
+                                                trimmed_val
+                                            }
+                                        } else {
+                                            trimmed_val.trim_matches('\'').trim_matches('"')
+                                        };
+                                        break Some((variable_name, operator, value_str));
                                     }
                                 } else {
                                     break None;
                                 };
                             };
 
-                            if let Some((variable_name, comparison_function)) = filter {
+                            if let Some((variable_name, comparison_function, value_str)) = filter {
                                 let Some(member_id) =
                                     data.get_member_id_by_name(variable_name.trim())
                                 else {
@@ -187,11 +201,12 @@ impl DcpsDomainParticipant {
                                     crate::xtypes::dynamic_type::TypeKind::INT16 => todo!(),
                                     crate::xtypes::dynamic_type::TypeKind::INT32 => {
                                         let member_value = data.get_int32_value(member_id).unwrap();
+                                        let Ok(rhs) = value_str.parse::<i32>() else {
+                                            continue 'data_readers;
+                                        };
                                         if !comparison_function.compare_int32(
                                             member_value,
-                                            &content_filtered_topic.expression_parameters[0]
-                                                .parse()
-                                                .expect("valid number"),
+                                            &rhs,
                                         ) {
                                             continue 'data_readers;
                                         }
@@ -212,8 +227,8 @@ impl DcpsDomainParticipant {
                                         let member_value =
                                             data.get_string_value(member_id).unwrap();
                                         if !comparison_function.compare_string(
-                                            member_value,
-                                            &content_filtered_topic.expression_parameters[0],
+                                            member_value.as_str(),
+                                            value_str,
                                         ) {
                                             continue 'data_readers;
                                         }

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -915,7 +915,7 @@ impl DcpsDomainParticipant {
                             if let Some(writer_proxy) =
                                 dr.transport_reader.matched_writer_lookup(writer_guid)
                             {
-                                if writer_proxy.last_received_heartbeat_count()
+                                if writer_proxy.last_received_heartbeat_frag_count()
                                     < heartbeat_frag_submessage.count()
                                 {
                                     writer_proxy.set_last_received_heartbeat_frag_count(

--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -41,7 +41,7 @@ use crate::{
             heartbeat::HeartbeatSubmessage,
         },
     },
-    transport::types::{ChangeKind, Guid},
+    transport::types::{ChangeKind, Guid, TopicKind},
     xtypes::{
         deserializer::deserialize_top_level_type,
         type_support::{Type, TypeSupport},
@@ -250,60 +250,63 @@ impl DcpsDomainParticipant {
                         }
                     }
 
-                    let change_instance_handle = if let Some(i) = cache_change.instance_handle {
-                        InstanceHandle::new(i)
-                    } else {
-                        match cache_change.kind {
-                            ChangeKind::Alive | ChangeKind::AliveFiltered => {
-                                let Some(data_value) = deserialize_topic_type(
-                                    &data_reader.topic_name,
-                                    type_support,
-                                    cache_change.data_value.as_ref(),
-                                ) else {
-                                    tracing::warn!("Failed to deserialize user defined data");
-                                    continue 'data_readers;
-                                };
-                                let Ok(instance_handle) =
-                                    get_instance_handle_from_dynamic_data(&data_value)
-                                else {
-                                    tracing::warn!(
-                                        "Failed to get instance handle from dynamic_data"
-                                    );
-                                    continue 'data_readers;
-                                };
-                                instance_handle
-                            }
-                            ChangeKind::NotAliveDisposed
-                            | ChangeKind::NotAliveUnregistered
-                            | ChangeKind::NotAliveDisposedUnregistered => {
-                                let key_holder = KeyHolderType::new(&type_support);
-                                let Some(dynamic_type) = key_holder.as_dynamic_type() else {
-                                    tracing::warn!("Failed to create key holder");
-                                    continue 'data_readers;
-                                };
+                    let change_instance_handle =
+                        if TopicKind::from(&type_support) == TopicKind::NoKey {
+                            InstanceHandle::default()
+                        } else if let Some(i) = cache_change.instance_handle {
+                            InstanceHandle::new(i)
+                        } else {
+                            match cache_change.kind {
+                                ChangeKind::Alive | ChangeKind::AliveFiltered => {
+                                    let Some(data_value) = deserialize_topic_type(
+                                        &data_reader.topic_name,
+                                        type_support,
+                                        cache_change.data_value.as_ref(),
+                                    ) else {
+                                        tracing::warn!("Failed to deserialize user defined data");
+                                        continue 'data_readers;
+                                    };
+                                    let Ok(instance_handle) =
+                                        get_instance_handle_from_dynamic_data(&data_value)
+                                    else {
+                                        tracing::warn!(
+                                            "Failed to get instance handle from dynamic_data"
+                                        );
+                                        continue 'data_readers;
+                                    };
+                                    instance_handle
+                                }
+                                ChangeKind::NotAliveDisposed
+                                | ChangeKind::NotAliveUnregistered
+                                | ChangeKind::NotAliveDisposedUnregistered => {
+                                    let key_holder = KeyHolderType::new(&type_support);
+                                    let Some(dynamic_type) = key_holder.as_dynamic_type() else {
+                                        tracing::warn!("Failed to create key holder");
+                                        continue 'data_readers;
+                                    };
 
-                                let Ok(data_value) = deserialize_top_level_type(
-                                    dynamic_type,
-                                    cache_change.data_value.as_ref(),
-                                ) else {
-                                    tracing::warn!(
-                                        "Failed to deserialize disposed user defined data"
-                                    );
-                                    continue 'data_readers;
-                                };
+                                    let Ok(data_value) = deserialize_top_level_type(
+                                        dynamic_type,
+                                        cache_change.data_value.as_ref(),
+                                    ) else {
+                                        tracing::warn!(
+                                            "Failed to deserialize disposed user defined data"
+                                        );
+                                        continue 'data_readers;
+                                    };
 
-                                let Ok(instance_handle) =
-                                    get_instance_handle_from_dynamic_data(&data_value)
-                                else {
-                                    tracing::warn!(
-                                        "Failed to deserialize disposed key user defined data"
-                                    );
-                                    continue 'data_readers;
-                                };
-                                instance_handle
+                                    let Ok(instance_handle) =
+                                        get_instance_handle_from_dynamic_data(&data_value)
+                                    else {
+                                        tracing::warn!(
+                                            "Failed to deserialize disposed key user defined data"
+                                        );
+                                        continue 'data_readers;
+                                    };
+                                    instance_handle
+                                }
                             }
-                        }
-                    };
+                        };
 
                     match data_reader.add_reader_change(
                         cache_change.writer_guid,

--- a/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
@@ -7,7 +7,7 @@ use crate::{
         qos_policy::{DestinationOrderQosPolicyKind, HistoryQosPolicyKind, OwnershipQosPolicyKind},
         sample_info::{InstanceStateKind, SampleInfo, SampleStateKind, ViewStateKind},
         status::SampleRejectedStatusKind,
-        time::{DurationKind, TIME_INVALID_NSEC, TIME_INVALID_SEC, Time},
+        time::{Duration, DurationKind, TIME_INVALID_NSEC, TIME_INVALID_SEC, Time},
     },
     transport::types::{ChangeKind, Guid},
 };
@@ -22,7 +22,8 @@ pub enum AddChangeResult {
 }
 
 pub struct InstanceState {
-    pub handle: InstanceHandle,
+    handle: InstanceHandle,
+    last_accepted_source_timestamp: Option<Time>,
     view_state: ViewStateKind,
     instance_state: InstanceStateKind,
     most_recent_disposed_generation_count: i32,
@@ -34,6 +35,7 @@ impl InstanceState {
     pub fn new(handle: InstanceHandle) -> Self {
         Self {
             handle,
+            last_accepted_source_timestamp: None,
             view_state: ViewStateKind::New,
             instance_state: InstanceStateKind::Alive,
             most_recent_disposed_generation_count: 0,
@@ -42,7 +44,12 @@ impl InstanceState {
         }
     }
 
-    pub fn update_state(&mut self, change_kind: ChangeKind, now: Option<Time>) {
+    pub fn update_state(
+        &mut self,
+        change_kind: ChangeKind,
+        now: Option<Time>,
+        source_timestamp: Option<Time>,
+    ) {
         match self.instance_state {
             InstanceStateKind::Alive => {
                 if change_kind == ChangeKind::NotAliveDisposed
@@ -79,6 +86,9 @@ impl InstanceState {
         }
         if let Some(t) = now {
             self.last_received_time_stamp = t;
+        }
+        if let Some(t) = source_timestamp {
+            self.last_accepted_source_timestamp = Some(t);
         }
     }
 
@@ -241,7 +251,7 @@ impl<T> DataReaderEntity<T> {
 
             instance_in_coll
                 .instance_state
-                .update_state(cache_change.kind, None);
+                .update_state(cache_change.kind, None, None);
             let sample_state = cache_change.sample_state;
             let view_state = instance.view_state;
             let instance_state = instance.instance_state;
@@ -356,68 +366,31 @@ impl<T> DataReaderEntity<T> {
         reception_timestamp: Time,
     ) -> DdsResult<AddChangeResult> {
         let instance_handle = InstanceHandle::new(change_instance_handle);
-        // Update the state of the instance before creating since this has direct impact on
-        // the information that is stored on the sample
-        match change_kind {
-            ChangeKind::Alive | ChangeKind::AliveFiltered => {
-                match self
-                    .instances
-                    .iter_mut()
-                    .find(|x| x.handle() == &instance_handle)
-                {
-                    Some(x) => x.update_state(change_kind, Some(reception_timestamp)),
-                    None => {
-                        let mut s = InstanceState::new(instance_handle);
-                        s.update_state(change_kind, Some(reception_timestamp));
-                        self.instances.push(s);
-                    }
-                }
-                Ok(())
-            }
+
+        if matches!(
+            change_kind,
             ChangeKind::NotAliveDisposed
-            | ChangeKind::NotAliveUnregistered
-            | ChangeKind::NotAliveDisposedUnregistered => {
-                match self
-                    .instances
-                    .iter_mut()
-                    .find(|x| x.handle() == &instance_handle)
-                {
-                    Some(instance) => {
-                        instance.update_state(change_kind, Some(reception_timestamp));
-                        Ok(())
-                    }
-                    None => Err(DdsError::Error(
-                        "Received message changing state of unknown instance".to_string(),
-                    )),
-                }
-            }
-        }?;
-        let instance = self
+                | ChangeKind::NotAliveUnregistered
+                | ChangeKind::NotAliveDisposedUnregistered
+        ) && !self
             .instances
             .iter()
-            .find(|x| x.handle() == &instance_handle)
-            .expect("Sample with handle must exist");
-        let sample = ReaderSample {
-            kind: change_kind,
-            writer_guid: writer_guid.into(),
-            instance_handle,
-            source_timestamp: change_source_timestamp,
-            data_value,
-            sample_state: SampleStateKind::NotRead,
-            disposed_generation_count: instance.most_recent_disposed_generation_count,
-            no_writers_generation_count: instance.most_recent_no_writers_generation_count,
-        };
+            .any(|x| x.handle() == &instance_handle)
+        {
+            return Err(DdsError::Error(
+                "Received message changing state of unknown instance".to_string(),
+            ));
+        }
 
-        let change_instance_handle = sample.instance_handle;
-        // data_reader exclusive access if the writer is not the allowed to write the sample do an early return
+        // data_reader exclusive access if the writer is not allowed to write the sample do an early return
         if self.qos.ownership.kind == OwnershipQosPolicyKind::Exclusive {
             // Get the InstanceHandle of the data writer owning this instance
             if let Some(instance_owner) = self
                 .instance_ownership
                 .iter()
-                .find(|x| x.instance_handle == sample.instance_handle)
+                .find(|x| x.instance_handle == instance_handle)
             {
-                let instance_writer = InstanceHandle::new(sample.writer_guid);
+                let instance_writer = InstanceHandle::new(writer_guid.into());
                 let Some(sample_owner) = self
                     .matched_publication_list
                     .iter()
@@ -432,7 +405,7 @@ impl<T> DataReaderEntity<T> {
                 else {
                     return Ok(AddChangeResult::NotAdded);
                 };
-                if instance_owner.owner_handle != sample.writer_guid
+                if instance_owner.owner_handle != writer_guid
                     && sample_writer.ownership_strength().value
                         <= sample_owner.ownership_strength().value
                 {
@@ -443,21 +416,21 @@ impl<T> DataReaderEntity<T> {
             match self
                 .instance_ownership
                 .iter_mut()
-                .find(|x| x.instance_handle == sample.instance_handle)
+                .find(|x| x.instance_handle == instance_handle)
             {
                 Some(x) => {
-                    x.owner_handle = sample.writer_guid;
+                    x.owner_handle = writer_guid.into();
                 }
                 None => self.instance_ownership.push(InstanceOwnership {
-                    instance_handle: sample.instance_handle,
-                    owner_handle: sample.writer_guid,
+                    instance_handle,
+                    owner_handle: writer_guid.into(),
                     last_received_time: reception_timestamp,
                 }),
             }
         }
 
         if matches!(
-            sample.kind,
+            change_kind,
             ChangeKind::NotAliveDisposed
                 | ChangeKind::NotAliveUnregistered
                 | ChangeKind::NotAliveDisposedUnregistered
@@ -465,26 +438,33 @@ impl<T> DataReaderEntity<T> {
             if let Some(i) = self
                 .instance_ownership
                 .iter()
-                .position(|x| x.instance_handle == sample.instance_handle)
+                .position(|x| x.instance_handle == instance_handle)
             {
                 self.instance_ownership.remove(i);
             }
         }
 
         let is_sample_of_interest_based_on_time = {
-            let closest_timestamp_before_received_sample = self
-                .sample_list
-                .iter()
-                .filter(|cc| cc.instance_handle == sample.instance_handle)
-                .filter(|cc| cc.source_timestamp <= sample.source_timestamp)
-                .map(|cc| cc.source_timestamp)
-                .max();
-
-            if let Some(Some(t)) = closest_timestamp_before_received_sample {
-                if let Some(sample_source_time) = sample.source_timestamp {
-                    let sample_separation = sample_source_time - t;
-                    DurationKind::Finite(sample_separation)
-                        >= self.qos.time_based_filter.minimum_separation
+            if self.qos.time_based_filter.minimum_separation
+                > DurationKind::Finite(Duration::new(0, 0))
+            {
+                if let Some(instance) = self.instances.iter().find(|x| x.handle == instance_handle)
+                {
+                    if let Some(last_accepted_time) = instance.last_accepted_source_timestamp {
+                        if let Some(sample_source_time) = change_source_timestamp {
+                            if sample_source_time >= last_accepted_time {
+                                let sample_separation = sample_source_time - last_accepted_time;
+                                DurationKind::Finite(sample_separation)
+                                    >= self.qos.time_based_filter.minimum_separation
+                            } else {
+                                false
+                            }
+                        } else {
+                            true
+                        }
+                    } else {
+                        true
+                    }
                 } else {
                     true
                 }
@@ -514,7 +494,7 @@ impl<T> DataReaderEntity<T> {
                 }
             }
 
-            if instance_handle_list.contains(&sample.instance_handle) {
+            if instance_handle_list.contains(&instance_handle) {
                 false
             } else {
                 instance_handle_list.len() == self.qos.resource_limits.max_instances
@@ -524,33 +504,31 @@ impl<T> DataReaderEntity<T> {
             let total_samples_of_instance = self
                 .sample_list
                 .iter()
-                .filter(|cc| cc.instance_handle == sample.instance_handle)
+                .filter(|cc| cc.instance_handle == instance_handle)
                 .count();
 
             total_samples_of_instance == self.qos.resource_limits.max_samples_per_instance
         };
         if is_max_samples_limit_reached {
             return Ok(AddChangeResult::Rejected(
-                sample.instance_handle,
+                instance_handle,
                 SampleRejectedStatusKind::RejectedBySamplesLimit,
             ));
         } else if is_max_instances_limit_reached {
             return Ok(AddChangeResult::Rejected(
-                sample.instance_handle,
+                instance_handle,
                 SampleRejectedStatusKind::RejectedByInstancesLimit,
             ));
         } else if is_max_samples_per_instance_limit_reached {
             return Ok(AddChangeResult::Rejected(
-                sample.instance_handle,
+                instance_handle,
                 SampleRejectedStatusKind::RejectedBySamplesPerInstanceLimit,
             ));
         }
         let num_alive_samples_of_instance = self
             .sample_list
             .iter()
-            .filter(|cc| {
-                cc.instance_handle == sample.instance_handle && cc.kind == ChangeKind::Alive
-            })
+            .filter(|cc| cc.instance_handle == instance_handle && cc.kind == ChangeKind::Alive)
             .count() as u32;
 
         if let HistoryQosPolicyKind::KeepLast(depth) = self.qos.history.kind {
@@ -559,49 +537,77 @@ impl<T> DataReaderEntity<T> {
                     .sample_list
                     .iter()
                     .position(|cc| {
-                        cc.instance_handle == sample.instance_handle && cc.kind == ChangeKind::Alive
+                        cc.instance_handle == instance_handle && cc.kind == ChangeKind::Alive
                     })
                     .expect("Samples must exist");
                 self.sample_list.remove(index_sample_to_remove);
             }
         }
 
-        match sample.kind {
+        let (disposed_generation_count, no_writers_generation_count) = match change_kind {
             ChangeKind::Alive | ChangeKind::AliveFiltered => {
                 match self
                     .instances
                     .iter_mut()
-                    .find(|x| x.handle() == &sample.instance_handle)
+                    .find(|x| x.handle() == &instance_handle)
                 {
-                    Some(x) => x.update_state(sample.kind, Some(reception_timestamp)),
+                    Some(x) => {
+                        x.update_state(
+                            change_kind,
+                            Some(reception_timestamp),
+                            change_source_timestamp,
+                        );
+                        (
+                            x.most_recent_disposed_generation_count,
+                            x.most_recent_no_writers_generation_count,
+                        )
+                    }
                     None => {
-                        let mut s = InstanceState::new(sample.instance_handle);
-                        s.update_state(sample.kind, Some(reception_timestamp));
+                        let mut s = InstanceState::new(instance_handle);
+                        s.update_state(
+                            change_kind,
+                            Some(reception_timestamp),
+                            change_source_timestamp,
+                        );
+                        let counts = (
+                            s.most_recent_disposed_generation_count,
+                            s.most_recent_no_writers_generation_count,
+                        );
                         self.instances.push(s);
+                        counts
                     }
                 }
-                Ok(())
             }
             ChangeKind::NotAliveDisposed
             | ChangeKind::NotAliveUnregistered
             | ChangeKind::NotAliveDisposedUnregistered => {
-                match self
+                let instance = self
                     .instances
                     .iter_mut()
-                    .find(|x| x.handle() == &sample.instance_handle)
-                {
-                    Some(instance) => {
-                        instance.update_state(sample.kind, Some(reception_timestamp));
-                        Ok(())
-                    }
-                    None => Err(DdsError::Error(
-                        "Received message changing state of unknown instance".to_string(),
-                    )),
-                }
+                    .find(|x| x.handle() == &instance_handle)
+                    .expect("Instance must exist");
+                instance.update_state(
+                    change_kind,
+                    Some(reception_timestamp),
+                    change_source_timestamp,
+                );
+                (
+                    instance.most_recent_disposed_generation_count,
+                    instance.most_recent_no_writers_generation_count,
+                )
             }
-        }?;
+        };
 
-        let sample_writer_guid = sample.writer_guid;
+        let sample = ReaderSample {
+            kind: change_kind,
+            writer_guid: writer_guid.into(),
+            instance_handle,
+            source_timestamp: change_source_timestamp,
+            data_value,
+            sample_state: SampleStateKind::NotRead,
+            disposed_generation_count,
+            no_writers_generation_count,
+        };
         tracing::debug!(cache_change = ?sample, "Adding change to data reader history cache");
 
         match self.qos.destination_order.kind {
@@ -620,7 +626,7 @@ impl<T> DataReaderEntity<T> {
         match self
             .instance_ownership
             .iter_mut()
-            .find(|x| x.instance_handle == change_instance_handle)
+            .find(|x| x.instance_handle == instance_handle)
         {
             Some(x) => {
                 if x.last_received_time < reception_timestamp {
@@ -628,9 +634,9 @@ impl<T> DataReaderEntity<T> {
                 }
             }
             None => self.instance_ownership.push(InstanceOwnership {
-                instance_handle: change_instance_handle,
+                instance_handle,
                 last_received_time: reception_timestamp,
-                owner_handle: sample_writer_guid,
+                owner_handle: writer_guid.into(),
             }),
         }
         Ok(AddChangeResult::Added)

--- a/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
@@ -29,6 +29,7 @@ pub struct InstanceState {
     most_recent_disposed_generation_count: i32,
     most_recent_no_writers_generation_count: i32,
     last_received_time_stamp: Time,
+    registered_writers: Vec<[u8; 16]>,
 }
 
 impl InstanceState {
@@ -41,35 +42,49 @@ impl InstanceState {
             most_recent_disposed_generation_count: 0,
             most_recent_no_writers_generation_count: 0,
             last_received_time_stamp: Time::new(TIME_INVALID_SEC, TIME_INVALID_NSEC),
+            registered_writers: Vec::new(),
         }
     }
 
     pub fn update_state(
         &mut self,
         change_kind: ChangeKind,
+        writer_guid: [u8; 16],
         now: Option<Time>,
         source_timestamp: Option<Time>,
     ) {
-        match self.instance_state {
-            InstanceStateKind::Alive => {
-                if change_kind == ChangeKind::NotAliveDisposed
-                    || change_kind == ChangeKind::NotAliveDisposedUnregistered
-                {
-                    self.instance_state = InstanceStateKind::NotAliveDisposed;
-                } else if change_kind == ChangeKind::NotAliveUnregistered {
+        match change_kind {
+            ChangeKind::Alive | ChangeKind::AliveFiltered => {
+                if !self.registered_writers.contains(&writer_guid) {
+                    self.registered_writers.push(writer_guid);
+                }
+                match self.instance_state {
+                    InstanceStateKind::Alive => (),
+                    InstanceStateKind::NotAliveDisposed => {
+                        self.instance_state = InstanceStateKind::Alive;
+                        self.most_recent_disposed_generation_count += 1;
+                    }
+                    InstanceStateKind::NotAliveNoWriters => {
+                        self.instance_state = InstanceStateKind::Alive;
+                        self.most_recent_no_writers_generation_count += 1;
+                    }
+                }
+            }
+            ChangeKind::NotAliveDisposed => {
+                self.instance_state = InstanceStateKind::NotAliveDisposed;
+            }
+            ChangeKind::NotAliveUnregistered => {
+                self.registered_writers.retain(|x| x != &writer_guid);
+                if self.registered_writers.is_empty() {
                     self.instance_state = InstanceStateKind::NotAliveNoWriters;
                 }
             }
-            InstanceStateKind::NotAliveDisposed => {
-                if change_kind == ChangeKind::Alive {
-                    self.instance_state = InstanceStateKind::Alive;
-                    self.most_recent_disposed_generation_count += 1;
-                }
-            }
-            InstanceStateKind::NotAliveNoWriters => {
-                if change_kind == ChangeKind::Alive {
-                    self.instance_state = InstanceStateKind::Alive;
-                    self.most_recent_no_writers_generation_count += 1;
+            ChangeKind::NotAliveDisposedUnregistered => {
+                self.registered_writers.retain(|x| x != &writer_guid);
+                if self.registered_writers.is_empty() {
+                    self.instance_state = InstanceStateKind::NotAliveNoWriters;
+                } else {
+                    self.instance_state = InstanceStateKind::NotAliveDisposed;
                 }
             }
         }
@@ -77,9 +92,12 @@ impl InstanceState {
         match self.view_state {
             ViewStateKind::New => (),
             ViewStateKind::NotNew => {
-                if change_kind == ChangeKind::NotAliveDisposed
-                    || change_kind == ChangeKind::NotAliveUnregistered
-                {
+                if matches!(
+                    change_kind,
+                    ChangeKind::NotAliveDisposed
+                        | ChangeKind::NotAliveUnregistered
+                        | ChangeKind::NotAliveDisposedUnregistered
+                ) {
                     self.view_state = ViewStateKind::New;
                 }
             }
@@ -249,9 +267,12 @@ impl<T> DataReaderEntity<T> {
                 }
             };
 
-            instance_in_coll
-                .instance_state
-                .update_state(cache_change.kind, None, None);
+            instance_in_coll.instance_state.update_state(
+                cache_change.kind,
+                cache_change.writer_guid,
+                None,
+                None,
+            );
             let sample_state = cache_change.sample_state;
             let view_state = instance.view_state;
             let instance_state = instance.instance_state;
@@ -554,6 +575,7 @@ impl<T> DataReaderEntity<T> {
                     Some(x) => {
                         x.update_state(
                             change_kind,
+                            writer_guid.into(),
                             Some(reception_timestamp),
                             change_source_timestamp,
                         );
@@ -566,6 +588,7 @@ impl<T> DataReaderEntity<T> {
                         let mut s = InstanceState::new(instance_handle);
                         s.update_state(
                             change_kind,
+                            writer_guid.into(),
                             Some(reception_timestamp),
                             change_source_timestamp,
                         );
@@ -588,6 +611,7 @@ impl<T> DataReaderEntity<T> {
                     .expect("Instance must exist");
                 instance.update_state(
                     change_kind,
+                    writer_guid.into(),
                     Some(reception_timestamp),
                     change_source_timestamp,
                 );

--- a/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
@@ -185,6 +185,27 @@ impl<T> DataReaderEntity<T> {
         }
     }
 
+    pub fn remove_stale_samples(&mut self, now: Time) {
+        self.sample_list.retain(|sample| {
+            if let Some(source_timestamp) = sample.source_timestamp {
+                if let Some(matched_publication) = self
+                    .matched_publication_list
+                    .iter()
+                    .find(|x| x.key().value == sample.writer_guid)
+                {
+                    if let DurationKind::Finite(lifespan_duration) =
+                        matched_publication.lifespan().duration
+                    {
+                        if now >= source_timestamp + lifespan_duration {
+                            return false;
+                        }
+                    }
+                }
+            }
+            true
+        });
+    }
+
     pub fn create_sample_collection(
         &mut self,
         max_samples: i32,

--- a/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
@@ -75,16 +75,20 @@ impl InstanceState {
             }
             ChangeKind::NotAliveUnregistered => {
                 self.registered_writers.retain(|x| x != &writer_guid);
-                if self.registered_writers.is_empty() {
+                if self.registered_writers.is_empty()
+                    && self.instance_state == InstanceStateKind::Alive
+                {
                     self.instance_state = InstanceStateKind::NotAliveNoWriters;
                 }
             }
             ChangeKind::NotAliveDisposedUnregistered => {
                 self.registered_writers.retain(|x| x != &writer_guid);
-                if self.registered_writers.is_empty() {
-                    self.instance_state = InstanceStateKind::NotAliveNoWriters;
-                } else {
-                    self.instance_state = InstanceStateKind::NotAliveDisposed;
+                if self.instance_state == InstanceStateKind::Alive {
+                    if self.registered_writers.is_empty() {
+                        self.instance_state = InstanceStateKind::NotAliveNoWriters;
+                    } else {
+                        self.instance_state = InstanceStateKind::NotAliveDisposed;
+                    }
                 }
             }
         }
@@ -116,7 +120,7 @@ impl InstanceState {
 
     pub fn remove_writer(&mut self, writer_guid: &[u8; 16]) {
         self.registered_writers.retain(|x| x != writer_guid);
-        if self.registered_writers.is_empty() {
+        if self.registered_writers.is_empty() && self.instance_state == InstanceStateKind::Alive {
             self.instance_state = InstanceStateKind::NotAliveNoWriters;
             self.view_state = ViewStateKind::New;
         }

--- a/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
@@ -114,6 +114,14 @@ impl InstanceState {
         self.view_state = ViewStateKind::NotNew;
     }
 
+    pub fn remove_writer(&mut self, writer_guid: &[u8; 16]) {
+        self.registered_writers.retain(|x| x != writer_guid);
+        if self.registered_writers.is_empty() {
+            self.instance_state = InstanceStateKind::NotAliveNoWriters;
+            self.view_state = ViewStateKind::New;
+        }
+    }
+
     pub fn handle(&self) -> &InstanceHandle {
         &self.handle
     }
@@ -433,36 +441,6 @@ impl<T> DataReaderEntity<T> {
                     return Ok(AddChangeResult::NotAdded);
                 }
             }
-
-            match self
-                .instance_ownership
-                .iter_mut()
-                .find(|x| x.instance_handle == instance_handle)
-            {
-                Some(x) => {
-                    x.owner_handle = writer_guid.into();
-                }
-                None => self.instance_ownership.push(InstanceOwnership {
-                    instance_handle,
-                    owner_handle: writer_guid.into(),
-                    last_received_time: reception_timestamp,
-                }),
-            }
-        }
-
-        if matches!(
-            change_kind,
-            ChangeKind::NotAliveDisposed
-                | ChangeKind::NotAliveUnregistered
-                | ChangeKind::NotAliveDisposedUnregistered
-        ) {
-            if let Some(i) = self
-                .instance_ownership
-                .iter()
-                .position(|x| x.instance_handle == instance_handle)
-            {
-                self.instance_ownership.remove(i);
-            }
         }
 
         let is_sample_of_interest_based_on_time = {
@@ -647,21 +625,39 @@ impl<T> DataReaderEntity<T> {
             DestinationOrderQosPolicyKind::ByReceptionTimestamp => self.sample_list.push(sample),
         }
 
-        match self
-            .instance_ownership
-            .iter_mut()
-            .find(|x| x.instance_handle == instance_handle)
-        {
-            Some(x) => {
-                if x.last_received_time < reception_timestamp {
-                    x.last_received_time = reception_timestamp;
+        if self.qos.ownership.kind == OwnershipQosPolicyKind::Exclusive {
+            if matches!(
+                change_kind,
+                ChangeKind::NotAliveDisposed
+                    | ChangeKind::NotAliveUnregistered
+                    | ChangeKind::NotAliveDisposedUnregistered
+            ) {
+                if let Some(i) = self
+                    .instance_ownership
+                    .iter()
+                    .position(|x| x.instance_handle == instance_handle)
+                {
+                    self.instance_ownership.remove(i);
+                }
+            } else {
+                match self
+                    .instance_ownership
+                    .iter_mut()
+                    .find(|x| x.instance_handle == instance_handle)
+                {
+                    Some(x) => {
+                        x.owner_handle = writer_guid.into();
+                        if x.last_received_time < reception_timestamp {
+                            x.last_received_time = reception_timestamp;
+                        }
+                    }
+                    None => self.instance_ownership.push(InstanceOwnership {
+                        instance_handle,
+                        last_received_time: reception_timestamp,
+                        owner_handle: writer_guid.into(),
+                    }),
                 }
             }
-            None => self.instance_ownership.push(InstanceOwnership {
-                instance_handle,
-                last_received_time: reception_timestamp,
-                owner_handle: writer_guid.into(),
-            }),
         }
         Ok(AddChangeResult::Added)
     }

--- a/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
@@ -129,7 +129,11 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             writer_guid: self.transport_writer.guid(),
             sequence_number: self.last_change_sequence_number,
             source_timestamp: Some(sample_timestamp.into()),
-            instance_handle: Some(sample_instance_handle.into()),
+            instance_handle: if self.key_holder_type.is_empty() {
+                None
+            } else {
+                Some(sample_instance_handle.into())
+            },
             data_value: serialized_data.into(),
         };
 

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -2630,52 +2630,59 @@ impl DcpsDomainParticipant {
             .iter()
             .any(|handle| handle == &discovered_participant_data.dds_participant_data.key.value);
 
-        if is_domain_id_matching
-            && is_domain_tag_matching
-            && !is_participant_discovered
-            && !is_participant_ignored
-        {
-            self.add_matched_publications_detector(discovered_participant_data);
-            self.add_matched_publications_announcer(discovered_participant_data);
-            self.add_matched_subscriptions_detector(discovered_participant_data);
-            self.add_matched_subscriptions_announcer(discovered_participant_data);
-            self.add_matched_topics_detector(discovered_participant_data);
-            self.add_matched_topics_announcer(discovered_participant_data);
+        if is_domain_id_matching && is_domain_tag_matching && !is_participant_ignored {
+            if !is_participant_discovered {
+                self.add_matched_publications_detector(discovered_participant_data);
+                self.add_matched_publications_announcer(discovered_participant_data);
+                self.add_matched_subscriptions_detector(discovered_participant_data);
+                self.add_matched_subscriptions_announcer(discovered_participant_data);
+                self.add_matched_topics_detector(discovered_participant_data);
+                self.add_matched_topics_announcer(discovered_participant_data);
 
-            self.add_matched_service_request_data_reader(discovered_participant_data);
-            self.add_matched_service_request_data_writer(discovered_participant_data);
-            self.add_matched_service_reply_data_reader(discovered_participant_data);
-            self.add_matched_service_reply_data_writer(discovered_participant_data);
+                self.add_matched_service_request_data_reader(discovered_participant_data);
+                self.add_matched_service_request_data_writer(discovered_participant_data);
+                self.add_matched_service_reply_data_reader(discovered_participant_data);
+                self.add_matched_service_reply_data_writer(discovered_participant_data);
 
-            self.announce_participant(now);
+                self.announce_participant(now);
 
-            let discovered_participant_info = DiscoveredParticipantInfo {
-                dds_participant_data: discovered_participant_data.dds_participant_data.clone(),
-                guid_prefix: discovered_participant_data.participant_proxy.guid_prefix,
-                default_unicast_locator_list: discovered_participant_data
-                    .participant_proxy
-                    .default_unicast_locator_list
-                    .clone(),
-                default_multicast_locator_list: discovered_participant_data
-                    .participant_proxy
-                    .default_multicast_locator_list
-                    .clone(),
-                lease_duration: discovered_participant_data.lease_duration,
-                last_communication_timestamp: now,
-            };
-            match self
+                let discovered_participant_info = DiscoveredParticipantInfo {
+                    dds_participant_data: discovered_participant_data.dds_participant_data.clone(),
+                    guid_prefix: discovered_participant_data.participant_proxy.guid_prefix,
+                    default_unicast_locator_list: discovered_participant_data
+                        .participant_proxy
+                        .default_unicast_locator_list
+                        .clone(),
+                    default_multicast_locator_list: discovered_participant_data
+                        .participant_proxy
+                        .default_multicast_locator_list
+                        .clone(),
+                    lease_duration: discovered_participant_data.lease_duration,
+                    last_communication_timestamp: now,
+                };
+                self.domain_participant
+                    .discovered_participant_list
+                    .push(discovered_participant_info);
+            } else if let Some(p) = self
                 .domain_participant
                 .discovered_participant_list
                 .iter_mut()
                 .find(|p| {
-                    p.dds_participant_data.key()
-                        == discovered_participant_info.dds_participant_data.key()
-                }) {
-                Some(x) => *x = discovered_participant_info,
-                None => self
-                    .domain_participant
-                    .discovered_participant_list
-                    .push(discovered_participant_info),
+                    p.dds_participant_data.key().value
+                        == discovered_participant_data.dds_participant_data.key.value
+                })
+            {
+                p.dds_participant_data = discovered_participant_data.dds_participant_data.clone();
+                p.default_unicast_locator_list = discovered_participant_data
+                    .participant_proxy
+                    .default_unicast_locator_list
+                    .clone();
+                p.default_multicast_locator_list = discovered_participant_data
+                    .participant_proxy
+                    .default_multicast_locator_list
+                    .clone();
+                p.lease_duration = discovered_participant_data.lease_duration;
+                p.last_communication_timestamp = now;
             }
         }
     }

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -476,6 +476,14 @@ impl DcpsDomainParticipant {
         }
     }
 
+    pub fn remove_stale_reader_samples(&mut self, now: Time) {
+        for subscriber in &mut self.domain_participant.user_defined_subscriber_list {
+            for data_reader in &mut subscriber.data_reader_list {
+                data_reader.remove_stale_samples(now);
+            }
+        }
+    }
+
     #[tracing::instrument(skip(self))]
     pub fn announce_data_writer(
         &mut self,

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -252,7 +252,7 @@ impl DcpsDomainParticipant {
                         .iter()
                         .filter_map(|x| {
                             if now - x.last_received_time_stamp() > deadline {
-                                Some(x.handle)
+                                Some(*x.handle())
                             } else {
                                 None
                             }

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -2684,11 +2684,6 @@ impl DcpsDomainParticipant {
 
         for subscriber in &mut self.domain_participant.user_defined_subscriber_list {
             for data_reader in &mut subscriber.data_reader_list {
-                // Remove samples
-                data_reader
-                    .sample_list
-                    .retain(|sample| sample.writer_guid[..12] != prefix);
-
                 let removed_writer_guids: Vec<_> = data_reader
                     .matched_publication_list
                     .iter()
@@ -2699,6 +2694,7 @@ impl DcpsDomainParticipant {
                     data_reader
                         .transport_reader
                         .delete_matched_writer(key.into());
+                    data_reader.remove_matched_publication(&InstanceHandle::new(key));
                 }
             }
         }

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -977,7 +977,7 @@ impl DcpsDomainParticipant {
                                                             .guid(),
                                                         sequence_number: (type_request_writer
                                                             .last_change_sequence_number
-                                                            + 1)
+                                                            )
                                                         .into(),
                                                     },
                                                     instance_name: format!(
@@ -1025,7 +1025,7 @@ impl DcpsDomainParticipant {
                                                         .guid(),
                                                     sequence_number: (type_request_writer
                                                         .last_change_sequence_number
-                                                        + 1)
+                                                        )
                                                         .into(),
                                                 },
                                                 instance_name: format!(
@@ -1635,7 +1635,7 @@ impl DcpsDomainParticipant {
                                                             .guid(),
                                                         sequence_number: (type_request_writer
                                                             .last_change_sequence_number
-                                                            + 1)
+                                                            )
                                                         .into(),
                                                     },
                                                     instance_name: format!(
@@ -1683,7 +1683,7 @@ impl DcpsDomainParticipant {
                                                         .guid(),
                                                     sequence_number: (type_request_writer
                                                         .last_change_sequence_number
-                                                        + 1)
+                                                        )
                                                         .into(),
                                                 },
                                                 instance_name: format!(
@@ -2191,9 +2191,8 @@ impl DcpsDomainParticipant {
                                 request_id: SampleIdentity {
                                     writer_guid: type_request_writer.transport_writer.guid(),
                                     sequence_number: (type_request_writer
-                                        .last_change_sequence_number
-                                        + 1)
-                                    .into(),
+                                        .last_change_sequence_number)
+                                        .into(),
                                 },
                                 instance_name: format!(
                                     "dds.builtin.TOS.{:x}",
@@ -2505,9 +2504,8 @@ impl DcpsDomainParticipant {
                                                 .transport_writer
                                                 .guid(),
                                             sequence_number: (type_request_writer
-                                                .last_change_sequence_number
-                                                + 1)
-                                            .into(),
+                                                .last_change_sequence_number)
+                                                .into(),
                                         },
                                         instance_name: format!(
                                             "dds.builtin.TOS.{:x}",
@@ -2555,9 +2553,8 @@ impl DcpsDomainParticipant {
                                     request_id: SampleIdentity {
                                         writer_guid: type_request_writer.transport_writer.guid(),
                                         sequence_number: (type_request_writer
-                                            .last_change_sequence_number
-                                            + 1)
-                                        .into(),
+                                            .last_change_sequence_number)
+                                            .into(),
                                     },
                                     instance_name: format!(
                                         "dds.builtin.TOS.{:x}",
@@ -3250,7 +3247,7 @@ impl DcpsDomainParticipant {
                 header: RequestHeader {
                     request_id: SampleIdentity {
                         writer_guid: w.transport_writer.guid(),
-                        sequence_number: (w.last_change_sequence_number + 1).into(),
+                        sequence_number: (w.last_change_sequence_number).into(),
                     },
                     instance_name: String::from(""),
                 },

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -977,12 +977,17 @@ impl DcpsDomainParticipant {
                                                             .guid(),
                                                         sequence_number: (type_request_writer
                                                             .last_change_sequence_number
-                                                            )
+                                                            + 1)
                                                         .into(),
                                                     },
                                                     instance_name: format!(
                                                         "dds.builtin.TOS.{:x}",
-                                                        participant_instance_handle,
+                                                        InstanceHandle::new(
+                                                            discovered_reader_data
+                                                                .dds_subscription_data
+                                                                .participant_key()
+                                                                .value
+                                                        ),
                                                     ),
                                                 },
                                                 call:
@@ -1025,12 +1030,17 @@ impl DcpsDomainParticipant {
                                                         .guid(),
                                                     sequence_number: (type_request_writer
                                                         .last_change_sequence_number
-                                                        )
+                                                        + 1)
                                                         .into(),
                                                 },
                                                 instance_name: format!(
                                                     "dds.builtin.TOS.{:x}",
-                                                    participant_instance_handle,
+                                                    InstanceHandle::new(
+                                                        discovered_reader_data
+                                                            .dds_subscription_data
+                                                            .participant_key()
+                                                            .value
+                                                    ),
                                                 ),
                                             },
                                             call: TypeLookupCall::TypeLookupGetTypesHashId {
@@ -1635,12 +1645,17 @@ impl DcpsDomainParticipant {
                                                             .guid(),
                                                         sequence_number: (type_request_writer
                                                             .last_change_sequence_number
-                                                            )
+                                                            + 1)
                                                         .into(),
                                                     },
                                                     instance_name: format!(
                                                         "dds.builtin.TOS.{:x}",
-                                                        participant_instance_handle,
+                                                        InstanceHandle::new(
+                                                            discovered_writer_data
+                                                                .dds_publication_data
+                                                                .participant_key()
+                                                                .value
+                                                        ),
                                                     ),
                                                 },
                                                 call:
@@ -1683,12 +1698,17 @@ impl DcpsDomainParticipant {
                                                         .guid(),
                                                     sequence_number: (type_request_writer
                                                         .last_change_sequence_number
-                                                        )
+                                                        + 1)
                                                         .into(),
                                                 },
                                                 instance_name: format!(
                                                     "dds.builtin.TOS.{:x}",
-                                                    participant_instance_handle,
+                                                    InstanceHandle::new(
+                                                        discovered_writer_data
+                                                            .dds_publication_data
+                                                            .participant_key()
+                                                            .value
+                                                    ),
                                                 ),
                                             },
                                             call: TypeLookupCall::TypeLookupGetTypesHashId {
@@ -2191,8 +2211,9 @@ impl DcpsDomainParticipant {
                                 request_id: SampleIdentity {
                                     writer_guid: type_request_writer.transport_writer.guid(),
                                     sequence_number: (type_request_writer
-                                        .last_change_sequence_number)
-                                        .into(),
+                                        .last_change_sequence_number
+                                        + 1)
+                                    .into(),
                                 },
                                 instance_name: format!(
                                     "dds.builtin.TOS.{:x}",
@@ -2504,8 +2525,9 @@ impl DcpsDomainParticipant {
                                                 .transport_writer
                                                 .guid(),
                                             sequence_number: (type_request_writer
-                                                .last_change_sequence_number)
-                                                .into(),
+                                                .last_change_sequence_number
+                                                + 1)
+                                            .into(),
                                         },
                                         instance_name: format!(
                                             "dds.builtin.TOS.{:x}",
@@ -2553,8 +2575,9 @@ impl DcpsDomainParticipant {
                                     request_id: SampleIdentity {
                                         writer_guid: type_request_writer.transport_writer.guid(),
                                         sequence_number: (type_request_writer
-                                            .last_change_sequence_number)
-                                            .into(),
+                                            .last_change_sequence_number
+                                            + 1)
+                                        .into(),
                                     },
                                     instance_name: format!(
                                         "dds.builtin.TOS.{:x}",
@@ -3247,7 +3270,7 @@ impl DcpsDomainParticipant {
                 header: RequestHeader {
                     request_id: SampleIdentity {
                         writer_guid: w.transport_writer.guid(),
-                        sequence_number: (w.last_change_sequence_number).into(),
+                        sequence_number: (w.last_change_sequence_number + 1).into(),
                     },
                     instance_name: String::from(""),
                 },

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -171,6 +171,29 @@ impl DcpsDomainParticipant {
                         min_time = min_time.map_or(Some(remaining), |m| Some(m.min(remaining)));
                     }
                 }
+
+                for sample in &data_reader.sample_list {
+                    if let Some(source_timestamp) = sample.source_timestamp {
+                        if let Some(matched_publication) = data_reader
+                            .matched_publication_list
+                            .iter()
+                            .find(|x| x.key().value == sample.writer_guid)
+                        {
+                            if let DurationKind::Finite(lifespan) =
+                                matched_publication.lifespan().duration
+                            {
+                                let expiry = Time::from(source_timestamp) + lifespan;
+                                let remaining = if expiry > now {
+                                    expiry - now
+                                } else {
+                                    Duration::new(0, 0)
+                                };
+                                min_time =
+                                    min_time.map_or(Some(remaining), |m| Some(m.min(remaining)));
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -182,7 +182,7 @@ impl DcpsDomainParticipant {
                             if let DurationKind::Finite(lifespan) =
                                 matched_publication.lifespan().duration
                             {
-                                let expiry = Time::from(source_timestamp) + lifespan;
+                                let expiry = source_timestamp + lifespan;
                                 let remaining = if expiry > now {
                                     expiry - now
                                 } else {

--- a/dds/src/dcps/dcps_domain_participant/user_defined_data_reader.rs
+++ b/dds/src/dcps/dcps_domain_participant/user_defined_data_reader.rs
@@ -103,6 +103,18 @@ impl UserDefinedDataReader {
         };
         self.matched_publication_list.remove(i);
 
+        let writer_guid: [u8; 16] = *publication_handle.as_ref();
+        for instance in &mut self.instances {
+            instance.remove_writer(&writer_guid);
+        }
+        if let Some(i) = self
+            .instance_ownership
+            .iter()
+            .position(|x| x.owner_handle == writer_guid)
+        {
+            self.instance_ownership.remove(i);
+        }
+
         self.subscription_matched_status.current_count = self.matched_publication_list.len() as i32;
         self.subscription_matched_status.current_count_change -= 1;
         self.status_condition

--- a/dds/src/dcps/infrastructure/instance.rs
+++ b/dds/src/dcps/infrastructure/instance.rs
@@ -84,7 +84,7 @@ impl Index<usize> for InstanceHandle {
 impl core::fmt::LowerHex for InstanceHandle {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         for byte in self.0 {
-            f.write_fmt(format_args!("{:x}", byte))?;
+            f.write_fmt(format_args!("{:02x}", byte))?;
         }
         Ok(())
     }
@@ -96,6 +96,9 @@ mod tests {
     #[test]
     fn lower_hex_instance_handle() {
         let h = InstanceHandle::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-        assert_eq!(format!("{:x}", h), "0123456789abcdef")
+        assert_eq!(
+            format!("{:x}", h),
+            "000102030405060708090a0b0c0d0e0f"
+        );
     }
 }

--- a/dds/src/dcps/infrastructure/instance.rs
+++ b/dds/src/dcps/infrastructure/instance.rs
@@ -96,9 +96,6 @@ mod tests {
     #[test]
     fn lower_hex_instance_handle() {
         let h = InstanceHandle::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-        assert_eq!(
-            format!("{:x}", h),
-            "000102030405060708090a0b0c0d0e0f"
-        );
+        assert_eq!(format!("{:x}", h), "000102030405060708090a0b0c0d0e0f");
     }
 }

--- a/dds/src/dcps/infrastructure/time.rs
+++ b/dds/src/dcps/infrastructure/time.rs
@@ -119,7 +119,7 @@ impl dust_dds::xtypes::type_support::Type for Duration {
                         id: 0,
                         r#type: <i32 as dust_dds::xtypes::type_support::Type>::TYPE,
                         default_value: None,
-                        index: 0u32 as u32,
+                        index: 0u32,
                         try_construct_kind:
                             dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
                         label: &[],
@@ -137,7 +137,7 @@ impl dust_dds::xtypes::type_support::Type for Duration {
                         id: 1,
                         r#type: <u32 as dust_dds::xtypes::type_support::Type>::TYPE,
                         default_value: None,
-                        index: 1u32 as u32,
+                        index: 1u32,
                         try_construct_kind:
                             dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
                         label: &[],

--- a/dds/src/dcps/infrastructure/time.rs
+++ b/dds/src/dcps/infrastructure/time.rs
@@ -57,11 +57,100 @@ impl PartialOrd<DurationKind> for DurationKind {
 }
 
 /// Structure representing a time interval with a nanosecond resolution.
-#[derive(PartialOrd, Ord, PartialEq, Eq, Debug, Clone, Copy, TypeSupport)]
-#[dust_dds(extensibility = "final", nested)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Debug, Clone, Copy)]
 pub struct Duration {
-    pub(crate) sec: i32,
-    pub(crate) nanosec: u32,
+    sec: i32,
+    nanosec: u32,
+}
+
+impl dust_dds::xtypes::type_support::TypeSupport for Duration {
+    fn create_sample(
+        src: &mut dust_dds::xtypes::dynamic_type::DynamicData,
+    ) -> ::core::option::Option<Self> {
+        Some(Self {
+            sec: dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(
+                src.remove_value(0).ok()?,
+            )
+            .ok()?,
+            nanosec: fraction_to_nanosec(
+                dust_dds::xtypes::data_storage::DataStorageMapping::try_from_storage(
+                    src.remove_value(1).ok()?,
+                )
+                .ok()?,
+            ),
+        })
+    }
+    fn create_dynamic_sample(self) -> dust_dds::xtypes::dynamic_type::DynamicData<'static> {
+        let mut data =
+            dust_dds::xtypes::dynamic_type::DynamicDataFactory::create_data(Self::get_type());
+        data.set_value(
+            0,
+            dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(self.sec),
+        );
+        data.set_value(
+            1,
+            dust_dds::xtypes::data_storage::DataStorageMapping::into_storage(nanosec_to_fraction(
+                self.nanosec,
+            )),
+        );
+        data
+    }
+}
+
+impl dust_dds::xtypes::type_support::Type for Duration {
+    const TYPE: dust_dds::xtypes::dynamic_type::DynamicType<'static> =
+        dust_dds::xtypes::dynamic_type::DynamicType {
+            descriptor: &dust_dds::xtypes::dynamic_type::TypeDescriptor {
+                kind: dust_dds::xtypes::dynamic_type::TypeKind::STRUCTURE,
+                name: "Duration",
+                base_type: None,
+                discriminator_type: None,
+                bound: &[],
+                element_type: None,
+                key_element_type: None,
+                extensibility_kind: dust_dds::xtypes::dynamic_type::ExtensibilityKind::Final,
+                is_nested: true,
+                is_autoid_hash: false,
+            },
+            member_list: &[
+                dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+                    descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+                        name: "sec",
+                        id: 0,
+                        r#type: <i32 as dust_dds::xtypes::type_support::Type>::TYPE,
+                        default_value: None,
+                        index: 0u32 as u32,
+                        try_construct_kind:
+                            dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
+                        label: &[],
+                        is_key: false,
+                        is_optional: false,
+                        is_must_understand: false,
+                        is_shared: false,
+                        is_default_label: false,
+                        is_external: false,
+                    },
+                },
+                dust_dds::xtypes::dynamic_type::DynamicTypeMember {
+                    descriptor: dust_dds::xtypes::dynamic_type::MemberDescriptor {
+                        name: "fraction",
+                        id: 1,
+                        r#type: <u32 as dust_dds::xtypes::type_support::Type>::TYPE,
+                        default_value: None,
+                        index: 1u32 as u32,
+                        try_construct_kind:
+                            dust_dds::xtypes::dynamic_type::TryConstructKind::Discard,
+                        label: &[],
+                        is_key: false,
+                        is_optional: false,
+                        is_must_understand: false,
+                        is_shared: false,
+                        is_default_label: false,
+                        is_external: false,
+                    },
+                },
+            ],
+        };
 }
 
 impl Duration {
@@ -115,11 +204,11 @@ impl Sub<Duration> for Duration {
     }
 }
 
-fn fraction_to_nanosec(fraction: u32) -> u32 {
+const fn fraction_to_nanosec(fraction: u32) -> u32 {
     ((fraction as u64 * 1_000_000_000) / (1u64 << 32)) as u32
 }
 
-fn nanosec_to_fraction(nanosec: u32) -> u32 {
+const fn nanosec_to_fraction(nanosec: u32) -> u32 {
     (((nanosec as u64 * (1u64 << 32)) + (500_000_000)) / 1_000_000_000) as u32
 }
 

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -135,12 +135,16 @@ pub fn get_instance_handle_from_key_holder_data<'a>(
     key_holder_data: &KeyHolderData<'a>,
 ) -> Result<InstanceHandle, XTypesError> {
     let data = serialize_final_without_header(Vec::with_capacity(16), &key_holder_data.0)?;
-    let key = if data.len() <= 16 {
-        let mut key = [0; 16];
-        key[0..data.len()].copy_from_slice(&data);
-        key
-    } else {
-        md5::compute(data).into()
+    let dynamic_type = key_holder_data.0.r#type();
+    let max_size = dynamic_type.max_size_serialized_cdr_be(0);
+    let key = match max_size {
+        Some(size) if size <= 16 => {
+            let mut key = [0; 16];
+            let len = data.len().min(16);
+            key[0..len].copy_from_slice(&data[0..len]);
+            key
+        }
+        _ => md5::compute(data).into(),
     };
 
     Ok(InstanceHandle::new(key))
@@ -162,6 +166,139 @@ pub fn get_instance_handle_from_dynamic_data<'a>(
 ) -> Result<InstanceHandle, XTypesError> {
     let key_holder_type = KeyHolderType::new(&value.r#type());
     get_instance_handle_from_dynamic_data_and_key_holder(value, &key_holder_type)
+}
+
+impl<'a> DynamicType<'a> {
+    /// Computes the maximum serialized size in bytes using CDR Big-Endian encoding.
+    /// Returns `None` if the type has unbounded size (such as unbounded strings or sequences).
+    fn max_size_serialized_cdr_be(&self, current_offset: usize) -> Option<usize> {
+        fn align_to(offset: usize, alignment: usize) -> usize {
+            if alignment <= 1 {
+                offset
+            } else {
+                (offset + alignment - 1) & !(alignment - 1)
+            }
+        }
+
+        match self.get_kind() {
+            TypeKind::NONE => Some(current_offset),
+            TypeKind::BOOLEAN
+            | TypeKind::BYTE
+            | TypeKind::INT8
+            | TypeKind::UINT8
+            | TypeKind::CHAR8 => Some(current_offset.checked_add(1)?),
+            TypeKind::INT16 | TypeKind::UINT16 | TypeKind::CHAR16 => {
+                let aligned = align_to(current_offset, 2);
+                Some(aligned.checked_add(2)?)
+            }
+            TypeKind::INT32 | TypeKind::UINT32 | TypeKind::FLOAT32 | TypeKind::ENUM => {
+                let aligned = align_to(current_offset, 4);
+                Some(aligned.checked_add(4)?)
+            }
+            TypeKind::INT64 | TypeKind::UINT64 | TypeKind::FLOAT64 => {
+                let aligned = align_to(current_offset, 8);
+                Some(aligned.checked_add(8)?)
+            }
+            TypeKind::FLOAT128 => {
+                let aligned = align_to(current_offset, 16);
+                Some(aligned.checked_add(16)?)
+            }
+            TypeKind::STRING8 => {
+                let bound = self.descriptor.bound.first().copied().unwrap_or(0);
+                if bound == 0 || bound == u32::MAX {
+                    None
+                } else {
+                    let aligned = align_to(current_offset, 4);
+                    let size = (bound as usize).checked_add(5)?;
+                    aligned.checked_add(size)
+                }
+            }
+            TypeKind::STRING16 => {
+                let bound = self.descriptor.bound.first().copied().unwrap_or(0);
+                if bound == 0 || bound == u32::MAX {
+                    None
+                } else {
+                    let aligned = align_to(current_offset, 4);
+                    let chars_size = (bound as usize).checked_mul(2)?;
+                    let size = chars_size.checked_add(6)?;
+                    aligned.checked_add(size)
+                }
+            }
+            TypeKind::ALIAS => {
+                if let Some(base_type) = &self.descriptor.base_type {
+                    base_type.max_size_serialized_cdr_be(current_offset)
+                } else {
+                    None
+                }
+            }
+            TypeKind::BITMASK => {
+                let bound = self.descriptor.bound.first().copied().unwrap_or(32);
+                let (align, size) = match bound {
+                    0..=8 => (1, 1),
+                    9..=16 => (2, 2),
+                    17..=32 => (4, 4),
+                    _ => (8, 8),
+                };
+                let aligned = align_to(current_offset, align);
+                aligned.checked_add(size)
+            }
+            TypeKind::STRUCTURE => {
+                let mut offset = current_offset;
+                for member in self.member_list {
+                    offset = member
+                        .descriptor
+                        .r#type
+                        .max_size_serialized_cdr_be(offset)?;
+                }
+                Some(offset)
+            }
+            TypeKind::UNION => {
+                let disc_type = self.descriptor.discriminator_type.as_ref()?;
+                let disc_offset = disc_type.max_size_serialized_cdr_be(current_offset)?;
+                if self.member_list.is_empty() {
+                    Some(disc_offset)
+                } else {
+                    let mut max_offset = disc_offset;
+                    for member in self.member_list {
+                        let member_offset = member
+                            .descriptor
+                            .r#type
+                            .max_size_serialized_cdr_be(disc_offset)?;
+                        if member_offset > max_offset {
+                            max_offset = member_offset;
+                        }
+                    }
+                    Some(max_offset)
+                }
+            }
+            TypeKind::SEQUENCE => {
+                let bound = self.descriptor.bound.first().copied().unwrap_or(0);
+                if bound == 0 || bound == u32::MAX {
+                    None
+                } else {
+                    let elem_type = self.descriptor.element_type.as_ref()?;
+                    let mut offset = align_to(current_offset, 4).checked_add(4)?;
+                    for _ in 0..bound {
+                        offset = elem_type.max_size_serialized_cdr_be(offset)?;
+                    }
+                    Some(offset)
+                }
+            }
+            TypeKind::ARRAY => {
+                let elem_type = self.descriptor.element_type.as_ref()?;
+                let mut total_count: usize = 1;
+                for &dim in self.descriptor.bound {
+                    total_count = total_count.checked_mul(dim as usize)?;
+                }
+                let mut offset = current_offset;
+                for _ in 0..total_count {
+                    offset = elem_type.max_size_serialized_cdr_be(offset)?;
+                }
+                Some(offset)
+            }
+            TypeKind::MAP | TypeKind::ANNOTATION | TypeKind::BITSET => None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -232,5 +369,27 @@ mod tests {
             instance_handle,
             InstanceHandle::new([1, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         )
+    }
+
+    #[test]
+    fn test_string_key_md5_hash() {
+        #[derive(TypeSupport)]
+        struct ShapeTypeKey {
+            #[dust_dds(key)]
+            color: String,
+        }
+
+        let shape = ShapeTypeKey {
+            color: "BLUE".to_string(),
+        };
+
+        let data = shape.create_dynamic_sample();
+        let instance_handle = get_instance_handle_from_dynamic_data(&data).unwrap();
+
+        // CDR_BE serialized bytes for string "BLUE": [0, 0, 0, 5, 'B', 'L', 'U', 'E', 0]
+        let expected_bytes: [u8; 9] = [0, 0, 0, 5, b'B', b'L', b'U', b'E', 0];
+        let expected_hash = md5::compute(expected_bytes);
+
+        assert_eq!(instance_handle, InstanceHandle::new(expected_hash.0));
     }
 }

--- a/dds/src/dds_async/domain_participant_factory.rs
+++ b/dds/src/dds_async/domain_participant_factory.rs
@@ -314,6 +314,7 @@ impl<T: TransportParticipantFactory> DomainParticipantFactoryAsync<T> {
                                 dp.check_missed_reader_deadline(now);
                                 dp.check_missed_writer_deadline(now);
                                 dp.remove_stale_writer_samples(now);
+                                dp.remove_stale_reader_samples(now);
                                 dp.check_pending_writer_sample_timeout(now);
                                 dp.process_pending_write_samples(now);
                                 dp.announce_participant_if_needed(now);

--- a/dds/src/rtps/reader_proxy.rs
+++ b/dds/src/rtps/reader_proxy.rs
@@ -202,6 +202,7 @@ impl RtpsReaderProxy {
             .rev()
             .map(|cc| cc.sequence_number)
             .filter(|cc_sn| cc_sn > &self.highest_sent_seq_num)
+            .filter(|cc_sn| cc_sn >= &self.first_relevant_sample_seq_num)
             .min()
     }
 
@@ -274,10 +275,6 @@ impl RtpsReaderProxy {
 
     pub fn first_relevant_sample_seq_num(&self) -> SequenceNumber {
         self.first_relevant_sample_seq_num
-    }
-
-    pub fn _set_first_relevant_sample_seq_num(&mut self, seq_num: SequenceNumber) {
-        self.first_relevant_sample_seq_num = seq_num;
     }
 
     pub fn last_received_acknack_count(&self) -> Count {

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -472,8 +472,12 @@ impl RtpsReaderProxy {
                                 };
 
                             let len = if fragment_number == number_of_fragments - 1 {
-                                let first_sn = seq_num_min.unwrap_or(1);
-                                let last_sn = seq_num_max.unwrap_or(0);
+                                let first_sn = seq_num_min
+                                    .unwrap_or(1)
+                                    .max(self.first_relevant_sample_seq_num());
+                                let last_sn = seq_num_max
+                                    .unwrap_or(0)
+                                    .max(self.first_relevant_sample_seq_num());
                                 let heartbeat = self.heartbeat_machine().generate_new_heartbeat(
                                     writer_id, first_sn, last_sn, now, false,
                                 );
@@ -519,8 +523,12 @@ impl RtpsReaderProxy {
                             inline_qos,
                         );
 
-                        let first_sn = seq_num_min.unwrap_or(1);
-                        let last_sn = seq_num_max.unwrap_or(0);
+                        let first_sn = seq_num_min
+                            .unwrap_or(1)
+                            .max(self.first_relevant_sample_seq_num());
+                        let last_sn = seq_num_max
+                            .unwrap_or(0)
+                            .max(self.first_relevant_sample_seq_num());
                         let heartbeat = self
                             .heartbeat_machine()
                             .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
@@ -563,8 +571,12 @@ impl RtpsReaderProxy {
             .heartbeat_machine()
             .is_time_for_heartbeat(now, heartbeat_period.into())
         {
-            let first_sn = seq_num_min.unwrap_or(1);
-            let last_sn = seq_num_max.unwrap_or(0);
+            let first_sn = seq_num_min
+                .unwrap_or(1)
+                .max(self.first_relevant_sample_seq_num());
+            let last_sn = seq_num_max
+                .unwrap_or(0)
+                .max(self.first_relevant_sample_seq_num());
             let heartbeat_submessage = self
                 .heartbeat_machine()
                 .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
@@ -618,8 +630,12 @@ impl RtpsReaderProxy {
                                     InfoTimestampSubmessage::new(true, TIME_INVALID)
                                 };
                             let len = if fragment_number == number_of_fragments - 1 {
-                                let first_sn = seq_num_min.unwrap_or(1);
-                                let last_sn = seq_num_max.unwrap_or(0);
+                                let first_sn = seq_num_min
+                                    .unwrap_or(1)
+                                    .max(self.first_relevant_sample_seq_num());
+                                let last_sn = seq_num_max
+                                    .unwrap_or(0)
+                                    .max(self.first_relevant_sample_seq_num());
                                 let heartbeat = self.heartbeat_machine().generate_new_heartbeat(
                                     writer_id, first_sn, last_sn, now, false,
                                 );
@@ -666,8 +682,12 @@ impl RtpsReaderProxy {
                             inline_qos,
                         );
 
-                        let first_sn = seq_num_min.unwrap_or(1);
-                        let last_sn = seq_num_max.unwrap_or(0);
+                        let first_sn = seq_num_min
+                            .unwrap_or(1)
+                            .max(self.first_relevant_sample_seq_num());
+                        let last_sn = seq_num_max
+                            .unwrap_or(0)
+                            .max(self.first_relevant_sample_seq_num());
                         let heartbeat = self
                             .heartbeat_machine()
                             .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -367,8 +367,10 @@ impl RtpsReaderProxy {
                 .len();
                 message_writer.write_message(len, self.unicast_locator_list());
 
-                self.set_highest_sent_seq_num(next_unsent_change_seq_num);
-            } else if let Some(cache_change) = changes
+                self.set_highest_sent_seq_num(gap_end_sequence_number);
+            }
+
+            if let Some(cache_change) = changes
                 .iter()
                 .find(|cc| cc.sequence_number == next_unsent_change_seq_num)
             {
@@ -475,22 +477,20 @@ impl RtpsReaderProxy {
                         gap_start_sequence_number,
                         SequenceNumberSet::new(gap_end_sequence_number + 1, []),
                     );
-                    let first_sn = seq_num_min.unwrap_or(1);
-                    let last_sn = seq_num_max.unwrap_or(0);
-                    let heartbeat_submessage = self
-                        .heartbeat_machine()
-                        .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
                     let info_dst =
                         InfoDestinationSubmessage::new(self.remote_reader_guid().prefix());
                     let len = RtpsMessageWrite::from_submessages(
                         message_writer.write_buffer_mut(),
-                        &[&info_dst, &gap_submessage, &heartbeat_submessage],
+                        &[&info_dst, &gap_submessage],
                         guid_prefix,
                     )
                     .buffer()
                     .len();
-                    message_writer.write_message(len, self.unicast_locator_list())
-                } else if let Some(cache_change) = changes.iter().find(|cc| {
+                    message_writer.write_message(len, self.unicast_locator_list());
+                    self.set_highest_sent_seq_num(gap_end_sequence_number);
+                }
+
+                if let Some(cache_change) = changes.iter().find(|cc| {
                     cc.sequence_number == next_unsent_change_seq_num
                         && next_unsent_change_seq_num > self.first_relevant_sample_seq_num()
                 }) {

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -325,12 +325,6 @@ impl RtpsReaderProxy {
         guid_prefix: GuidPrefix,
     ) {
         // a_change_seq_num := the_reader_proxy.next_unsent_change();
-        // if ( a_change_seq_num > the_reader_proxy.higuest_sent_seq_num +1 ) {
-        //      GAP = new GAP(the_reader_locator.higuest_sent_seq_num + 1, a_change_seq_num -1);
-        //      GAP.readerId := ENTITYID_UNKNOWN;
-        //      GAP.filteredCount := 0;
-        //      send GAP;
-        // }
         // a_change := the_writer.writer_cache.get_change(a_change_seq_num );
         // if ( DDS_FILTER(the_reader_proxy, a_change) ) {
         //      DATA = new DATA(a_change);
@@ -338,42 +332,15 @@ impl RtpsReaderProxy {
         //          DATA.inlineQos := the_rtps_writer.related_dds_writer.qos;
         //          DATA.inlineQos += a_change.inlineQos;
         //      }
-        //      DATA.readerId := ENTITYID_UNKNOWN;
+        //      DATA.readerId := the_reader_proxy.remoteReaderGuid.entityId;
         //      send DATA;
         // }
-        // else {
-        //      GAP = new GAP(a_change.sequenceNumber);
-        //      GAP.readerId := ENTITYID_UNKNOWN;
-        //      GAP.filteredCount := 1;
-        //      send GAP;
-        // }
-        // the_reader_proxy.higuest_sent_seq_num := a_change_seq_num;
+        // the_reader_proxy.highest_sent_seq_num := a_change_seq_num;
         while let Some(next_unsent_change_seq_num) = self.next_unsent_change(changes) {
-            if next_unsent_change_seq_num > self.highest_sent_seq_num() + 1 {
-                let gap_start_sequence_number = self.highest_sent_seq_num() + 1;
-                let gap_end_sequence_number = next_unsent_change_seq_num - 1;
-                let gap_submessage = GapSubmessage::new(
-                    self.remote_reader_guid().entity_id(),
-                    writer_id,
-                    gap_start_sequence_number,
-                    SequenceNumberSet::new(gap_end_sequence_number + 1, []),
-                );
-                let len = RtpsMessageWrite::from_submessages(
-                    message_writer.write_buffer_mut(),
-                    &[&gap_submessage],
-                    guid_prefix,
-                )
-                .buffer()
-                .len();
-                message_writer.write_message(len, self.unicast_locator_list());
-
-                self.set_highest_sent_seq_num(gap_end_sequence_number);
-            }
-
-            if let Some(cache_change) = changes
-                .iter()
-                .find(|cc| cc.sequence_number == next_unsent_change_seq_num)
-            {
+            if let Some(cache_change) = changes.iter().find(|cc| {
+                cc.sequence_number == next_unsent_change_seq_num
+                    && next_unsent_change_seq_num > self.first_relevant_sample_seq_num()
+            }) {
                 let number_of_fragments = cache_change
                     .data_value
                     .len()
@@ -431,21 +398,6 @@ impl RtpsReaderProxy {
                     .len();
                     message_writer.write_message(len, self.unicast_locator_list())
                 }
-            } else {
-                let gap_submessage = GapSubmessage::new(
-                    ENTITYID_UNKNOWN,
-                    writer_id,
-                    next_unsent_change_seq_num,
-                    SequenceNumberSet::new(next_unsent_change_seq_num + 1, []),
-                );
-                let len = RtpsMessageWrite::from_submessages(
-                    message_writer.write_buffer_mut(),
-                    &[&gap_submessage],
-                    guid_prefix,
-                )
-                .buffer()
-                .len();
-                message_writer.write_message(len, self.unicast_locator_list())
             }
 
             self.set_highest_sent_seq_num(next_unsent_change_seq_num);
@@ -896,5 +848,83 @@ mod tests {
         );
 
         assert_eq!(*message_writer.total_fragments_sent.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_best_effort_reader_no_gap_submessage_on_non_contiguous_sequence_numbers() {
+        struct MockWriter {
+            gap_count: Mutex<usize>,
+            data_count: Mutex<usize>,
+            buffer: [u8; 65535],
+        }
+        impl WriteMessage for MockWriter {
+            fn write_buffer_mut(&mut self) -> &mut [u8] {
+                &mut self.buffer
+            }
+            fn write_message(
+                &mut self,
+                len: usize,
+                _locator_list: &[crate::transport::types::Locator],
+            ) {
+                let message = RtpsMessageRead::try_from(&self.buffer[..len]).unwrap();
+                for submessage in message.submessages() {
+                    match submessage {
+                        RtpsSubmessageReadKind::Gap(_) => *self.gap_count.lock().unwrap() += 1,
+                        RtpsSubmessageReadKind::Data(_) => *self.data_count.lock().unwrap() += 1,
+                        _ => (),
+                    }
+                }
+            }
+        }
+
+        let data_max_size_serialized = 500;
+        let writer_id = EntityId::new([1; 3], 1);
+        let guid = Guid::new([1; 12], writer_id);
+        let mut writer = RtpsStatefulWriter::new(guid, data_max_size_serialized);
+
+        let remote_reader_id = EntityId::new([2; 3], 2);
+        let remote_reader_guid = Guid::new([2; 12], remote_reader_id);
+        writer.add_matched_reader(ReaderProxy {
+            remote_reader_guid,
+            remote_group_entity_id: ENTITYID_UNKNOWN,
+            reliability_kind: ReliabilityKind::BestEffort,
+            durability_kind: DurabilityKind::Volatile,
+            unicast_locator_list: vec![],
+            multicast_locator_list: vec![],
+            expects_inline_qos: false,
+        });
+
+        // Add non-contiguous sequence numbers (e.g. 2 and 5)
+        writer.add_change(CacheChange {
+            kind: ChangeKind::Alive,
+            writer_guid: guid,
+            sequence_number: 2,
+            source_timestamp: None,
+            instance_handle: Some([10; 16]),
+            data_value: vec![1, 2, 3].into(),
+        });
+        writer.add_change(CacheChange {
+            kind: ChangeKind::Alive,
+            writer_guid: guid,
+            sequence_number: 5,
+            source_timestamp: None,
+            instance_handle: Some([10; 16]),
+            data_value: vec![4, 5, 6].into(),
+        });
+
+        let mut message_writer = MockWriter {
+            gap_count: Mutex::new(0),
+            data_count: Mutex::new(0),
+            buffer: [0; 65535],
+        };
+
+        writer.write_message(&mut message_writer, Time::new(1, 0));
+
+        assert_eq!(
+            *message_writer.gap_count.lock().unwrap(),
+            0,
+            "Best-effort reader proxy should not receive any GAP submessages"
+        );
+        assert_eq!(*message_writer.data_count.lock().unwrap(), 2);
     }
 }

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -93,11 +93,11 @@ impl RtpsStatefulWriter {
             DurabilityKind::Volatile => self
                 .changes
                 .last()
-                .map(|cc| cc.sequence_number)
-                .unwrap_or(0),
+                .map(|cc| cc.sequence_number + 1)
+                .unwrap_or(1),
             DurabilityKind::TransientLocal
             | DurabilityKind::Transient
-            | DurabilityKind::Persistent => 0,
+            | DurabilityKind::Persistent => 1,
         };
         let rtps_reader_proxy = RtpsReaderProxy::new(
             reader_proxy.remote_reader_guid,
@@ -339,7 +339,7 @@ impl RtpsReaderProxy {
         while let Some(next_unsent_change_seq_num) = self.next_unsent_change(changes) {
             if let Some(cache_change) = changes.iter().find(|cc| {
                 cc.sequence_number == next_unsent_change_seq_num
-                    && next_unsent_change_seq_num > self.first_relevant_sample_seq_num()
+                    && next_unsent_change_seq_num >= self.first_relevant_sample_seq_num()
             }) {
                 let number_of_fragments = cache_change
                     .data_value
@@ -444,7 +444,7 @@ impl RtpsReaderProxy {
 
                 if let Some(cache_change) = changes.iter().find(|cc| {
                     cc.sequence_number == next_unsent_change_seq_num
-                        && next_unsent_change_seq_num > self.first_relevant_sample_seq_num()
+                        && next_unsent_change_seq_num >= self.first_relevant_sample_seq_num()
                 }) {
                     let number_of_fragments = cache_change
                         .data_value
@@ -475,9 +475,7 @@ impl RtpsReaderProxy {
                                 let first_sn = seq_num_min
                                     .unwrap_or(1)
                                     .max(self.first_relevant_sample_seq_num());
-                                let last_sn = seq_num_max
-                                    .unwrap_or(0)
-                                    .max(self.first_relevant_sample_seq_num());
+                                let last_sn = seq_num_max.unwrap_or(0).max(first_sn - 1);
                                 let heartbeat = self.heartbeat_machine().generate_new_heartbeat(
                                     writer_id, first_sn, last_sn, now, false,
                                 );
@@ -526,9 +524,7 @@ impl RtpsReaderProxy {
                         let first_sn = seq_num_min
                             .unwrap_or(1)
                             .max(self.first_relevant_sample_seq_num());
-                        let last_sn = seq_num_max
-                            .unwrap_or(0)
-                            .max(self.first_relevant_sample_seq_num());
+                        let last_sn = seq_num_max.unwrap_or(0).max(first_sn - 1);
                         let heartbeat = self
                             .heartbeat_machine()
                             .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
@@ -574,9 +570,7 @@ impl RtpsReaderProxy {
             let first_sn = seq_num_min
                 .unwrap_or(1)
                 .max(self.first_relevant_sample_seq_num());
-            let last_sn = seq_num_max
-                .unwrap_or(0)
-                .max(self.first_relevant_sample_seq_num());
+            let last_sn = seq_num_max.unwrap_or(0).max(first_sn - 1);
             let heartbeat_submessage = self
                 .heartbeat_machine()
                 .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
@@ -603,7 +597,7 @@ impl RtpsReaderProxy {
                 // should be full-filled by next_requested_change()
                 if let Some(cache_change) = changes.iter().find(|cc| {
                     cc.sequence_number == next_requested_change_seq_num
-                        && next_requested_change_seq_num > self.first_relevant_sample_seq_num()
+                        && next_requested_change_seq_num >= self.first_relevant_sample_seq_num()
                 }) {
                     let number_of_fragments = cache_change
                         .data_value
@@ -633,9 +627,7 @@ impl RtpsReaderProxy {
                                 let first_sn = seq_num_min
                                     .unwrap_or(1)
                                     .max(self.first_relevant_sample_seq_num());
-                                let last_sn = seq_num_max
-                                    .unwrap_or(0)
-                                    .max(self.first_relevant_sample_seq_num());
+                                let last_sn = seq_num_max.unwrap_or(0).max(first_sn - 1);
                                 let heartbeat = self.heartbeat_machine().generate_new_heartbeat(
                                     writer_id, first_sn, last_sn, now, false,
                                 );
@@ -685,9 +677,7 @@ impl RtpsReaderProxy {
                         let first_sn = seq_num_min
                             .unwrap_or(1)
                             .max(self.first_relevant_sample_seq_num());
-                        let last_sn = seq_num_max
-                            .unwrap_or(0)
-                            .max(self.first_relevant_sample_seq_num());
+                        let last_sn = seq_num_max.unwrap_or(0).max(first_sn - 1);
                         let heartbeat = self
                             .heartbeat_machine()
                             .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);

--- a/dds/src/rtps/stateful_writer.rs
+++ b/dds/src/rtps/stateful_writer.rs
@@ -219,7 +219,7 @@ impl RtpsStatefulWriter {
                     {
                         let request_fragment_number = request_fragment_number as usize;
                         // Either send a DATAFRAG submessages or send a single DATA submessage
-                        if (request_fragment_number) < number_of_fragments
+                        if (1..=number_of_fragments).contains(&request_fragment_number)
                             && cache_change.kind == ChangeKind::Alive
                         {
                             let writer_id = self.guid.entity_id();
@@ -228,7 +228,7 @@ impl RtpsStatefulWriter {
                                 reader_id,
                                 writer_id,
                                 self.data_max_size_serialized,
-                                request_fragment_number,
+                                request_fragment_number - 1,
                             );
 
                             let info_dst = InfoDestinationSubmessage::new(
@@ -648,37 +648,46 @@ impl RtpsReaderProxy {
 
                     // Either send a DATAFRAG submessages or send a single DATA submessage
                     if number_of_fragments > 1 && cache_change.kind == ChangeKind::Alive {
-                        let fragment_number = 0;
-                        let reader_id = self.remote_reader_guid().entity_id();
-                        let data_frag = cache_change.as_data_frag_submessage(
-                            reader_id,
-                            writer_id,
-                            data_max_size_serialized,
-                            fragment_number,
-                        );
+                        for fragment_number in 0..number_of_fragments {
+                            let reader_id = self.remote_reader_guid().entity_id();
+                            let data_frag = cache_change.as_data_frag_submessage(
+                                reader_id,
+                                writer_id,
+                                data_max_size_serialized,
+                                fragment_number,
+                            );
 
-                        let info_dst =
-                            InfoDestinationSubmessage::new(self.remote_reader_guid().prefix());
-                        let info_timestamp = if let Some(timestamp) = cache_change.source_timestamp
-                        {
-                            InfoTimestampSubmessage::new(false, timestamp.into())
-                        } else {
-                            InfoTimestampSubmessage::new(true, TIME_INVALID)
-                        };
-                        let first_sn = seq_num_min.unwrap_or(1);
-                        let last_sn = seq_num_max.unwrap_or(0);
-                        let heartbeat = self
-                            .heartbeat_machine()
-                            .generate_new_heartbeat(writer_id, first_sn, last_sn, now, false);
+                            let info_dst =
+                                InfoDestinationSubmessage::new(self.remote_reader_guid().prefix());
+                            let info_timestamp =
+                                if let Some(timestamp) = cache_change.source_timestamp {
+                                    InfoTimestampSubmessage::new(false, timestamp.into())
+                                } else {
+                                    InfoTimestampSubmessage::new(true, TIME_INVALID)
+                                };
+                            let len = if fragment_number == number_of_fragments - 1 {
+                                let first_sn = seq_num_min.unwrap_or(1);
+                                let last_sn = seq_num_max.unwrap_or(0);
+                                let heartbeat = self.heartbeat_machine().generate_new_heartbeat(
+                                    writer_id, first_sn, last_sn, now, false,
+                                );
 
-                        let len = RtpsMessageWrite::from_submessages(
-                            message_writer.write_buffer_mut(),
-                            &[&info_dst, &info_timestamp, &data_frag, &heartbeat],
-                            guid_prefix,
-                        )
-                        .buffer()
-                        .len();
-                        message_writer.write_message(len, self.unicast_locator_list());
+                                RtpsMessageWrite::from_submessages(
+                                    message_writer.write_buffer_mut(),
+                                    &[&info_dst, &info_timestamp, &data_frag, &heartbeat],
+                                    guid_prefix,
+                                )
+                            } else {
+                                RtpsMessageWrite::from_submessages(
+                                    message_writer.write_buffer_mut(),
+                                    &[&info_dst, &info_timestamp, &data_frag],
+                                    guid_prefix,
+                                )
+                            }
+                            .buffer()
+                            .len();
+                            message_writer.write_message(len, self.unicast_locator_list());
+                        }
                     } else {
                         let info_dst =
                             InfoDestinationSubmessage::new(self.remote_reader_guid().prefix());

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -238,6 +238,10 @@ impl RtpsWriterProxy {
         self.last_received_heartbeat_count = last_received_heartbeat_count;
     }
 
+    pub fn last_received_heartbeat_frag_count(&self) -> Count {
+        self.last_received_heartbeat_frag_count
+    }
+
     pub fn set_last_received_heartbeat_frag_count(
         &mut self,
         last_received_heartbeat_frag_count: Count,
@@ -265,15 +269,11 @@ impl RtpsWriterProxy {
             let info_dst_submessage =
                 InfoDestinationSubmessage::new(self.remote_writer_guid().prefix());
 
-            // We report missing changes up to the one where we have received at least one fragment
-            let missing_changes = self.missing_changes().take(256).take_while(|x| {
-                x < &self
-                    .frag_buffer
-                    .iter()
-                    .map(|x| x.writer_sn())
-                    .min()
-                    .unwrap_or(i64::MAX)
-            });
+            // We report missing changes excluding those where we have received at least one fragment
+            let missing_changes = self
+                .missing_changes()
+                .take(256)
+                .filter(|x| !self.frag_buffer.iter().any(|f| &f.writer_sn() == x));
             let acknack_submessage = AckNackSubmessage::new(
                 true,
                 reader_guid.entity_id(),

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -257,6 +257,10 @@ impl RtpsWriterProxy {
         self.acknack_count = self.acknack_count.wrapping_add(1);
     }
 
+    pub fn increment_nack_frag_count(&mut self) {
+        self.nack_frag_count = self.nack_frag_count.wrapping_add(1);
+    }
+
     pub fn write_message(
         &mut self,
         reader_guid: &Guid,
@@ -282,10 +286,12 @@ impl RtpsWriterProxy {
                 self.acknack_count(),
             );
 
-            let len = if let Some(missing_change_fragments_seq_num) = self
+            let missing_change_fragments_seq_num = self
                 .missing_changes()
                 .take(256)
-                .find(|s| self.frag_buffer.iter().any(|x| &x.writer_sn() == s))
+                .find(|s| self.frag_buffer.iter().any(|x| &x.writer_sn() == s));
+
+            let len = if let Some(missing_change_fragments_seq_num) = missing_change_fragments_seq_num
             {
                 let frag = self
                     .frag_buffer
@@ -307,6 +313,7 @@ impl RtpsWriterProxy {
                     .peek()
                     .expect("At least a fragment must be missing");
                 let fragment_number_state = FragmentNumberSet::new(base, missing_fragments_iter);
+                self.increment_nack_frag_count();
                 let nack_frag_submessage = NackFragSubmessage::new(
                     reader_guid.entity_id(),
                     self.remote_writer_guid().entity_id(),

--- a/dds/src/rtps/writer_proxy.rs
+++ b/dds/src/rtps/writer_proxy.rs
@@ -291,7 +291,8 @@ impl RtpsWriterProxy {
                 .take(256)
                 .find(|s| self.frag_buffer.iter().any(|x| &x.writer_sn() == s));
 
-            let len = if let Some(missing_change_fragments_seq_num) = missing_change_fragments_seq_num
+            let len = if let Some(missing_change_fragments_seq_num) =
+                missing_change_fragments_seq_num
             {
                 let frag = self
                     .frag_buffer

--- a/dds/tests/content_filtered_topic.rs
+++ b/dds/tests/content_filtered_topic.rs
@@ -430,5 +430,3 @@ fn samples_should_be_content_filtered_by_literal_string() {
     assert_eq!(samples.len(), 1);
     assert_eq!(samples[0].data.as_ref().unwrap(), &data2);
 }
-
-

--- a/dds/tests/content_filtered_topic.rs
+++ b/dds/tests/content_filtered_topic.rs
@@ -22,6 +22,15 @@ struct KeyedData {
     value: String,
 }
 
+#[derive(Clone, Debug, PartialEq, DdsType)]
+struct ShapeType {
+    #[dust_dds(key)]
+    color: String,
+    x: i32,
+    y: i32,
+    shapesize: i32,
+}
+
 #[test]
 fn samples_should_be_content_filtered() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
@@ -119,3 +128,307 @@ fn samples_should_be_content_filtered() {
     assert_eq!(samples.len(), 1);
     assert_eq!(samples[0].data.as_ref().unwrap(), &data2);
 }
+
+#[test]
+fn samples_should_be_content_filtered_by_shapesize() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<ShapeType>(
+            "ShapeTopic",
+            "ShapeType",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let content_filtered_topic = participant
+        .create_contentfilteredtopic(
+            "ShapeTopicFiltered",
+            &topic,
+            String::from("shapesize <= 20"),
+            vec![],
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader::<ShapeType>(
+            &content_filtered_topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data1 = ShapeType {
+        color: String::from("BLUE"),
+        x: 100,
+        y: 100,
+        shapesize: 30,
+    };
+    let data2 = ShapeType {
+        color: String::from("RED"),
+        x: 100,
+        y: 100,
+        shapesize: 20,
+    };
+
+    writer.write(data1.clone(), None).unwrap();
+    writer.write(data2.clone(), None).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(5, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data2);
+}
+
+#[test]
+fn samples_should_be_content_filtered_by_parameterized_shapesize() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<ShapeType>(
+            "ShapeTopic",
+            "ShapeType",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let content_filtered_topic = participant
+        .create_contentfilteredtopic(
+            "ShapeTopicFiltered",
+            &topic,
+            String::from("shapesize <= %0"),
+            vec![String::from("20")],
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader::<ShapeType>(
+            &content_filtered_topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data1 = ShapeType {
+        color: String::from("BLUE"),
+        x: 100,
+        y: 100,
+        shapesize: 30,
+    };
+    let data2 = ShapeType {
+        color: String::from("RED"),
+        x: 100,
+        y: 100,
+        shapesize: 20,
+    };
+
+    writer.write(data1.clone(), None).unwrap();
+    writer.write(data2.clone(), None).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(5, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data2);
+}
+
+#[test]
+fn samples_should_be_content_filtered_by_literal_string() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let content_filtered_topic = participant
+        .create_contentfilteredtopic(
+            "MyTopicFiltered",
+            &topic,
+            String::from("value = 'RED'"),
+            vec![],
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader::<KeyedData>(
+            &content_filtered_topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data1 = KeyedData {
+        id: 1,
+        value: String::from("BLUE"),
+    };
+    let data2 = KeyedData {
+        id: 2,
+        value: String::from("RED"),
+    };
+
+    writer.write(data1.clone(), None).unwrap();
+    writer.write(data2.clone(), None).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(5, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data2);
+}
+
+

--- a/dds/tests/discovery.rs
+++ b/dds/tests/discovery.rs
@@ -1107,6 +1107,49 @@ fn reader_requesting_exclusive_ownership_should_not_match_writer_offering_shared
 }
 
 #[test]
+fn two_participants_stay_discovered() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let domain_participant_factory = DomainParticipantFactory::get_instance();
+
+    let participant1 = domain_participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let participant2 = domain_participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let start = Instant::now();
+    loop {
+        if participant1.get_discovered_participants().unwrap().len() == 2
+            && participant2.get_discovered_participants().unwrap().len() == 2
+        {
+            break;
+        }
+        if start.elapsed() > std::time::Duration::from_secs(10) {
+            panic!("Participants not discovered within timeout");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    assert_eq!(participant1.get_discovered_participants().unwrap().len(), 2);
+    assert_eq!(participant2.get_discovered_participants().unwrap().len(), 2);
+
+    let discovered = participant1.get_discovered_participants().unwrap();
+    let remote_handle = discovered
+        .into_iter()
+        .find(|h| h.as_ref() == participant2.get_instance_handle().as_ref())
+        .expect("Participant 2 must be in discovered list");
+    let participant_data = participant1
+        .get_discovered_participant_data(remote_handle)
+        .unwrap();
+    assert_eq!(
+        participant_data.key().value,
+        *participant2.get_instance_handle().as_ref()
+    );
+}
+
+#[test]
 #[ignore]
 fn participant_removed_after_lease_duration() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();

--- a/dds/tests/listener_and_wait_set.rs
+++ b/dds/tests/listener_and_wait_set.rs
@@ -215,8 +215,17 @@ fn reader_on_data_available_matched_listener_and_wait_set_should_both_trigger() 
     wait_set
         .attach_condition(Condition::StatusCondition(condition))
         .unwrap();
-
     wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let reader_condition = reader.get_statuscondition();
+    reader_condition
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut reader_wait_set = WaitSet::new();
+    reader_wait_set
+        .attach_condition(Condition::StatusCondition(reader_condition))
+        .unwrap();
+    reader_wait_set.wait(Duration::new(10, 0)).unwrap();
 
     writer.write(MyData { id: 1, value: 1 }, None).unwrap();
 

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -3138,7 +3138,9 @@ fn data_reader_instance_state_not_alive_no_writers_when_writer_is_deleted() {
 
     // Delete writer / publisher / participant1
     participant1.delete_contained_entities().unwrap();
-    participant_factory.delete_participant(&participant1).unwrap();
+    participant_factory
+        .delete_participant(&participant1)
+        .unwrap();
 
     // Wait for subscription matched status to update or reader to detect writer deletion
     let cond_reader = reader.get_statuscondition();
@@ -3887,7 +3889,6 @@ fn reader_with_exclusive_ownership_should_read_samples_from_second_writer_after_
 }
 
 #[test]
-#[ignore = "Broken after runtime refactor"]
 fn reader_with_exclusive_ownership_should_read_samples_from_second_weaker_writer_after_unregister()
 {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
@@ -4012,6 +4013,149 @@ fn reader_with_exclusive_ownership_should_read_samples_from_second_weaker_writer
         .unwrap();
 
     writer1.unregister_instance(data1.clone(), None).unwrap();
+    writer1
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let data2 = KeyedData { id: 1, value: 20 };
+    writer2.write(data2.clone(), None).unwrap();
+    writer2
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .read(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 3);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data1);
+    assert_eq!(samples[2].data.as_ref().unwrap(), &data2);
+}
+
+#[test]
+fn reader_with_exclusive_ownership_should_read_samples_from_second_weaker_writer_after_dispose() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer1_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Exclusive,
+        },
+        ownership_strength: OwnershipStrengthQosPolicy { value: 10 },
+        ..Default::default()
+    };
+    let writer1 = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer1_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+    let writer2_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Exclusive,
+        },
+        ownership_strength: OwnershipStrengthQosPolicy { value: 1 },
+        ..Default::default()
+    };
+    let writer2 = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer2_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ownership: OwnershipQosPolicy {
+            kind: OwnershipQosPolicyKind::Exclusive,
+        },
+        ..Default::default()
+    };
+
+    let reader = subscriber
+        .create_datareader::<KeyedData>(
+            &topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let start_time = std::time::Instant::now();
+    while std::time::Instant::now().duration_since(start_time) < std::time::Duration::from_secs(10)
+    {
+        if reader.get_matched_publications().unwrap().len() >= 2 {
+            break;
+        }
+    }
+    assert_eq!(
+        reader.get_matched_publications().unwrap().len(),
+        2,
+        "Reader must have 2 matched writers"
+    );
+
+    let cond = writer1.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let cond = writer2.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let data1 = KeyedData { id: 1, value: 10 };
+    writer1.write(data1.clone(), None).unwrap();
+    writer1
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    writer1.dispose(data1.clone(), None).unwrap();
     writer1
         .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2010,6 +2010,124 @@ fn reader_with_minimum_time_separation_qos() {
 }
 
 #[test]
+fn reader_with_minimum_time_separation_qos_taking_samples() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        time_based_filter: TimeBasedFilterQosPolicy {
+            minimum_separation: DurationKind::Finite(Duration::new(2, 0)),
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader::<KeyedData>(
+            &topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data1_1 = KeyedData { id: 1, value: 1 };
+    let data1_2 = KeyedData { id: 1, value: 2 };
+    let data1_3 = KeyedData { id: 1, value: 3 };
+
+    writer
+        .write_w_timestamp(data1_1.clone(), None, Time::new(1, 0))
+        .unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data1_1);
+
+    writer
+        .write_w_timestamp(data1_2, None, Time::new(2, 0))
+        .unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+    assert_eq!(samples.len(), 0);
+
+    writer
+        .write_w_timestamp(data1_3.clone(), None, Time::new(3, 0))
+        .unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data1_3);
+}
+
+#[test]
 fn transient_local_writer_reader_wait_for_historical_data() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -3474,6 +3474,16 @@ fn reader_joining_after_writer_writes_many_samples() {
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
+    let reader_cond = reader.get_statuscondition();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut reader_wait_set = WaitSet::new();
+    reader_wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond))
+        .unwrap();
+    reader_wait_set.wait(Duration::new(10, 0)).unwrap();
+
     let new_data = KeyedData { id: 1, value: 1000 };
     writer.write(new_data.clone(), None).unwrap();
     writer

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -1067,7 +1067,7 @@ fn each_key_sample_is_read() {
     let data3_handle = writer.lookup_instance(data3.clone()).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(2, 0))
+        .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
     let samples = reader
@@ -2618,7 +2618,7 @@ fn data_reader_order_by_source_timestamp() {
         .unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(2, 0))
+        .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
     let samples = reader
@@ -3571,7 +3571,7 @@ fn reader_joining_after_writer_writes_many_samples() {
     let writer_qos = DataWriterQos {
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::Reliable,
-            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+            max_blocking_time: DurationKind::Finite(Duration::new(5, 0)),
         },
         ..Default::default()
     };
@@ -3597,7 +3597,7 @@ fn reader_joining_after_writer_writes_many_samples() {
     let reader_qos = DataReaderQos {
         reliability: ReliabilityQosPolicy {
             kind: ReliabilityQosPolicyKind::Reliable,
-            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+            max_blocking_time: DurationKind::Finite(Duration::new(5, 0)),
         },
         ..Default::default()
     };
@@ -4469,134 +4469,6 @@ fn samples_are_transfered_between_two_participants() {
 }
 
 #[test]
-fn large_data_transfer_between_two_participants() {
-    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
-
-    let participant1 = DomainParticipantFactory::get_instance()
-        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
-        .unwrap();
-
-    let topic1 = participant1
-        .create_topic::<LargeData>(
-            "LargeDataTopic",
-            "LargeData",
-            QosKind::Default,
-            NO_LISTENER,
-            NO_STATUS,
-        )
-        .unwrap();
-
-    let publisher = participant1
-        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
-        .unwrap();
-    let writer_qos = DataWriterQos {
-        reliability: ReliabilityQosPolicy {
-            kind: ReliabilityQosPolicyKind::Reliable,
-            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
-        },
-        history: HistoryQosPolicy {
-            kind: HistoryQosPolicyKind::KeepAll,
-        },
-        ..Default::default()
-    };
-    let writer = publisher
-        .create_datawriter(
-            &topic1,
-            QosKind::Specific(writer_qos),
-            NO_LISTENER,
-            NO_STATUS,
-        )
-        .unwrap();
-
-    let participant2 = DomainParticipantFactory::get_instance()
-        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
-        .unwrap();
-    let subscriber = participant2
-        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
-        .unwrap();
-    let reader_qos = DataReaderQos {
-        reliability: ReliabilityQosPolicy {
-            kind: ReliabilityQosPolicyKind::Reliable,
-            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
-        },
-        history: HistoryQosPolicy {
-            kind: HistoryQosPolicyKind::KeepAll,
-        },
-        ..Default::default()
-    };
-    let topic2 = participant2
-        .create_topic::<LargeData>(
-            "LargeDataTopic",
-            "LargeData",
-            QosKind::Default,
-            NO_LISTENER,
-            NO_STATUS,
-        )
-        .unwrap();
-
-    let reader = subscriber
-        .create_datareader::<LargeData>(
-            &topic2,
-            QosKind::Specific(reader_qos),
-            NO_LISTENER,
-            NO_STATUS,
-        )
-        .unwrap();
-
-    let cond = writer.get_statuscondition();
-    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
-        .unwrap();
-
-    let mut wait_set = WaitSet::new();
-    wait_set
-        .attach_condition(Condition::StatusCondition(cond))
-        .unwrap();
-    wait_set.wait(Duration::new(10, 0)).unwrap();
-
-    let cond = reader.get_statuscondition();
-    cond.set_enabled_statuses(&[StatusKind::SubscriptionMatched])
-        .unwrap();
-    let mut wait_set = WaitSet::new();
-    wait_set
-        .attach_condition(Condition::StatusCondition(cond))
-        .unwrap();
-    wait_set.wait(Duration::new(10, 0)).unwrap();
-
-    let data = LargeData {
-        id: 1,
-        value: vec![255; 100_000],
-    };
-
-    let total_samples = 200;
-    let writer_thread = std::thread::spawn(move || {
-        for _ in 0..total_samples {
-            writer.write(data.clone(), None).unwrap();
-            std::thread::sleep(std::time::Duration::from_millis(15));
-        }
-        writer
-            .wait_for_acknowledgments(Duration::new(10, 0))
-            .unwrap();
-    });
-
-    let start_time = std::time::Instant::now();
-    let mut received_samples = 0;
-    while received_samples < total_samples
-        && start_time.elapsed() < std::time::Duration::from_secs(12)
-    {
-        if let Ok(samples) = reader.take(100, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
-        {
-            if !samples.is_empty() {
-                received_samples += samples.len();
-            }
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
-    }
-
-    writer_thread.join().unwrap();
-    assert_eq!(received_samples, total_samples);
-}
-
-#[test]
 fn shared_ownership_writer1_should_write_and_writer2_should_dispose_same_data() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
@@ -4742,6 +4614,7 @@ fn shared_ownership_writer1_should_write_and_writer2_should_dispose_same_data() 
 }
 
 #[test]
+#[ignore]
 fn data_reader_does_not_read_lifespan_expired_samples() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -3038,6 +3038,130 @@ fn multiple_writers_unregister_instance() {
 }
 
 #[test]
+fn data_reader_instance_state_not_alive_no_writers_when_writer_is_deleted() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant_factory = DomainParticipantFactory::get_instance();
+    let participant1 = participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let participant2 = participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic1 = participant1
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+    let topic2 = participant2
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant1
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic1,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant2
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader::<KeyedData>(
+            &topic2,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data1 = KeyedData { id: 1, value: 1 };
+    writer.write(data1.clone(), None).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+    assert_eq!(samples.len(), 1);
+    assert_eq!(
+        samples[0].sample_info.instance_state,
+        InstanceStateKind::Alive
+    );
+
+    // Delete writer / publisher / participant1
+    participant1.delete_contained_entities().unwrap();
+    participant_factory.delete_participant(&participant1).unwrap();
+
+    // Wait for subscription matched status to update or reader to detect writer deletion
+    let cond_reader = reader.get_statuscondition();
+    cond_reader
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut wait_set_reader = WaitSet::new();
+    wait_set_reader
+        .attach_condition(Condition::StatusCondition(cond_reader))
+        .unwrap();
+    wait_set_reader.wait(Duration::new(10, 0)).unwrap();
+
+    let samples_after_delete = reader
+        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(
+        samples_after_delete[0].sample_info.instance_state,
+        InstanceStateKind::NotAliveNoWriters
+    );
+}
+
+#[test]
 fn transient_local_writer_does_not_deliver_lifespan_expired_data_at_write() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2999,6 +2999,19 @@ fn multiple_writers_unregister_instance() {
         )
         .unwrap();
 
+    let start_time = std::time::Instant::now();
+    while std::time::Instant::now().duration_since(start_time) < std::time::Duration::from_secs(10)
+    {
+        if reader.get_matched_publications().unwrap().len() >= 2 {
+            break;
+        }
+    }
+    assert_eq!(
+        reader.get_matched_publications().unwrap().len(),
+        2,
+        "Reader must have 2 matched writers"
+    );
+
     let cond1 = writer1.get_statuscondition();
     cond1
         .set_enabled_statuses(&[StatusKind::PublicationMatched])

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -260,6 +260,8 @@ fn large_data_should_be_fragmented_reliable() {
     assert_eq!(samples[0].data.as_ref().unwrap(), &data);
 }
 
+
+
 #[test]
 fn writer_with_keep_last_1_should_send_only_last_sample_to_reader() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
@@ -4466,6 +4468,135 @@ fn samples_are_transfered_between_two_participants() {
 
     assert_eq!(samples.len(), 1);
     assert_eq!(samples[0].data.as_ref().unwrap(), &data);
+}
+
+#[test]
+fn large_data_transfer_between_two_participants() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant1 = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic1 = participant1
+        .create_topic::<LargeData>(
+            "LargeDataTopic",
+            "LargeData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant1
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic1,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let participant2 = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let subscriber = participant2
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+    let topic2 = participant2
+        .create_topic::<LargeData>(
+            "LargeDataTopic",
+            "LargeData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let reader = subscriber
+        .create_datareader::<LargeData>(
+            &topic2,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let cond = reader.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data = LargeData {
+        id: 1,
+        value: vec![255; 100_000],
+    };
+
+    let total_samples = 10;
+    let writer_thread = std::thread::spawn(move || {
+        for _ in 0..total_samples {
+            writer.write(data.clone(), None).unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        writer
+            .wait_for_acknowledgments(Duration::new(10, 0))
+            .unwrap();
+    });
+
+    let start_time = std::time::Instant::now();
+    let mut received_samples = 0;
+    while received_samples < total_samples && start_time.elapsed() < std::time::Duration::from_secs(30) {
+        if let Ok(samples) = reader.take(100, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE) {
+            received_samples += samples.len();
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    writer_thread.join().unwrap();
+
+    if received_samples < total_samples {
+        if let Ok(samples) = reader.take(100, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE) {
+            received_samples += samples.len();
+        }
+    }
+    assert_eq!(received_samples, total_samples);
 }
 
 #[test]

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -10,7 +10,7 @@ use dust_dds::{
             DurabilityQosPolicy, DurabilityQosPolicyKind, HistoryQosPolicy, HistoryQosPolicyKind,
             Length, LifespanQosPolicy, OwnershipQosPolicy, OwnershipQosPolicyKind,
             OwnershipStrengthQosPolicy, ReliabilityQosPolicy, ReliabilityQosPolicyKind,
-            ResourceLimitsQosPolicy, TimeBasedFilterQosPolicy, WriterDataLifecycleQosPolicy,
+            ResourceLimitsQosPolicy, TimeBasedFilterQosPolicy,
         },
         sample_info::{
             ANY_INSTANCE_STATE, ANY_SAMPLE_STATE, ANY_VIEW_STATE, InstanceStateKind,
@@ -2802,107 +2802,6 @@ fn volatile_writer_with_reader_new_reader_receives_only_new_samples() {
 }
 
 #[test]
-fn write_read_unregistered_samples_are_also_disposed() {
-    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
-    let participant_factory = DomainParticipantFactory::get_instance();
-
-    let participant = participant_factory
-        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
-        .unwrap();
-
-    let topic = participant
-        .create_topic::<KeyedData>(
-            "MyTopic",
-            "KeyedData",
-            QosKind::Default,
-            NO_LISTENER,
-            NO_STATUS,
-        )
-        .unwrap();
-
-    let publisher = participant
-        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
-        .unwrap();
-    let writer_qos = DataWriterQos {
-        reliability: ReliabilityQosPolicy {
-            kind: ReliabilityQosPolicyKind::Reliable,
-            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
-        },
-        history: HistoryQosPolicy {
-            kind: HistoryQosPolicyKind::KeepAll,
-        },
-        writer_data_lifecycle: WriterDataLifecycleQosPolicy {
-            autodispose_unregistered_instances: true,
-        },
-        ..Default::default()
-    };
-    let writer = publisher
-        .create_datawriter(
-            &topic,
-            QosKind::Specific(writer_qos),
-            NO_LISTENER,
-            NO_STATUS,
-        )
-        .unwrap();
-
-    let subscriber = participant
-        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
-        .unwrap();
-    let reader_qos = DataReaderQos {
-        reliability: ReliabilityQosPolicy {
-            kind: ReliabilityQosPolicyKind::Reliable,
-            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
-        },
-        history: HistoryQosPolicy {
-            kind: HistoryQosPolicyKind::KeepAll,
-        },
-        ..Default::default()
-    };
-
-    let reader = subscriber
-        .create_datareader::<KeyedData>(
-            &topic,
-            QosKind::Specific(reader_qos),
-            NO_LISTENER,
-            NO_STATUS,
-        )
-        .unwrap();
-
-    let cond = writer.get_statuscondition();
-    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
-        .unwrap();
-
-    let mut wait_set = WaitSet::new();
-    wait_set
-        .attach_condition(Condition::StatusCondition(cond))
-        .unwrap();
-    wait_set.wait(Duration::new(10, 0)).unwrap();
-
-    let data1 = KeyedData { id: 1, value: 1 };
-
-    writer.write(data1.clone(), None).unwrap();
-    writer.unregister_instance(data1, None).unwrap();
-
-    writer
-        .wait_for_acknowledgments(Duration::new(10, 0))
-        .unwrap();
-
-    let samples = reader
-        .read(2, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
-        .unwrap();
-
-    assert_eq!(samples.len(), 2);
-    assert_eq!(
-        samples[0].sample_info.instance_state,
-        InstanceStateKind::NotAliveDisposed
-    );
-    assert_eq!(
-        samples[1].sample_info.instance_state,
-        InstanceStateKind::NotAliveDisposed
-    );
-}
-
-#[test]
 fn write_read_unregistered_samples_not_alive_no_writers() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
@@ -2995,6 +2894,145 @@ fn write_read_unregistered_samples_not_alive_no_writers() {
     );
     assert_eq!(
         samples[1].sample_info.instance_state,
+        InstanceStateKind::NotAliveNoWriters
+    );
+}
+
+#[test]
+fn multiple_writers_unregister_instance() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+    let writer1 = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos.clone()),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+    let writer2 = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+
+    let reader = subscriber
+        .create_datareader::<KeyedData>(
+            &topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond1 = writer1.get_statuscondition();
+    cond1
+        .set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let cond2 = writer2.get_statuscondition();
+    cond2
+        .set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond1))
+        .unwrap();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond2))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data1 = KeyedData { id: 1, value: 1 };
+
+    writer1.write(data1.clone(), None).unwrap();
+    writer2.write(data1.clone(), None).unwrap();
+    writer1.unregister_instance(data1.clone(), None).unwrap();
+
+    writer1
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+    writer2
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .read(3, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 3);
+    // Since writer1 unregisters with autodispose=true and writer2 is still registered, instance is NotAliveDisposed
+    assert_eq!(
+        samples[0].sample_info.instance_state,
+        InstanceStateKind::NotAliveDisposed
+    );
+    assert_eq!(
+        samples[1].sample_info.instance_state,
+        InstanceStateKind::NotAliveDisposed
+    );
+    assert_eq!(
+        samples[2].sample_info.instance_state,
+        InstanceStateKind::NotAliveDisposed
+    );
+
+    // Now writer2 unregisters as well
+    writer2.unregister_instance(data1, None).unwrap();
+    writer2
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples2 = reader
+        .read(4, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples2.len(), 4);
+    // Now that both writers have unregistered, instance is NotAliveNoWriters
+    assert_eq!(
+        samples2[3].sample_info.instance_state,
         InstanceStateKind::NotAliveNoWriters
     );
 }

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2108,10 +2108,8 @@ fn reader_with_minimum_time_separation_qos_taking_samples() {
         .wait_for_acknowledgments(Duration::new(10, 0))
         .unwrap();
 
-    let samples = reader
-        .take(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
-        .unwrap();
-    assert_eq!(samples.len(), 0);
+    let samples = reader.take(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE);
+    assert_eq!(samples, Err(DdsError::NoData));
 
     writer
         .write_w_timestamp(data1_3.clone(), None, Time::new(3, 0))

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -108,6 +108,16 @@ fn large_data_should_be_fragmented() {
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
+    let reader_cond = reader.get_statuscondition();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut reader_wait_set = WaitSet::new();
+    reader_wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond))
+        .unwrap();
+    reader_wait_set.wait(Duration::new(10, 0)).unwrap();
+
     let even_data = LargeData {
         id: 1,
         value: vec![8; 15000],
@@ -220,6 +230,16 @@ fn large_data_should_be_fragmented_reliable() {
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
     wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let reader_cond = reader.get_statuscondition();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut reader_wait_set = WaitSet::new();
+    reader_wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond))
+        .unwrap();
+    reader_wait_set.wait(Duration::new(5, 0)).unwrap();
 
     let data = LargeData {
         id: 1,
@@ -619,6 +639,16 @@ fn wait_for_samples_to_be_taken_best_effort() {
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let reader_cond = reader.get_statuscondition();
+    reader_cond
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut reader_wait_set = WaitSet::new();
+    reader_wait_set
+        .attach_condition(Condition::StatusCondition(reader_cond))
+        .unwrap();
+    reader_wait_set.wait(Duration::new(10, 0)).unwrap();
 
     let data1 = KeyedData { id: 1, value: 1 };
     let data2 = KeyedData { id: 2, value: 10 };
@@ -1037,7 +1067,7 @@ fn each_key_sample_is_read() {
     let data3_handle = writer.lookup_instance(data3.clone()).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(1, 0))
+        .wait_for_acknowledgments(Duration::new(2, 0))
         .unwrap();
 
     let samples = reader
@@ -1881,7 +1911,7 @@ fn write_read_sample_view_state() {
     writer.write(data2, None).unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(1, 0))
+        .wait_for_acknowledgments(Duration::new(2, 0))
         .unwrap();
 
     let samples = reader
@@ -2588,7 +2618,7 @@ fn data_reader_order_by_source_timestamp() {
         .unwrap();
 
     writer
-        .wait_for_acknowledgments(Duration::new(1, 0))
+        .wait_for_acknowledgments(Duration::new(2, 0))
         .unwrap();
 
     let samples = reader
@@ -2973,19 +3003,21 @@ fn multiple_writers_unregister_instance() {
     cond1
         .set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
+    let mut wait_set1 = WaitSet::new();
+    wait_set1
+        .attach_condition(Condition::StatusCondition(cond1))
+        .unwrap();
+    wait_set1.wait(Duration::new(10, 0)).unwrap();
+
     let cond2 = writer2.get_statuscondition();
     cond2
         .set_enabled_statuses(&[StatusKind::PublicationMatched])
         .unwrap();
-
-    let mut wait_set = WaitSet::new();
-    wait_set
-        .attach_condition(Condition::StatusCondition(cond1))
-        .unwrap();
-    wait_set
+    let mut wait_set2 = WaitSet::new();
+    wait_set2
         .attach_condition(Condition::StatusCondition(cond2))
         .unwrap();
-    wait_set.wait(Duration::new(10, 0)).unwrap();
+    wait_set2.wait(Duration::new(10, 0)).unwrap();
 
     let data1 = KeyedData { id: 1, value: 1 };
 
@@ -3135,6 +3167,8 @@ fn data_reader_instance_state_not_alive_no_writers_when_writer_is_deleted() {
         samples[0].sample_info.instance_state,
         InstanceStateKind::Alive
     );
+
+    reader.get_subscription_matched_status().unwrap();
 
     // Delete writer / publisher / participant1
     participant1.delete_contained_entities().unwrap();

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -2903,6 +2903,103 @@ fn write_read_unregistered_samples_are_also_disposed() {
 }
 
 #[test]
+fn write_read_unregistered_samples_not_alive_no_writers() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic = participant
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+
+    let reader = subscriber
+        .create_datareader::<KeyedData>(
+            &topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data1 = KeyedData { id: 1, value: 1 };
+
+    writer.write(data1.clone(), None).unwrap();
+    writer.unregister_instance(data1, None).unwrap();
+
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .read(2, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(samples.len(), 2);
+    assert_eq!(
+        samples[0].sample_info.instance_state,
+        InstanceStateKind::NotAliveNoWriters
+    );
+    assert_eq!(
+        samples[1].sample_info.instance_state,
+        InstanceStateKind::NotAliveNoWriters
+    );
+}
+
+#[test]
 fn transient_local_writer_does_not_deliver_lifespan_expired_data_at_write() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -4740,3 +4740,121 @@ fn shared_ownership_writer1_should_write_and_writer2_should_dispose_same_data() 
         InstanceStateKind::NotAliveDisposed
     );
 }
+
+#[test]
+fn data_reader_does_not_read_lifespan_expired_samples() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant1 = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic1 = participant1
+        .create_topic::<KeyedData>(
+            "LifespanTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant1
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        lifespan: LifespanQosPolicy {
+            duration: DurationKind::Finite(Duration::new(0, 250_000_000)), // 250ms
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic1,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let participant2 = DomainParticipantFactory::get_instance()
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic2 = participant2
+        .create_topic::<KeyedData>(
+            "LifespanTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant2
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        ..Default::default()
+    };
+
+    let reader = subscriber
+        .create_datareader::<KeyedData>(
+            &topic2,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    let cond = reader.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(5, 0)).unwrap();
+
+    for i in 0..6 {
+        let data = KeyedData { id: 1, value: i };
+        writer.write(data, None).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    let samples = reader
+        .take(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    // With 100ms write period and 250ms lifespan, reading after 500ms (6 samples sent: 0, 1, 2, 3, 4, 5)
+    // samples 0, 1, 2 (age >= 300ms) must have expired.
+    // Only 2 or 3 unexpired samples (e.g. samples 3, 4, 5) should be received.
+    assert!(
+        samples.len() == 2 || samples.len() == 3,
+        "Expected 2 or 3 samples, but received {}",
+        samples.len()
+    );
+}

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -260,8 +260,6 @@ fn large_data_should_be_fragmented_reliable() {
     assert_eq!(samples[0].data.as_ref().unwrap(), &data);
 }
 
-
-
 #[test]
 fn writer_with_keep_last_1_should_send_only_last_sample_to_reader() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
@@ -4569,11 +4567,11 @@ fn large_data_transfer_between_two_participants() {
         value: vec![255; 100_000],
     };
 
-    let total_samples = 10;
+    let total_samples = 200;
     let writer_thread = std::thread::spawn(move || {
         for _ in 0..total_samples {
             writer.write(data.clone(), None).unwrap();
-            std::thread::sleep(std::time::Duration::from_millis(50));
+            std::thread::sleep(std::time::Duration::from_millis(15));
         }
         writer
             .wait_for_acknowledgments(Duration::new(10, 0))
@@ -4582,20 +4580,19 @@ fn large_data_transfer_between_two_participants() {
 
     let start_time = std::time::Instant::now();
     let mut received_samples = 0;
-    while received_samples < total_samples && start_time.elapsed() < std::time::Duration::from_secs(30) {
-        if let Ok(samples) = reader.take(100, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE) {
-            received_samples += samples.len();
+    while received_samples < total_samples
+        && start_time.elapsed() < std::time::Duration::from_secs(12)
+    {
+        if let Ok(samples) = reader.take(100, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        {
+            if !samples.is_empty() {
+                received_samples += samples.len();
+            }
         }
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
     writer_thread.join().unwrap();
-
-    if received_samples < total_samples {
-        if let Ok(samples) = reader.take(100, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE) {
-            received_samples += samples.len();
-        }
-    }
     assert_eq!(received_samples, total_samples);
 }
 

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -3075,10 +3075,10 @@ fn multiple_writers_unregister_instance() {
         .unwrap();
 
     assert_eq!(samples2.len(), 4);
-    // Now that both writers have unregistered, instance is NotAliveNoWriters
+    // Since instance was disposed by writer1 (autodispose=true), it remains NotAliveDisposed
     assert_eq!(
         samples2[3].sample_info.instance_state,
-        InstanceStateKind::NotAliveNoWriters
+        InstanceStateKind::NotAliveDisposed
     );
 }
 
@@ -3207,6 +3207,139 @@ fn data_reader_instance_state_not_alive_no_writers_when_writer_is_deleted() {
     assert_eq!(
         samples_after_delete[0].sample_info.instance_state,
         InstanceStateKind::NotAliveNoWriters
+    );
+}
+
+#[test]
+fn data_reader_instance_state_not_alive_disposed_when_writer_disposes_and_is_deleted() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+
+    let participant_factory = DomainParticipantFactory::get_instance();
+    let participant1 = participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let participant2 = participant_factory
+        .create_participant(domain_id, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+
+    let topic1 = participant1
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+    let topic2 = participant2
+        .create_topic::<KeyedData>(
+            "MyTopic",
+            "KeyedData",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let publisher = participant1
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer_qos = DataWriterQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+    let writer = publisher
+        .create_datawriter(
+            &topic1,
+            QosKind::Specific(writer_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let subscriber = participant2
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let reader_qos = DataReaderQos {
+        reliability: ReliabilityQosPolicy {
+            kind: ReliabilityQosPolicyKind::Reliable,
+            max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
+        },
+        history: HistoryQosPolicy {
+            kind: HistoryQosPolicyKind::KeepAll,
+        },
+        ..Default::default()
+    };
+    let reader = subscriber
+        .create_datareader::<KeyedData>(
+            &topic2,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    let cond = writer.get_statuscondition();
+    cond.set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set = WaitSet::new();
+    wait_set
+        .attach_condition(Condition::StatusCondition(cond))
+        .unwrap();
+    wait_set.wait(Duration::new(10, 0)).unwrap();
+
+    let data1 = KeyedData { id: 1, value: 1 };
+    writer.write(data1.clone(), None).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    let samples = reader
+        .take(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+    assert_eq!(samples.len(), 1);
+    assert_eq!(
+        samples[0].sample_info.instance_state,
+        InstanceStateKind::Alive
+    );
+
+    writer.dispose(data1, None).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    reader.get_subscription_matched_status().unwrap();
+
+    // Delete writer / publisher / participant1
+    participant1.delete_contained_entities().unwrap();
+    participant_factory
+        .delete_participant(&participant1)
+        .unwrap();
+
+    // Wait for subscription matched status to update or reader to detect writer deletion
+    let cond_reader = reader.get_statuscondition();
+    cond_reader
+        .set_enabled_statuses(&[StatusKind::SubscriptionMatched])
+        .unwrap();
+    let mut wait_set_reader = WaitSet::new();
+    wait_set_reader
+        .attach_condition(Condition::StatusCondition(cond_reader))
+        .unwrap();
+    wait_set_reader.wait(Duration::new(10, 0)).unwrap();
+
+    let samples_after_delete = reader
+        .take(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .unwrap();
+
+    assert_eq!(
+        samples_after_delete[0].sample_info.instance_state,
+        InstanceStateKind::NotAliveDisposed
     );
 }
 

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -4614,7 +4614,6 @@ fn shared_ownership_writer1_should_write_and_writer2_should_dispose_same_data() 
 }
 
 #[test]
-#[ignore]
 fn data_reader_does_not_read_lifespan_expired_samples() {
     let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
 
@@ -4644,7 +4643,7 @@ fn data_reader_does_not_read_lifespan_expired_samples() {
             max_blocking_time: DurationKind::Finite(Duration::new(1, 0)),
         },
         lifespan: LifespanQosPolicy {
-            duration: DurationKind::Finite(Duration::new(0, 250_000_000)), // 250ms
+            duration: DurationKind::Finite(Duration::new(1, 0)),
         },
         ..Default::default()
     };
@@ -4712,22 +4711,24 @@ fn data_reader_does_not_read_lifespan_expired_samples() {
         .unwrap();
     wait_set.wait(Duration::new(5, 0)).unwrap();
 
-    for i in 0..6 {
-        let data = KeyedData { id: 1, value: i };
-        writer.write(data, None).unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
+    let data1 = KeyedData { id: 1, value: 1 };
+    let data2 = KeyedData { id: 1, value: 2 };
+
+    writer
+        .write_w_timestamp(data1, None, Time::new(0, 0))
+        .unwrap();
+    writer
+        .write_w_timestamp(data2.clone(), None, Time::new(i32::MAX, 0))
+        .unwrap();
+
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
 
     let samples = reader
         .take(10, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
 
-    // With 100ms write period and 250ms lifespan, reading after 500ms (6 samples sent: 0, 1, 2, 3, 4, 5)
-    // samples 0, 1, 2 (age >= 300ms) must have expired.
-    // Only 2 or 3 unexpired samples (e.g. samples 3, 4, 5) should be received.
-    assert!(
-        samples.len() == 2 || samples.len() == 3,
-        "Expected 2 or 3 samples, but received {}",
-        samples.len()
-    );
+    assert_eq!(samples.len(), 1);
+    assert_eq!(samples[0].data.as_ref().unwrap(), &data2);
 }

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -673,6 +673,7 @@ fn wait_for_samples_to_be_taken_best_effort() {
         if samples.len() >= 5 {
             break;
         }
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
 
     assert_eq!(samples.len(), 5);
@@ -3005,6 +3006,7 @@ fn multiple_writers_unregister_instance() {
         if reader.get_matched_publications().unwrap().len() >= 2 {
             break;
         }
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
     assert_eq!(
         reader.get_matched_publications().unwrap().len(),
@@ -3736,6 +3738,7 @@ fn reader_with_exclusive_ownership_should_not_read_samples_from_second_weaker_wr
         if reader.get_matched_publications().unwrap().len() >= 2 {
             break;
         }
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
     assert_eq!(
         reader.get_matched_publications().unwrap().len(),
@@ -3875,6 +3878,7 @@ fn reader_with_exclusive_ownership_should_read_samples_from_second_writer_with_h
         if reader.get_matched_publications().unwrap().len() >= 2 {
             break;
         }
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
     assert_eq!(
         reader.get_matched_publications().unwrap().len(),
@@ -4023,6 +4027,7 @@ fn reader_with_exclusive_ownership_should_read_samples_from_second_writer_after_
         if reader.get_matched_publications().unwrap().len() >= 2 {
             break;
         }
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
     assert_eq!(
         reader.get_matched_publications().unwrap().len(),
@@ -4171,6 +4176,7 @@ fn reader_with_exclusive_ownership_should_read_samples_from_second_weaker_writer
         if reader.get_matched_publications().unwrap().len() >= 2 {
             break;
         }
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
     assert_eq!(
         reader.get_matched_publications().unwrap().len(),
@@ -4314,6 +4320,7 @@ fn reader_with_exclusive_ownership_should_read_samples_from_second_weaker_writer
         if reader.get_matched_publications().unwrap().len() >= 2 {
             break;
         }
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
     assert_eq!(
         reader.get_matched_publications().unwrap().len(),
@@ -4555,6 +4562,7 @@ fn shared_ownership_writer1_should_write_and_writer2_should_dispose_same_data() 
         if reader.get_matched_publications().unwrap().len() >= 2 {
             break;
         }
+        std::thread::sleep(std::time::Duration::from_millis(20));
     }
     assert_eq!(
         reader.get_matched_publications().unwrap().len(),

--- a/dds/tests/write_read_special_types.rs
+++ b/dds/tests/write_read_special_types.rs
@@ -586,6 +586,16 @@ fn enum_should_be_always_same_instance() {
         .unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
 
+    let cond1 = writer.get_statuscondition();
+    cond1
+        .set_enabled_statuses(&[StatusKind::PublicationMatched])
+        .unwrap();
+    let mut wait_set1 = WaitSet::new();
+    wait_set1
+        .attach_condition(Condition::StatusCondition(cond1))
+        .unwrap();
+    wait_set1.wait(Duration::new(10, 0)).unwrap();
+
     let cond = reader.get_statuscondition();
     cond.set_enabled_statuses(&[StatusKind::DataAvailable])
         .unwrap();
@@ -593,6 +603,7 @@ fn enum_should_be_always_same_instance() {
     wait_set
         .attach_condition(Condition::StatusCondition(cond))
         .unwrap();
+
     writer.write(UnKeyedData::On, None).unwrap();
     wait_set.wait(Duration::new(10, 0)).unwrap();
     let sample = reader

--- a/interoperability_tests/fast_dds/CMakeLists.txt
+++ b/interoperability_tests/fast_dds/CMakeLists.txt
@@ -2,56 +2,56 @@ cmake_minimum_required(VERSION 3.14.0)
 project(FastDdsInteroperability)
 
 find_package(fastcdr REQUIRED)
-find_package(fastrtps REQUIRED)
+find_package(fastdds REQUIRED)
 set (CMAKE_CXX_STANDARD 11)
 add_compile_options(-Werror -Wall)
 
-set_source_files_properties(${CMAKE_BINARY_DIR}/idl/HelloWorld.cxx PROPERTIES GENERATED TRUE)
-set_source_files_properties(${CMAKE_BINARY_DIR}/idl/HelloWorldPubSubTypes.cxx PROPERTIES GENERATED TRUE)
-set_source_files_properties(${CMAKE_BINARY_DIR}/idl/DisposeData.cxx PROPERTIES GENERATED TRUE)
-set_source_files_properties(${CMAKE_BINARY_DIR}/idl/DisposeDataPubSubTypes.cxx PROPERTIES GENERATED TRUE)
+set_source_files_properties(${CMAKE_BINARY_DIR}/idl/interoperability_tests/HelloWorldTypeObjectSupport.cxx PROPERTIES GENERATED TRUE)
+set_source_files_properties(${CMAKE_BINARY_DIR}/idl/interoperability_tests/HelloWorldPubSubTypes.cxx PROPERTIES GENERATED TRUE)
+set_source_files_properties(${CMAKE_BINARY_DIR}/idl/interoperability_tests/DisposeDataTypeObjectSupport.cxx PROPERTIES GENERATED TRUE)
+set_source_files_properties(${CMAKE_BINARY_DIR}/idl/interoperability_tests/DisposeDataPubSubTypes.cxx PROPERTIES GENERATED TRUE)
 
 add_executable(FastDdsPublisher
   fast_dds_publisher.cpp
-  ${CMAKE_BINARY_DIR}/idl/HelloWorld.cxx
-  ${CMAKE_BINARY_DIR}/idl/HelloWorldPubSubTypes.cxx
+  ${CMAKE_BINARY_DIR}/idl/interoperability_tests/HelloWorldTypeObjectSupport.cxx
+  ${CMAKE_BINARY_DIR}/idl/interoperability_tests/HelloWorldPubSubTypes.cxx
 )
 target_link_libraries(FastDdsPublisher PRIVATE
-  fastrtps
+  fastdds
   fastcdr
 )
-target_include_directories(FastDdsPublisher PRIVATE ${CMAKE_BINARY_DIR}/idl)
+target_include_directories(FastDdsPublisher PRIVATE ${CMAKE_BINARY_DIR}/idl/interoperability_tests)
 
 
 add_executable(FastDdsSubscriber
   fast_dds_subscriber.cpp
-  ${CMAKE_BINARY_DIR}/idl/HelloWorld.cxx
-  ${CMAKE_BINARY_DIR}/idl/HelloWorldPubSubTypes.cxx
+  ${CMAKE_BINARY_DIR}/idl/interoperability_tests/HelloWorldTypeObjectSupport.cxx
+  ${CMAKE_BINARY_DIR}/idl/interoperability_tests/HelloWorldPubSubTypes.cxx
 )
 target_link_libraries(FastDdsSubscriber PRIVATE
-  fastrtps
+  fastdds
   fastcdr
 )
-target_include_directories(FastDdsSubscriber PRIVATE ${CMAKE_BINARY_DIR}/idl)
+target_include_directories(FastDdsSubscriber PRIVATE ${CMAKE_BINARY_DIR}/idl/interoperability_tests)
 
 add_executable(FastDdsPublisherDispose
   fast_dds_publisher_dispose.cpp
-  ${CMAKE_BINARY_DIR}/idl/DisposeData.cxx
-  ${CMAKE_BINARY_DIR}/idl/DisposeDataPubSubTypes.cxx
+  ${CMAKE_BINARY_DIR}/idl/interoperability_tests/DisposeDataTypeObjectSupport.cxx
+  ${CMAKE_BINARY_DIR}/idl/interoperability_tests/DisposeDataPubSubTypes.cxx
 )
 target_link_libraries(FastDdsPublisherDispose PRIVATE
-  fastrtps
+  fastdds
   fastcdr
 )
-target_include_directories(FastDdsPublisherDispose PRIVATE ${CMAKE_BINARY_DIR}/idl)
+target_include_directories(FastDdsPublisherDispose PRIVATE ${CMAKE_BINARY_DIR}/idl/interoperability_tests)
 
 add_executable(FastDdsSubscriberDispose
   fast_dds_subscriber_dispose.cpp
-  ${CMAKE_BINARY_DIR}/idl/DisposeData.cxx
-  ${CMAKE_BINARY_DIR}/idl/DisposeDataPubSubTypes.cxx
+  ${CMAKE_BINARY_DIR}/idl/interoperability_tests/DisposeDataTypeObjectSupport.cxx
+  ${CMAKE_BINARY_DIR}/idl/interoperability_tests/DisposeDataPubSubTypes.cxx
 )
 target_link_libraries(FastDdsSubscriberDispose PRIVATE
-  fastrtps
+  fastdds
   fastcdr
 )
-target_include_directories(FastDdsSubscriberDispose PRIVATE ${CMAKE_BINARY_DIR}/idl)
+target_include_directories(FastDdsSubscriberDispose PRIVATE ${CMAKE_BINARY_DIR}/idl/interoperability_tests)

--- a/interoperability_tests/fast_dds/fast_dds_publisher.cpp
+++ b/interoperability_tests/fast_dds/fast_dds_publisher.cpp
@@ -18,7 +18,10 @@ int main(int argc, char *argv[])
 {
 	const std::string topic_name = "HelloWorld";
 
-	auto participant = DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+	DomainParticipantQos participant_qos;
+	participant_qos.properties().properties().emplace_back("fastdds.type_propagation", "disabled");
+
+	auto participant = DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
 	TypeSupport hello_world_type{new interoperability::test::HelloWorldTypePubSubType()};
 	hello_world_type.register_type(participant);
 	auto topic = participant->create_topic(topic_name, hello_world_type.get_type_name(), TOPIC_QOS_DEFAULT);

--- a/interoperability_tests/fast_dds/fast_dds_publisher.cpp
+++ b/interoperability_tests/fast_dds/fast_dds_publisher.cpp
@@ -1,4 +1,4 @@
-#include "HelloWorldPubSubTypes.h"
+#include "HelloWorldPubSubTypes.hpp"
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
@@ -33,8 +33,8 @@ int main(int argc, char *argv[])
 	WaitSet wait_set;
 	wait_set.attach_condition(writer_condition);
 	ConditionSeq active_conditions;
-	auto ret_wait = wait_set.wait(active_conditions, eprosima::fastrtps::Duration_t{60, 0});
-	if (ret_wait != ReturnCode_t::RETCODE_OK)
+	auto ret_wait = wait_set.wait(active_conditions, Duration_t{60, 0});
+	if (ret_wait != RETCODE_OK)
 	{
 		throw std::runtime_error{"Subscription not matched"};
 	}
@@ -44,8 +44,8 @@ int main(int argc, char *argv[])
 	hello.msg('a');
 	writer->write(&hello);
 
-	auto ret_ack = writer->wait_for_acknowledgments(eprosima::fastrtps::Duration_t{30, 0});
-	if (ret_ack != ReturnCode_t::RETCODE_OK)
+	auto ret_ack = writer->wait_for_acknowledgments(Duration_t{30, 0});
+	if (ret_ack != RETCODE_OK)
 	{
 		throw std::runtime_error{"Acknowledgements did not arrive in time"};
 	}

--- a/interoperability_tests/fast_dds/fast_dds_publisher_dispose.cpp
+++ b/interoperability_tests/fast_dds/fast_dds_publisher_dispose.cpp
@@ -18,7 +18,10 @@ int main(int argc, char *argv[])
 {
 	const std::string topic_name = "DisposeData";
 
-	auto participant = DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+	DomainParticipantQos participant_qos;
+	participant_qos.properties().properties().emplace_back("fastdds.type_propagation", "disabled");
+
+	auto participant = DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
 	TypeSupport dispose_data_type{new interoperability::test::DisposeDataTypePubSubType()};
 	dispose_data_type.register_type(participant);
 	auto topic = participant->create_topic(topic_name, dispose_data_type.get_type_name(), TOPIC_QOS_DEFAULT);

--- a/interoperability_tests/fast_dds/fast_dds_publisher_dispose.cpp
+++ b/interoperability_tests/fast_dds/fast_dds_publisher_dispose.cpp
@@ -1,4 +1,4 @@
-#include "DisposeDataPubSubTypes.h"
+#include "DisposeDataPubSubTypes.hpp"
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
@@ -33,8 +33,8 @@ int main(int argc, char *argv[])
 	WaitSet wait_set;
 	wait_set.attach_condition(writer_condition);
 	ConditionSeq active_conditions;
-	auto ret_wait = wait_set.wait(active_conditions, eprosima::fastrtps::Duration_t{60, 0});
-	if (ret_wait != ReturnCode_t::RETCODE_OK)
+	auto ret_wait = wait_set.wait(active_conditions, Duration_t{60, 0});
+	if (ret_wait != RETCODE_OK)
 	{
 		throw std::runtime_error{"Subscription not matched"};
 	}
@@ -45,15 +45,15 @@ int main(int argc, char *argv[])
 	auto handle = writer->register_instance(&dispose_msg);
 
 	writer->write(&dispose_msg);
-	auto ret_ack = writer->wait_for_acknowledgments(eprosima::fastrtps::Duration_t{30, 0});
-	if (ret_ack != ReturnCode_t::RETCODE_OK)
+	auto ret_ack = writer->wait_for_acknowledgments(Duration_t{30, 0});
+	if (ret_ack != RETCODE_OK)
 	{
 		throw std::runtime_error{"Acknowledgements for write did not arrive in time"};
 	}
 
 	writer->dispose(&dispose_msg, handle);
-	ret_ack = writer->wait_for_acknowledgments(eprosima::fastrtps::Duration_t{30, 0});
-	if (ret_ack != ReturnCode_t::RETCODE_OK)
+	ret_ack = writer->wait_for_acknowledgments(Duration_t{30, 0});
+	if (ret_ack != RETCODE_OK)
 	{
 		throw std::runtime_error{"Acknowledgements for dispose did not arrive in time"};
 	}

--- a/interoperability_tests/fast_dds/fast_dds_subscriber.cpp
+++ b/interoperability_tests/fast_dds/fast_dds_subscriber.cpp
@@ -18,7 +18,10 @@ int main(int argc, char *argv[])
 {
 	const std::string topic_name = "HelloWorld";
 
-	auto participant = DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+	DomainParticipantQos participant_qos;
+	participant_qos.properties().properties().emplace_back("fastdds.type_propagation", "disabled");
+
+	auto participant = DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
 	TypeSupport hello_world_type{new interoperability::test::HelloWorldTypePubSubType()};
 	hello_world_type.register_type(participant);
 	auto topic = participant->create_topic(topic_name, hello_world_type.get_type_name(), TOPIC_QOS_DEFAULT);

--- a/interoperability_tests/fast_dds/fast_dds_subscriber.cpp
+++ b/interoperability_tests/fast_dds/fast_dds_subscriber.cpp
@@ -1,4 +1,4 @@
-#include "HelloWorldPubSubTypes.h"
+#include "HelloWorldPubSubTypes.hpp"
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
@@ -34,8 +34,8 @@ int main(int argc, char *argv[])
 	WaitSet wait_set_publication_matched;
 	wait_set_publication_matched.attach_condition(reader_condition);
 	ConditionSeq active_conditions;
-	const auto ret_wait_publication = wait_set_publication_matched.wait(active_conditions, eprosima::fastrtps::Duration_t{60, 0});
-	if (ret_wait_publication != ReturnCode_t::RETCODE_OK)
+	const auto ret_wait_publication = wait_set_publication_matched.wait(active_conditions, eprosima::fastdds::dds::Duration_t{60, 0});
+	if (ret_wait_publication != RETCODE_OK)
 	{
 		throw std::runtime_error{"Publication not matched"};
 	}
@@ -43,15 +43,15 @@ int main(int argc, char *argv[])
 	reader_condition.set_enabled_statuses(StatusMask::data_available());
 	WaitSet wait_set_data_available;
 	wait_set_data_available.attach_condition(reader_condition);
-	const auto ret_wait_data = wait_set_data_available.wait(active_conditions, eprosima::fastrtps::Duration_t{30, 0});
-	if (ret_wait_data != ReturnCode_t::RETCODE_OK)
+	const auto ret_wait_data = wait_set_data_available.wait(active_conditions, eprosima::fastdds::dds::Duration_t{30, 0});
+	if (ret_wait_data != RETCODE_OK)
 	{
 		throw std::runtime_error{"No data available on time"};
 	}
 
 	interoperability::test::HelloWorldType sample;
 	SampleInfo info;
-	if (reader->take_next_sample(&sample, &info) != ReturnCode_t::RETCODE_OK)
+	if (reader->take_next_sample(&sample, &info) != RETCODE_OK)
 	{
 		throw std::runtime_error{"take_next_sample failed with"};
 	}

--- a/interoperability_tests/fast_dds/fast_dds_subscriber_dispose.cpp
+++ b/interoperability_tests/fast_dds/fast_dds_subscriber_dispose.cpp
@@ -18,7 +18,10 @@ int main(int argc, char *argv[])
 {
 	const std::string topic_name = "DisposeData";
 
-	auto participant = DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+	DomainParticipantQos participant_qos;
+	participant_qos.properties().properties().emplace_back("fastdds.type_propagation", "disabled");
+
+	auto participant = DomainParticipantFactory::get_instance()->create_participant(0, participant_qos);
 	TypeSupport dispose_data_type{new interoperability::test::DisposeDataTypePubSubType()};
 	dispose_data_type.register_type(participant);
 	auto topic = participant->create_topic(topic_name, dispose_data_type.get_type_name(), TOPIC_QOS_DEFAULT);

--- a/interoperability_tests/fast_dds/fast_dds_subscriber_dispose.cpp
+++ b/interoperability_tests/fast_dds/fast_dds_subscriber_dispose.cpp
@@ -1,4 +1,4 @@
-#include "DisposeDataPubSubTypes.h"
+#include "DisposeDataPubSubTypes.hpp"
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
@@ -34,8 +34,8 @@ int main(int argc, char *argv[])
 	WaitSet wait_set_publication_matched;
 	wait_set_publication_matched.attach_condition(reader_condition);
 	ConditionSeq active_conditions;
-	const auto ret_wait_publication = wait_set_publication_matched.wait(active_conditions, eprosima::fastrtps::Duration_t{60, 0});
-	if (ret_wait_publication != ReturnCode_t::RETCODE_OK)
+	const auto ret_wait_publication = wait_set_publication_matched.wait(active_conditions, Duration_t{60, 0});
+	if (ret_wait_publication != RETCODE_OK)
 	{
 		throw std::runtime_error{"Publication not matched"};
 	}
@@ -43,15 +43,15 @@ int main(int argc, char *argv[])
 	reader_condition.set_enabled_statuses(StatusMask::data_available());
 	WaitSet wait_set_data_available;
 	wait_set_data_available.attach_condition(reader_condition);
-	auto ret_wait_data = wait_set_data_available.wait(active_conditions, eprosima::fastrtps::Duration_t{30, 0});
-	if (ret_wait_data != ReturnCode_t::RETCODE_OK)
+	auto ret_wait_data = wait_set_data_available.wait(active_conditions, Duration_t{30, 0});
+	if (ret_wait_data != RETCODE_OK)
 	{
 		throw std::runtime_error{"No data available on time"};
 	}
 
 	interoperability::test::DisposeDataType sample;
 	SampleInfo info;
-	if (reader->take_next_sample(&sample, &info) != ReturnCode_t::RETCODE_OK)
+	if (reader->take_next_sample(&sample, &info) != RETCODE_OK)
 	{
 		throw std::runtime_error{"take_next_sample failed with"};
 	}
@@ -63,13 +63,13 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	ret_wait_data = wait_set_data_available.wait(active_conditions, eprosima::fastrtps::Duration_t{30, 0});
-	if (ret_wait_data != ReturnCode_t::RETCODE_OK)
+	ret_wait_data = wait_set_data_available.wait(active_conditions, Duration_t{30, 0});
+	if (ret_wait_data != RETCODE_OK)
 	{
 		throw std::runtime_error{"No data available on time"};
 	}
 
-	if (reader->take_next_sample(&sample, &info) != ReturnCode_t::RETCODE_OK)
+	if (reader->take_next_sample(&sample, &info) != RETCODE_OK)
 	{
 		throw std::runtime_error{"take_next_sample failed with"};
 	}


### PR DESCRIPTION
This PR does a number of fixes to improve interoperability with other vendors:
- Fix hash calculation for types with sequences
- Fix issue with participant lease not being renewed
- Fix issue with content topic filter
- Do not send PID_KEY_HASH for topics with no key
- Fix issues with sample unregister and lifetime handling
- Update FastDDS to a more recent version and disable type information exchange