### PR TITLE
Fix handling of deleted writer

### DIFF
--- a/dds/src/dcps/dcps_domain_participant/communication_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/communication_methods.rs
@@ -475,7 +475,7 @@ impl DcpsDomainParticipant {
                 } else {
                     let instance_handle =
                         InstanceHandle::new(cache_change.instance_handle.unwrap_or_default());
-                    self.remove_discovered_participant(&instance_handle);
+                    self.remove_discovered_participant(&instance_handle, reception_timestamp);
                     self.domain_participant
                         .builtin_subscriber
                         .dcps_participant_reader
@@ -639,19 +639,25 @@ impl DcpsDomainParticipant {
                     self.domain_participant
                         .remove_discovered_writer(&instance_handle);
 
-                    let mut handle_list = Vec::new();
-                    for subscriber in &self.domain_participant.user_defined_subscriber_list {
-                        for data_reader in subscriber.data_reader_list.iter() {
-                            handle_list
-                                .push((subscriber.instance_handle, data_reader.instance_handle));
-                        }
-                    }
-                    for (subscriber_handle, data_reader_handle) in handle_list {
-                        self.remove_discovered_writer(
-                            instance_handle,
-                            subscriber_handle,
-                            data_reader_handle,
+                    for subscriber in &mut self.domain_participant.user_defined_subscriber_list {
+                        let (subscriber_status_condition, data_reader_list) = (
+                            &mut subscriber.status_condition,
+                            &mut subscriber.data_reader_list,
                         );
+                        for data_reader in data_reader_list {
+                            if data_reader
+                                .matched_publication_list
+                                .iter()
+                                .any(|x| &x.key().value == instance_handle.as_ref())
+                            {
+                                data_reader.remove_matched_publication(
+                                    &instance_handle,
+                                    reception_timestamp,
+                                );
+                                subscriber_status_condition
+                                    .add_communication_state(StatusKind::DataOnReaders);
+                            }
+                        }
                     }
                     self.domain_participant
                         .builtin_subscriber

--- a/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_reader_entity.rs
@@ -126,6 +126,10 @@ impl InstanceState {
         }
     }
 
+    pub fn has_registered_writer(&self, writer_guid: &[u8; 16]) -> bool {
+        self.registered_writers.contains(writer_guid)
+    }
+
     pub fn handle(&self) -> &InstanceHandle {
         &self.handle
     }

--- a/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
@@ -197,9 +197,6 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
 
         instance_info.last_write_time = None;
 
-        let serialized_key =
-            serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;
-
         self.last_change_sequence_number += 1;
         let cache_change = CacheChange {
             kind: ChangeKind::NotAliveDisposed,
@@ -207,7 +204,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             sequence_number: self.last_change_sequence_number,
             source_timestamp: Some(timestamp.into()),
             instance_handle: Some(instance_handle.into()),
-            data_value: serialized_key.into(),
+            data_value: Default::default(),
         };
         self.transport_writer.add_change(cache_change);
 
@@ -280,9 +277,6 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
 
         instance_info.last_write_time = None;
 
-        let serialized_key =
-            serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;
-
         self.last_change_sequence_number += 1;
         let kind = if self
             .qos
@@ -299,7 +293,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             sequence_number: self.last_change_sequence_number,
             source_timestamp: Some(timestamp.into()),
             instance_handle: Some(instance_handle.into()),
-            data_value: serialized_key.into(),
+            data_value: Default::default(),
         };
         self.transport_writer.add_change(cache_change);
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
@@ -170,22 +170,13 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
 
     pub fn dispose_w_timestamp(
         &mut self,
-        dynamic_data: &DynamicData<'static>,
-        type_support: &DynamicType<'static>,
+        instance_handle: InstanceHandle,
+        serialized_key: Vec<u8>,
         timestamp: Time,
     ) -> DdsResult<()> {
         if !self.enabled {
             return Err(DdsError::NotEnabled);
         }
-
-        let key_holder_type = KeyHolderType::new(&dynamic_data.r#type());
-        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &key_holder_type)?;
-
-        if TopicKind::from(type_support) == TopicKind::NoKey {
-            return Err(DdsError::IllegalOperation);
-        }
-
-        let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
 
         let Some(instance_info) = self
             .registered_instance_info
@@ -196,9 +187,6 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
         };
 
         instance_info.last_write_time = None;
-
-        let serialized_key =
-            serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;
 
         self.last_change_sequence_number += 1;
         let cache_change = CacheChange {
@@ -254,22 +242,14 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
 
     pub fn unregister_w_timestamp(
         &mut self,
-        dynamic_data: &DynamicData<'static>,
-        type_support: &DynamicType<'static>,
+        instance_handle: InstanceHandle,
+        serialized_key: Vec<u8>,
         timestamp: Time,
     ) -> DdsResult<()> {
         if !self.enabled {
             return Err(DdsError::NotEnabled);
         }
 
-        let key_holder_type = KeyHolderType::new(&dynamic_data.r#type());
-        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &key_holder_type)?;
-
-        if TopicKind::from(type_support) == TopicKind::NoKey {
-            return Err(DdsError::IllegalOperation);
-        }
-
-        let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
         let Some(instance_info) = self
             .registered_instance_info
             .iter_mut()
@@ -279,9 +259,6 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
         };
 
         instance_info.last_write_time = None;
-
-        let serialized_key =
-            serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;
 
         self.last_change_sequence_number += 1;
         let kind = if self

--- a/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/data_writer_entity.rs
@@ -197,6 +197,9 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
 
         instance_info.last_write_time = None;
 
+        let serialized_key =
+            serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;
+
         self.last_change_sequence_number += 1;
         let cache_change = CacheChange {
             kind: ChangeKind::NotAliveDisposed,
@@ -204,7 +207,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             sequence_number: self.last_change_sequence_number,
             source_timestamp: Some(timestamp.into()),
             instance_handle: Some(instance_handle.into()),
-            data_value: Default::default(),
+            data_value: serialized_key.into(),
         };
         self.transport_writer.add_change(cache_change);
 
@@ -277,6 +280,9 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
 
         instance_info.last_write_time = None;
 
+        let serialized_key =
+            serialize(key_holder_data.as_dynamic_data(), &self.qos.representation)?;
+
         self.last_change_sequence_number += 1;
         let kind = if self
             .qos
@@ -293,7 +299,7 @@ impl<T: RtpsWriter> DataWriterEntity<T> {
             sequence_number: self.last_change_sequence_number,
             source_timestamp: Some(timestamp.into()),
             instance_handle: Some(instance_handle.into()),
-            data_value: Default::default(),
+            data_value: serialized_key.into(),
         };
         self.transport_writer.add_change(cache_change);
         Ok(())

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -236,7 +236,7 @@ impl DcpsDomainParticipant {
                 }
             })
         {
-            self.remove_discovered_participant(&handle);
+            self.remove_discovered_participant(&handle, now);
         }
     }
 
@@ -2045,36 +2045,7 @@ impl DcpsDomainParticipant {
         }
     }
 
-    #[tracing::instrument(skip(self))]
-    pub(crate) fn remove_discovered_writer(
-        &mut self,
-        publication_handle: InstanceHandle,
-        subscriber_handle: InstanceHandle,
-        data_reader_handle: InstanceHandle,
-    ) {
-        let Some(subscriber) = self
-            .domain_participant
-            .user_defined_subscriber_list
-            .iter_mut()
-            .find(|x| x.instance_handle == subscriber_handle)
-        else {
-            return;
-        };
-        let Some(data_reader) = subscriber
-            .data_reader_list
-            .iter_mut()
-            .find(|x| x.instance_handle == data_reader_handle)
-        else {
-            return;
-        };
-        if data_reader
-            .matched_publication_list
-            .iter()
-            .any(|x| &x.key().value == publication_handle.as_ref())
-        {
-            data_reader.remove_matched_publication(&publication_handle);
-        }
-    }
+
 
     pub fn handle_type_lookup_request(
         &mut self,
@@ -2708,7 +2679,7 @@ impl DcpsDomainParticipant {
     }
 
     /// Remove discovered [domain participant](SpdpDiscoveredParticipantData) with the speficied [handle](InstanceHandle).
-    pub fn remove_discovered_participant(&mut self, handle: &InstanceHandle) {
+    pub fn remove_discovered_participant(&mut self, handle: &InstanceHandle, now: Time) {
         self.domain_participant
             .discovered_participant_list
             .retain(|domain_participant| {
@@ -2718,7 +2689,11 @@ impl DcpsDomainParticipant {
         let prefix = Guid::from(<[u8; 16]>::from(*handle)).prefix();
 
         for subscriber in &mut self.domain_participant.user_defined_subscriber_list {
-            for data_reader in &mut subscriber.data_reader_list {
+            let (subscriber_status_condition, data_reader_list) = (
+                &mut subscriber.status_condition,
+                &mut subscriber.data_reader_list,
+            );
+            for data_reader in data_reader_list {
                 let removed_writer_guids: Vec<_> = data_reader
                     .matched_publication_list
                     .iter()
@@ -2729,7 +2704,8 @@ impl DcpsDomainParticipant {
                     data_reader
                         .transport_reader
                         .delete_matched_writer(key.into());
-                    data_reader.remove_matched_publication(&InstanceHandle::new(key));
+                    data_reader.remove_matched_publication(&InstanceHandle::new(key), now);
+                    subscriber_status_condition.add_communication_state(StatusKind::DataOnReaders);
                 }
             }
         }

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -8,6 +8,8 @@ use crate::{
             discovered_reader_data::{DiscoveredReaderData, ReaderProxy},
             discovered_topic_data::DiscoveredTopicData,
             discovered_writer_data::{DiscoveredWriterData, WriterProxy},
+            parameter_id_values::PID_ENDPOINT_GUID,
+            rtps_data_representation_serialization::ParameterListSerializer,
             spdp_discovered_participant_data::{
                 BuiltinEndpointQos, BuiltinEndpointSet, ParticipantProxy,
                 SpdpDiscoveredParticipantData,
@@ -32,8 +34,7 @@ use crate::{
             data_reader_entity::DataReaderEntity,
             data_writer_entity::IncompatibleSubscriptions,
             participant_entity::{
-                BuiltInKeyHolder, DcpsDomainParticipant, DiscoveredParticipantInfo,
-                DomainParticipantEntity,
+                DcpsDomainParticipant, DiscoveredParticipantInfo, DomainParticipantEntity,
             },
             user_defined_data_reader::UserDefinedDataReader,
             user_defined_data_writer::UserDefinedDataWriter,
@@ -69,10 +70,9 @@ use crate::{
         types::{DurabilityKind, ENTITYID_UNKNOWN, Guid, GuidPrefix, ReliabilityKind},
     },
     xtypes::{
-        dynamic_type::DynamicDataFactory,
         serializer::serialize_cdr2_le,
         type_object::{TypeIdentifier, TypeIdentifierTypeObjectPair, TypeObject},
-        type_support::{_String, Type, TypeSupport},
+        type_support::{_String, TypeSupport},
     },
 };
 use alloc::{
@@ -176,14 +176,14 @@ impl DcpsDomainParticipant {
                 .builtin_publisher
                 .dcps_participant_writer;
             let builtin_topic_key = *self.domain_participant.instance_handle.as_ref();
-            let mut dynamic_data = DynamicDataFactory::create_data(BuiltInKeyHolder::TYPE);
+
             let topic_key_data = BuiltInTopicKey {
                 value: builtin_topic_key,
-            }
-            .create_dynamic_sample();
-            dynamic_data.set_complex_value(0, topic_key_data).unwrap();
+            };
+            let instance_handle = InstanceHandle::new(topic_key_data.value);
+            let serialized_key = topic_key_data.into_bytes();
 
-            dw.unregister_w_timestamp(&dynamic_data, &BuiltInKeyHolder::TYPE, timestamp)
+            dw.unregister_w_timestamp(instance_handle, serialized_key, timestamp)
                 .ok();
             self.domain_participant
                 .builtin_publisher
@@ -593,14 +593,13 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .builtin_publisher
                 .dcps_publications_writer;
-            let mut dynamic_data = DynamicDataFactory::create_data(BuiltInKeyHolder::TYPE);
             let topic_key_data = BuiltInTopicKey {
                 value: data_writer.transport_writer.guid().into(),
-            }
-            .create_dynamic_sample();
-            dynamic_data.set_complex_value(0, topic_key_data).unwrap();
+            };
+            let instance_handle = InstanceHandle::new(topic_key_data.value);
+            let serialized_key = topic_key_data.into_bytes();
 
-            dw.unregister_w_timestamp(&dynamic_data, &BuiltInKeyHolder::TYPE, timestamp)
+            dw.unregister_w_timestamp(instance_handle, serialized_key, timestamp)
                 .ok();
         }
         self.domain_participant
@@ -739,14 +738,13 @@ impl DcpsDomainParticipant {
                 .domain_participant
                 .builtin_publisher
                 .dcps_subscriptions_writer;
-            let mut dynamic_data = DynamicDataFactory::create_data(BuiltInKeyHolder::TYPE);
             let topic_key_data = BuiltInTopicKey {
                 value: data_reader.transport_reader.guid().into(),
-            }
-            .create_dynamic_sample();
-            dynamic_data.set_complex_value(0, topic_key_data).unwrap();
+            };
+            let instance_handle = InstanceHandle::new(topic_key_data.value);
+            let serialized_key = topic_key_data.into_bytes();
 
-            dw.unregister_w_timestamp(&dynamic_data, &BuiltInKeyHolder::TYPE, timestamp)
+            dw.unregister_w_timestamp(instance_handle, serialized_key, timestamp)
                 .ok();
         }
         self.domain_participant
@@ -3573,5 +3571,16 @@ impl InconsistentTopicStatus {
         self.total_count_change = 0;
 
         status
+    }
+}
+
+impl BuiltInTopicKey {
+    fn into_bytes(self) -> Vec<u8> {
+        let mut buffer = Vec::new();
+        let mut pl = ParameterListSerializer::new(&mut buffer);
+        pl.write_header();
+        pl.write_xcdr1_parameter(PID_ENDPOINT_GUID, self);
+        pl.write_sentinel();
+        buffer
     }
 }

--- a/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/discovery_methods.rs
@@ -2045,8 +2045,6 @@ impl DcpsDomainParticipant {
         }
     }
 
-
-
     pub fn handle_type_lookup_request(
         &mut self,
         type_lookup_request: TypeLookupRequest,

--- a/dds/src/dcps/dcps_domain_participant/participant_entity.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_entity.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
     builtin_topics::{
-        BuiltInTopicKey, DCPS_PARTICIPANT, DCPS_PUBLICATION, DCPS_SUBSCRIPTION, DCPS_TOPIC,
+        DCPS_PARTICIPANT, DCPS_PUBLICATION, DCPS_SUBSCRIPTION, DCPS_TOPIC,
         ParticipantBuiltinTopicData, TopicBuiltinTopicData,
     },
     dcps::{
@@ -35,7 +35,7 @@ use crate::{
         interface::RtpsTransportParticipant,
         types::{ENTITYID_PARTICIPANT, Guid, GuidPrefix, Locator, USER_DEFINED_TOPIC},
     },
-    xtypes::{dynamic_type::DynamicType, type_support::TypeSupport},
+    xtypes::dynamic_type::DynamicType,
 };
 use alloc::{
     collections::BTreeSet,
@@ -51,12 +51,6 @@ pub struct DiscoveredParticipantInfo {
     pub default_multicast_locator_list: Vec<Locator>,
     pub lease_duration: Duration,
     pub last_communication_timestamp: Time,
-}
-
-#[derive(Debug, Clone, TypeSupport)]
-pub struct BuiltInKeyHolder {
-    #[dust_dds(key)]
-    pub key: BuiltInTopicKey,
 }
 
 pub struct DcpsDomainParticipant {

--- a/dds/src/dcps/dcps_domain_participant/participant_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/participant_methods.rs
@@ -471,7 +471,7 @@ impl DcpsDomainParticipant {
 
     /// Ignore participant with the specified [`handle`](InstanceHandle).
     #[tracing::instrument(skip(self))]
-    pub fn ignore_participant(&mut self, handle: &InstanceHandle) -> DdsResult<()> {
+    pub fn ignore_participant(&mut self, handle: &InstanceHandle, now: Time) -> DdsResult<()> {
         // Check enabled
         if !self.domain_participant.enabled {
             return Err(DdsError::NotEnabled);
@@ -484,7 +484,7 @@ impl DcpsDomainParticipant {
         }
 
         // Remove participant
-        self.remove_discovered_participant(handle);
+        self.remove_discovered_participant(handle, now);
 
         Ok(())
     }

--- a/dds/src/dcps/dcps_domain_participant/user_defined_data_reader.rs
+++ b/dds/src/dcps/dcps_domain_participant/user_defined_data_reader.rs
@@ -16,13 +16,15 @@ use crate::{
             QosPolicyCount, RequestedDeadlineMissedStatus, RequestedIncompatibleQosStatus,
             SampleRejectedStatus, SampleRejectedStatusKind, StatusKind, SubscriptionMatchedStatus,
         },
+        time::Time,
     },
     rtps::stateful_reader::RtpsStatefulReader,
+    transport::types::ChangeKind,
 };
 use alloc::{sync::Arc, vec::Vec};
 use core::ops::{Deref, DerefMut};
 
-use super::data_reader_entity::{DataReaderEntity, SampleList};
+use super::data_reader_entity::{AddChangeResult, DataReaderEntity, SampleList};
 
 pub struct UserDefinedDataReader {
     pub reader: DataReaderEntity<RtpsStatefulReader>,
@@ -93,7 +95,11 @@ impl UserDefinedDataReader {
         self.subscription_matched_status.total_count_change += 1;
     }
 
-    pub fn remove_matched_publication(&mut self, publication_handle: &InstanceHandle) {
+    pub fn remove_matched_publication(
+        &mut self,
+        publication_handle: &InstanceHandle,
+        timestamp: Time,
+    ) {
         let Some(i) = self
             .matched_publication_list
             .iter()
@@ -101,12 +107,36 @@ impl UserDefinedDataReader {
         else {
             return;
         };
-        self.matched_publication_list.remove(i);
 
         let writer_guid: [u8; 16] = *publication_handle.as_ref();
+
+        let instance_handles: Vec<InstanceHandle> = self
+            .instances
+            .iter()
+            .filter(|x| x.has_registered_writer(&writer_guid))
+            .map(|x| *x.handle())
+            .collect();
+
+        for instance_handle in instance_handles {
+            if let Ok(AddChangeResult::Added) = self.add_reader_change(
+                writer_guid.into(),
+                Arc::from([]),
+                ChangeKind::NotAliveUnregistered,
+                *instance_handle.as_ref(),
+                None,
+                timestamp,
+            ) {
+                self.status_condition
+                    .add_communication_state(StatusKind::DataAvailable);
+            }
+        }
+
         for instance in &mut self.instances {
             instance.remove_writer(&writer_guid);
         }
+
+        self.matched_publication_list.remove(i);
+
         if let Some(i) = self
             .instance_ownership
             .iter()

--- a/dds/src/dcps/dcps_domain_participant/writer_methods.rs
+++ b/dds/src/dcps/dcps_domain_participant/writer_methods.rs
@@ -10,7 +10,10 @@ use crate::{
         },
         listeners::data_writer_listener::DcpsDataWriterListener,
         status_mask::StatusMask,
-        xtypes_glue::key_and_instance_handle::get_instance_handle_from_dynamic_data_and_key_holder,
+        xtypes_glue::key_and_instance_handle::{
+            KeyHolderData, KeyHolderType, get_instance_handle_from_dynamic_data_and_key_holder,
+            get_instance_handle_from_key_holder_data,
+        },
     },
     infrastructure::{
         error::{DdsError, DdsResult},
@@ -21,6 +24,7 @@ use crate::{
         time::{DurationKind, Time},
     },
     runtime::DdsRuntime,
+    transport::types::TopicKind,
     xtypes::dynamic_type::DynamicData,
 };
 
@@ -244,7 +248,19 @@ impl DcpsDomainParticipant {
             .get_dynamic_type(&topic.type_information.complete.typeid_with_size.type_id)
             .expect("Type must exist in type_register");
 
-        let res = data_writer.unregister_w_timestamp(dynamic_data, &type_support, timestamp);
+        if TopicKind::from(&type_support) == TopicKind::NoKey {
+            return Err(DdsError::IllegalOperation);
+        }
+
+        let key_holder_type = KeyHolderType::new(&dynamic_data.r#type());
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &key_holder_type)?;
+        let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
+        let serialized_key = serialize(
+            key_holder_data.as_dynamic_data(),
+            &data_writer.qos.representation,
+        )?;
+
+        let res = data_writer.unregister_w_timestamp(instance_handle, serialized_key, timestamp);
         if res.is_ok() {
             data_writer
                 .transport_writer
@@ -452,7 +468,19 @@ impl DcpsDomainParticipant {
             .get_dynamic_type(&topic.type_information.complete.typeid_with_size.type_id)
             .expect("Type must exist in type_register");
 
-        let res = data_writer.dispose_w_timestamp(dynamic_data, &type_support, timestamp);
+        if TopicKind::from(&type_support) == TopicKind::NoKey {
+            return Err(DdsError::IllegalOperation);
+        }
+
+        let key_holder_type = KeyHolderType::new(&dynamic_data.r#type());
+        let key_holder_data = KeyHolderData::from_dynamic_data(dynamic_data, &key_holder_type)?;
+        let instance_handle = get_instance_handle_from_key_holder_data(&key_holder_data)?;
+        let serialized_key = serialize(
+            key_holder_data.as_dynamic_data(),
+            &data_writer.qos.representation,
+        )?;
+
+        let res = data_writer.dispose_w_timestamp(instance_handle, serialized_key, timestamp);
         if res.is_ok() {
             data_writer
                 .transport_writer

--- a/dds/src/dcps/dcps_mail_handler.rs
+++ b/dds/src/dcps/dcps_mail_handler.rs
@@ -178,7 +178,7 @@ impl<R: DdsRuntime> DcpsParticipantFactory<R> {
                 participant_handle,
                 handle,
             }) => match self.find_participant(&participant_handle) {
-                Ok(p) => DcpsReply::Ok(p.ignore_participant(&handle)),
+                Ok(p) => DcpsReply::Ok(p.ignore_participant(&handle, now)),
                 Err(e) => DcpsReply::Ok(Err(e)),
             },
             DcpsMail::Participant(ParticipantServiceMail::IgnoreSubscription {

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -126,7 +126,7 @@ impl<'a> KeyHolderData<'a> {
         Ok(Self(key_holder_data))
     }
 
-    pub fn _as_dynamic_data(&self) -> &DynamicData<'a> {
+    pub fn as_dynamic_data(&self) -> &DynamicData<'a> {
         &self.0
     }
 }

--- a/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
+++ b/dds/src/dcps/xtypes_glue/key_and_instance_handle.rs
@@ -126,7 +126,7 @@ impl<'a> KeyHolderData<'a> {
         Ok(Self(key_holder_data))
     }
 
-    pub fn as_dynamic_data(&self) -> &DynamicData<'a> {
+    pub fn _as_dynamic_data(&self) -> &DynamicData<'a> {
         &self.0
     }
 }

--- a/dds/src/rtps/cache_change.rs
+++ b/dds/src/rtps/cache_change.rs
@@ -53,11 +53,15 @@ impl CacheChange {
         writer_id: EntityId,
         inline_qos: &'a [ParameterWrite<'a>],
     ) -> DataSubmessageWrite<'a> {
-        let (data_flag, key_flag) = match self.kind {
-            ChangeKind::Alive | ChangeKind::AliveFiltered => (true, false),
-            ChangeKind::NotAliveDisposed
-            | ChangeKind::NotAliveUnregistered
-            | ChangeKind::NotAliveDisposedUnregistered => (false, true),
+        let (data_flag, key_flag) = if self.data_value.is_empty() {
+            (false, false)
+        } else {
+            match self.kind {
+                ChangeKind::Alive | ChangeKind::AliveFiltered => (true, false),
+                ChangeKind::NotAliveDisposed
+                | ChangeKind::NotAliveUnregistered
+                | ChangeKind::NotAliveDisposedUnregistered => (false, true),
+            }
         };
 
         let inline_qos_flag = !inline_qos.is_empty();

--- a/dds/tests/write_read_samples.rs
+++ b/dds/tests/write_read_samples.rs
@@ -3175,7 +3175,7 @@ fn data_reader_instance_state_not_alive_no_writers_when_writer_is_deleted() {
         .unwrap();
 
     let samples = reader
-        .read(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
+        .take(1, ANY_SAMPLE_STATE, ANY_VIEW_STATE, ANY_INSTANCE_STATE)
         .unwrap();
     assert_eq!(samples.len(), 1);
     assert_eq!(


### PR DESCRIPTION
When a writer is announced by the discovery as disposed, the instances already existing on the reader are supposed to be marked as NotAliveNoWriters. This was already handled but when all samples were taken it was not possible to read the new state since no new sample was added. The changes in this PR make sure that a new sample is added to the reader samples list when a writer is announced to be deleted.

We also fixed an issue with the builtin data for deletion being sent as a final type instead of a parameter list.