### PR TITLE
dds_gen: refactor attribute generation, add union extensibility

### DIFF
--- a/dds_gen/src/generator/rust.rs
+++ b/dds_gen/src/generator/rust.rs
@@ -1,6 +1,8 @@
 use crate::parser::{IdlPair, Rule};
 use std::borrow::Cow;
 
+const MODULE_SEP: &str = "::";
+
 /// _Rust_ generator.
 #[derive(Debug)]
 pub struct RustGenerator<'a> {
@@ -1173,11 +1175,17 @@ impl<'a> RustGenerator<'a> {
     fn compute_scoped_name<'pair>(&self, pair: IdlPair<'pair>) -> Cow<'pair, str> {
         let pair_str = pair.as_str();
 
-        if pair_str.starts_with("::") {
-            // A fully-qualified name is resolved relative to the current module nesting.
-            // To reach the root, prepend "super" for each nesting level, then append the name itself
-            let supers = vec!["super"; self.modules.len()].join("::");
-            Cow::Owned(format!("{supers}{pair_str}"))
+        if pair_str.starts_with(MODULE_SEP) {
+            // A fully-qualified name is resolved relative to the current module nesting
+
+            if self.modules.is_empty() {
+                // Already at the root, trim the fully qualified name prefix
+                Cow::Borrowed(pair_str.trim_start_matches(MODULE_SEP))
+            } else {
+                // To reach the root, prepend "super" for each nesting level, then append the name itself
+                let supers = vec!["super"; self.modules.len()].join(MODULE_SEP);
+                Cow::Owned(format!("{supers}{pair_str}"))
+            }
         } else {
             Cow::Borrowed(pair_str)
         }
@@ -1237,8 +1245,6 @@ impl<'a> RustGenerator<'a> {
     }
 
     fn hierarchical_type_name<'ident>(&self, ident: &'ident str) -> Cow<'ident, str> {
-        const MODULE_SEP: &str = "::";
-
         if self.modules.is_empty() {
             Cow::Borrowed(ident)
         } else {

--- a/dds_gen/src/generator/rust.rs
+++ b/dds_gen/src/generator/rust.rs
@@ -1,4 +1,5 @@
 use crate::parser::{IdlPair, Rule};
+use std::borrow::Cow;
 
 /// _Rust_ generator.
 #[derive(Debug)]
@@ -318,10 +319,13 @@ impl<'a> RustGenerator<'a> {
         let identifier = inner_pairs
             .clone()
             .find(|p| p.as_rule() == Rule::identifier)
-            .expect("Identifier must exist according to the grammar");
+            .expect("Must have an identifier according to the grammar");
 
         self.writer
-            .push_str("#[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]\n");
+            .push_str("#[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]\n");
+
+        let mut attr_meta = Vec::new();
+
         for annotation_appl in inner_pairs
             .clone()
             .filter(|p| p.as_rule() == Rule::annotation_appl)
@@ -337,41 +341,40 @@ impl<'a> RustGenerator<'a> {
                 .into_inner()
                 .next()
                 .expect("Must have an identifier according to the grammar");
+            let identifier_str = identifier.as_str();
 
-            match identifier.as_str() {
-                "final" => self
-                    .writer
-                    .push_str("#[dust_dds(extensibility = \"final\")]\n"),
-                "appendable" => self
-                    .writer
-                    .push_str("#[dust_dds(extensibility = \"appendable\")]\n"),
-                "mutable" => self
-                    .writer
-                    .push_str("#[dust_dds(extensibility = \"mutable\")]\n"),
+            match identifier_str {
+                "final" | "appendable" | "mutable" => {
+                    attr_meta.push(format!("extensibility = \"{identifier_str}\""));
+                }
                 _ => (),
             }
         }
 
         if !self.modules.is_empty() {
-            let name = format!(
-                "#[dust_dds(name = \"{}\")]\n",
+            attr_meta.push(format!(
+                "name = \"{}\"",
                 self.hierarchical_type_name(identifier.as_str())
-            );
-            self.writer.push_str(&name);
+            ));
         }
 
         if let Some(base_type) = inner_pairs
             .clone()
             .find(|p| p.as_rule() == Rule::scoped_name)
         {
-            self.writer.push_str("#[dust_dds(base_type =");
-            self.scoped_name(base_type);
-            self.writer.push_str(")]");
+            attr_meta.push(format!(
+                "base_type = {}",
+                self.compute_scoped_name(base_type)
+            ));
+        }
+
+        if !attr_meta.is_empty() {
+            let attr = format!("#[dust_dds({})]\n", attr_meta.join(", "));
+            self.writer.push_str(&attr);
         }
 
         self.writer.push_str("pub struct ");
         self.generate(identifier);
-
         self.writer.push_str(" {");
 
         if let Some(base_type) = inner_pairs
@@ -391,23 +394,20 @@ impl<'a> RustGenerator<'a> {
     }
 
     fn enum_dcl(&mut self, pair: IdlPair) {
-        let inner_pairs = pair.clone().into_inner();
+        let inner_pairs = pair.into_inner();
         let identifier = inner_pairs
             .clone()
             .find(|p| p.as_rule() == Rule::identifier)
             .expect("Must have an identifier according to the grammar");
+
         self.writer
-            .push_str("#[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]\n");
-        if !self.modules.is_empty() {
-            let name = format!(
-                "#[dust_dds(name = \"{}\")]\n",
-                self.hierarchical_type_name(identifier.as_str())
-            );
-            self.writer.push_str(&name);
-        }
-        for annotation_appl in pair
-            .into_inner()
-            .filter(|x| x.as_rule() == Rule::annotation_appl)
+            .push_str("#[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]\n");
+
+        let mut attr_meta = Vec::new();
+
+        for annotation_appl in inner_pairs
+            .clone()
+            .filter(|p| p.as_rule() == Rule::annotation_appl)
         {
             let inner_pairs = annotation_appl.into_inner();
 
@@ -420,23 +420,38 @@ impl<'a> RustGenerator<'a> {
                 .into_inner()
                 .next()
                 .expect("Must have an identifier according to the grammar");
+            let identifier_str = identifier.as_str();
 
-            if identifier.as_str() == "bit_bound" {
-                if let Some(annotation_appl_params) = inner_pairs
-                    .clone()
-                    .find(|p| p.as_rule() == Rule::annotation_appl_params)
-                {
-                    if let Some(expr) = annotation_appl_params
-                        .into_inner()
-                        .find(|p| p.as_rule() == Rule::const_expr)
+            match identifier_str {
+                "bit_bound" => {
+                    if let Some(annotation_appl_params) = inner_pairs
+                        .clone()
+                        .find(|p| p.as_rule() == Rule::annotation_appl_params)
                     {
-                        self.writer.push_str("#[dust_dds(bit_bound( ");
-                        self.writer.push_str(expr.as_str());
-                        self.writer.push_str("))]");
+                        if let Some(expr) = annotation_appl_params
+                            .into_inner()
+                            .find(|p| p.as_rule() == Rule::const_expr)
+                        {
+                            attr_meta.push(format!("bit_bound = \"{}\"", expr.as_str()));
+                        }
                     }
                 }
+                _ => (),
             }
         }
+
+        if !self.modules.is_empty() {
+            attr_meta.push(format!(
+                "name = \"{}\"",
+                self.hierarchical_type_name(identifier.as_str())
+            ));
+        }
+
+        if !attr_meta.is_empty() {
+            let attr = format!("#[dust_dds({})]\n", attr_meta.join(", "));
+            self.writer.push_str(&attr);
+        }
+
         self.writer.push_str("pub enum ");
         self.generate(identifier);
         self.writer.push_str(" {");
@@ -453,57 +468,34 @@ impl<'a> RustGenerator<'a> {
     }
 
     fn union_def(&mut self, pair: IdlPair) {
-        let identifier = pair
+        let inner_pairs = pair.into_inner();
+        let identifier = inner_pairs
             .clone()
-            .into_inner()
-            .find(|x| x.as_rule() == Rule::identifier)
+            .find(|p| p.as_rule() == Rule::identifier)
             .expect("Must have an identifier according to the grammar");
 
-        let switch_type_spec = pair
+        let switch_type_spec = inner_pairs
             .clone()
-            .into_inner()
             .find(|x| x.as_rule() == Rule::switch_type_spec)
             .expect("Must have a switch_type_spec according to the grammar");
 
-        let switch_body = pair
+        let switch_body = inner_pairs
             .clone()
-            .into_inner()
             .find(|x| x.as_rule() == Rule::switch_body)
             .expect("Must have a switch_body according to the grammar");
 
         self.writer
-            .push_str("#[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]\n");
+            .push_str("#[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]\n");
 
         self.writer.push_str("#[dust_dds(switch(");
         self.generate(switch_type_spec);
-        self.writer.push_str("),");
-        if !self.modules.is_empty() {
-            let name = format!(
-                "name = \"{}\"",
-                self.hierarchical_type_name(identifier.as_str())
-            );
-            self.writer.push_str(&name);
-        }
-        self.writer.push_str(")]");
+        self.writer.push(')');
 
-        self.writer.push_str("pub enum ");
-        self.generate(identifier);
-        self.writer.push_str(" {");
-        self.generate(switch_body);
-        self.writer.push_str("}\n");
-    }
+        let mut attr_meta = Vec::new();
 
-    #[inline]
-    fn enumerator(&mut self, pair: IdlPair) {
-        let identifier = pair
+        for annotation_appl in inner_pairs
             .clone()
-            .into_inner()
-            .find(|x| x.as_rule() == Rule::identifier)
-            .expect("Must have an identifier according to the grammar");
-        self.writer.push_str(identifier.as_str());
-        for annotation_appl in pair
-            .into_inner()
-            .filter(|x| x.as_rule() == Rule::annotation_appl)
+            .filter(|p| p.as_rule() == Rule::annotation_appl)
         {
             let inner_pairs = annotation_appl.into_inner();
 
@@ -516,20 +508,78 @@ impl<'a> RustGenerator<'a> {
                 .into_inner()
                 .next()
                 .expect("Must have an identifier according to the grammar");
+            let identifier_str = identifier.as_str();
 
-            if identifier.as_str() == "value" {
-                if let Some(annotation_appl_params) = inner_pairs
-                    .clone()
-                    .find(|p| p.as_rule() == Rule::annotation_appl_params)
-                {
-                    if let Some(expr) = annotation_appl_params
-                        .into_inner()
-                        .find(|p| p.as_rule() == Rule::const_expr)
+            match identifier_str {
+                "final" | "appendable" | "mutable" => {
+                    attr_meta.push(format!("extensibility = \"{identifier_str}\""));
+                }
+                _ => (),
+            }
+        }
+
+        if !self.modules.is_empty() {
+            attr_meta.push(format!(
+                "name = \"{}\"",
+                self.hierarchical_type_name(identifier.as_str())
+            ));
+        }
+
+        if !attr_meta.is_empty() {
+            let attr_meta = format!(", {}", attr_meta.join(", "));
+            self.writer.push_str(&attr_meta);
+        }
+        self.writer.push_str(")]\n");
+
+        self.writer.push_str("pub enum ");
+        self.generate(identifier);
+        self.writer.push_str(" {\n");
+        self.generate(switch_body);
+        self.writer.push_str("}\n");
+    }
+
+    fn enumerator(&mut self, pair: IdlPair) {
+        let inner_pairs = pair.into_inner();
+        let identifier = inner_pairs
+            .clone()
+            .find(|x| x.as_rule() == Rule::identifier)
+            .expect("Must have an identifier according to the grammar");
+
+        self.writer.push_str(identifier.as_str());
+
+        for annotation_appl in inner_pairs
+            .clone()
+            .filter(|p| p.as_rule() == Rule::annotation_appl)
+        {
+            let inner_pairs = annotation_appl.into_inner();
+
+            let scoped_name = inner_pairs
+                .clone()
+                .find(|p| p.as_rule() == Rule::scoped_name)
+                .expect("Must have a scoped name according to the grammar");
+
+            let identifier = scoped_name
+                .into_inner()
+                .next()
+                .expect("Must have an identifier according to the grammar");
+            let identifier_str = identifier.as_str();
+
+            match identifier_str {
+                "value" => {
+                    if let Some(annotation_appl_params) = inner_pairs
+                        .clone()
+                        .find(|p| p.as_rule() == Rule::annotation_appl_params)
                     {
-                        self.writer.push_str(" = ");
-                        self.writer.push_str(expr.as_str());
+                        if let Some(expr) = annotation_appl_params
+                            .into_inner()
+                            .find(|p| p.as_rule() == Rule::const_expr)
+                        {
+                            self.writer.push_str(" = ");
+                            self.writer.push_str(expr.as_str());
+                        }
                     }
                 }
+                _ => (),
             }
         }
     }
@@ -643,13 +693,16 @@ impl<'a> RustGenerator<'a> {
         let type_spec = inner_pairs
             .clone()
             .find(|p| p.as_rule() == Rule::type_spec)
-            .expect("Type spec must exist according to grammar");
+            .expect("Must have a type_spec according to the grammar");
+
         let declarators = inner_pairs
             .clone()
             .find(|p| p.as_rule() == Rule::declarators)
-            .expect("Declarator must exist according to grammar");
+            .expect("Must have a declarators according to the grammar");
 
         let mut is_optional = false;
+        let mut attr_meta = Vec::new();
+
         for annotation_appl in inner_pairs
             .clone()
             .filter(|p| p.as_rule() == Rule::annotation_appl)
@@ -665,26 +718,36 @@ impl<'a> RustGenerator<'a> {
                 .into_inner()
                 .next()
                 .expect("Must have an identifier according to the grammar");
+            let identifier_str = identifier.as_str();
 
-            if identifier.as_str() == "key" {
-                self.writer.push_str("#[dust_dds(key)]");
-            } else if identifier.as_str() == "id" {
-                if let Some(annotation_appl_params) = inner_pairs
-                    .clone()
-                    .find(|p| p.as_rule() == Rule::annotation_appl_params)
-                {
-                    if let Some(const_expr) = annotation_appl_params
-                        .into_inner()
-                        .find(|p| p.as_rule() == Rule::const_expr)
+            match identifier_str {
+                "key" => {
+                    attr_meta.push("key".to_string());
+                }
+                "id" => {
+                    if let Some(annotation_appl_params) = inner_pairs
+                        .clone()
+                        .find(|p| p.as_rule() == Rule::annotation_appl_params)
                     {
-                        self.writer
-                            .push_str(&format!("#[dust_dds(id = {})]", const_expr.as_str()));
+                        if let Some(expr) = annotation_appl_params
+                            .into_inner()
+                            .find(|p| p.as_rule() == Rule::const_expr)
+                        {
+                            attr_meta.push(format!("id = {}", expr.as_str()));
+                        }
                     }
                 }
-            } else if identifier.as_str() == "optional" {
-                is_optional = true;
-                self.writer.push_str("#[dust_dds(optional)]");
+                "optional" => {
+                    is_optional = true;
+                    attr_meta.push("optional".to_string());
+                }
+                _ => (),
             }
+        }
+
+        if !attr_meta.is_empty() {
+            let attr = format!("#[dust_dds({})]\n", attr_meta.join(", "));
+            self.writer.push_str(&attr);
         }
 
         for declarator in declarators.into_inner() {
@@ -692,6 +755,7 @@ impl<'a> RustGenerator<'a> {
                 .into_inner()
                 .next()
                 .expect("Must have an element according to the grammar");
+
             self.writer.push_str("pub ");
             match array_or_simple_declarator.as_rule() {
                 Rule::array_declarator => {
@@ -708,7 +772,7 @@ impl<'a> RustGenerator<'a> {
                     self.generate(identifier);
                     self.writer.push(':');
                     if is_optional {
-                        self.writer.push_str(" Option<");
+                        self.writer.push_str(" ::core::option::Option<");
                     }
                     self.writer.push('[');
                     self.generate(type_spec.clone());
@@ -723,7 +787,7 @@ impl<'a> RustGenerator<'a> {
                     self.generate(array_or_simple_declarator);
                     self.writer.push(':');
                     if is_optional {
-                        self.writer.push_str(" Option<");
+                        self.writer.push_str(" ::core::option::Option<");
                     }
                     self.generate(type_spec.clone());
                     if is_optional {
@@ -1099,19 +1163,22 @@ impl<'a> RustGenerator<'a> {
         self.writer.push_str(pair.as_str())
     }
 
+    #[inline]
     fn scoped_name(&mut self, pair: IdlPair) {
+        self.writer.push_str(&self.compute_scoped_name(pair));
+    }
+
+    fn compute_scoped_name<'pair>(&self, pair: IdlPair<'pair>) -> Cow<'pair, str> {
         let pair_str = pair.as_str();
+
         if pair_str.starts_with("::") {
-            // The :: is added as part of the pair so make sure it doesn't start with ::
-            // and that the last iteration doesn't get ::
-            for i in 0..self.modules.len() {
-                if i > 0 {
-                    self.writer.push_str("::");
-                }
-                self.writer.push_str("super");
-            }
+            // A fully-qualified name is resolved relative to the current module nesting.
+            // To reach the root, prepend "super" for each nesting level, then append the name itself
+            let supers = vec!["super"; self.modules.len()].join("::");
+            Cow::Owned(format!("{supers}{pair_str}"))
+        } else {
+            Cow::Borrowed(pair_str)
         }
-        self.writer.push_str(pair.as_str())
     }
 
     fn const_dcl(&mut self, pair: IdlPair) {
@@ -1167,12 +1234,16 @@ impl<'a> RustGenerator<'a> {
         self.writer.push_str("bool")
     }
 
-    fn hierarchical_type_name(&self, ident: &str) -> String {
+    fn hierarchical_type_name<'ident>(&self, ident: &'ident str) -> Cow<'ident, str> {
         const MODULE_SEP: &str = "::";
+
         if self.modules.is_empty() {
-            ident.to_owned()
+            Cow::Borrowed(ident)
         } else {
-            format!("{}{}{ident}", self.modules.join(MODULE_SEP), MODULE_SEP)
+            Cow::Owned(format!(
+                "{}{MODULE_SEP}{ident}",
+                self.modules.join(MODULE_SEP)
+            ))
         }
     }
 }
@@ -1202,7 +1273,7 @@ mod tests {
 
         assert_eq!(
             &writer,
-            "#[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]\npub struct MyStruct {pub a:i32,pub b:i64,pub c:i64,pub xary:[u8;32],pub yary:[u8;64],}\n",
+            "#[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]\npub struct MyStruct {pub a:i32,pub b:i64,pub c:i64,pub xary:[u8;32],pub yary:[u8;64],}\n",
         );
     }
 
@@ -1225,7 +1296,7 @@ mod tests {
 
         assert_eq!(
             &writer,
-            "#[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]\npub enum MyEnum {A,B,C,}\n",
+            "#[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]\npub enum MyEnum {A,B,C,}\n",
         );
     }
 
@@ -1241,7 +1312,7 @@ mod tests {
 
         assert_eq!(
             &writer,
-            "#[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]\n#[dust_dds(extensibility = \"appendable\")]\npub struct MyStruct {pub a:i32,}\n",
+            "#[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]\n#[dust_dds(extensibility = \"appendable\")]\npub struct MyStruct {pub a:i32,}\n",
         );
     }
 
@@ -1255,7 +1326,7 @@ mod tests {
         let mut rust_generator = RustGenerator::new(&mut writer);
         rust_generator.generate(p);
 
-        assert_eq!(&writer, "#[dust_dds(key)]pub a:i32,");
+        assert_eq!(&writer, "#[dust_dds(key)]\npub a:i32,");
     }
 
     #[test]
@@ -1376,7 +1447,7 @@ mod tests {
 
         assert_eq!(
             &writer,
-            "pub mod root{pub mod a{#[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]\n#[dust_dds(name = \"root::a::A\")]\npub struct A {pub x:u8,pub y:u16,pub z:u32,}\n}pub mod b{#[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]\n#[dust_dds(name = \"root::b::B\")]\npub enum B {X,Y,Z,}\n}}",
+            "pub mod root{pub mod a{#[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]\n#[dust_dds(name = \"root::a::A\")]\npub struct A {pub x:u8,pub y:u16,pub z:u32,}\n}pub mod b{#[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]\n#[dust_dds(name = \"root::b::B\")]\npub enum B {X,Y,Z,}\n}}",
         );
     }
 

--- a/dds_gen/src/generator/rust.rs
+++ b/dds_gen/src/generator/rust.rs
@@ -422,6 +422,7 @@ impl<'a> RustGenerator<'a> {
                 .expect("Must have an identifier according to the grammar");
             let identifier_str = identifier.as_str();
 
+            #[allow(clippy::single_match)]
             match identifier_str {
                 "bit_bound" => {
                     if let Some(annotation_appl_params) = inner_pairs
@@ -564,6 +565,7 @@ impl<'a> RustGenerator<'a> {
                 .expect("Must have an identifier according to the grammar");
             let identifier_str = identifier.as_str();
 
+            #[allow(clippy::single_match)]
             match identifier_str {
                 "value" => {
                     if let Some(annotation_appl_params) = inner_pairs

--- a/dds_gen/src/parser/idl_v4_grammar.pest
+++ b/dds_gen/src/parser/idl_v4_grammar.pest
@@ -416,7 +416,7 @@ union_dcl = {
     | union_forward_dcl
 }
 // (50)
-union_def = { "union" ~ identifier ~ "switch" ~ "(" ~ switch_type_spec ~ ")" ~ "{" ~ switch_body ~ "}" }
+union_def = { annotation_appl* ~ "union" ~ identifier ~ "switch" ~ "(" ~ switch_type_spec ~ ")" ~ "{" ~ switch_body ~ "}" }
 // (51)
 switch_type_spec = {
     integer_type

--- a/dds_gen/tests/appendable_struct.rs
+++ b/dds_gen/tests/appendable_struct.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
@@ -8,14 +7,14 @@ fn appendable_struct() {
 
     let expected = syn::parse2::<File>(
         r#"
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             #[dust_dds(extensibility = "appendable")]
             pub struct Point {
                 pub x: f64,
                 pub y: f64,
             }
 
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             #[dust_dds(extensibility = "mutable")]
             pub struct Data {
                 #[dust_dds(key)]
@@ -23,13 +22,13 @@ fn appendable_struct() {
                 pub x: f64,
             }
 
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             #[dust_dds(extensibility = "appendable")]
             pub struct MultiDimensionalPoint {
                 pub x: f64,
                 pub y: f64,
                 #[dust_dds(optional)]
-                pub z: Option<f64>,
+                pub z: ::core::option::Option<f64>,
             }
     "#
         .parse()

--- a/dds_gen/tests/basic_types.rs
+++ b/dds_gen/tests/basic_types.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
@@ -7,7 +6,7 @@ fn basic_types() {
     let idl_file = Path::new("tests/basic_types.idl");
     let expected = syn::parse2::<File>(
         r#"
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct BasicTypes {
                 pub a: bool,
                 pub b: char,

--- a/dds_gen/tests/const_declarations.rs
+++ b/dds_gen/tests/const_declarations.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]

--- a/dds_gen/tests/enums.rs
+++ b/dds_gen/tests/enums.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
@@ -8,7 +7,7 @@ fn enums() {
 
     let expected = syn::parse2::<File>(
         r#"
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub enum Suits {
                 Spades,
                 Hearts,
@@ -16,8 +15,8 @@ fn enums() {
                 Clubs,
             }
 
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(bit_bound(16))]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(bit_bound = "16")]
             pub enum HttpStatusCode {
                 CONTINUE = 100,
                 OK = 200,

--- a/dds_gen/tests/i11eperf.rs
+++ b/dds_gen/tests/i11eperf.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
@@ -9,96 +8,84 @@ fn i11eperf() {
     let expected = syn::parse2::<File>(
         r#"
         pub mod i11eperf {
-          #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-          #[dust_dds(extensibility = "final")]
-          #[dust_dds(name = "i11eperf::ou")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::ou")]
             pub struct ou {
               pub ts: u64,
               pub s: u32,
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a32")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a32")]
             pub struct a32 {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 32 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a128")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a128")]
             pub struct a128 {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 128 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a1024")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a1024")]
             pub struct a1024 {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 1024 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a16k")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a16k")]
             pub struct a16k {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 16*1024 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a48k")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a48k")]
             pub struct a48k {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 48*1024 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a64k")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a64k")]
             pub struct a64k {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 64*1024 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a1M")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a1M")]
             pub struct a1M {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 1024*1024 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a2M")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a2M")]
             pub struct a2M {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 2*1024*1024 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a4M")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a4M")]
             pub struct a4M {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 4*1024*1024 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::a8M")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::a8M")]
             pub struct a8M {
               pub ts: u64,
               pub s: u32,
               pub xary: [u8; 8*1024*1024 - 12],
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
-            #[dust_dds(extensibility = "final")]
-            #[dust_dds(name = "i11eperf::seq")]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(extensibility = "final", name = "i11eperf::seq")]
             pub struct seq {
               pub ts: u64,
               pub s: u32,

--- a/dds_gen/tests/id_attributes.rs
+++ b/dds_gen/tests/id_attributes.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
@@ -8,7 +7,7 @@ fn id_attributes() {
 
     let expected = syn::parse2::<File>(
         r#"
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct Person {
                 #[dust_dds(id = 1)]
                 pub name: String,
@@ -18,10 +17,9 @@ fn id_attributes() {
                 pub height: f64,
             }
 
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct Message {
-                #[dust_dds(key)]
-                #[dust_dds(id = 1)]
+                #[dust_dds(key, id = 1)]
                 pub id: i32,
                 #[dust_dds(id = 2)]
                 pub content: String,

--- a/dds_gen/tests/module_generation.rs
+++ b/dds_gen/tests/module_generation.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
@@ -9,7 +8,7 @@ fn module_generation() {
     let expected_string = r#"
         pub mod Game {
             pub mod Chess {
-                #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+                #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
                 #[dust_dds(name = "Game::Chess::ChessPiece")]
                 pub enum ChessPiece {
                     Pawn,
@@ -19,7 +18,7 @@ fn module_generation() {
                     Queen,
                     King,
                 }
-                #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+                #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
                 #[dust_dds(name = "Game::Chess::ChessSquare")]
                 pub struct ChessSquare {
                     pub column: char,
@@ -27,7 +26,7 @@ fn module_generation() {
                 }
             }
             pub mod Cards {
-                #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+                #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
                 #[dust_dds(name = "Game::Cards::Suit")]
                 pub enum Suit {
                     Spades,
@@ -37,7 +36,7 @@ fn module_generation() {
                 }
             }
         }
-        #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+        #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
         pub struct Point {
             pub x: f64,
             pub y: f64,
@@ -47,7 +46,7 @@ fn module_generation() {
             pub type Bar=i32;
             pub type Car=i32;
             pub mod frob{
-                #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+                #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
                 #[dust_dds(name = "foo::frob::Baz")]
                 pub struct Baz {
                     #[dust_dds(key)]

--- a/dds_gen/tests/nested_types.rs
+++ b/dds_gen/tests/nested_types.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
@@ -8,19 +7,19 @@ fn nested_types() {
 
     let expected = syn::parse2::<File>(
         r#"
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub enum Presence {
                 Present,
                 NotPresent,
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct Color {
                 pub red: u8,
                 pub green: u8,
                 pub blue: u8,
             }
 
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct ColorSensor {
                 pub state: Presence,
                 pub value: Color,

--- a/dds_gen/tests/scoped_name.idl
+++ b/dds_gen/tests/scoped_name.idl
@@ -1,0 +1,30 @@
+module first {
+    enum MyEnum {
+        A,
+        B,
+        C
+    };
+
+    module second {
+        enum ColorRGB {
+            RED,
+            GREEN,
+            BLUE
+        };
+
+        struct MyStruct {
+            ::first::MyEnum my_enum_fqn;
+            ::first::second::ColorRGB color_rgb_fqn;
+            ColorRGB color_rgb;
+        };
+    };
+};
+
+struct Wrapper {
+    first::MyEnum my_enum;
+    first::second::ColorRGB color_rgb;
+    first::second::MyStruct my_struct;
+    ::first::MyEnum my_enum_fqn;
+    ::first::second::ColorRGB color_rgb_fqn;
+    ::first::second::MyStruct my_struct_fqn;
+};

--- a/dds_gen/tests/scoped_name.rs
+++ b/dds_gen/tests/scoped_name.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+use syn::File;
+
+#[test]
+fn basic_types() {
+    let idl_file = Path::new("tests/scoped_name.idl");
+    let expected = syn::parse2::<File>(
+        r#"
+            pub mod first{
+                #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+                #[dust_dds(name = "first::MyEnum")]
+                pub enum MyEnum {
+                    A,
+                    B,
+                    C,
+                }
+                pub mod second{
+                    #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+                    #[dust_dds(name = "first::second::ColorRGB")]
+                    pub enum ColorRGB {
+                        RED,
+                        GREEN,
+                        BLUE,
+                    }
+                    #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+                    #[dust_dds(name = "first::second::MyStruct")]
+                    pub struct MyStruct {
+                        pub my_enum_fqn: super::super::first::MyEnum,
+                        pub color_rgb_fqn: super::super::first::second::ColorRGB,
+                        pub color_rgb: ColorRGB,
+                    }
+                }
+            }
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            pub struct Wrapper {
+                pub my_enum: first::MyEnum,
+                pub color_rgb: first::second::ColorRGB,
+                pub my_struct: first::second::MyStruct,
+                pub my_enum_fqn: first::MyEnum,
+                pub color_rgb_fqn: first::second::ColorRGB,
+                pub my_struct_fqn: first::second::MyStruct,
+            }
+        "#
+        .parse()
+        .unwrap(),
+    )
+    .unwrap();
+
+    let result = syn::parse2::<File>(
+        dust_dds_gen::compile_idl(idl_file)
+            .unwrap()
+            .parse()
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(result, expected);
+}

--- a/dds_gen/tests/structs_generation.rs
+++ b/dds_gen/tests/structs_generation.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
@@ -8,47 +7,47 @@ fn structs_generation() {
 
     let expected = syn::parse2::<File>(
         r#"
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct Point {
                 pub x: f64,
                 pub y: f64,
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct ChessSquare {
                 #[dust_dds(key)] pub column: char,
                 #[dust_dds(key)] pub line: u16,
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct HelloWorld {
                 pub message: String,
                 pub id: u32,
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct Sentence {
                 pub words: Vec<String>,
                 pub dependencies: Vec<Vec<u32>>,
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct User {
                 pub name: String,
                 pub active: bool,
             }
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct ObjectiveType {
                 pub name: String,
             }
 
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct Objective {
                 pub objective_type: ObjectiveType,
             }
 
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct Parent {
                 pub a: u8,
             }
 
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             #[dust_dds(base_type = Parent)]
             pub struct Child {
                 pub parent: Parent,

--- a/dds_gen/tests/template_types.rs
+++ b/dds_gen/tests/template_types.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
@@ -8,7 +7,7 @@ fn template_types() {
 
     let expected = syn::parse2::<File>(
         r#"
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             pub struct TemplateTypes {
                 pub a: Vec<Vec<u8>>,
                 pub b: String,

--- a/dds_gen/tests/union_types.idl
+++ b/dds_gen/tests/union_types.idl
@@ -10,3 +10,33 @@ union TestUnion switch(u8) {
     case 60:
         int64 z;
 };
+
+@final
+union FinalUnion switch(uint8) {
+    case 0:
+        uint8 x;
+    case 1:
+        uint8 y;
+    case 2:
+        uint8 z;
+};
+
+@appendable
+union AppendableUnion switch(uint8) {
+    case 0:
+        uint8 x;
+    case 1:
+        uint8 y;
+    case 2:
+        uint8 z;
+};
+
+@mutable
+union MutableUnion switch(uint8) {
+    case 0:
+        uint8 x;
+    case 1:
+        uint8 y;
+    case 2:
+        uint8 z;
+};

--- a/dds_gen/tests/union_types.rs
+++ b/dds_gen/tests/union_types.rs
@@ -1,15 +1,13 @@
 use std::path::Path;
-
 use syn::File;
 
 #[test]
-#[ignore]
 fn union_types() {
     let idl_file = Path::new("tests/union_types.idl");
 
     let expected = syn::parse2::<File>(
         r#"
-            #[derive(Debug, Clone, dust_dds::infrastructure::type_support::DdsType)]
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
             #[dust_dds(switch(u8))]
             pub enum TestUnion {
                 #[dust_dds(case = 10, )]
@@ -18,6 +16,39 @@ fn union_types() {
                 Case20{y:i32},
                 #[dust_dds(case = 50, default, case = 60, )]
                 Case50{z: i64},
+            }
+
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(switch(u8), extensibility = "final")]
+            pub enum FinalUnion {
+                #[dust_dds(case = 0, )]
+            	Case0{x:u8},
+                #[dust_dds(case = 1, )]
+            	Case1{y:u8},
+                #[dust_dds(case = 2, )]
+            	Case2{z:u8},
+            }
+
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(switch(u8), extensibility = "appendable")]
+            pub enum AppendableUnion {
+                #[dust_dds(case = 0, )]
+                Case0{x:u8},
+                #[dust_dds(case = 1, )]
+                Case1{y:u8},
+                #[dust_dds(case = 2, )]
+                Case2{z:u8},
+            }
+
+            #[derive(::core::fmt::Debug, ::core::clone::Clone, ::dust_dds::infrastructure::type_support::DdsType)]
+            #[dust_dds(switch(u8), extensibility = "mutable")]
+            pub enum MutableUnion {
+                #[dust_dds(case = 0, )]
+            	Case0{x:u8},
+                #[dust_dds(case = 1, )]
+            	Case1{y:u8},
+                #[dust_dds(case = 2, )]
+            	Case2{z:u8},
             }
             "#
         .parse()


### PR DESCRIPTION
Fixes: #677, #685

### This PR adds the following changes:
- refactor: generate a single `#[dust_dds(...)]` per item instead of multiple ones
  `#[dust_dds(name = "HelloWorld", extensibility = "final")]`
  instead of
  `#[dust_dds(name = "HelloWorld")]`
  `#[dust_dds(extensibility = "final")]`
- refactor: use fully qualified path for both `derive` and `type` when possible
   `::core::option::Option` instead of `Option`
- feat: union extensibility
- fix: enum `bit_bound` meta value via `=` instead of `()`
  `bit_bound = "16"` instead of `bit_bound("16")`
- fix: correctly computes the scoped name for a fully qualified name when already in root
- perf: use [`Cow`](https://doc.rust-lang.org/std/borrow/enum.Cow.html) when possible
- chore: use the same error messages in `expect`

### Open question
Currently, the generator does not take into account types that live in the [`alloc`](https://doc.rust-lang.org/alloc) crate (such as [`String`](https://doc.rust-lang.org/alloc/string/struct.String.html) and [`Vec`](https://doc.rust-lang.org/alloc/vec/struct.Vec.html)) and simply emits them without a fully qualified path. This works fine for projects using the standard library because these types are available through the [standard prelude](https://doc.rust-lang.org/std/prelude/index.html). However, in `no_std` projects that rely on `alloc`, these types must be referenced through the `alloc` crate instead.

What do you think about adding a flag to the `Rust` generator (or a similar mechanism) to control this behavior? When enabled, the generator could emit fully qualified paths such as `::alloc::string::String` and `::alloc::vec::Vec`, making the generated code compatible with `no_std + alloc` environments while preserving the current behavior by default.
