### PR TITLE
Add omg xtypes XCDR1 tests

### DIFF
--- a/.github/workflows/omg_xtypes_interoperability.yml
+++ b/.github/workflows/omg_xtypes_interoperability.yml
@@ -110,9 +110,6 @@ jobs:
       run: mkdir reports
     - name: Run Interoperability script
       run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr${{ matrix.xcdr }}_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 2 -x ${{ matrix.xcdr }}
-    - name: Run Interoperability script enable-typeid-tests
-      run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_typeid_report_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --enable-typeid-tests --type-object-version 2
-
     - name: Upload reports
       uses: actions/upload-artifact@v7
       with:
@@ -142,10 +139,14 @@ jobs:
         python-version: '3.11.4'
     - name: Install omg-dds dds-xtypes Python requirements
       run: pip install --requirement dds-xtypes/requirements.txt
-    - name: merge reports
-      run: junitparser merge *.xml junit_interoperability_report.xml
-    - name: Generate xlsx report
-      run: python3 ./dds-xtypes/generate_xlsx_report.py --input junit_interoperability_report.xml --output interoperability_report.xlsx
+    - name: merge reports xcdr1
+      run: junitparser merge junit_report_xcdr1_to2*.xml junit_xtypes_interoperability_report_xcdr1_to2.xml
+    - name: merge reports xcdr2
+      run: junitparser merge junit_report_xcdr2_to2*.xml junit_xtypes_interoperability_report_xcdr2_to2.xml
+    - name: Generate xlsx report xcdr1
+      run: python3 ./dds-xtypes/generate_xlsx_report.py --input junit_xtypes_interoperability_report_xcdr1_to2.xml --output xtypes_interoperability_report_xcdr1_to2.xlsx
+    - name: Generate xlsx report xcdr2
+      run: python3 ./dds-xtypes/generate_xlsx_report.py --input junit_xtypes_interoperability_report_xcdr2_to2.xml --output xtypes_interoperability_report_xcdr2_to2.xlsx
     - name: Upload report
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/omg_xtypes_interoperability.yml
+++ b/.github/workflows/omg_xtypes_interoperability.yml
@@ -46,20 +46,34 @@ jobs:
         include:
         - publisher: dust_dds
           subscriber: dust_dds
+          xcdr: 1
         - publisher: dust_dds
           subscriber: connext_dds
-        # - publisher: dust_dds
-        #   subscriber: toc_coredx_dds
-        # - publisher: dust_dds
-        #   subscriber: eclipse_cyclone
-
-
+          xcdr: 1
+        - publisher: dust_dds
+          subscriber: eclipse_cyclone
+          xcdr: 1
         - publisher: connext_dds
           subscriber: dust_dds
-        # - publisher: toc_coredx_dds
-        #   subscriber: dust_dds
-        # - publisher: eclipse_cyclone
-        #   subscriber: dust_dds
+          xcdr: 1
+        - publisher: eclipse_cyclone
+          subscriber: dust_dds
+          xcdr: 1
+        - publisher: dust_dds
+          subscriber: dust_dds
+          xcdr: 2
+        - publisher: dust_dds
+          subscriber: connext_dds
+          xcdr: 2
+        - publisher: dust_dds
+          subscriber: eclipse_cyclone
+          xcdr: 2
+        - publisher: connext_dds
+          subscriber: dust_dds
+          xcdr: 2
+        - publisher: eclipse_cyclone
+          subscriber: dust_dds
+          xcdr: 2
 
     steps:
     - name: Checkout omg dds-xtypes
@@ -94,17 +108,9 @@ jobs:
       run: pip install --requirement requirements.txt
     - name: Create reports directory
       run: mkdir reports
-    # - name: Run Interoperability script
-    #   run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr1_to1-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 1 -x 1
-    - name: Run Interoperability script XCDR1 TypeObject V2
-      run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr1_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 2 -x 1
-    # - name: Run Interoperability script
-    #   run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr2_to1-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 1 -x 2
-    - name: Run Interoperability_report.py XCDR2 TypeObject V2
-      run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr2_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 2 -x 2
-    # - name: Run Interoperability script
-    #   run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_typeid_report_to1-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --enable-typeid-tests --type-object-version 1
-    - name: Run Interoperability script enable-typeid-tests TypeObject V2
+    - name: Run Interoperability script
+      run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr${{ matrix.xcdr }}_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 2 -x ${{ matrix.xcdr }}
+    - name: Run Interoperability script enable-typeid-tests
       run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_typeid_report_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --enable-typeid-tests --type-object-version 2
 
     - name: Upload reports

--- a/.github/workflows/omg_xtypes_interoperability.yml
+++ b/.github/workflows/omg_xtypes_interoperability.yml
@@ -113,7 +113,7 @@ jobs:
     - name: Upload reports
       uses: actions/upload-artifact@v7
       with:
-        name: junit_report-${{ matrix.publisher }}-${{ matrix.subscriber }}
+        name: junit_report_xcdr${{ matrix.xcdr }}-${{ matrix.publisher }}-${{ matrix.subscriber }}
         path: ./reports
 
   report:

--- a/.github/workflows/omg_xtypes_interoperability.yml
+++ b/.github/workflows/omg_xtypes_interoperability.yml
@@ -96,16 +96,16 @@ jobs:
       run: mkdir reports
     # - name: Run Interoperability script
     #   run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr1_to1-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 1 -x 1
-    # - name: Run Interoperability script
-    #   run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr1_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 2 -x 1
+    - name: Run Interoperability script XCDR1 TypeObject V2
+      run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr1_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 2 -x 1
     # - name: Run Interoperability script
     #   run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr2_to1-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 1 -x 2
     - name: Run Interoperability_report.py XCDR2 TypeObject V2
       run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_report_xcdr2_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --type-object-version 2 -x 2
     # - name: Run Interoperability script
     #   run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_typeid_report_to1-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --enable-typeid-tests --type-object-version 1
-    # - name: Run Interoperability script
-    #   run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_typeid_report_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --enable-typeid-tests --type-object-version 2
+    - name: Run Interoperability script enable-typeid-tests TypeObject V2
+      run: python3 ./interoperability_report.py --pub-exe ./executables/${{ matrix.publisher }}*test_main_linux --sub-exe ./executables/${{ matrix.subscriber }}*test_main_linux --output-name reports/junit_typeid_report_to2-${{ matrix.publisher }}-${{ matrix.subscriber }}.xml --enable-typeid-tests --type-object-version 2
 
     - name: Upload reports
       uses: actions/upload-artifact@v7

--- a/dds/src/xtypes/deserializer.rs
+++ b/dds/src/xtypes/deserializer.rs
@@ -315,8 +315,10 @@ impl EncodingVersion for EncodingVersion1 {
         Self::align(deserializer, 4)?;
         let pid = member.get_id();
         let orig_pos = deserializer.reader.pos;
+        let orig_origin = deserializer.reader.origin;
         let result = if let Ok(length) = Self::seek_to_pid(deserializer, pid) {
             if length > 0 {
+                deserializer.reader.origin = deserializer.reader.pos;
                 deserializer.deserialize_value(member, dynamic_data)
             } else {
                 Ok(())
@@ -325,6 +327,7 @@ impl EncodingVersion for EncodingVersion1 {
             Ok(())
         };
         deserializer.reader.pos = orig_pos;
+        deserializer.reader.origin = orig_origin;
         result
 
         // TODO (25) using long PL encoding
@@ -715,7 +718,11 @@ fn is_element_type_kind_primitive(member: &DynamicTypeMember) -> XTypesResult<bo
 impl<'a, E: EndiannessRead, V: EncodingVersion> XTypesDeserializer<'a, E, V> {
     fn new(buffer: &'a [u8], encoding_version: V, endianness: E) -> Self {
         Self {
-            reader: Reader { buffer, pos: 0 },
+            reader: Reader {
+                buffer,
+                pos: 0,
+                origin: 0,
+            },
             _endianness: endianness,
             _encoding_version: encoding_version,
         }
@@ -1334,6 +1341,7 @@ impl AsBytes for char {
 struct Reader<'a> {
     buffer: &'a [u8],
     pos: usize,
+    origin: usize,
 }
 
 impl<'a> Reader<'a> {
@@ -1366,7 +1374,8 @@ impl<'a> Reader<'a> {
 
     fn seek_padding(&mut self, alignment: usize) -> XTypesResult<()> {
         let mask = alignment - 1;
-        self.seek(((self.pos + mask) & !mask) - self.pos)
+        let offset = self.pos - self.origin;
+        self.seek(((offset + mask) & !mask) - offset)
     }
 }
 
@@ -1934,6 +1943,31 @@ mod tests {
                     0, 0, 0, 6, // DHEADER
                     0, 0, 0, 2, // length
                     1, 2, 77
+                ],
+            )
+            .unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn deserialize_mutable_struct_primitive() {
+        #[derive(Debug, PartialEq, TypeSupport)]
+        #[dust_dds(extensibility = "mutable")]
+        struct MutableType {
+            #[dust_dds(id = 3)]
+            uint64: u64,
+        }
+        let expected = MutableType { uint64: 73 }.create_dynamic_sample();
+        assert_eq!(
+            deserialize_top_level_type(
+                MutableType::TYPE,
+                &[
+                    0x00, 0x02, 0x00, 0x00, // PL_CDR_BE
+                    0x00, 3, 0, 8, // PID | length
+                    0, 0, 0, 0, // uint64
+                    0, 0, 0, 73, // uint64
+                    0x3F, 0x02, 0, 0, // Sentinel
                 ],
             )
             .unwrap(),

--- a/dds/tests/xtypes.rs
+++ b/dds/tests/xtypes.rs
@@ -11,7 +11,7 @@ use dust_dds::{
         qos_policy::{
             DataRepresentationQosPolicy, ReliabilityQosPolicy, ReliabilityQosPolicyKind,
             TypeConsistencyEnforcementQosPolicy, TypeConsistencyKind::AllowTypeCoercion,
-            XCDR2_DATA_REPRESENTATION,
+            XCDR_DATA_REPRESENTATION, XCDR2_DATA_REPRESENTATION,
         },
         status::{NO_STATUS, StatusKind},
         time::{Duration, DurationKind},
@@ -87,6 +87,164 @@ impl DomainParticipantListener for Listener {
         core::future::ready(())
     }
 }
+
+/// 'primitives_struct_mutable': {
+///     'common_args': ['--type-folder types --type-file primitives'],
+///     'apps': ['pub-exe -P -t test -y Test::struct_primitives_mutable --data-folder data --data-file struct_primitives',
+///                 'sub-exe -S -t test -y Test::struct_primitives_mutable --data-folder data --data-file struct_primitives'],
+///     'expected_codes': [ReturnCode.OK, ReturnCode.OK],
+///     'check_function': tsf.data_is_correct,
+///     'title' : 'Communication between identical struct_primitives_mutable',
+///     'description' : 'Verifies identical mutable primitive structs communicate:\n\n'
+///                     ' * Publisher and Subscriber use `struct_primitives_mutable` (mutable) from `primitives`.\n'
+///                     ' * Both use the same mutable struct with 14 primitive members.\n'
+///                     '**Test passes if:** Discovery succeeds and the subscriber receives the sample.\n'
+/// },
+#[test]
+fn xcdr1_xtypes_v2_struct_test_suite_primitives_struct_mutable() {
+    let domain_id = TEST_DOMAIN_ID_GENERATOR.generate_unique_domain_id();
+    let (sender, receiver) = channel();
+    let publisher_participant = DomainParticipantFactory::get_instance()
+        .create_participant(
+            domain_id,
+            QosKind::Default,
+            Some(Listener {
+                sender: sender.clone(),
+            }),
+            &[StatusKind::PublicationMatched],
+        )
+        .unwrap();
+
+    let type_xml = r#"
+    <dds>
+        <types>
+            <module name="Test">
+                <struct name="struct_primitives_mutable"   extensibility="mutable">
+                    <member name="x1"   type="uint8"   />
+                    <member name="x2"   type="uint16"  />
+                    <member name="x3"   type="uint32"  />
+                    <member name="x4"   type="uint64"  />
+                    <member name="x5"   type="int8"   />
+                    <member name="x6"   type="int16"   />
+                    <member name="x7"   type="int32"   />
+                    <member name="x8"   type="int64"   />
+                    <member name="x9"   type="boolean" />
+                    <member name="x10"  type="float32" />
+                    <member name="x11"  type="float64" />
+                    <member name="x12"  type="float128"/>
+                    <member name="x13"  type="byte"    />
+                    <member name="x14"  type="char8"   />
+                </struct>
+            </module>
+        </types>
+    </dds>
+    "#;
+    let type_builder = DynamicTypeBuilderFactory::create_type_w_document(
+        type_xml,
+        "Test::struct_primitives_mutable",
+        vec![],
+    )
+    .unwrap();
+    let publisher_dynamic_type = type_builder.build();
+    let publisher_topic = publisher_participant
+        .create_dynamic_topic(
+            "test",
+            "Test::struct_primitives_mutable",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+            publisher_dynamic_type,
+        )
+        .unwrap();
+    let publisher = publisher_participant
+        .create_publisher(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let writer = publisher
+        .create_datawriter(&publisher_topic, QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let subscriber_participant = DomainParticipantFactory::get_instance()
+        .create_participant(
+            domain_id,
+            QosKind::Default,
+            Some(Listener {
+                sender: sender.clone(),
+            }),
+            &[StatusKind::SubscriptionMatched],
+        )
+        .unwrap();
+    let type_builder = DynamicTypeBuilderFactory::create_type_w_document(
+        type_xml,
+        "Test::struct_primitives_mutable",
+        vec![],
+    )
+    .unwrap();
+    let subscriber_topic = subscriber_participant
+        .create_dynamic_topic(
+            "test",
+            "Test::struct_primitives_mutable",
+            QosKind::Default,
+            NO_LISTENER,
+            NO_STATUS,
+            type_builder.build(),
+        )
+        .unwrap();
+    let subscriber = subscriber_participant
+        .create_subscriber(QosKind::Default, NO_LISTENER, NO_STATUS)
+        .unwrap();
+    let mut reader_qos = reader_qos();
+    reader_qos.type_consistency.ignore_member_names = false;
+    reader_qos.representation.value = vec![XCDR_DATA_REPRESENTATION];
+    let reader = subscriber
+        .create_datareader::<DynamicData<'static>>(
+            &subscriber_topic,
+            QosKind::Specific(reader_qos),
+            NO_LISTENER,
+            NO_STATUS,
+        )
+        .unwrap();
+
+    // Note: In the OMG XTYpes tests the DomainParticipantListener is used to check
+    // if the publication or subscriptions are matched. To mimic that test even closer here
+    // the (actually better fitting) status condition is not used
+    receiver
+        .recv_timeout(std::time::Duration::from_secs(30))
+        .unwrap();
+    receiver
+        .recv_timeout(std::time::Duration::from_secs(30))
+        .unwrap();
+
+    let mut data = DynamicDataFactory::create_data(publisher_dynamic_type);
+    data.from_xml(
+        "<struct_primitives>
+            <x1>0x01</x1>
+            <x2>2</x2>
+            <x3>3</x3>
+            <x4>4</x4>
+            <x5>0x05</x5>
+            <x6>6</x6>
+            <x7>7</x7>
+            <x8>8</x8>
+            <x9>true</x9>
+            <x10>10.100000</x10>
+            <x11>11.200000</x11>
+            <x12>12.300000</x12>
+            <x13>13</x13>
+            <x14>0x0e</x14>
+        </struct_primitives>",
+    )
+    .unwrap();
+
+    writer.write(data.clone(), None).unwrap();
+    writer
+        .wait_for_acknowledgments(Duration::new(10, 0))
+        .unwrap();
+
+    assert_eq!(
+        reader.read_next_sample().unwrap().data.as_ref().unwrap(),
+        &data
+    );
+}
+
 /// 'ext_final_struct_1' : {
 ///     'common_args' : ['--type-folder types --type-file extensibility'],
 ///     'apps' : ['pub-exe -P -t test -y Test::struct_f1 --data-folder data --data-file struct_num_x1',


### PR DESCRIPTION
Add omg xtypes XCDR1 tests. Fix deserialization of 64bit types that occur after a PID + length in mutable types. The PUSH(origin=0) was not yet implemented